### PR TITLE
Per-provider model discovery and readiness checks

### DIFF
--- a/scripts/model-discovery/providers/_openai-compatible-provider.ts
+++ b/scripts/model-discovery/providers/_openai-compatible-provider.ts
@@ -1,0 +1,71 @@
+import { asArray, asRecord, defineProvider, fetchJson, normalizeModelEntries } from "./_shared";
+
+type OpenAICompatProviderConfig = {
+    providerId: string;
+    name: string;
+    apiKeyEnv: string;
+    baseUrl?: string;
+    baseUrlEnv?: string;
+    pathPrefix?: string;
+    apiKeyHeader?: string;
+    apiKeyPrefix?: string;
+};
+
+function normalizePathSegment(value?: string): string {
+    if (!value) return "";
+    return "/" + value.replace(/^\/+|\/+$/g, "");
+}
+
+function normalizeModelsUrl(baseUrl: string, pathPrefix?: string): string {
+    const base = baseUrl.replace(/\/+$/, "");
+    let prefix = normalizePathSegment(pathPrefix);
+
+    if (prefix) {
+        try {
+            const parsed = new URL(base);
+            const basePath = parsed.pathname.replace(/\/+$/, "");
+            if (basePath === prefix || basePath.endsWith(prefix)) {
+                prefix = "";
+            }
+        } catch {
+            // Ignore parse errors and use default behavior.
+        }
+    }
+
+    return prefix ? base + prefix + "/models" : base + "/models";
+}
+
+export function defineOpenAICompatibleProvider(config: OpenAICompatProviderConfig) {
+    return defineProvider({
+        id: config.providerId,
+        name: config.name,
+        requiredEnv: config.baseUrlEnv && !config.baseUrl ? [config.apiKeyEnv, config.baseUrlEnv] : [config.apiKeyEnv],
+        async fetchModels() {
+            const key = process.env[config.apiKeyEnv];
+            const configuredBaseUrl = config.baseUrlEnv ? process.env[config.baseUrlEnv] : undefined;
+            const baseUrl = config.baseUrl ?? configuredBaseUrl;
+
+            if (!key) {
+                throw new Error("Missing API key: " + config.apiKeyEnv);
+            }
+            if (!baseUrl) {
+                throw new Error("Missing base URL for " + config.providerId);
+            }
+
+            const payload = await fetchJson({
+                url: normalizeModelsUrl(baseUrl, config.pathPrefix),
+                init: {
+                    headers: {
+                        [config.apiKeyHeader ?? "Authorization"]: (config.apiKeyPrefix ?? "Bearer ") + key,
+                    },
+                },
+            });
+
+            const models = asArray(asRecord(payload)?.data).length
+                ? asArray(asRecord(payload)?.data)
+                : asArray(asRecord(payload)?.models);
+
+            return normalizeModelEntries(models, (item) => (typeof item.id === "string" ? item.id : null));
+        },
+    });
+}

--- a/scripts/model-discovery/providers/ai21.ts
+++ b/scripts/model-discovery/providers/ai21.ts
@@ -1,0 +1,11 @@
+import { defineOpenAICompatibleProvider } from "./_openai-compatible-provider";
+
+export default defineOpenAICompatibleProvider({
+    providerId: "ai21",
+    name: "AI21",
+    apiKeyEnv: "AI21_API_KEY",
+    baseUrl: "https://api.ai21.com",
+    baseUrlEnv: "AI21_BASE_URL",
+    pathPrefix: "/studio/v1",
+});
+

--- a/scripts/model-discovery/providers/aion-labs.ts
+++ b/scripts/model-discovery/providers/aion-labs.ts
@@ -1,0 +1,11 @@
+import { defineOpenAICompatibleProvider } from "./_openai-compatible-provider";
+
+export default defineOpenAICompatibleProvider({
+    providerId: "aion-labs",
+    name: "Aion Labs",
+    apiKeyEnv: "AION_LABS_API_KEY",
+    baseUrl: "https://api.aionlabs.ai",
+    baseUrlEnv: "AION_LABS_BASE_URL",
+    pathPrefix: "/v1",
+});
+

--- a/scripts/model-discovery/providers/aionlabs.ts
+++ b/scripts/model-discovery/providers/aionlabs.ts
@@ -1,0 +1,11 @@
+import { defineOpenAICompatibleProvider } from "./_openai-compatible-provider";
+
+export default defineOpenAICompatibleProvider({
+    providerId: "aionlabs",
+    name: "AionLabs",
+    apiKeyEnv: "AION_LABS_API_KEY",
+    baseUrl: "https://api.aionlabs.ai",
+    baseUrlEnv: "AION_LABS_BASE_URL",
+    pathPrefix: "/v1",
+});
+

