### PR TITLE
fix(web): improve email sign-in UX and widen models table header

### DIFF
--- a/apps/web/src/app/(auth)/sign-in/actions.ts
+++ b/apps/web/src/app/(auth)/sign-in/actions.ts
@@ -31,11 +31,14 @@ export async function handleOAuthRedirect(formData: FormData) {
 
 export async function handlePasswordSignIn(formData: FormData) {
     const supabase = await createClient();
-    const email = String(formData.get("email") ?? "");
+    const email = String(formData.get("email") ?? "").trim();
     const password = String(formData.get("password") ?? "");
 
     const { error } = await supabase.auth.signInWithPassword({ email, password });
-    if (error) redirect("/error?message=Authentication failed");
+    if (error) {
+        const message = error.message || "Authentication failed";
+        redirect(`/sign-in?error=${encodeURIComponent(message)}`);
+    }
 
     // Only remember the method, not the identifier
     await (await cookies()).set("auth_provider", "email", cookieOpts);

--- a/apps/web/src/app/(auth)/sign-in/page.tsx
+++ b/apps/web/src/app/(auth)/sign-in/page.tsx
@@ -21,6 +21,8 @@ export default async function Page({ searchParams }: SignInPageProps) {
 	const params = (await searchParams) ?? {};
 	const signup = Array.isArray(params.signup) ? params.signup[0] : params.signup;
 	const signupNotice = signup === "exists" || signup === "check-email" ? signup : null;
+	const authErrorParam = Array.isArray(params.error) ? params.error[0] : params.error;
+	const authError = typeof authErrorParam === "string" ? authErrorParam : null;
 
 	return (
 		<div className="grid min-h-svh lg:grid-cols-2">
@@ -41,7 +43,7 @@ export default async function Page({ searchParams }: SignInPageProps) {
 				<div className="flex flex-1 items-center justify-center">
 					<div className="mx-auto w-full max-w-xs">
 						<Suspense fallback={<div>Loading…</div>}>
-							<Login signupNotice={signupNotice} />
+							<Login signupNotice={signupNotice} authError={authError} />
 						</Suspense>
 					</div>
 				</div>

--- a/apps/web/src/components/(gateway)/auth/EmailPassword.tsx
+++ b/apps/web/src/components/(gateway)/auth/EmailPassword.tsx
@@ -2,12 +2,22 @@
 
 import * as React from "react";
 import Link from "next/link";
+import { useFormStatus } from "react-dom";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { handlePasswordSignIn, forgotPasswordAction } from "@/app/(auth)/sign-in/actions";
 import { ForgotPasswordDialog } from "./ForgotPasswordDialog";
 import { Eye, EyeOff } from "lucide-react";
+
+function SubmitButton() {
+	const { pending } = useFormStatus();
+	return (
+		<Button type="submit" className="w-full" disabled={pending}>
+			{pending ? "Signing in..." : "Sign in with email"}
+		</Button>
+	);
+}
 
 export default function EmailPassword() {
 	const [forgotPasswordOpen, setForgotPasswordOpen] = React.useState(false);
@@ -75,9 +85,7 @@ export default function EmailPassword() {
 					</div>
 				</div>
 
-				<Button type="submit" className="w-full">
-					Sign in with email
-				</Button>
+				<SubmitButton />
 			</form>
 
 			<div className="text-center text-sm">

--- a/apps/web/src/components/(gateway)/auth/Login.tsx
+++ b/apps/web/src/components/(gateway)/auth/Login.tsx
@@ -10,7 +10,25 @@ type OAuthProvider = (typeof OAUTH)[number];
 type Provider = OAuthProvider | "email";
 type SignupNotice = "exists" | "check-email" | null;
 
-export async function Login({ signupNotice = null }: { signupNotice?: SignupNotice }) {
+function normalizeAuthError(message: string | null): string | null {
+	if (!message) return null;
+	const lower = message.toLowerCase();
+	if (lower.includes("invalid login credentials")) {
+		return "Invalid email or password. Please try again.";
+	}
+	if (lower.includes("email not confirmed")) {
+		return "Please verify your email before signing in.";
+	}
+	return message;
+}
+
+export async function Login({
+	signupNotice = null,
+	authError = null,
+}: {
+	signupNotice?: SignupNotice;
+	authError?: string | null;
+}) {
 	let lastProvider: Provider | null = null;
 	try {
 		const c = await cookies();
@@ -32,6 +50,7 @@ export async function Login({ signupNotice = null }: { signupNotice?: SignupNoti
 			: signupNotice === "check-email"
 				? "Account created. Check your email to verify, then sign in."
 				: null;
+	const authErrorText = normalizeAuthError(authError);
 
 	return (
 		<div className="flex flex-col gap-6">
@@ -46,6 +65,15 @@ export async function Login({ signupNotice = null }: { signupNotice?: SignupNoti
 			{signupNoticeText ? (
 				<p className="rounded-md border border-border bg-muted/40 px-3 py-2 text-sm text-muted-foreground">
 					{signupNoticeText}
+				</p>
+			) : null}
+			{authErrorText ? (
+				<p
+					className="rounded-md border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700 dark:border-red-900/60 dark:bg-red-950/40 dark:text-red-300"
+					role="alert"
+					aria-live="polite"
+				>
+					{authErrorText}
 				</p>
 			) : null}
 

--- a/apps/web/src/components/(gateway)/auth/OAuthButtons.tsx
+++ b/apps/web/src/components/(gateway)/auth/OAuthButtons.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import Image from "next/image";
+import { useFormStatus } from "react-dom";
 import { Button } from "@/components/ui/button";
 import { handleOAuthRedirect } from "@/app/(auth)/sign-in/actions";
 import { Logo } from "@/components/Logo";
@@ -26,6 +27,55 @@ const META: Record<Provider, ProviderMeta> = {
 	gitlab: { label: "GitLab", light: "/social/gitlab.svg" },
 };
 
+function OAuthSubmitButton({ meta }: { meta: ProviderMeta }) {
+	const { pending } = useFormStatus();
+	return (
+		<Button
+			type="submit"
+			variant="outline"
+			aria-label={`Continue with ${meta.label}`}
+			className="w-full h-10 flex items-center justify-center relative"
+			disabled={pending}
+		>
+			<div className="absolute left-3 flex items-center">
+				{meta.logoId ? (
+					<Logo
+						id={meta.logoId}
+						width={16}
+						height={16}
+						className="h-4 w-4 shrink-0"
+					/>
+				) : (
+					<>
+						{meta.light ? (
+							<Image
+								src={meta.light}
+								alt={`${meta.label} logo`}
+								width={16}
+								height={16}
+								className="h-4 w-4 shrink-0 dark:hidden"
+							/>
+						) : null}
+						{(meta.dark ?? meta.light) ? (
+							<Image
+								src={meta.dark ?? meta.light!}
+								alt={`${meta.label} logo`}
+								width={16}
+								height={16}
+								className="hidden h-4 w-4 shrink-0 dark:block"
+							/>
+						) : null}
+					</>
+				)}
+			</div>
+
+			<span className="text-center">
+				{pending ? `Continuing with ${meta.label}...` : `Continue with ${meta.label}`}
+			</span>
+		</Button>
+	);
+}
+
 export default function OAuthButtons() {
 	return (
 		<div className="grid gap-4">
@@ -41,50 +91,7 @@ export default function OAuthButtons() {
 					return (
 						<form action={handleOAuthRedirect} key={id}>
 							<input type="hidden" name="provider" value={id} />
-							<Button
-								type="submit"
-								variant="outline"
-								aria-label={`Continue with ${meta.label}`}
-								className="w-full h-10 flex items-center justify-center relative"
-							>
-								<div className="absolute left-3 flex items-center">
-									{meta.logoId ? (
-										<Logo
-											id={meta.logoId}
-											width={16}
-											height={16}
-											className="h-4 w-4 shrink-0"
-										/>
-									) : (
-										<>
-											{meta.light ? (
-												<Image
-													src={meta.light}
-													alt={`${meta.label} logo`}
-													width={16}
-													height={16}
-													className="h-4 w-4 shrink-0 dark:hidden"
-												/>
-											) : null}
-											{(meta.dark ?? meta.light) ? (
-												<Image
-													src={
-														meta.dark ?? meta.light!
-													}
-													alt={`${meta.label} logo`}
-													width={16}
-													height={16}
-													className="hidden h-4 w-4 shrink-0 dark:block"
-												/>
-											) : null}
-										</>
-									)}
-								</div>
-
-								<span className="text-center">
-									Continue with {meta.label}
-								</span>
-							</Button>
+							<OAuthSubmitButton meta={meta} />
 						</form>
 					);
 				})}

--- a/apps/web/src/components/header/HeaderShell.tsx
+++ b/apps/web/src/components/header/HeaderShell.tsx
@@ -10,18 +10,19 @@ type HeaderShellProps = {
 
 export default function HeaderShell({ children }: HeaderShellProps) {
 	const pathname = usePathname() ?? "";
-	const isSettingsRoute = pathname.startsWith("/settings");
+	const isWideRoute =
+		pathname.startsWith("/settings") || pathname.startsWith("/models/table");
 
 	return (
 		<div
 			className={cn(
 				"mx-auto w-full [view-transition-name:site-header-shell]",
 				"transition-[max-width,padding-inline] duration-300 ease-[cubic-bezier(0.22,1,0.36,1)] motion-reduce:transition-none",
-				isSettingsRoute
+				isWideRoute
 					? "max-w-full px-4"
 					: "max-w-full px-4 sm:max-w-[640px] md:max-w-[768px] lg:max-w-[1024px] xl:max-w-[1280px] 2xl:max-w-[1536px]",
 			)}
-			data-variant={isSettingsRoute ? "wide" : "default"}
+			data-variant={isWideRoute ? "wide" : "default"}
 		>
 			{children}
 		</div>


### PR DESCRIPTION
## Summary
This PR fixes two web regressions:

1. Email sign-in failure UX (`AI-79` / `#115`)
2. Header width behavior on models table view (`AI-78` / `#114`)

## What changed
- Sign-in server action now trims email and returns auth failures back to `/sign-in` with the provider error message in query params, instead of redirecting to a generic `/error` page.
- Sign-in page now reads `error` from search params and passes it into the login UI.
- Login UI now renders a friendly inline error alert for common auth failures (invalid credentials, unverified email), while still displaying other upstream messages.
- Added loading/pending feedback to email sign-in submit and OAuth provider submit buttons so users see immediate visual response when submitting.
- Header shell widening logic now treats `/models/table` as a wide-layout route, matching the settings page behavior.

## Root cause
- Email/password auth errors were being collapsed into a generic redirect, hiding useful failure details from users.
- Auth buttons had no pending state, so submits appeared unresponsive.
- Header width expansion only checked `/settings` paths and excluded `/models/table`.

## Validation
- `pnpm --filter @ai-stats/web typecheck`

## Issues
Closes #114
Closes #115
