### PR TITLE
feat(web): add notifier tool link and normalize marketing rollup buckets

### DIFF
--- a/apps/web/src/components/internal/InternalToolsGrid.tsx
+++ b/apps/web/src/components/internal/InternalToolsGrid.tsx
@@ -18,6 +18,7 @@ import {
 	GitCompare,
 	RefreshCcw,
 	Gift,
+	Bell,
 } from "lucide-react";
 
 const internalTools = [
@@ -73,6 +74,15 @@ const internalTools = [
 			"Create, review, and disable friendly promo credit codes for wallet credits.",
 		icon: Gift,
 		href: "/internal/credits",
+		comingSoon: false,
+	},
+	{
+		id: "model-discovery-notifier",
+		title: "Model Discovery Notifier",
+		description:
+			"Preview and send Discord embed payloads for internal model discovery alerts.",
+		icon: Bell,
+		href: "/internal/model-discovery-notifier",
 		comingSoon: false,
 	},
 	{

--- a/apps/web/src/lib/fetchers/gateway/getMarketingMetrics.ts
+++ b/apps/web/src/lib/fetchers/gateway/getMarketingMetrics.ts
@@ -90,6 +90,18 @@ function bucketStartISOHour(date: Date): string {
 	return bucket.toISOString();
 }
 
+function normalizeBucketHour(value: string | null): string | null {
+	const raw = String(value ?? "").trim();
+	if (!raw) return null;
+
+	const parsed = new Date(raw);
+	if (Number.isFinite(parsed.getTime())) {
+		return bucketStartISOHour(parsed);
+	}
+
+	return raw;
+}
+
 async function fetchActiveGatewayModels(
 	client: SupabaseClient,
 	now = new Date(),
@@ -151,7 +163,7 @@ function buildMetricsFromRollup(
 	>();
 
 	for (const row of rollupRows) {
-		const bucket = String(row.bucket_hour ?? "").trim();
+		const bucket = normalizeBucketHour(row.bucket_hour);
 		if (!bucket) continue;
 		byHour.set(bucket, {
 			requests: coerceNumber(row.requests, 0),


### PR DESCRIPTION
## Summary
- add a new Internal Tools card linking to the Model Discovery Notifier page
- normalize rollup `bucket_hour` values in gateway marketing metrics before aggregation to prevent mismatched bucket keys

## Validation
- pnpm --filter @ai-stats/web typecheck

## Scope Notes
- excludes `.entire/logs/entire.log` (local runtime log noise)