--- a/scripts/model-discovery/providers/alibaba.ts
+++ b/scripts/model-discovery/providers/alibaba.ts
@@ -1,0 +1,11 @@
+import { defineOpenAICompatibleProvider } from "./_openai-compatible-provider";
+
+export default defineOpenAICompatibleProvider({
+    providerId: "alibaba",
+    name: "Alibaba",
+    apiKeyEnv: "ALIBABA_API_KEY",
+    baseUrl: "https://dashscope-intl.aliyuncs.com",
+    baseUrlEnv: "ALIBABA_BASE_URL",
+    pathPrefix: "/compatible-mode/v1",
+});
+

--- a/scripts/model-discovery/providers/amazon-bedrock.ts
+++ b/scripts/model-discovery/providers/amazon-bedrock.ts
@@ -1,0 +1,10 @@
+import { defineOpenAICompatibleProvider } from "./_openai-compatible-provider";
+
+export default defineOpenAICompatibleProvider({
+    providerId: "amazon-bedrock",
+    name: "Amazon Bedrock",
+    apiKeyEnv: "AMAZON_BEDROCK_API_KEY",
+    baseUrlEnv: "AMAZON_BEDROCK_BASE_URL",
+    pathPrefix: "/v1",
+});
+

--- a/scripts/model-discovery/providers/arcee-ai.ts
+++ b/scripts/model-discovery/providers/arcee-ai.ts
@@ -1,0 +1,11 @@
+import { defineOpenAICompatibleProvider } from "./_openai-compatible-provider";
+
+export default defineOpenAICompatibleProvider({
+    providerId: "arcee-ai",
+    name: "Arcee Ai",
+    apiKeyEnv: "ARCEE_API_KEY",
+    baseUrl: "https://api.arcee.ai",
+    baseUrlEnv: "ARCEE_BASE_URL",
+    pathPrefix: "/api/v1",
+});
+

--- a/scripts/model-discovery/providers/arcee.ts
+++ b/scripts/model-discovery/providers/arcee.ts
@@ -1,0 +1,11 @@
+import { defineOpenAICompatibleProvider } from "./_openai-compatible-provider";
+
+export default defineOpenAICompatibleProvider({
+    providerId: "arcee",
+    name: "Arcee",
+    apiKeyEnv: "ARCEE_API_KEY",
+    baseUrl: "https://api.arcee.ai",
+    baseUrlEnv: "ARCEE_BASE_URL",
+    pathPrefix: "/api/v1",
+});
+

--- a/scripts/model-discovery/providers/atlas-cloud.ts
+++ b/scripts/model-discovery/providers/atlas-cloud.ts
@@ -1,0 +1,11 @@
+import { defineOpenAICompatibleProvider } from "./_openai-compatible-provider";
+
+export default defineOpenAICompatibleProvider({
+    providerId: "atlas-cloud",
+    name: "Atlas Cloud",
+    apiKeyEnv: "ATLAS_CLOUD_API_KEY",
+    baseUrl: "https://api.atlascloud.ai",
+    baseUrlEnv: "ATLAS_CLOUD_BASE_URL",
+    pathPrefix: "/v1",
+});
+

--- a/scripts/model-discovery/providers/atlascloud.ts
+++ b/scripts/model-discovery/providers/atlascloud.ts
@@ -1,0 +1,11 @@
+import { defineOpenAICompatibleProvider } from "./_openai-compatible-provider";
+
+export default defineOpenAICompatibleProvider({
+    providerId: "atlascloud",
+    name: "AtlasCloud",
+    apiKeyEnv: "ATLAS_CLOUD_API_KEY",
+    baseUrl: "https://api.atlascloud.ai",
+    baseUrlEnv: "ATLAS_CLOUD_BASE_URL",
+    pathPrefix: "/v1",
+});
+

--- a/scripts/model-discovery/providers/azure.ts
+++ b/scripts/model-discovery/providers/azure.ts
@@ -1,0 +1,32 @@
+import { asArray, asRecord, defineProvider, fetchJson, normalizeModelEntries } from "./_shared";
+
+export default defineProvider({
+    id: "azure",
+    name: "Azure",
+    requiredEnv: ["AZURE_OPENAI_API_KEY", "AZURE_OPENAI_BASE_URL"],
+    async fetchModels() {
+        const key = process.env.AZURE_OPENAI_API_KEY;
+        const baseUrl = process.env.AZURE_OPENAI_BASE_URL;
+        if (!key) {
+            throw new Error("Missing API key: AZURE_OPENAI_API_KEY");
+        }
+        if (!baseUrl) {
+            throw new Error("Missing base URL for azure");
+        }
+
+        const apiVersion = process.env.AZURE_OPENAI_API_VERSION ?? "2024-02-15-preview";
+        const payload = await fetchJson({
+            url: `${baseUrl.replace(/\/+$/, "")}/openai/models?api-version=${encodeURIComponent(apiVersion)}`,
+            init: {
+                headers: {
+                    "api-key": key,
+                },
+            },
+        });
+
+        const models = asArray(asRecord(payload)?.data).length
+            ? asArray(asRecord(payload)?.data)
+            : asArray(asRecord(payload)?.models);
+        return normalizeModelEntries(models, (item) => (typeof item.id === "string" ? item.id : null));
+    },
+});

