### PR TITLE
fix(ci): repair API type errors and sync generated SDK outputs

### DIFF
--- a/apps/api/src/core/types.ts
+++ b/apps/api/src/core/types.ts
@@ -21,6 +21,16 @@ export type Endpoint =
     | "files.list"
     | "files.retrieve";
 
+export type RequestBetaOptions = {
+    openai_websocket_mode?: boolean;
+    openaiWebsocketMode?: boolean;
+    openai?: {
+        websocket_mode?: boolean;
+        websocketMode?: boolean;
+    };
+    [key: string]: unknown;
+};
+
 export type RequestMeta = {
     apiKeyId: string;             // Internal UUID for the gateway key
     apiKeyRef: string;            // Human-readable reference, e.g. kid_xxx
@@ -46,6 +56,7 @@ export type RequestMeta = {
     returnUpstreamResponse?: boolean;
     startedAtMs?: number;
     upstreamStartMs?: number;
+    beta?: RequestBetaOptions;
     keySource?: "gateway" | "byok";
     byokKeyId?: string | null;
     // Performance metrics

--- a/apps/api/src/routes/v1/data/responses-ws.ts
+++ b/apps/api/src/routes/v1/data/responses-ws.ts
@@ -129,7 +129,7 @@ async function resolveOpenAIGatewayKey(state: WsState, model: string): Promise<{
 		requestId: state.requestId,
 		internal: state.internal,
 	});
-	if (!ctx.ok) {
+	if (ctx.ok === false) {
 		return { ok: false, errorResponse: ctx.response };
 	}
 	const openAICandidate = ctx.value.providers.find((provider) => provider.providerId === "openai");
@@ -275,7 +275,7 @@ const responsesWsHandler = async (req: Request): Promise<Response> => {
 	}
 
 	const auth = await guardAuth(req);
-	if (!auth.ok) return auth.response;
+	if (auth.ok === false) return auth.response;
 	const state: WsState = {
 		requestId: auth.value.requestId,
 		teamId: auth.value.teamId,
@@ -476,7 +476,7 @@ const responsesWsHandler = async (req: Request): Promise<Response> => {
 	const ensureUpstreamSocket = async (model: string): Promise<boolean> => {
 		if (state.upstreamWs) return true;
 		const keyResolution = await resolveOpenAIGatewayKey(state, model);
-		if (!keyResolution.ok) {
+		if (keyResolution.ok === false) {
 			let detail = "OpenAI routing unavailable";
 			try {
 				detail = (await keyResolution.errorResponse.clone().text()).slice(0, 500) || detail;
@@ -498,7 +498,7 @@ const responsesWsHandler = async (req: Request): Promise<Response> => {
 		state.pricingCard = keyResolution.pricingCard;
 		state.teamTier = keyResolution.teamTier;
 		const upstream = await connectUpstreamOpenAIWebSocket(keyResolution.key);
-		if (!upstream.ok) {
+		if (upstream.ok === false) {
 			let detail = "";
 			try {
 				detail = (await upstream.response.clone().text()).slice(0, 500);
@@ -555,7 +555,7 @@ const responsesWsHandler = async (req: Request): Promise<Response> => {
 			}
 
 			const normalized = normalizeOpenAIWsResponseCreateEvent(rawPayload);
-			if (!normalized.ok) {
+			if (normalized.ok === false) {
 				sendSocketJson(gatewayWs, {
 					type: "error",
 					status: 400,

--- a/packages/sdk/sdk-cpp/src/gen/models.hpp
+++ b/packages/sdk/sdk-cpp/src/gen/models.hpp
@@ -544,6 +544,23 @@ struct ResponsesResponse {
 	std::map<std::string, std::any> usage;
 };
 
+struct ResponsesWebSocketCreateEvent {
+	std::any input;
+	std::string model;
+	std::optional<std::string> previous_response_id;
+	std::optional<bool> store;
+	std::any tool_choice;
+	std::vector<std::map<std::string, std::any>> tools;
+	std::any type;
+};
+
+struct ResponsesWebSocketServerEvent {
+	std::map<std::string, std::any> error;
+	std::map<std::string, std::any> response;
+	std::optional<int> status;
+	std::string type;
+};
+
 struct TextContentPart {
 	std::string text;
 	std::any type;

--- a/packages/sdk/sdk-cpp/src/gen/operations.hpp
+++ b/packages/sdk/sdk-cpp/src/gen/operations.hpp
@@ -334,6 +334,11 @@ inline Response ListProvisioningKeysLegacy(Client& client, const std::map<std::s
 	return client.request("GET", resolved_path, body);
 }
 
+inline Response OpenResponsesWebSocket(Client& client, const std::map<std::string, std::string>& path = {}, const std::string& body = "") {
+	const std::string resolved_path = "/responses/ws";
+	return client.request("GET", resolved_path, body);
+}
+
 inline Response RegenerateOAuthClientSecret(Client& client, const std::map<std::string, std::string>& path = {}, const std::string& body = "") {
 	const std::string resolved_path = "/oauth-clients/" + (path.count("client_id") ? path.at("client_id") : std::string{}) + "/regenerate-secret";
 	return client.request("POST", resolved_path, body);

--- a/packages/sdk/sdk-csharp/src/gen/Models.cs
+++ b/packages/sdk/sdk-csharp/src/gen/Models.cs
@@ -1318,6 +1318,47 @@ public sealed class ResponsesResponse
 
 }
 
+public sealed class ResponsesWebSocketCreateEvent
+{
+	[JsonPropertyName("input")]
+	public object? Input { get; set; }
+
+	[JsonPropertyName("model")]
+	public string Model { get; set; }
+
+	[JsonPropertyName("previous_response_id")]
+	public string? PreviousResponseId { get; set; }
+
+	[JsonPropertyName("store")]
+	public bool? Store { get; set; }
+
+	[JsonPropertyName("tool_choice")]
+	public object? ToolChoice { get; set; }
+
+	[JsonPropertyName("tools")]
+	public List<Dictionary<string, object>>? Tools { get; set; }
+
+	[JsonPropertyName("type")]
+	public string Type { get; set; }
+
+}
+
+public sealed class ResponsesWebSocketServerEvent
+{
+	[JsonPropertyName("error")]
+	public Dictionary<string, object>? Error { get; set; }
+
+	[JsonPropertyName("response")]
+	public Dictionary<string, object>? Response { get; set; }
+
+	[JsonPropertyName("status")]
+	public int? Status { get; set; }
+
+	[JsonPropertyName("type")]
+	public string? Type { get; set; }
+
+}
+
 public sealed class TextContentPart
 {
 	[JsonPropertyName("text")]

--- a/packages/sdk/sdk-csharp/src/gen/Operations.cs
+++ b/packages/sdk/sdk-csharp/src/gen/Operations.cs
@@ -798,6 +798,18 @@ public static class Operations
 		return client.SendAsync<Dictionary<string, object>>("GET", resolvedPath, query, headers, body);
 	}
 
+	public static Task<object?> OpenResponsesWebSocketAsync(
+		Client client,
+		Dictionary<string, string>? path = null,
+		Dictionary<string, string>? query = null,
+		Dictionary<string, string>? headers = null,
+		object? body = null
+	)
+	{
+		var resolvedPath = "/responses/ws";
+		return client.SendAsync<object>("GET", resolvedPath, query, headers, body);
+	}
+
 	public static Task<Dictionary<string, object>?> RegenerateOAuthClientSecretAsync(
 		Client client,
 		Dictionary<string, string>? path = null,

--- a/packages/sdk/sdk-go/src/gen/models.go
+++ b/packages/sdk/sdk-go/src/gen/models.go
@@ -1303,6 +1303,23 @@ type ResponsesResponse struct {
 	Usage *map[string]interface{} `json:"usage,omitempty"`
 }
 
+type ResponsesWebSocketCreateEvent struct {
+	Input interface{} `json:"input,omitempty"`
+	Model string `json:"model"`
+	PreviousResponseId *string `json:"previous_response_id,omitempty"`
+	Store *bool `json:"store,omitempty"`
+	ToolChoice interface{} `json:"tool_choice,omitempty"`
+	Tools *[]map[string]interface{} `json:"tools,omitempty"`
+	Type string `json:"type"`
+}
+
+type ResponsesWebSocketServerEvent struct {
+	Error *map[string]interface{} `json:"error,omitempty"`
+	Response *map[string]interface{} `json:"response,omitempty"`
+	Status *int `json:"status,omitempty"`
+	Type *string `json:"type,omitempty"`
+}
+
 type TextContentPart struct {
 	Text string `json:"text"`
 	Type string `json:"type"`

--- a/packages/sdk/sdk-go/src/gen/operations.go
+++ b/packages/sdk/sdk-go/src/gen/operations.go
@@ -992,6 +992,21 @@ func ListProvisioningKeysLegacy(client *Client, path map[string]string, query ma
 	return out, nil
 }
 
+func OpenResponsesWebSocket(client *Client, path map[string]string, query map[string]string, headers map[string]string, body any) (interface{}, error) {
+	resolvedPath := "/responses/ws"
+	data, err := client.Request("GET", resolvedPath, query, headers, body)
+	if err != nil {
+		var zero interface{}
+		return zero, err
+	}
+	var out interface{}
+	if err := DecodeJSON(data, &out); err != nil {
+		var zero interface{}
+		return zero, err
+	}
+	return out, nil
+}
+
 func RegenerateOAuthClientSecret(client *Client, path map[string]string, query map[string]string, headers map[string]string, body any) (map[string]interface{}, error) {
 	resolvedPath := "/oauth-clients/" + url.PathEscape(path["client_id"]) + "/regenerate-secret"
 	data, err := client.Request("POST", resolvedPath, query, headers, body)

--- a/packages/sdk/sdk-java/src/gen/Models.java
+++ b/packages/sdk/sdk-java/src/gen/Models.java
@@ -546,6 +546,23 @@ public final class Models {
 		public Object usage;
 	}
 
+	public static class ResponsesWebSocketCreateEvent {
+		public Object input;
+		public String model;
+		public String previous_response_id;
+		public Boolean store;
+		public Object tool_choice;
+		public java.util.List<Object> tools;
+		public Object type;
+	}
+
+	public static class ResponsesWebSocketServerEvent {
+		public Object error;
+		public Object response;
+		public Integer status;
+		public String type;
+	}
+
 	public static class TextContentPart {
 		public String text;
 		public Object type;

--- a/packages/sdk/sdk-java/src/gen/Operations.java
+++ b/packages/sdk/sdk-java/src/gen/Operations.java
@@ -336,6 +336,11 @@ public final class Operations {
 		return client.request("GET", resolvedPath, query, headers, body);
 	}
 
+	public static Object openResponsesWebSocket(Client client, Map<String, String> path, Map<String, String> query, Map<String, String> headers, String body) throws IOException, InterruptedException {
+		String resolvedPath = "/responses/ws";
+		return client.request("GET", resolvedPath, query, headers, body);
+	}
+
 	public static Object regenerateOAuthClientSecret(Client client, Map<String, String> path, Map<String, String> query, Map<String, String> headers, String body) throws IOException, InterruptedException {
 		String resolvedPath = "/oauth-clients/" + (path != null && path.containsKey("client_id") ? path.get("client_id") : "") + "/regenerate-secret";
 		return client.request("POST", resolvedPath, query, headers, body);

--- a/packages/sdk/sdk-php/src/gen/Models.php
+++ b/packages/sdk/sdk-php/src/gen/Models.php
@@ -597,6 +597,25 @@ class ResponsesResponse
 	public $usage;
 }
 
+class ResponsesWebSocketCreateEvent
+{
+	public $input;
+	public $model;
+	public $previous_response_id;
+	public $store;
+	public $tool_choice;
+	public $tools;
+	public $type;
+}
+
+class ResponsesWebSocketServerEvent
+{
+	public $error;
+	public $response;
+	public $status;
+	public $type;
+}
+
 class TextContentPart
 {
 	public $text;

--- a/packages/sdk/sdk-php/src/gen/Operations.php
+++ b/packages/sdk/sdk-php/src/gen/Operations.php
@@ -465,6 +465,13 @@ function listProvisioningKeysLegacy(Client $client, ?array $path = null, ?array 
 	return $client->request("GET", $resolvedPath, $query, $headers, $body);
 }
 
+function openResponsesWebSocket(Client $client, ?array $path = null, ?array $query = null, ?array $headers = null, $body = null)
+{
+	$path = $path ?? [];
+	$resolvedPath = "/responses/ws";
+	return $client->request("GET", $resolvedPath, $query, $headers, $body);
+}
+
 function regenerateOAuthClientSecret(Client $client, ?array $path = null, ?array $query = null, ?array $headers = null, $body = null)
 {
 	$path = $path ?? [];

--- a/packages/sdk/sdk-py/src/gen/models.py
+++ b/packages/sdk/sdk-py/src/gen/models.py
@@ -487,6 +487,21 @@ class ResponsesResponse(TypedDict):
 	type: NotRequired[str]
 	usage: NotRequired[Dict[str, Any]]
 
+class ResponsesWebSocketCreateEvent(TypedDict):
+	input: NotRequired[Union[str, List[Dict[str, Any]], Dict[str, Any]]]
+	model: str
+	previous_response_id: NotRequired[Optional[str]]
+	store: NotRequired[bool]
+	tool_choice: NotRequired[Union[str, Dict[str, Any]]]
+	tools: NotRequired[List[Dict[str, Any]]]
+	type: Literal["response.create"]
+
+class ResponsesWebSocketServerEvent(TypedDict):
+	error: NotRequired[Dict[str, Any]]
+	response: NotRequired[Dict[str, Any]]
+	status: NotRequired[int]
+	type: NotRequired[str]
+
 class TextContentPart(TypedDict):
 	text: str
 	type: Literal["text"]
@@ -556,4 +571,4 @@ class VideoGenerationResponse(TypedDict):
 	output: NotRequired[List[Dict[str, Any]]]
 	status: NotRequired[str]
 
-models___all__ = ["ActivityEntry", "AnthropicContentBlock", "AnthropicMessage", "AnthropicMessagesRequest", "AnthropicMessagesResponse", "AnthropicTool", "AnthropicUsage", "AudioContentPart", "AudioSpeechRequest", "AudioTranscriptionRequest", "AudioTranscriptionResponse", "AudioTranslationRequest", "AudioTranslationResponse", "BatchRequest", "BatchRequestCounts", "BatchResponse", "BenchmarkId", "ChatChoice", "ChatCompletionsRequest", "ChatCompletionsResponse", "ChatMessage", "DebugOptions", "Embedding", "EmbeddingsRequest", "EmbeddingsResponse", "ErrorResponse", "FileResponse", "FileUploadRequest", "GenerationResponse", "Image", "ImageContentPart", "ImageModerationInput", "ImagesEditRequest", "ImagesEditResponse", "ImagesGenerationRequest", "ImagesGenerationResponse", "ListFilesResponse", "MessageContentPart", "Model", "ModelId", "ModerationCategories", "ModerationCategoryScores", "ModerationResult", "ModerationsRequest", "ModerationsResponse", "MusicGenerateRequest", "MusicGenerateResponse", "NotImplementedResponse", "OcrRequest", "OcrResponse", "OrganisationId", "OrganisationIdList", "Provider", "ProviderRoutingOptions", "ProvisioningKey", "ProvisioningKeyDetail", "ProvisioningKeyWithValue", "RealtimeNotImplementedResponse", "ReasoningConfig", "ResponsesRequest", "ResponsesResponse", "TextContentPart", "TextModerationInput", "ToolCall", "ToolCallContentPart", "Usage", "VideoContentPart", "VideoDeleteResponse", "VideoGenerationRequest", "VideoGenerationResponse"]
+models___all__ = ["ActivityEntry", "AnthropicContentBlock", "AnthropicMessage", "AnthropicMessagesRequest", "AnthropicMessagesResponse", "AnthropicTool", "AnthropicUsage", "AudioContentPart", "AudioSpeechRequest", "AudioTranscriptionRequest", "AudioTranscriptionResponse", "AudioTranslationRequest", "AudioTranslationResponse", "BatchRequest", "BatchRequestCounts", "BatchResponse", "BenchmarkId", "ChatChoice", "ChatCompletionsRequest", "ChatCompletionsResponse", "ChatMessage", "DebugOptions", "Embedding", "EmbeddingsRequest", "EmbeddingsResponse", "ErrorResponse", "FileResponse", "FileUploadRequest", "GenerationResponse", "Image", "ImageContentPart", "ImageModerationInput", "ImagesEditRequest", "ImagesEditResponse", "ImagesGenerationRequest", "ImagesGenerationResponse", "ListFilesResponse", "MessageContentPart", "Model", "ModelId", "ModerationCategories", "ModerationCategoryScores", "ModerationResult", "ModerationsRequest", "ModerationsResponse", "MusicGenerateRequest", "MusicGenerateResponse", "NotImplementedResponse", "OcrRequest", "OcrResponse", "OrganisationId", "OrganisationIdList", "Provider", "ProviderRoutingOptions", "ProvisioningKey", "ProvisioningKeyDetail", "ProvisioningKeyWithValue", "RealtimeNotImplementedResponse", "ReasoningConfig", "ResponsesRequest", "ResponsesResponse", "ResponsesWebSocketCreateEvent", "ResponsesWebSocketServerEvent", "TextContentPart", "TextModerationInput", "ToolCall", "ToolCallContentPart", "Usage", "VideoContentPart", "VideoDeleteResponse", "VideoGenerationRequest", "VideoGenerationResponse"]

--- a/packages/sdk/sdk-py/src/gen/operations.py
+++ b/packages/sdk/sdk-py/src/gen/operations.py
@@ -862,6 +862,19 @@ def listProvisioningKeysLegacy(
 	return client.request("GET", resolved_path, query=query, headers=headers, body=body)
 
 
+def openResponsesWebSocket(
+	client: Client,
+	*,
+	path: Optional[Dict[str, Any]] = None,
+	query: Optional[Dict[str, Any]] = None,
+	headers: Optional[Dict[str, str]] = None,
+	body: Optional[Any] = None,
+) -> Any:
+	path = path or {}
+	resolved_path = "/responses/ws"
+	return client.request("GET", resolved_path, query=query, headers=headers, body=body)
+
+
 def regenerateOAuthClientSecret(
 	client: Client,
 	*,
@@ -966,4 +979,4 @@ def uploadFile(
 	return client.request("POST", resolved_path, query=query, headers=headers, body=body)
 
 
-operations___all__ = ["calculatePricing", "createAnthropicMessage", "createAudioRealtimeCallPlaceholder", "createAudioRealtimeClientSecretsPlaceholder", "createAudioRealtimeSessionPlaceholder", "createAudioRealtimeSessionsPlaceholder", "createBatch", "createBatchAlias", "createChatCompletion", "createEmbedding", "createImage", "createImageEdit", "createModeration", "createOAuthClient", "createOcr", "createProvisioningKey", "createProvisioningKeyAlias", "createProvisioningKeyLegacy", "createRealtimeCallPlaceholder", "createRealtimeClientSecretsPlaceholder", "createRealtimeSessionPlaceholder", "createRealtimeSessionsPlaceholder", "createResponse", "createSpeech", "createTranscription", "createTranslation", "createVideo", "createVideoAlias", "deleteOAuthClient", "deleteProvisioningKey", "deleteProvisioningKeyAlias", "deleteVideo", "deleteVideoAlias", "generateMusic", "generateMusicAlias", "getActivity", "getAnalytics", "getAudioRealtimeCallPlaceholder", "getCredits", "getGeneration", "getMusicGeneration", "getMusicGenerationAlias", "getOAuthClient", "getProviderDerankStatus", "getProvisioningKey", "getProvisioningKeyAlias", "getProvisioningKeyLegacy", "getRealtimeCallPlaceholder", "getVideo", "getVideoAlias", "getVideoContent", "getVideoContentAlias", "healthz", "invalidateGatewayKeyCache", "listEndpoints", "listFiles", "listModels", "listModelsAliasApi", "listModelsAliasData", "listOAuthClients", "listOrganisations", "listPricingModels", "listProviders", "listProvisioningKeys", "listProvisioningKeysAlias", "listProvisioningKeysLegacy", "regenerateOAuthClientSecret", "retrieveBatch", "retrieveBatchAlias", "retrieveFile", "updateOAuthClient", "updateProvisioningKey", "updateProvisioningKeyAlias", "uploadFile"]
+operations___all__ = ["calculatePricing", "createAnthropicMessage", "createAudioRealtimeCallPlaceholder", "createAudioRealtimeClientSecretsPlaceholder", "createAudioRealtimeSessionPlaceholder", "createAudioRealtimeSessionsPlaceholder", "createBatch", "createBatchAlias", "createChatCompletion", "createEmbedding", "createImage", "createImageEdit", "createModeration", "createOAuthClient", "createOcr", "createProvisioningKey", "createProvisioningKeyAlias", "createProvisioningKeyLegacy", "createRealtimeCallPlaceholder", "createRealtimeClientSecretsPlaceholder", "createRealtimeSessionPlaceholder", "createRealtimeSessionsPlaceholder", "createResponse", "createSpeech", "createTranscription", "createTranslation", "createVideo", "createVideoAlias", "deleteOAuthClient", "deleteProvisioningKey", "deleteProvisioningKeyAlias", "deleteVideo", "deleteVideoAlias", "generateMusic", "generateMusicAlias", "getActivity", "getAnalytics", "getAudioRealtimeCallPlaceholder", "getCredits", "getGeneration", "getMusicGeneration", "getMusicGenerationAlias", "getOAuthClient", "getProviderDerankStatus", "getProvisioningKey", "getProvisioningKeyAlias", "getProvisioningKeyLegacy", "getRealtimeCallPlaceholder", "getVideo", "getVideoAlias", "getVideoContent", "getVideoContentAlias", "healthz", "invalidateGatewayKeyCache", "listEndpoints", "listFiles", "listModels", "listModelsAliasApi", "listModelsAliasData", "listOAuthClients", "listOrganisations", "listPricingModels", "listProviders", "listProvisioningKeys", "listProvisioningKeysAlias", "listProvisioningKeysLegacy", "openResponsesWebSocket", "regenerateOAuthClientSecret", "retrieveBatch", "retrieveBatchAlias", "retrieveFile", "updateOAuthClient", "updateProvisioningKey", "updateProvisioningKeyAlias", "uploadFile"]

--- a/packages/sdk/sdk-ruby/lib/gen/models.rb
+++ b/packages/sdk/sdk-ruby/lib/gen/models.rb
@@ -61,6 +61,8 @@ module AiStats
     ReasoningConfig = Struct.new(:effort, :summary, keyword_init: true)
     ResponsesRequest = Struct.new(:background, :conversation, :debug, :include, :input, :input_items, :instructions, :max_output_tokens, :max_tool_calls, :meta, :metadata, :model, :parallel_tool_calls, :previous_response_id, :prompt, :prompt_cache_key, :prompt_cache_retention, :provider, :reasoning, :safety_identifier, :service_tier, :store, :stream, :stream_options, :temperature, :text, :tool_choice, :tools, :top_logprobs, :top_p, :truncation, :usage, :user, keyword_init: true)
     ResponsesResponse = Struct.new(:content, :created, :id, :model, :object, :role, :stop_reason, :type, :usage, keyword_init: true)
+    ResponsesWebSocketCreateEvent = Struct.new(:input, :model, :previous_response_id, :store, :tool_choice, :tools, :type, keyword_init: true)
+    ResponsesWebSocketServerEvent = Struct.new(:error, :response, :status, :type, keyword_init: true)
     TextContentPart = Struct.new(:text, :type, keyword_init: true)
     TextModerationInput = Struct.new(:text, :type, keyword_init: true)
     ToolCall = Struct.new(:function, :id, :type, keyword_init: true)

--- a/packages/sdk/sdk-ruby/lib/gen/operations.rb
+++ b/packages/sdk/sdk-ruby/lib/gen/operations.rb
@@ -399,6 +399,12 @@ module AiStats
         client.request(method: "GET", path: resolved_path, query: query, headers: headers, body: body)
       end
 
+      def self.openResponsesWebSocket(client, path: nil, query: nil, headers: nil, body: nil)
+        path ||= {}
+        resolved_path = "/responses/ws"
+        client.request(method: "GET", path: resolved_path, query: query, headers: headers, body: body)
+      end
+
       def self.regenerateOAuthClientSecret(client, path: nil, query: nil, headers: nil, body: nil)
         path ||= {}
         resolved_path = "/oauth-clients/#{path["client_id"]}/regenerate-secret"

--- a/packages/sdk/sdk-rust/src/gen/models.rs
+++ b/packages/sdk/sdk-rust/src/gen/models.rs
@@ -540,6 +540,23 @@ pub struct ResponsesResponse {
 	pub usage: Option<HashMap<String, String>>,
 }
 
+pub struct ResponsesWebSocketCreateEvent {
+	pub input: Option<String>,
+	pub model: String,
+	pub previous_response_id: Option<Option<String>>,
+	pub store: Option<bool>,
+	pub tool_choice: Option<String>,
+	pub tools: Option<Vec<HashMap<String, String>>>,
+	pub r#type: String,
+}
+
+pub struct ResponsesWebSocketServerEvent {
+	pub error: Option<HashMap<String, String>>,
+	pub response: Option<HashMap<String, String>>,
+	pub status: Option<i64>,
+	pub r#type: Option<String>,
+}
+
 pub struct TextContentPart {
 	pub text: String,
 	pub r#type: String,

--- a/packages/sdk/sdk-rust/src/gen/operations.rs
+++ b/packages/sdk/sdk-rust/src/gen/operations.rs
@@ -335,6 +335,11 @@ pub fn listProvisioningKeysLegacy<T: Transport>(client: &Client<T>, path: &HashM
 	client.request("GET", &resolved_path, body)
 }
 
+pub fn openResponsesWebSocket<T: Transport>(client: &Client<T>, path: &HashMap<String, String>, body: Option<&str>) -> Result<Response, String> {
+	let resolved_path = String::from("/responses/ws");
+	client.request("GET", &resolved_path, body)
+}
+
 pub fn regenerateOAuthClientSecret<T: Transport>(client: &Client<T>, path: &HashMap<String, String>, body: Option<&str>) -> Result<Response, String> {
 	let resolved_path = format!("/oauth-clients/{}/regenerate-secret", path.get("client_id").cloned().unwrap_or_default());
 	client.request("POST", &resolved_path, body)

--- a/packages/sdk/sdk-ts/src/oapi-gen/.gen-manifest.json
+++ b/packages/sdk/sdk-ts/src/oapi-gen/.gen-manifest.json
@@ -65,6 +65,8 @@
     "models/ReasoningConfig.ts",
     "models/ResponsesRequest.ts",
     "models/ResponsesResponse.ts",
+    "models/ResponsesWebSocketCreateEvent.ts",
+    "models/ResponsesWebSocketServerEvent.ts",
     "models/TextContentPart.ts",
     "models/TextModerationInput.ts",
     "models/ToolCall.ts",

--- a/packages/sdk/sdk-ts/src/oapi-gen/client/default.ts
+++ b/packages/sdk/sdk-ts/src/oapi-gen/client/default.ts
@@ -4720,6 +4720,36 @@ export async function listProvisioningKeysLegacy(
   });
 }
 
+export type OpenResponsesWebSocketParams = {
+  path?: Record<string, never>;
+  query?: Record<string, never>;
+  headers?: Record<string, never>;
+  body?: never;
+};
+
+/**
+ * Opens a persistent websocket session for OpenAI Responses WebSocket mode.
+ *
+ * This endpoint is OpenAI-only and accepts `response.create` websocket messages.
+ * The gateway enforces `store=false`, allows one in-flight response per connection,
+ * and forwards OpenAI Responses streaming events back to the client.
+ *
+ */
+export async function openResponsesWebSocket(
+  client: Client,
+  args: OpenResponsesWebSocketParams = {},
+): Promise<unknown> {
+  const { path, query, headers, body } = args;
+  const resolvedPath = "/responses/ws";
+  return client.request<unknown>({
+    method: "GET",
+    path: resolvedPath,
+    query,
+    headers,
+    body,
+  });
+}
+
 export type RegenerateOAuthClientSecretParams = {
   path?: {
     client_id: string;

--- a/packages/sdk/sdk-ts/src/oapi-gen/models/ResponsesWebSocketCreateEvent.ts
+++ b/packages/sdk/sdk-ts/src/oapi-gen/models/ResponsesWebSocketCreateEvent.ts
@@ -1,0 +1,10 @@
+export interface ResponsesWebSocketCreateEvent {
+  input?: string | {}[] | {};
+  model: string;
+  previous_response_id?: string | null;
+  store?: boolean;
+  tool_choice?: string | {};
+  tools?: {}[];
+  type: "response.create";
+  [key: string]: unknown;
+}

--- a/packages/sdk/sdk-ts/src/oapi-gen/models/ResponsesWebSocketServerEvent.ts
+++ b/packages/sdk/sdk-ts/src/oapi-gen/models/ResponsesWebSocketServerEvent.ts
@@ -1,0 +1,11 @@
+/**
+ * Streamed websocket event. Mirrors OpenAI Responses event payloads (for example `response.created`, `response.output_text.delta`, `response.completed`, or `error`).
+ *
+ */
+export interface ResponsesWebSocketServerEvent {
+  error?: {};
+  response?: {};
+  status?: number;
+  type?: string;
+  [key: string]: unknown;
+}

--- a/packages/sdk/sdk-ts/src/oapi-gen/models/index.ts
+++ b/packages/sdk/sdk-ts/src/oapi-gen/models/index.ts
@@ -59,6 +59,8 @@ export type { RealtimeNotImplementedResponse } from "./RealtimeNotImplementedRes
 export type { ReasoningConfig } from "./ReasoningConfig.js";
 export type { ResponsesRequest } from "./ResponsesRequest.js";
 export type { ResponsesResponse } from "./ResponsesResponse.js";
+export type { ResponsesWebSocketCreateEvent } from "./ResponsesWebSocketCreateEvent.js";
+export type { ResponsesWebSocketServerEvent } from "./ResponsesWebSocketServerEvent.js";
 export type { TextContentPart } from "./TextContentPart.js";
 export type { TextModerationInput } from "./TextModerationInput.js";
 export type { ToolCall } from "./ToolCall.js";


### PR DESCRIPTION
## Summary
- restore missing `RequestBetaOptions` and `RequestMeta.beta` typing used by before-pipeline and executors
- tighten websocket route narrowing (`ok === false`) in `responses-ws` to satisfy TypeScript unions
- regenerate OpenAPI SDK outputs so CI generation checks are clean

## Validation
- `pnpm --filter @ai-stats/gateway-api lint`
- `pnpm --filter @ai-stats/gateway-api build`
- `pnpm run openapi:gen`