### PR TITLE
[codex] set sonnet 4.6 available and disable gateway

### DIFF
--- a/apps/web/src/data/api_providers/anthropic/models.json
+++ b/apps/web/src/data/api_providers/anthropic/models.json
@@ -917,7 +917,7 @@
     "provider_api_model_id": "anthropic:anthropic/claude-sonnet-4.6",
     "provider_model_slug": "claude-sonnet-4-6",
     "internal_model_id": "anthropic/claude-sonnet-4-6-2026-02-17",
-    "is_active_gateway": true,
+    "is_active_gateway": false,
     "quantization_scheme": null,
     "input_modalities": "text,image",
     "output_modalities": "text",

--- a/apps/web/src/data/models/anthropic/claude-sonnet-4-6-2026-02-17/model.json
+++ b/apps/web/src/data/models/anthropic/claude-sonnet-4-6-2026-02-17/model.json
@@ -2,7 +2,7 @@
   "model_id": "anthropic/claude-sonnet-4-6-2026-02-17",
   "organisation_id": "anthropic",
   "name": "Claude Sonnet 4.6",
-  "status": "Rumoured",
+  "status": "available",
   "previous_model_id": "anthropic/claude-sonnet-4-5-2025-09-29",
   "announced_date": "2026-02-17T00:00:00",
   "release_date": "2026-02-17T00:00:00",


### PR DESCRIPTION
## Summary
This change updates Anthropic Claude Sonnet 4.6 metadata to match the desired rollout state.

Users were seeing this model marked as rumoured and still gateway-enabled, which is not the intended current behavior.

## Root Cause
The generated data previously set:
- model status to `Rumoured`
- provider gateway flag `is_active_gateway` to `true`

That state did not match the intended operational status for this model.

## Fix
- Set `status` to `available` for `anthropic/claude-sonnet-4-6-2026-02-17` in the model JSON.
- Set `is_active_gateway` to `false` for `anthropic/claude-sonnet-4.6` in Anthropic provider models.

## User Impact
- Data views and downstream consumers now show Sonnet 4.6 as available.
- Gateway routing metadata now reflects that Sonnet 4.6 should not be available through gateway yet.

## Validation
- `pnpm validate:data`