--- a/scripts/model-discovery/providers/baseten.ts
+++ b/scripts/model-discovery/providers/baseten.ts
@@ -1,0 +1,11 @@
+import { defineOpenAICompatibleProvider } from "./_openai-compatible-provider";
+
+export default defineOpenAICompatibleProvider({
+    providerId: "baseten",
+    name: "Baseten",
+    apiKeyEnv: "BASETEN_API_KEY",
+    baseUrl: "https://api.baseten.co",
+    baseUrlEnv: "BASETEN_BASE_URL",
+    pathPrefix: "/v1",
+});
+

--- a/scripts/model-discovery/providers/bytedance-seed.ts
+++ b/scripts/model-discovery/providers/bytedance-seed.ts
@@ -1,0 +1,10 @@
+import { defineOpenAICompatibleProvider } from "./_openai-compatible-provider";
+
+export default defineOpenAICompatibleProvider({
+    providerId: "bytedance-seed",
+    name: "Bytedance Seed",
+    apiKeyEnv: "BYTEDANCE_SEED_API_KEY",
+    baseUrlEnv: "BYTEDANCE_SEED_BASE_URL",
+    pathPrefix: "/v1",
+});
+

--- a/scripts/model-discovery/providers/cerebras.ts
+++ b/scripts/model-discovery/providers/cerebras.ts
@@ -1,0 +1,11 @@
+import { defineOpenAICompatibleProvider } from "./_openai-compatible-provider";
+
+export default defineOpenAICompatibleProvider({
+    providerId: "cerebras",
+    name: "Cerebras",
+    apiKeyEnv: "CEREBRAS_API_KEY",
+    baseUrl: "https://api.cerebras.ai",
+    baseUrlEnv: "CEREBRAS_BASE_URL",
+    pathPrefix: "/v1",
+});
+

--- a/scripts/model-discovery/providers/chutes.ts
+++ b/scripts/model-discovery/providers/chutes.ts
@@ -1,0 +1,11 @@
+import { defineOpenAICompatibleProvider } from "./_openai-compatible-provider";
+
+export default defineOpenAICompatibleProvider({
+    providerId: "chutes",
+    name: "Chutes",
+    apiKeyEnv: "CHUTES_API_KEY",
+    baseUrl: "https://llm.chutes.ai",
+    baseUrlEnv: "CHUTES_BASE_URL",
+    pathPrefix: "/v1",
+});
+

--- a/scripts/model-discovery/providers/clarifai.ts
+++ b/scripts/model-discovery/providers/clarifai.ts
@@ -1,0 +1,11 @@
+import { defineOpenAICompatibleProvider } from "./_openai-compatible-provider";
+
+export default defineOpenAICompatibleProvider({
+    providerId: "clarifai",
+    name: "Clarifai",
+    apiKeyEnv: "CLARIFAI_PAT",
+    baseUrl: "https://api.clarifai.com",
+    baseUrlEnv: "CLARIFAI_BASE_URL",
+    pathPrefix: "/v2/ext/openai/v1",
+});
+

--- a/scripts/model-discovery/providers/cloudflare.ts
+++ b/scripts/model-discovery/providers/cloudflare.ts
@@ -1,0 +1,10 @@
+import { defineOpenAICompatibleProvider } from "./_openai-compatible-provider";
+
+export default defineOpenAICompatibleProvider({
+    providerId: "cloudflare",
+    name: "Cloudflare",
+    apiKeyEnv: "CLOUDFLARE_API_TOKEN",
+    baseUrlEnv: "CLOUDFLARE_AI_GATEWAY_BASE_URL",
+    pathPrefix: "",
+});
+

--- a/scripts/model-discovery/providers/cohere.ts
+++ b/scripts/model-discovery/providers/cohere.ts
@@ -1,0 +1,11 @@
+import { defineOpenAICompatibleProvider } from "./_openai-compatible-provider";
+
+export default defineOpenAICompatibleProvider({
+    providerId: "cohere",
+    name: "Cohere",
+    apiKeyEnv: "COHERE_API_KEY",
+    baseUrl: "https://api.cohere.ai",
+    baseUrlEnv: "COHERE_BASE_URL",
+    pathPrefix: "/compatibility/v1",
+});
+

