### PR TITLE
chore(github): simplify issue templates and allow blank issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,48 +1,48 @@
-name: "🐞 Bug Report"
+name: "Bug Report"
 description: Report a defect or unintended behaviour
 title: "[Bug] "
 assignees:
-    - DanielButler1
+  - DanielButler1
 body:
-    - type: dropdown
-      id: area
-      attributes:
-          label: Area
-          options:
-              - API
-              - Data
-              - Docs
-              - Other
-              - SDKs
-              - Web
-      validations:
-          required: true
-    - type: textarea
-      id: summary
-      attributes:
-          label: Summary
-          placeholder: One clear paragraph of what’s broken.
-      validations:
-          required: true
-    - type: textarea
-      id: repro
-      attributes:
-          label: Steps to reproduce
-          placeholder: |
-              1. …
-              2. …
-              3. …
-      validations:
-          required: true
-    - type: textarea
-      id: expected
-      attributes:
-          label: Expected vs actual
-          placeholder: What should have happened?
-      validations:
-          required: true
-    - type: input
-      id: env
-      attributes:
-          label: Environment
-          placeholder: OS / Browser / Device / App version / Commit SHA
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      options:
+        - API
+        - Data
+        - Docs
+        - Other
+        - SDKs
+        - Web
+    validations:
+      required: true
+
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      placeholder: One clear paragraph of what's broken.
+    validations:
+      required: true
+
+  - type: textarea
+    id: repro
+    attributes:
+      label: Steps to reproduce
+      placeholder: |
+        1. ...
+        2. ...
+        3. ...
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected vs actual
+      placeholder: What should have happened?
+
+  - type: input
+    id: env
+    attributes:
+      label: Environment
+      placeholder: OS / Browser / Device / App version / Commit SHA

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,2 +1,2 @@
 # .github/ISSUE_TEMPLATE/config.yml
-blank_issues_enabled: false
+blank_issues_enabled: true


### PR DESCRIPTION
## Summary
This PR reduces friction when creating GitHub issues by relaxing the bug report form and enabling blank issues.

## Problem
The current issue flow is too heavy for quick reporting:
- Blank issues are disabled.
- The bug template requires multiple detailed sections (`Steps to reproduce` and `Expected vs actual`) even when a reporter only has minimal context.

That increases the time/cognitive load to file bugs and can discourage reporting.

## Root Cause
Issue template validation is currently strict by default:
- `.github/ISSUE_TEMPLATE/config.yml` has `blank_issues_enabled: false`
- `.github/ISSUE_TEMPLATE/bug.yml` marks additional fields as required beyond the core signal.

## Changes
- Enabled blank issues in GitHub issue template config.
- Simplified bug template requirements so only the core fields are mandatory:
  - Required: `Area`, `Summary` (plus GitHub issue title)
  - Optional: `Steps to reproduce`, `Expected vs actual`, `Environment`
- Cleaned template content/formatting to keep it easy to read and maintain.

## Validation
- `git diff --check`
