### PR TITLE
fix(web): address CodeQL request forgery findings

### DIFF
--- a/scripts/model-discovery/providers/_shared.ts
+++ b/scripts/model-discovery/providers/_shared.ts
@@ -46,7 +46,16 @@ function isPlaceholderValue(value: string): boolean {
     if (exactPlaceholders.has(normalized)) return true;
     if (normalized.startsWith("your-")) return true;
     if (normalized.startsWith("example-")) return true;
-    if (normalized.includes("your-resource.openai.azure.com")) return true;
+    if (normalized === "your-resource.openai.azure.com") return true;
+
+    try {
+        const parsed = new URL(normalized.includes("://") ? normalized : `https://${normalized}`);
+        if (parsed.hostname.toLowerCase() === "your-resource.openai.azure.com") {
+            return true;
+        }
+    } catch {
+        // Not a URL-like value; continue with non-URL placeholder checks.
+    }
 
     return false;
 }


### PR DESCRIPTION
## Summary
- lock playground and unified chat proxy routes to fixed gateway base URL
- reject non-matching custom aseUrl values on both routes
- allowlist forwarded app headers and prevent auth header override behavior
- harden broadcast actions by validating outbound endpoints and making test action validation-only
- improve model-discovery placeholder hostname checks with URL parsing

## Validation
- pnpm --filter @ai-stats/web typecheck

## Files
- apps/web/src/app/api/chat/playground/route.ts
- apps/web/src/app/api/chat/unified/route.ts
- apps/web/src/app/(dashboard)/settings/broadcast/actions.ts
- scripts/model-discovery/providers/_shared.ts