--- a/scripts/model-discovery/providers/crusoe.ts
+++ b/scripts/model-discovery/providers/crusoe.ts
@@ -1,0 +1,11 @@
+import { defineOpenAICompatibleProvider } from "./_openai-compatible-provider";
+
+export default defineOpenAICompatibleProvider({
+    providerId: "crusoe",
+    name: "Crusoe",
+    apiKeyEnv: "CRUSOE_API_KEY",
+    baseUrl: "https://api.crusoe.ai",
+    baseUrlEnv: "CRUSOE_BASE_URL",
+    pathPrefix: "/v1",
+});
+

--- a/scripts/model-discovery/providers/deepinfra.ts
+++ b/scripts/model-discovery/providers/deepinfra.ts
@@ -1,0 +1,11 @@
+import { defineOpenAICompatibleProvider } from "./_openai-compatible-provider";
+
+export default defineOpenAICompatibleProvider({
+    providerId: "deepinfra",
+    name: "Deepinfra",
+    apiKeyEnv: "DEEPINFRA_API_KEY",
+    baseUrl: "https://api.deepinfra.com",
+    baseUrlEnv: "DEEPINFRA_BASE_URL",
+    pathPrefix: "/v1/openai",
+});
+

--- a/scripts/model-discovery/providers/featherless.ts
+++ b/scripts/model-discovery/providers/featherless.ts
@@ -1,0 +1,12 @@
+import { defineOpenAICompatibleProvider } from "./_openai-compatible-provider";
+
+export default defineOpenAICompatibleProvider({
+    providerId: "featherless",
+    name: "Featherless",
+    apiKeyEnv: "FEATHERLESS_API_KEY",
+    baseUrl: "https://api.featherless.ai",
+    baseUrlEnv: "FEATHERLESS_BASE_URL",
+    pathPrefix: "/v1",
+    apiKeyHeader: "Authentication",
+});
+

--- a/scripts/model-discovery/providers/fireworks.ts
+++ b/scripts/model-discovery/providers/fireworks.ts
@@ -1,0 +1,11 @@
+import { defineOpenAICompatibleProvider } from "./_openai-compatible-provider";
+
+export default defineOpenAICompatibleProvider({
+    providerId: "fireworks",
+    name: "Fireworks",
+    apiKeyEnv: "FIREWORKS_API_KEY",
+    baseUrl: "https://api.fireworks.ai",
+    baseUrlEnv: "FIREWORKS_BASE_URL",
+    pathPrefix: "/inference/v1",
+});
+

--- a/scripts/model-discovery/providers/friendli.ts
+++ b/scripts/model-discovery/providers/friendli.ts
@@ -1,0 +1,11 @@
+import { defineOpenAICompatibleProvider } from "./_openai-compatible-provider";
+
+export default defineOpenAICompatibleProvider({
+    providerId: "friendli",
+    name: "Friendli",
+    apiKeyEnv: "FRIENDLI_TOKEN",
+    baseUrl: "https://api.friendli.ai",
+    baseUrlEnv: "FRIENDLI_BASE_URL",
+    pathPrefix: "/serverless/v1",
+});
+

--- a/scripts/model-discovery/providers/gmicloud.ts
+++ b/scripts/model-discovery/providers/gmicloud.ts
@@ -1,0 +1,11 @@
+import { defineOpenAICompatibleProvider } from "./_openai-compatible-provider";
+
+export default defineOpenAICompatibleProvider({
+    providerId: "gmicloud",
+    name: "GMI Cloud",
+    apiKeyEnv: "GMI_API_KEY",
+    baseUrl: "https://api.gmi-serving.com",
+    baseUrlEnv: "GMI_BASE_URL",
+    pathPrefix: "/v1",
+});
+

--- a/scripts/model-discovery/providers/google-vertex.ts
+++ b/scripts/model-discovery/providers/google-vertex.ts
@@ -1,0 +1,10 @@
+import { defineOpenAICompatibleProvider } from "./_openai-compatible-provider";
+
+export default defineOpenAICompatibleProvider({
+    providerId: "google-vertex",
+    name: "Google Vertex",
+    apiKeyEnv: "GOOGLE_VERTEX_API_KEY",
+    baseUrlEnv: "GOOGLE_VERTEX_BASE_URL",
+    pathPrefix: "",
+});
+

--- a/scripts/model-discovery/providers/google.ts
+++ b/scripts/model-discovery/providers/google.ts
@@ -1,0 +1,10 @@
+import { defineOpenAICompatibleProvider } from "./_openai-compatible-provider";
+
+export default defineOpenAICompatibleProvider({
+    providerId: "google",
+    name: "Google",
+    apiKeyEnv: "GOOGLE_API_KEY",
+    baseUrlEnv: "GOOGLE_BASE_URL",
+    pathPrefix: "/v1",
+});
+

