### PR TITLE
fix logo theme visibility in model links

### DIFF
--- a/apps/web/src/components/(data)/model/overview/ModelLinks.tsx
+++ b/apps/web/src/components/(data)/model/overview/ModelLinks.tsx
@@ -41,17 +41,17 @@ function getIconForLink(
 	if (key === "announcement_link") {
 		const providerId = model.organisation_id;
 		if (providerId) {
-			return (
-				<Logo
-					id={providerId}
-					alt="Provider"
-					width={16}
-					height={16}
-					className="w-4 h-4 rounded inline-block"
-				/>
-			);
+				return (
+					<Logo
+						id={providerId}
+						alt="Provider"
+						width={16}
+						height={16}
+						className="w-4 h-4 rounded"
+					/>
+				);
+			}
 		}
-	}
 	// Weights: /social/hugging_face.svg
 	if (key === "weights_link") {
 		return (

--- a/apps/web/src/components/Logo.tsx
+++ b/apps/web/src/components/Logo.tsx
@@ -77,7 +77,7 @@ export function Logo({
 				<Image
 					src={light.src}
 					alt={label}
-					className={["block dark:hidden", className]
+					className={[className, "block dark:hidden"]
 						.filter(Boolean)
 						.join(" ")}
 					{...imageProps}
@@ -87,7 +87,7 @@ export function Logo({
 				<Image
 					src={dark.src}
 					alt={label}
-					className={["hidden dark:block", className]
+					className={[className, "hidden dark:block"]
 						.filter(Boolean)
 						.join(" ")}
 					{...imageProps}


### PR DESCRIPTION
## Summary
This PR fixes the model links icon rendering issue where both light and dark provider logos could appear simultaneously in light mode.

## User Impact
On model pages, the announcement icon could render both theme variants at once in light mode, creating visual duplication and inconsistent icon behavior.

## Root Cause
The `Logo` component merged caller classes after theme visibility classes (`hidden`/`block`). When a caller passed display classes like `inline-block`, those could override the intended visibility behavior for the light/dark pair.

In addition, the announcement link usage passed `inline-block`, which increased the chance of display-class conflicts.

## Fix
1. Updated `Logo` class merge order so theme visibility classes are appended last:
   - light image: `... className, "block dark:hidden"`
   - dark image: `... className, "hidden dark:block"`
2. Removed `inline-block` from announcement link logo usage in model links.

## Files Changed
- `apps/web/src/components/Logo.tsx`
- `apps/web/src/components/(data)/model/overview/ModelLinks.tsx`

## Validation
- Ran `pnpm --filter @ai-stats/web typecheck`
- Result: pass

## Notes
This PR is intentionally scoped only to the logo/theme visibility fix.
