### PR TITLE
Align gateway websocket behavior and docs; mark /responses/ws experimental

### DIFF
--- a/apps/api/src/routes/v1/data/responses-ws.test.ts
+++ b/apps/api/src/routes/v1/data/responses-ws.test.ts
@@ -24,7 +24,7 @@ describe("responses websocket request normalization", () => {
 		expect(result.payload.background).toBeUndefined();
 	});
 
-	it("accepts plain OpenAI model slugs and rewrites gateway model", () => {
+	it("rejects plain model slugs without provider prefix", () => {
 		const result = normalizeOpenAIWsResponseCreateEvent({
 			type: "response.create",
 			model: "gpt-5-nano",
@@ -32,12 +32,9 @@ describe("responses websocket request normalization", () => {
 			stream_options: { include_usage: true },
 			input: "hello",
 		});
-		expect(result.ok).toBe(true);
-		if (!result.ok) return;
-		expect(result.gatewayModel).toBe("openai/gpt-5-nano");
-		expect(result.payload.model).toBe("gpt-5-nano");
-		expect(result.payload.store).toBe(false);
-		expect(result.payload.stream_options).toBeUndefined();
+		expect(result.ok).toBe(false);
+		if (result.ok) return;
+		expect(result.error).toContain("openai/<model>");
 	});
 
 	it("rejects non-OpenAI provider model prefixes", () => {
@@ -48,7 +45,7 @@ describe("responses websocket request normalization", () => {
 		});
 		expect(result.ok).toBe(false);
 		if (result.ok) return;
-		expect(result.error).toContain("only OpenAI models");
+		expect(result.error).toContain("openai/<model>");
 	});
 
 	it("rejects non-response.create events", () => {

--- a/apps/api/src/routes/v1/data/responses-ws.ts
+++ b/apps/api/src/routes/v1/data/responses-ws.ts
@@ -60,10 +60,10 @@ export function normalizeOpenAIWsResponseCreateEvent(raw: unknown): NormalizedRe
 		return { ok: false, error: "model is required" };
 	}
 	const modelRaw = payload.model.trim();
-	if (modelRaw.includes("/") && !modelRaw.startsWith("openai/")) {
-		return { ok: false, error: "only OpenAI models are supported on this endpoint" };
+	if (!modelRaw.startsWith("openai/")) {
+		return { ok: false, error: "model must use openai/<model> format on this endpoint" };
 	}
-	const upstreamModel = modelRaw.startsWith("openai/") ? modelRaw.slice("openai/".length) : modelRaw;
+	const upstreamModel = modelRaw.slice("openai/".length);
 	if (!upstreamModel) {
 		return { ok: false, error: "invalid OpenAI model" };
 	}

--- a/apps/docs/openapi/v1/openapi.yaml
+++ b/apps/docs/openapi/v1/openapi.yaml
@@ -292,10 +292,21 @@ paths:
             summary: Open Responses websocket session
             description: |
                 Opens a persistent websocket session for OpenAI Responses WebSocket mode.
+                This route is currently experimental on AI Stats Gateway and is not
+                recommended for production workloads.
 
-                This endpoint is OpenAI-only and accepts `response.create` websocket messages.
+                WebSocket handshake uses HTTP GET upgrade semantics and returns `101 Switching Protocols`
+                on success (not `200`).
+
+                This endpoint is OpenAI-only, requires `openai/<model>` format, and accepts
+                `response.create` websocket messages.
                 The gateway enforces `store=false`, allows one in-flight response per connection,
                 and forwards OpenAI Responses streaming events back to the client.
+
+                After upgrade, runtime failures are emitted as websocket `error` events
+                (for example `invalid_response_create`, `openai_routing_failed`,
+                `response_already_in_flight`, `model_mismatch`, `upstream_websocket_*`)
+                rather than additional HTTP response codes.
             responses:
                 "101":
                     description: WebSocket upgrade accepted.
@@ -304,12 +315,6 @@ paths:
                             $ref: "#/components/schemas/ResponsesWebSocketCreateEvent"
                         serverEvent:
                             $ref: "#/components/schemas/ResponsesWebSocketServerEvent"
-                "400":
-                    description: Bad request
-                    content:
-                        application/json:
-                            schema:
-                                $ref: "#/components/schemas/ErrorResponse"
                 "401":
                     description: Unauthorized
                     content:
@@ -321,13 +326,7 @@ paths:
                     content:
                         application/json:
                             schema:
-                                $ref: "#/components/schemas/ErrorResponse"
-                "503":
-                    description: Upstream websocket unavailable
-                    content:
-                        application/json:
-                            schema:
-                                $ref: "#/components/schemas/ErrorResponse"
+                                $ref: "#/components/schemas/ResponsesWebSocketUpgradeRequiredResponse"
     /messages:
         post:
             tags:
@@ -3123,6 +3122,10 @@ components:
                     $ref: "#/components/schemas/Usage"
         ResponsesWebSocketCreateEvent:
             type: object
+            description: >
+                Client message for websocket turn creation. Gateway performs lightweight validation
+                (`type` and `model` format) before forwarding to OpenAI; deeper request-shape
+                validation is enforced by upstream.
             required:
                 - type
                 - model
@@ -3134,7 +3137,7 @@ components:
                 model:
                     type: string
                     description: >
-                        OpenAI model id. Gateway accepts `openai/<model>` or plain OpenAI model slug.
+                        OpenAI model id in provider/model format: `openai/<model>`.
                 previous_response_id:
                     type: string
                     nullable: true
@@ -3178,6 +3181,21 @@ components:
                 status:
                     type: integer
             additionalProperties: true
+        ResponsesWebSocketUpgradeRequiredResponse:
+            type: object
+            properties:
+                error:
+                    type: object
+                    properties:
+                        type:
+                            type: string
+                            example: invalid_request_error
+                        code:
+                            type: string
+                            example: websocket_upgrade_required
+                        message:
+                            type: string
+                            example: Use WebSocket upgrade for /v1/responses/ws.
         EmbeddingsRequest:
             type: object
             properties:

--- a/apps/docs/v1/api-reference/endpoint/responses-ws.mdx
+++ b/apps/docs/v1/api-reference/endpoint/responses-ws.mdx
@@ -2,3 +2,11 @@
 title: "Responses WebSocket"
 openapi: "GET /responses/ws"
 ---
+
+<Note type="warning">
+Experimental endpoint. Use `openai/<model>` format only, and prefer `POST /v1/responses` for production workloads.
+</Note>
+
+Successful connection is HTTP `101 Switching Protocols` (not `200`). After upgrade, failures are emitted as WebSocket `error` events.
+
+For a full gateway walkthrough (connect, send turns, continue with `previous_response_id`, and recover from errors), see [WebSocket Mode guide](../../guides/websocket-mode).

--- a/apps/docs/v1/guides/websocket-mode.mdx
+++ b/apps/docs/v1/guides/websocket-mode.mdx
@@ -1,70 +1,159 @@
 ---
 title: "WebSocket Mode"
-description: "Use /v1/responses/ws for low-latency OpenAI Responses loops."
+description: "Gateway-first walkthrough for /v1/responses/ws with concrete connection, turn, and recovery flow."
 ---
 
-WebSocket mode keeps one long-lived connection open so you can run multi-turn, tool-heavy OpenAI Responses workflows with lower continuation overhead.
+This page explains how AI Stats Gateway `/v1/responses/ws` currently behaves.
 
-## Endpoint
+<Note type="warning">
+`/v1/responses/ws` is OpenAI-only and requires `openai/<model>` format.
+</Note>
 
-`wss://api.phaseo.app/v1/responses/ws`
+<Note type="warning">
+This endpoint is still experimental on AI Stats Gateway and is currently not recommended for production workloads. For production, prefer `POST /v1/responses` (and SSE streaming when needed).
+</Note>
 
-## Scope
+## Endpoint and handshake
 
-- OpenAI models only (`openai/<model>` or plain OpenAI model slug).
-- Responses protocol only (`type: "response.create"` messages).
-- One in-flight response per connection (sequential turns, no multiplexing).
-- Model must stay constant for the lifetime of a single websocket session.
-- `store` is always forced to `false` on this endpoint.
+- URL: `wss://api.phaseo.app/v1/responses/ws`
+- Method semantics: WebSocket starts as an HTTP `GET` with `Upgrade: websocket`.
+- Success status: `101 Switching Protocols` (not `200`).
+- Auth: `Authorization: Bearer YOUR_API_KEY`
 
-## Connect
+If you call this path as a normal HTTP GET without WebSocket upgrade headers, the gateway returns `426 websocket_upgrade_required`.
 
-```bash
-websocat \
-  -H="Authorization: Bearer YOUR_API_KEY" \
-  wss://api.phaseo.app/v1/responses/ws
+## How the gateway processes this endpoint
+
+For each socket session, the gateway enforces these rules:
+
+- Only `type: "response.create"` client messages are accepted.
+- Model must use provider/model format and OpenAI provider: `openai/<model>`.
+- Exactly one in-flight response is allowed per connection.
+- The model is locked after the first valid turn (`model_mismatch` if changed later).
+- `store` is always forced to `false`.
+- HTTP-style flags are removed before upstream send: `stream`, `stream_options`, `background`.
+
+## Step-by-step implementation
+
+### 1) Pick an OpenAI-routable model
+
+Use `GET /v1/models` to discover candidate model IDs, then run a first turn over `/v1/responses/ws` to confirm routing for your team/key.
+
+Example model IDs that work with this endpoint:
+
+- `openai/gpt-5-nano`
+
+### 2) Open one authenticated WebSocket connection
+
+```ts
+import WebSocket from "ws";
+
+const ws = new WebSocket("wss://api.phaseo.app/v1/responses/ws", {
+  headers: {
+    Authorization: `Bearer ${process.env.AI_STATS_API_KEY}`,
+  },
+});
+
+await new Promise<void>((resolve, reject) => {
+  ws.once("open", () => resolve());
+  ws.once("error", reject);
+});
 ```
 
-## Send a turn
+### 3) Send your first `response.create`
 
-```json
-{
-  "type": "response.create",
-  "model": "openai/gpt-5-nano",
-  "input": [
+```ts
+ws.send(JSON.stringify({
+  type: "response.create",
+  model: "openai/gpt-5-nano",
+  input: [
     {
-      "type": "message",
-      "role": "user",
-      "content": [{ "type": "input_text", "text": "Find bottlenecks in this function." }]
-    }
+      type: "message",
+      role: "user",
+      content: [{ type: "input_text", text: "Summarize this issue in 3 bullets." }],
+    },
   ],
-  "tools": []
-}
+  tools: [],
+}));
 ```
 
-The gateway forwards OpenAI Responses websocket events back to the client (for example `response.created`, `response.output_text.delta`, `response.completed`, and `error`).
+### 4) Read server events until completion
 
-## Continue a conversation
+The gateway forwards OpenAI Responses WebSocket events. In practice, handle at least:
 
-For continuation, send another `response.create` with:
+- `response.created`
+- `response.output_text.delta`
+- `response.completed`
+- `response.failed`
+- `error`
 
-- `previous_response_id` set to the prior response ID.
-- `input` containing only new items for the next turn.
+```ts
+let lastResponseId: string | null = null;
 
-If you receive `previous_response_not_found`, restart the chain by omitting `previous_response_id` (or setting it to `null`) and sending full context.
+ws.on("message", (raw) => {
+  const msg = JSON.parse(String(raw));
 
-## Errors to handle
+  if (msg.type === "response.output_text.delta") {
+    process.stdout.write(msg.delta ?? "");
+    return;
+  }
 
-- `previous_response_not_found`
-- `websocket_connection_limit_reached`
-- `response_already_in_flight`
-- `model_mismatch`
+  if (msg.type === "response.completed") {
+    lastResponseId = msg.response?.id ?? null;
+    console.log("\ncompleted:", lastResponseId);
+    return;
+  }
 
-## Billing and auth
+  if (msg.type === "response.failed" || msg.type === "error") {
+    console.error("gateway ws error:", msg.error ?? msg);
+  }
+});
+```
 
-Authentication and billing are enforced the same way as HTTP endpoints. Usage-based charging is recorded from completed websocket responses.
+### 5) Continue the same conversation chain
+
+For subsequent turns on the same chain:
+
+- Keep the same `model`.
+- Send only new turn input.
+- Set `previous_response_id` to the prior completed response id.
+
+```ts
+ws.send(JSON.stringify({
+  type: "response.create",
+  model: "openai/gpt-5-nano",
+  previous_response_id: lastResponseId,
+  input: [
+    {
+      type: "message",
+      role: "user",
+      content: [{ type: "input_text", text: "Now convert that to an action list." }],
+    },
+  ],
+}));
+```
+
+### 6) Handle gateway-specific errors with explicit recovery
+
+- `invalid_response_create`: gateway pre-validation failed (payload must be a JSON object with `type: "response.create"` and `model` in `openai/<model>` format).
+- `openai_routing_failed`: gateway could not route your OpenAI model for this key/team; inspect `error.message` details (which may include `openai_provider_unavailable` or `pricing_unavailable`) and choose a routable model.
+- `response_already_in_flight`: wait for current turn to finish before sending the next turn.
+- `model_mismatch`: open a new socket if you want a different model.
+- `upstream_websocket_handshake_failed` / `upstream_websocket_closed`: reconnect with backoff and retry the turn.
+- `previous_response_not_found`: resend without `previous_response_id` and include full context.
+
+Gateway behavior detail: if `previous_response_not_found` occurs and your prior payload had a non-null `previous_response_id` with array `input`, the gateway automatically retries once with `previous_response_id: null`.
+
+### 7) Evaluation checklist (non-production)
+
+- Keep one socket per active conversation worker.
+- Enforce per-socket turn queueing to avoid `response_already_in_flight`.
+- Add timeout + reconnect with exponential backoff.
+- Log response ids, error codes, and close codes.
+- Rotate API keys via normal gateway key management flow.
 
 ## Related pages
 
-1. [Responses Endpoint](../api-reference/endpoint/responses)
-2. [Streaming](./streaming)
+1. [Responses WebSocket API Reference](../api-reference/endpoint/responses-ws)
+2. [Responses Endpoint](../api-reference/endpoint/responses)
+3. [Streaming](./streaming)


### PR DESCRIPTION
## What changed
This PR aligns `/v1/responses/ws` runtime behavior, tests, and docs, and marks the endpoint as experimental for AI Stats Gateway.

## Issue and user impact
Users were seeing conflicting guidance around WebSocket mode:
- Docs implied plain model slugs might work on this endpoint.
- API reference language was noisy and still left confusion about HTTP `200` vs WebSocket `101` semantics.
- WebSocket runtime behavior and OpenAPI response modeling were not fully aligned.

This could lead users to send invalid model formats, misread connection success criteria, and assume production readiness when current behavior is still experimental.

## Root cause
- Runtime pre-validation and docs drifted over time.
- OpenAPI had generic HTTP error modeling that did not clearly represent post-upgrade WebSocket `error` event behavior.
- The endpoint maturity/status (experimental) was not prominently stated.

## Fix
### Runtime and tests
- Enforced `openai/<model>` format for `/v1/responses/ws` request normalization.
- Updated websocket route tests to reject plain model slugs and assert new validation messaging.

### API/OpenAPI reference
- Clarified that successful WebSocket upgrade is HTTP `101 Switching Protocols` (not `200`).
- Clarified that after upgrade, failures are delivered as WebSocket `error` events.
- Added a dedicated schema for `426 websocket_upgrade_required` response shape.
- Simplified `/responses/ws` API ref page to reduce repeated notices.

### Guide content
- Reworked WebSocket guide to be gateway-first and behavior-accurate.
- Corrected error-code guidance (`openai_routing_failed` event with details possibly containing `openai_provider_unavailable`).
- Explicitly marked endpoint as experimental and not recommended for production; pointed users to `POST /v1/responses` for production workloads.

## Validation
- `pnpm --filter @ai-stats/gateway-api test -- src/routes/v1/data/responses-ws.test.ts` (pass)
- Live benchmark check on gateway websocket path with `openai/gpt-5-nano` (pass)
  - `tests/integration/gateway-openai-http-vs-ws.live.spec.ts`
- Additional websocket structured-output probe was used during investigation and timed out; docs were updated to keep production guidance conservative while this remains experimental.