--- a/scripts/model-discovery/providers/groq.ts
+++ b/scripts/model-discovery/providers/groq.ts
@@ -1,0 +1,11 @@
+import { defineOpenAICompatibleProvider } from "./_openai-compatible-provider";
+
+export default defineOpenAICompatibleProvider({
+    providerId: "groq",
+    name: "Groq",
+    apiKeyEnv: "GROQ_API_KEY",
+    baseUrl: "https://api.groq.com",
+    baseUrlEnv: "GROQ_BASE_URL",
+    pathPrefix: "/openai/v1",
+});
+

--- a/scripts/model-discovery/providers/hyperbolic.ts
+++ b/scripts/model-discovery/providers/hyperbolic.ts
@@ -1,0 +1,11 @@
+import { defineOpenAICompatibleProvider } from "./_openai-compatible-provider";
+
+export default defineOpenAICompatibleProvider({
+    providerId: "hyperbolic",
+    name: "Hyperbolic",
+    apiKeyEnv: "HYPERBOLIC_API_KEY",
+    baseUrl: "https://api.hyperbolic.xyz",
+    baseUrlEnv: "HYPERBOLIC_BASE_URL",
+    pathPrefix: "/v1",
+});
+

--- a/scripts/model-discovery/providers/inception.ts
+++ b/scripts/model-discovery/providers/inception.ts
@@ -1,0 +1,11 @@
+import { defineOpenAICompatibleProvider } from "./_openai-compatible-provider";
+
+export default defineOpenAICompatibleProvider({
+    providerId: "inception",
+    name: "Inception",
+    apiKeyEnv: "INCEPTION_API_KEY",
+    baseUrl: "https://api.inceptionlabs.ai",
+    baseUrlEnv: "INCEPTION_BASE_URL",
+    pathPrefix: "/v1",
+});
+

--- a/scripts/model-discovery/providers/infermatic.ts
+++ b/scripts/model-discovery/providers/infermatic.ts
@@ -1,0 +1,11 @@
+import { defineOpenAICompatibleProvider } from "./_openai-compatible-provider";
+
+export default defineOpenAICompatibleProvider({
+    providerId: "infermatic",
+    name: "Infermatic",
+    apiKeyEnv: "INFERMATIC_API_KEY",
+    baseUrl: "https://api.totalgpt.ai",
+    baseUrlEnv: "INFERMATIC_BASE_URL",
+    pathPrefix: "/v1",
+});
+

--- a/scripts/model-discovery/providers/inflection.ts
+++ b/scripts/model-discovery/providers/inflection.ts
@@ -1,0 +1,10 @@
+import { defineOpenAICompatibleProvider } from "./_openai-compatible-provider";
+
+export default defineOpenAICompatibleProvider({
+    providerId: "inflection",
+    name: "Inflection",
+    apiKeyEnv: "INFLECTION_API_KEY",
+    baseUrlEnv: "INFLECTION_BASE_URL",
+    pathPrefix: "/v1",
+});
+

--- a/scripts/model-discovery/providers/liquid-ai.ts
+++ b/scripts/model-discovery/providers/liquid-ai.ts
@@ -1,0 +1,11 @@
+import { defineOpenAICompatibleProvider } from "./_openai-compatible-provider";
+
+export default defineOpenAICompatibleProvider({
+    providerId: "liquid-ai",
+    name: "Liquid Ai",
+    apiKeyEnv: "LIQUID_AI_API_KEY",
+    baseUrl: "https://api.liquid.ai",
+    baseUrlEnv: "LIQUID_AI_BASE_URL",
+    pathPrefix: "/v1",
+});
+

--- a/scripts/model-discovery/providers/liquid.ts
+++ b/scripts/model-discovery/providers/liquid.ts
@@ -1,0 +1,11 @@
+import { defineOpenAICompatibleProvider } from "./_openai-compatible-provider";
+
+export default defineOpenAICompatibleProvider({
+    providerId: "liquid",
+    name: "Liquid",
+    apiKeyEnv: "LIQUID_API_KEY",
+    baseUrl: "https://api.liquid.ai",
+    baseUrlEnv: "LIQUID_BASE_URL",
+    pathPrefix: "/v1",
+});
+

--- a/scripts/model-discovery/providers/mancer.ts
+++ b/scripts/model-discovery/providers/mancer.ts
@@ -1,0 +1,11 @@
+import { defineOpenAICompatibleProvider } from "./_openai-compatible-provider";
+
+export default defineOpenAICompatibleProvider({
+    providerId: "mancer",
+    name: "Mancer",
+    apiKeyEnv: "MANCER_API_KEY",
+    baseUrl: "https://mancer.tech",
+    baseUrlEnv: "MANCER_BASE_URL",
+    pathPrefix: "/oai/v1",
+});
+

