### PR TITLE
feat: add model statistics for the majority of the 2026 releases

### DIFF
--- a/apps/web/src/data/models/inclusionai/ring-1t-2-5-2026-02-12/model.json
+++ b/apps/web/src/data/models/inclusionai/ring-1t-2-5-2026-02-12/model.json
@@ -17,6 +17,15 @@
       "url": "https://huggingface.co/inclusionAI/Ring-1T-2.5-FP8"
     }
   ],
-  "details": [],
+  "details": [
+    {
+      "name": "input_context_length",
+      "value": 256000
+    },
+    {
+      "name": "parameter_count",
+      "value": 1000000000000
+    }
+  ],
   "benchmarks": []
 }

--- a/apps/web/src/data/models/minimax/minimax-m2-5-2026-02-12/model.json
+++ b/apps/web/src/data/models/minimax/minimax-m2-5-2026-02-12/model.json
@@ -17,6 +17,11 @@
       "url": "https://www.minimax.io/news/minimax-m25"
     }
   ],
-  "details": [],
+  "details": [
+    {
+      "name": "input_context_length",
+      "value": 204800
+    }
+  ],
   "benchmarks": []
 }

--- a/apps/web/src/data/models/prime-intellect/intellect-3-1-2026-02-18/model.json
+++ b/apps/web/src/data/models/prime-intellect/intellect-3-1-2026-02-18/model.json
@@ -12,6 +12,11 @@
   "input_types": "text",
   "output_types": "text",
   "links": [],
-  "details": [],
+  "details": [
+    {
+      "name": "parameter_count",
+      "value": 107000000000
+    }
+  ],
   "benchmarks": []
 }

--- a/apps/web/src/data/models/qwen/qwen-3-5-397b-a17b-2026-02-16/model.json
+++ b/apps/web/src/data/models/qwen/qwen-3-5-397b-a17b-2026-02-16/model.json
@@ -9,9 +9,18 @@
   "deprecation_date": null,
   "retirement_date": null,
   "license": "Apache 2.0",
-  "input_types": null,
-  "output_types": null,
+  "input_types": "text,image,video",
+  "output_types": "text",
   "links": [],
-  "details": [],
+  "details": [
+    {
+      "name": "input_context_length",
+      "value": 256000
+    },
+    {
+      "name": "output_context_length",
+      "value": 64000
+    }
+  ],
   "benchmarks": []
 }

--- a/apps/web/src/data/models/qwen/qwen-3-5-plus-2026-02-16/model.json
+++ b/apps/web/src/data/models/qwen/qwen-3-5-plus-2026-02-16/model.json
@@ -9,9 +9,18 @@
   "deprecation_date": null,
   "retirement_date": null,
   "license": null,
-  "input_types": null,
-  "output_types": null,
+  "input_types": "text,image,video",
+  "output_types": "text",
   "links": [],
-  "details": [],
+  "details": [
+    {
+      "name": "input_context_length",
+      "value": 1000000
+    },
+    {
+      "name": "output_context_length",
+      "value": 64000
+    }
+  ],
   "benchmarks": []
 }

--- a/apps/web/src/data/models/z-ai/glm-5-2026-02-11/model.json
+++ b/apps/web/src/data/models/z-ai/glm-5-2026-02-11/model.json
@@ -12,6 +12,15 @@
   "input_types": "text",
   "output_types": "text",
   "links": [],
-  "details": [],
+  "details": [
+    {
+      "name": "parameter_count",
+      "value": 744000000000
+    },
+    {
+      "name": "training_tokens",
+      "value": 28500000000000
+    }
+  ],
   "benchmarks": []
 }


### PR DESCRIPTION
## Summary

This PR adds missing model statistics for the majority of the major 2026 model releases. It updates the respective [model.json](cci:7://file:///c:/Users/Admin/Desktop/code/AI-Stats/apps/web/src/data/models/z-ai/glm-5-code/model.json:0:0-0:0) files for these models with key data points (such as parameter counts, input/output context lengths, and training tokens) extracted from their official release pages and documentation.

## Type of change

-   [x] Data / content update

## Affected areas

-   [x] Data / scrapers

## Deployment impact

-   [x] No migration / no special steps

## Notes

All the statistics have been verified against their official sources. 

**Sources:**
- **Intellect 3.1:** [Huggingface card](https://huggingface.co/PrimeIntellect/INTELLECT-3.1)
- **qwen3.5-plus:** [Qwen Model Studio Doc](https://modelstudio.console.alibabacloud.com/ap-southeast-1/?tab=doc#/doc/?type=model&url=2840914_2&modelId=qwen3.5-plus)
- **qwen3.5-397B-A17B:** [Qwen Model Studio Doc](https://modelstudio.console.alibabacloud.com/ap-southeast-1/?tab=doc#/doc/?type=model&url=2840914_2&modelId=group-qwen3.5)
- **Ring-2.5-1T:** [Huggingface card](https://huggingface.co/inclusionAI/Ring-2.5-1T)
- **minimax M2.5:** [Minimax API Doc](https://platform.minimax.io/docs/api-reference/api-overview)
- **glm-5:** [Zhipu AI Blog](https://z.ai/blog/glm-5)
