### PR TITLE
API: Cerebras responses fixes + observability dedupe

### DIFF
--- a/apps/api/src/executors/_shared/text-generate/openai-compat/providers/cerebras/quirks.ts
+++ b/apps/api/src/executors/_shared/text-generate/openai-compat/providers/cerebras/quirks.ts
@@ -1,0 +1,176 @@
+// Purpose: Shared OpenAI-compatible text adapter and transformations.
+// Why: Consolidates OpenAI-style quirks across many providers.
+// How: Maps IR to OpenAI formats and normalizes streaming events.
+
+import type { ProviderQuirks } from "../../quirks/types";
+
+type CerebrasReasoningEffort = "none" | "low" | "medium" | "high";
+const CEREBRAS_UNSUPPORTED_FIELDS = [
+	"prompt_cache_key",
+	"safety_identifier",
+] as const;
+
+function mapReasoningEffortToCerebras(value?: string): CerebrasReasoningEffort | undefined {
+	switch (value) {
+		case "none":
+			return "none";
+		case "minimal":
+		case "low":
+			return "low";
+		case "medium":
+			return "medium";
+		case "high":
+		case "xhigh":
+			return "high";
+		default:
+			return undefined;
+	}
+}
+
+function normalizeCerebrasServiceTier(value: unknown): string | undefined {
+	if (typeof value !== "string" || value.length === 0) return undefined;
+	if (value === "standard") return "default";
+	return value;
+}
+
+function isObject(value: unknown): value is Record<string, any> {
+	return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function isBooleanOrNull(value: unknown): value is boolean | null {
+	return typeof value === "boolean" || value === null;
+}
+
+function isNonNegativeInteger(value: unknown): value is number {
+	return Number.isInteger(value) && Number(value) >= 0;
+}
+
+function normalizeCerebrasReasoningEffort(value: unknown): CerebrasReasoningEffort | undefined {
+	if (typeof value !== "string") return undefined;
+	switch (value) {
+		case "none":
+		case "low":
+		case "medium":
+		case "high":
+			return value;
+		default:
+			return undefined;
+	}
+}
+
+function isZaiGlmModel(value: unknown): boolean {
+	if (typeof value !== "string") return false;
+	return value.toLowerCase().includes("glm-4.7");
+}
+
+export const cerebrasQuirks: ProviderQuirks = {
+	transformRequest: ({ request, ir }) => {
+		const raw = isObject(ir.rawRequest) ? ir.rawRequest : {};
+		const model = typeof request.model === "string" ? request.model : (typeof ir.model === "string" ? ir.model : "");
+		const isGlm = isZaiGlmModel(model);
+
+		if ("prediction" in raw && request.prediction == null && isObject(raw.prediction)) {
+			request.prediction = raw.prediction;
+		}
+
+		if ("reasoning_effort" in raw && request.reasoning_effort == null) {
+			const normalizedRawEffort = normalizeCerebrasReasoningEffort(raw.reasoning_effort);
+			if (normalizedRawEffort) {
+				request.reasoning_effort = normalizedRawEffort;
+			}
+		}
+
+		if ("max_reasoning_tokens" in raw && request.max_reasoning_tokens == null) {
+			if (isNonNegativeInteger(raw.max_reasoning_tokens)) {
+				request.max_reasoning_tokens = raw.max_reasoning_tokens;
+			}
+		}
+
+		if ("clear_thinking" in raw && request.clear_thinking == null) {
+			request.clear_thinking = raw.clear_thinking;
+		}
+		if ("disable_reasoning" in raw && request.disable_reasoning == null) {
+			request.disable_reasoning = raw.disable_reasoning;
+		}
+
+		if (typeof request.max_tokens === "number" && request.max_completion_tokens == null) {
+			request.max_completion_tokens = request.max_tokens;
+			delete request.max_tokens;
+		}
+
+		if (typeof ir.reasoning?.maxTokens === "number" && request.max_reasoning_tokens == null) {
+			request.max_reasoning_tokens = ir.reasoning.maxTokens;
+		}
+
+		const effort = mapReasoningEffortToCerebras(ir.reasoning?.effort);
+		if (effort) {
+			request.reasoning_effort = effort;
+		} else if (ir.reasoning?.enabled === false) {
+			request.reasoning_effort = "none";
+		} else if (ir.reasoning?.enabled === true) {
+			request.reasoning_effort = "medium";
+		}
+
+		if (Array.isArray(request.messages)) {
+			request.messages = request.messages.map((msg: any) =>
+				msg?.role === "developer"
+					? { ...msg, role: "system" }
+					: msg,
+			);
+		}
+
+		const normalizedTier = normalizeCerebrasServiceTier(request.service_tier);
+		if (normalizedTier) {
+			request.service_tier = normalizedTier;
+		}
+
+		for (const key of CEREBRAS_UNSUPPORTED_FIELDS) {
+			delete request[key];
+		}
+
+		// Cerebras marks these OpenAI fields as unsupported.
+		// Keep request construction deterministic to avoid upstream 400+retry loops.
+		delete request.frequency_penalty;
+		delete request.presence_penalty;
+		delete request.logit_bias;
+
+		if (isObject(request.response_format) && request.reasoning_effort && request.reasoning_effort !== "none") {
+			// Cerebras docs: response_format is unsupported with reasoning models.
+			// Drop it proactively when reasoning is enabled.
+			delete request.response_format;
+		}
+
+		// Cerebras exposes these as model-specific Z.AI extensions.
+		// Keep request routing resilient by silently dropping unsupported/invalid values.
+		if (!isGlm || !isBooleanOrNull(request.clear_thinking)) {
+			delete request.clear_thinking;
+		}
+		if (!isGlm || !isBooleanOrNull(request.disable_reasoning)) {
+			delete request.disable_reasoning;
+		}
+
+		if ("reasoning" in request) {
+			delete request.reasoning;
+		}
+	},
+
+	extractReasoning: ({ choice, rawContent }) => {
+		const reasoningRaw = choice?.message?.reasoning_content ?? choice?.message?.reasoning;
+		const reasoning = typeof reasoningRaw === "string" && reasoningRaw.length > 0
+			? [reasoningRaw]
+			: [];
+		return { main: rawContent, reasoning };
+	},
+
+	transformStreamChunk: ({ chunk }) => {
+		if (!chunk || !Array.isArray(chunk.choices)) return;
+		for (const choice of chunk.choices) {
+			if (typeof choice?.delta?.reasoning === "string" && !choice.delta.reasoning_content) {
+				choice.delta.reasoning_content = choice.delta.reasoning;
+			}
+			if (typeof choice?.message?.reasoning === "string" && !choice.message.reasoning_content) {
+				choice.message.reasoning_content = choice.message.reasoning;
+			}
+		}
+	},
+};

--- a/apps/api/src/executors/_shared/text-generate/openai-compat/quirks/__tests__/cerebras.test.ts
+++ b/apps/api/src/executors/_shared/text-generate/openai-compat/quirks/__tests__/cerebras.test.ts
@@ -1,0 +1,187 @@
+import { describe, expect, it } from "vitest";
+import { cerebrasQuirks } from "../../providers/cerebras/quirks";
+
+describe("Cerebras quirks", () => {
+	it("maps reasoning and service tier, and rewrites developer role", () => {
+		const request: Record<string, any> = {
+			max_tokens: 128,
+			service_tier: "standard",
+			messages: [
+				{ role: "developer", content: "You are a code assistant." },
+				{ role: "user", content: "hi" },
+			],
+		};
+		const ir: any = {
+			reasoning: {
+				effort: "xhigh",
+				maxTokens: 256,
+			},
+		};
+
+		cerebrasQuirks.transformRequest?.({ request, ir });
+
+		expect(request.max_tokens).toBeUndefined();
+		expect(request.max_completion_tokens).toBe(128);
+		expect(request.max_reasoning_tokens).toBe(256);
+		expect(request.reasoning_effort).toBe("high");
+		expect(request.service_tier).toBe("default");
+		expect(request.messages[0].role).toBe("system");
+	});
+
+	it("maps reasoning enabled=false to none", () => {
+		const request: Record<string, any> = {};
+		const ir: any = {
+			reasoning: {
+				enabled: false,
+			},
+		};
+
+		cerebrasQuirks.transformRequest?.({ request, ir });
+
+		expect(request.reasoning_effort).toBe("none");
+	});
+
+	it("drops unsupported penalties/logit_bias and response_format on reasoning", () => {
+		const request: Record<string, any> = {
+			frequency_penalty: 0.2,
+			presence_penalty: 0.1,
+			logit_bias: { 42: 1 },
+			response_format: {
+				type: "json_object",
+			},
+		};
+		const ir: any = {
+			reasoning: {
+				effort: "medium",
+			},
+		};
+
+		cerebrasQuirks.transformRequest?.({ request, ir });
+
+		expect(request.frequency_penalty).toBeUndefined();
+		expect(request.presence_penalty).toBeUndefined();
+		expect(request.logit_bias).toBeUndefined();
+		expect(request.response_format).toBeUndefined();
+	});
+
+	it("drops unsupported OpenAI fields used by responses payloads", () => {
+		const request: Record<string, any> = {
+			prompt_cache_key: null,
+			safety_identifier: null,
+			input_items: [
+				{
+					type: "message",
+					role: "user",
+					content: [{ type: "input_text", text: "hi" }],
+				},
+			],
+		};
+
+		cerebrasQuirks.transformRequest?.({ request, ir: {} as any });
+
+		expect(request.prompt_cache_key).toBeUndefined();
+		expect(request.safety_identifier).toBeUndefined();
+		expect(Array.isArray(request.input_items)).toBe(true);
+	});
+
+	it("extracts reasoning from message.reasoning", () => {
+		const out = cerebrasQuirks.extractReasoning?.({
+			choice: {
+				message: {
+					reasoning: "step-by-step",
+				},
+			},
+			rawContent: "final answer",
+		});
+
+		expect(out?.main).toBe("final answer");
+		expect(out?.reasoning).toEqual(["step-by-step"]);
+	});
+
+	it("maps stream reasoning deltas to reasoning_content", () => {
+		const chunk: any = {
+			object: "chat.completion.chunk",
+			choices: [
+				{
+					index: 0,
+					delta: {
+						reasoning: "chain ",
+					},
+				},
+			],
+		};
+
+		cerebrasQuirks.transformStreamChunk?.({
+			chunk,
+			accumulated: {},
+		});
+
+		expect(chunk.choices[0].delta.reasoning_content).toBe("chain ");
+	});
+
+	it("passes through Cerebras raw curl params for glm models", () => {
+		const request: Record<string, any> = {
+			model: "zai-glm-4.7",
+		};
+		const ir: any = {
+			model: "zai-glm-4.7",
+			rawRequest: {
+				clear_thinking: false,
+				disable_reasoning: true,
+				max_reasoning_tokens: 321,
+				reasoning_effort: "low",
+				prediction: {
+					type: "content",
+					content: "known prefix",
+				},
+			},
+		};
+
+		cerebrasQuirks.transformRequest?.({ request, ir });
+
+		expect(request.clear_thinking).toBe(false);
+		expect(request.disable_reasoning).toBe(true);
+		expect(request.max_reasoning_tokens).toBe(321);
+		expect(request.reasoning_effort).toBe("low");
+		expect(request.prediction).toEqual({
+			type: "content",
+			content: "known prefix",
+		});
+	});
+
+	it("silently drops glm-only params for non-glm models", () => {
+		const request: Record<string, any> = {
+			model: "gpt-oss-120b",
+		};
+		const ir: any = {
+			model: "gpt-oss-120b",
+			rawRequest: {
+				clear_thinking: false,
+				disable_reasoning: true,
+			},
+		};
+
+		cerebrasQuirks.transformRequest?.({ request, ir });
+
+		expect(request.clear_thinking).toBeUndefined();
+		expect(request.disable_reasoning).toBeUndefined();
+	});
+
+	it("silently drops invalid glm-only param values", () => {
+		const request: Record<string, any> = {
+			model: "zai-glm-4.7",
+		};
+		const ir: any = {
+			model: "zai-glm-4.7",
+			rawRequest: {
+				clear_thinking: "nope",
+				disable_reasoning: "nope",
+			},
+		};
+
+		cerebrasQuirks.transformRequest?.({ request, ir });
+
+		expect(request.clear_thinking).toBeUndefined();
+		expect(request.disable_reasoning).toBeUndefined();
+	});
+});

--- a/apps/api/src/observability/axiom.ts
+++ b/apps/api/src/observability/axiom.ts
@@ -5,13 +5,26 @@
 import { getBindings } from "@/runtime/env";
 
 export type WideEvent = Record<string, unknown>;
+let warnedMissingWideDataset = false;
+let warnedSharedDataset = false;
 
 export async function sendAxiomWideEvent(event: WideEvent) {
     const bindings = getBindings();
-    const dataset = bindings.AXIOM_WIDE_DATASET ?? bindings.AXIOM_DATASET;
+    const dataset = bindings.AXIOM_WIDE_DATASET;
     const token = bindings.AXIOM_API_KEY;
 
     if (!dataset || !token) {
+        if (!dataset && !warnedMissingWideDataset) {
+            warnedMissingWideDataset = true;
+            console.warn("[observability] AXIOM_WIDE_DATASET not set; skipping wide event ingestion.");
+        }
+        return;
+    }
+    if (bindings.AXIOM_DATASET && dataset === bindings.AXIOM_DATASET) {
+        if (!warnedSharedDataset) {
+            warnedSharedDataset = true;
+            console.warn("[observability] AXIOM_WIDE_DATASET matches AXIOM_DATASET; skipping wide event ingestion to avoid duplicates.");
+        }
         return;
     }
 

--- a/apps/api/src/pipeline/audit/axiom.ts
+++ b/apps/api/src/pipeline/audit/axiom.ts
@@ -228,6 +228,7 @@ export function buildAxiomEvent(a: AxiomArgs) {
 
     // A single flat object (Axiom-friendly) following loggingsucks.com wide event pattern
     return {
+        event_type: "gateway.audit",
         // ====================================================================
         // IDENTITY & CORE
         // ====================================================================

--- a/apps/api/src/pipeline/execute/guards.ts
+++ b/apps/api/src/pipeline/execute/guards.ts
@@ -8,8 +8,6 @@ import type { PipelineTiming } from "./index";
 import type { ProviderCandidate } from "../before/types";
 import { err } from "./http";
 import { captureTimingSnapshot } from "./utils";
-import { handleError } from "@core/error-handler";
-import { auditFailure } from "../audit";
 
 export type ExecuteGuardOk<T> = { ok: true; value: T };
 export type ExecuteGuardErr = { ok: false; response: Response };
@@ -27,14 +25,6 @@ export async function guardCandidates(
             model: ctx.model,
             endpoint: ctx.endpoint,
             request_id: ctx.requestId,
-        });
-
-        await handleError({
-            stage: "execute",
-            res,
-            endpoint: ctx.endpoint,
-            ctx,
-            auditFailure
         });
 
         return { ok: false, response: res };
@@ -61,14 +51,6 @@ export async function guardPricingFound(
             request_id: ctx.requestId,
         });
 
-        await handleError({
-            stage: "execute",
-            res,
-            endpoint: ctx.endpoint,
-            ctx,
-            auditFailure
-        });
-
         return { ok: false, response: res };
     }
 
@@ -83,20 +65,59 @@ export async function guardAllFailed(
         timing.timer.between("adapter_roundtrip_ms", "adapter_start");
     }
 
+    const attemptErrors: Array<Record<string, unknown>> = Array.isArray((ctx as any)?.attemptErrors)
+        ? ((ctx as any).attemptErrors as Array<Record<string, unknown>>)
+        : [];
+    const failedProviders = Array.from(
+        new Set(
+            attemptErrors
+                .map((entry) => (typeof entry?.provider === "string" ? entry.provider : null))
+                .filter((value): value is string => Boolean(value)),
+        ),
+    );
+    const failedStatuses = Array.from(
+        new Set(
+            attemptErrors
+                .map((entry) => {
+                    const status = Number(entry?.status ?? NaN);
+                    return Number.isFinite(status) ? status : null;
+                })
+                .filter((value): value is number => value != null),
+        ),
+    );
+    const failureSample = attemptErrors.slice(0, 3).map((entry) => ({
+        provider: typeof entry?.provider === "string" ? entry.provider : null,
+        type: typeof entry?.type === "string" ? entry.type : null,
+        status: Number.isFinite(Number(entry?.status)) ? Number(entry?.status) : null,
+        upstream_error_code:
+            typeof entry?.upstream_error_code === "string" ? entry.upstream_error_code : null,
+        upstream_error_message:
+            typeof entry?.upstream_error_message === "string"
+                ? entry.upstream_error_message
+                : null,
+        upstream_error_description:
+            typeof entry?.upstream_error_description === "string"
+                ? entry.upstream_error_description
+                : null,
+    }));
+    const routingDiagnostics = (ctx as any)?.routingDiagnostics ?? null;
+    const providerEnablement = (ctx as any)?.providerEnablementDiagnostics ?? null;
+    const candidateBuild = (ctx as any)?.providerCandidateBuildDiagnostics ?? null;
+
     captureTimingSnapshot(ctx, timing);
     const res = err("upstream_error", {
         reason: "all_candidates_failed",
+        description: "All provider candidates failed. Inspect failure_sample for upstream diagnostics.",
         model: ctx.model,
         endpoint: ctx.endpoint,
         request_id: ctx.requestId,
-    });
-
-    await handleError({
-        stage: "execute",
-        res,
-        endpoint: ctx.endpoint,
-        ctx,
-        auditFailure
+        attempt_count: attemptErrors.length || null,
+        failed_providers: failedProviders.length ? failedProviders : null,
+        failed_statuses: failedStatuses.length ? failedStatuses : null,
+        failure_sample: failureSample.length ? failureSample : null,
+        routing_diagnostics: routingDiagnostics,
+        provider_enablement: providerEnablement,
+        provider_candidate_diagnostics: candidateBuild,
     });
 
     return { ok: false, response: res };


### PR DESCRIPTION
## Summary\n- fix Cerebras responses mapping for unsupported fields\n- improve stream test helper for Anthropic messages shape\n- dedupe gateway wide-event emission and avoid duplicate Axiom dataset writes\n- tighten execute-guard error flow to avoid duplicate error handling\n\n## Notes\n- focused stability slice extracted from active working changes