--- a/scripts/model-discovery/providers/minimax-lightning.ts
+++ b/scripts/model-discovery/providers/minimax-lightning.ts
@@ -1,0 +1,11 @@
+import { defineOpenAICompatibleProvider } from "./_openai-compatible-provider";
+
+export default defineOpenAICompatibleProvider({
+    providerId: "minimax-lightning",
+    name: "Minimax Lightning",
+    apiKeyEnv: "MINIMAX_API_KEY",
+    baseUrl: "https://api.minimax.io",
+    baseUrlEnv: "MINIMAX_BASE_URL",
+    pathPrefix: "/v1",
+});
+

--- a/scripts/model-discovery/providers/moonshot-ai-turbo.ts
+++ b/scripts/model-discovery/providers/moonshot-ai-turbo.ts
@@ -1,0 +1,11 @@
+import { defineOpenAICompatibleProvider } from "./_openai-compatible-provider";
+
+export default defineOpenAICompatibleProvider({
+    providerId: "moonshot-ai-turbo",
+    name: "Moonshot Ai Turbo",
+    apiKeyEnv: "MOONSHOT_AI_API_KEY",
+    baseUrl: "https://api.moonshot.ai",
+    baseUrlEnv: "MOONSHOT_AI_BASE_URL",
+    pathPrefix: "/v1",
+});
+

--- a/scripts/model-discovery/providers/morph.ts
+++ b/scripts/model-discovery/providers/morph.ts
@@ -1,0 +1,11 @@
+import { defineOpenAICompatibleProvider } from "./_openai-compatible-provider";
+
+export default defineOpenAICompatibleProvider({
+    providerId: "morph",
+    name: "Morph",
+    apiKeyEnv: "MORPH_API_KEY",
+    baseUrl: "https://api.morphllm.com",
+    baseUrlEnv: "MORPH_BASE_URL",
+    pathPrefix: "/v1",
+});
+

--- a/scripts/model-discovery/providers/morpheus.ts
+++ b/scripts/model-discovery/providers/morpheus.ts
@@ -1,0 +1,11 @@
+import { defineOpenAICompatibleProvider } from "./_openai-compatible-provider";
+
+export default defineOpenAICompatibleProvider({
+    providerId: "morpheus",
+    name: "Morpheus",
+    apiKeyEnv: "MORPHEUS_API_KEY",
+    baseUrl: "https://api.mor.org",
+    baseUrlEnv: "MORPHEUS_BASE_URL",
+    pathPrefix: "/api/v1",
+});
+

--- a/scripts/model-discovery/providers/nebius-token-factory.ts
+++ b/scripts/model-discovery/providers/nebius-token-factory.ts
@@ -1,0 +1,11 @@
+import { defineOpenAICompatibleProvider } from "./_openai-compatible-provider";
+
+export default defineOpenAICompatibleProvider({
+    providerId: "nebius-token-factory",
+    name: "Nebius Token Factory",
+    apiKeyEnv: "NEBIUS_API_KEY",
+    baseUrl: "https://api.tokenfactory.nebius.com",
+    baseUrlEnv: "NEBIUS_BASE_URL",
+    pathPrefix: "/v1",
+});
+

--- a/scripts/model-discovery/providers/nvidia.ts
+++ b/scripts/model-discovery/providers/nvidia.ts
@@ -1,0 +1,11 @@
+import { defineOpenAICompatibleProvider } from "./_openai-compatible-provider";
+
+export default defineOpenAICompatibleProvider({
+    providerId: "nvidia",
+    name: "Nvidia",
+    apiKeyEnv: "NVIDIA_API_KEY",
+    baseUrl: "https://integrate.api.nvidia.com",
+    baseUrlEnv: "NVIDIA_BASE_URL",
+    pathPrefix: "/v1",
+});
+

--- a/scripts/model-discovery/providers/parasail.ts
+++ b/scripts/model-discovery/providers/parasail.ts
@@ -1,0 +1,11 @@
+import { defineOpenAICompatibleProvider } from "./_openai-compatible-provider";
+
+export default defineOpenAICompatibleProvider({
+    providerId: "parasail",
+    name: "Parasail",
+    apiKeyEnv: "PARASAIL_API_KEY",
+    baseUrl: "https://api.parasail.ai",
+    baseUrlEnv: "PARASAIL_BASE_URL",
+    pathPrefix: "/v1",
+});
+

--- a/scripts/model-discovery/providers/perplexity.ts
+++ b/scripts/model-discovery/providers/perplexity.ts
@@ -1,0 +1,11 @@
+import { defineOpenAICompatibleProvider } from "./_openai-compatible-provider";
+
+export default defineOpenAICompatibleProvider({
+    providerId: "perplexity",
+    name: "Perplexity",
+    apiKeyEnv: "PERPLEXITY_API_KEY",
+    baseUrl: "https://api.perplexity.ai",
+    baseUrlEnv: "PERPLEXITY_BASE_URL",
+    pathPrefix: "",
+});
+

