### PR TITLE
fix(data): correct Gemma 4 internal model mappings

### DIFF
--- a/packages/data/catalog/src/data/api_providers/gmicloud/models.json
+++ b/packages/data/catalog/src/data/api_providers/gmicloud/models.json
@@ -480,7 +480,7 @@
     "api_model_id": "google/gemma-4-26b-a4b",
     "provider_api_model_id": "gmicloud:google/gemma-4-26b-a4b",
     "provider_model_slug": "google/gemma-4-26b-a4b-it",
-    "internal_model_id": "google/gemma-4-26b-a3b",
+    "internal_model_id": "google/gemma-4-26b-a4b",
     "is_active_gateway": true,
     "quantization_scheme": "FP8",
     "input_modalities": "text,image",

--- a/packages/data/catalog/src/data/api_providers/google-ai-studio/models.json
+++ b/packages/data/catalog/src/data/api_providers/google-ai-studio/models.json
@@ -2188,7 +2188,7 @@
     "api_model_id": "google/gemma-4-26b-a4b:free",
     "provider_api_model_id": "google-ai-studio:google/gemma-4-26b-a4b:free",
     "provider_model_slug": "gemma-4-26b-a4b-it",
-    "internal_model_id": "google/gemma-4-26b-a3b",
+    "internal_model_id": "google/gemma-4-26b-a4b",
     "is_active_gateway": true,
     "quantization_scheme": null,
     "input_modalities": "text,image",

--- a/packages/data/catalog/src/data/api_providers/novita/models.json
+++ b/packages/data/catalog/src/data/api_providers/novita/models.json
@@ -8655,7 +8655,7 @@
     "api_model_id": "google/gemma-4-26b-a4b",
     "provider_api_model_id": "novita:google/gemma-4-26b-a4b",
     "provider_model_slug": "google/gemma-4-26b-a4b-it",
-    "internal_model_id": "google/gemma-4-26b-a3b",
+    "internal_model_id": "google/gemma-4-26b-a4b",
     "is_active_gateway": true,
     "quantization_scheme": "BF16",
     "input_modalities": "text,image",


### PR DESCRIPTION
## Summary
- fix Gemma 4 `internal_model_id` mappings that pointed to non-existent `google/gemma-4-26b-a3b`
- align provider mappings to existing internal model `google/gemma-4-26b-a4b`

## Files
- packages/data/catalog/src/data/api_providers/gmicloud/models.json
- packages/data/catalog/src/data/api_providers/google-ai-studio/models.json
- packages/data/catalog/src/data/api_providers/novita/models.json

## Validation
- pnpm validate:data