--- a/scripts/model-discovery/providers/phala.ts
+++ b/scripts/model-discovery/providers/phala.ts
@@ -1,0 +1,11 @@
+import { defineOpenAICompatibleProvider } from "./_openai-compatible-provider";
+
+export default defineOpenAICompatibleProvider({
+    providerId: "phala",
+    name: "Phala",
+    apiKeyEnv: "PHALA_API_KEY",
+    baseUrl: "https://api.redpill.ai",
+    baseUrlEnv: "PHALA_BASE_URL",
+    pathPrefix: "/v1",
+});
+

--- a/scripts/model-discovery/providers/qwen.ts
+++ b/scripts/model-discovery/providers/qwen.ts
@@ -1,0 +1,11 @@
+import { defineOpenAICompatibleProvider } from "./_openai-compatible-provider";
+
+export default defineOpenAICompatibleProvider({
+    providerId: "qwen",
+    name: "Qwen",
+    apiKeyEnv: "QWEN_API_KEY",
+    baseUrl: "https://dashscope-intl.aliyuncs.com",
+    baseUrlEnv: "QWEN_BASE_URL",
+    pathPrefix: "/compatible-mode/v1",
+});
+

--- a/scripts/model-discovery/providers/relace.ts
+++ b/scripts/model-discovery/providers/relace.ts
@@ -1,0 +1,11 @@
+import { defineOpenAICompatibleProvider } from "./_openai-compatible-provider";
+
+export default defineOpenAICompatibleProvider({
+    providerId: "relace",
+    name: "Relace",
+    apiKeyEnv: "RELACE_API_KEY",
+    baseUrl: "https://api.relace.ai",
+    baseUrlEnv: "RELACE_BASE_URL",
+    pathPrefix: "/v1",
+});
+

--- a/scripts/model-discovery/providers/sambanova.ts
+++ b/scripts/model-discovery/providers/sambanova.ts
@@ -1,0 +1,10 @@
+import { defineOpenAICompatibleProvider } from "./_openai-compatible-provider";
+
+export default defineOpenAICompatibleProvider({
+    providerId: "sambanova",
+    name: "Sambanova",
+    apiKeyEnv: "SAMBANOVA_API_KEY",
+    baseUrlEnv: "SAMBANOVA_BASE_URL",
+    pathPrefix: "",
+});
+

--- a/scripts/model-discovery/providers/siliconflow.ts
+++ b/scripts/model-discovery/providers/siliconflow.ts
@@ -1,0 +1,11 @@
+import { defineOpenAICompatibleProvider } from "./_openai-compatible-provider";
+
+export default defineOpenAICompatibleProvider({
+    providerId: "siliconflow",
+    name: "Siliconflow",
+    apiKeyEnv: "SILICONFLOW_API_KEY",
+    baseUrl: "https://api.siliconflow.com",
+    baseUrlEnv: "SILICONFLOW_BASE_URL",
+    pathPrefix: "/v1",
+});
+

--- a/scripts/model-discovery/providers/sourceful.ts
+++ b/scripts/model-discovery/providers/sourceful.ts
@@ -1,0 +1,11 @@
+import { defineOpenAICompatibleProvider } from "./_openai-compatible-provider";
+
+export default defineOpenAICompatibleProvider({
+    providerId: "sourceful",
+    name: "Sourceful",
+    apiKeyEnv: "SOURCEFUL_API_KEY",
+    baseUrl: "https://api.sourceful.ai",
+    baseUrlEnv: "SOURCEFUL_BASE_URL",
+    pathPrefix: "/v1",
+});
+

--- a/scripts/model-discovery/providers/stepfun.ts
+++ b/scripts/model-discovery/providers/stepfun.ts
@@ -1,0 +1,11 @@
+import { defineOpenAICompatibleProvider } from "./_openai-compatible-provider";
+
+export default defineOpenAICompatibleProvider({
+    providerId: "stepfun",
+    name: "Stepfun",
+    apiKeyEnv: "STEPFUN_API_KEY",
+    baseUrl: "https://api.stepfun.com",
+    baseUrlEnv: "STEPFUN_BASE_URL",
+    pathPrefix: "/v1",
+});
+

--- a/scripts/model-discovery/providers/together.ts
+++ b/scripts/model-discovery/providers/together.ts
@@ -1,0 +1,11 @@
+import { defineOpenAICompatibleProvider } from "./_openai-compatible-provider";
+
+export default defineOpenAICompatibleProvider({
+    providerId: "together",
+    name: "Together",
+    apiKeyEnv: "TOGETHER_API_KEY",
+    baseUrl: "https://api.together.xyz",
+    baseUrlEnv: "TOGETHER_BASE_URL",
+    pathPrefix: "/v1",
+});
+

--- a/scripts/model-discovery/providers/venice.ts
+++ b/scripts/model-discovery/providers/venice.ts
@@ -1,0 +1,11 @@
+import { defineOpenAICompatibleProvider } from "./_openai-compatible-provider";
+
+export default defineOpenAICompatibleProvider({
+    providerId: "venice",
+    name: "Venice",
+    apiKeyEnv: "VENICE_API_KEY",
+    baseUrl: "https://api.venice.ai",
+    baseUrlEnv: "VENICE_BASE_URL",
+    pathPrefix: "/v1",
+});
+

--- a/scripts/model-discovery/providers/weights-and-biases.ts
+++ b/scripts/model-discovery/providers/weights-and-biases.ts
@@ -1,0 +1,11 @@
+import { defineOpenAICompatibleProvider } from "./_openai-compatible-provider";
+
+export default defineOpenAICompatibleProvider({
+    providerId: "weights-and-biases",
+    name: "Weights And Biases",
+    apiKeyEnv: "WANDB_API_KEY",
+    baseUrl: "https://api.inference.wandb.ai",
+    baseUrlEnv: "WANDB_BASE_URL",
+    pathPrefix: "/v1",
+});
+

--- a/scripts/model-discovery/providers/xai.ts
+++ b/scripts/model-discovery/providers/xai.ts
@@ -1,0 +1,11 @@
+import { defineOpenAICompatibleProvider } from "./_openai-compatible-provider";
+
+export default defineOpenAICompatibleProvider({
+    providerId: "xai",
+    name: "xAI",
+    apiKeyEnv: "XAI_API_KEY",
+    baseUrl: "https://api.x.ai",
+    baseUrlEnv: "XAI_BASE_URL",
+    pathPrefix: "/v1",
+});
+

--- a/scripts/model-discovery/providers/xiaomi.ts
+++ b/scripts/model-discovery/providers/xiaomi.ts
@@ -1,0 +1,11 @@
+import { defineOpenAICompatibleProvider } from "./_openai-compatible-provider";
+
+export default defineOpenAICompatibleProvider({
+    providerId: "xiaomi",
+    name: "Xiaomi",
+    apiKeyEnv: "XIAOMI_MIMO_API_KEY",
+    baseUrl: "https://api.xiaomimimo.com",
+    baseUrlEnv: "XIAOMI_MIMO_BASE_URL",
+    pathPrefix: "/v1",
+});
+

--- a/scripts/model-discovery/providers/zai.ts
+++ b/scripts/model-discovery/providers/zai.ts
@@ -1,0 +1,11 @@
+import { defineOpenAICompatibleProvider } from "./_openai-compatible-provider";
+
+export default defineOpenAICompatibleProvider({
+    providerId: "zai",
+    name: "Z.AI",
+    apiKeyEnv: "ZAI_API_KEY",
+    baseUrl: "https://api.z.ai",
+    baseUrlEnv: "ZAI_BASE_URL",
+    pathPrefix: "/api/paas/v4",
+});
+


### PR DESCRIPTION
## Summary
This PR refactors model discovery to use explicit provider modules and improves run behavior for partial credentials.

## Problem
The model discovery workflow previously loaded providers via `scripts/model-discovery/providers/openai-compatible.ts`, which derived providers from a shared config map. This made changes for adding/updating providers less obvious, and the run output did not clearly surface which environment variables were missing across dozens of providers.

## Root Cause
- Discovery logic relied on a broad, generated-style OpenAI-compatible provider list.
- Missing API keys caused providers to be skipped in practice, but there was no quick inventory of exact key gaps.

## Fix
- Replaced the OpenAI-compatible aggregator with explicit one-file-per-provider modules for all providers in `scripts/model-discovery/providers`.
- Added shared helper `scripts/model-discovery/providers/_openai-compatible-provider.ts` to keep per-provider files compact while preserving centralized request behavior.
- Updated `scripts/model-discovery/run.ts` to:
  - load a broader set of local env files (`.env`, `.env.local`, `dev.env`, and service-scoped variants) so discovery can run with whatever keys are available,
  - precompute provider readiness and print a concise readiness summary (`ready/total` and missing env vars by provider),
  - keep execution robust by skipping only providers that lack required keys (unchanged success/error flow for available providers).

## Validation
- Executed: `pnpm data:check-new-models`
- Output confirmed partial run behavior:
  - `8/64` providers ready with current env,
  - skipped providers are clearly listed with missing keys,
  - ready providers continue to fetch models normally.

## Files Changed
- `scripts/model-discovery/run.ts`
- `scripts/model-discovery/providers/_openai-compatible-provider.ts`
- `scripts/model-discovery/providers/*.ts` (multiple explicit provider modules, including manual and OpenAI-compatible-backed providers)

## Notes
- This commit intentionally touches only model-discovery files and preserves existing runtime behavior for successful providers.
- This setup supports scaling discovery as more providers are added by adding provider files directly.
