### PR TITLE
fix(model-discovery): split public/private Discord channels and prevent duplicates

### DIFF
--- a/.github/workflows/check-new-models.yml
+++ b/.github/workflows/check-new-models.yml
@@ -55,11 +55,10 @@ jobs:
 
             - name: Check for new internal models
               run: |
-                  pnpm exec tsx scripts/model-discovery/run-internal.ts \
+                  pnpm exec tsx scripts/model-discovery/run-internal-public.ts \
                     --discord-user-id "${{ secrets.DISCORD_USER_ID }}" \
                     --discord-role-id "${{ secrets.DISCORD_ROLE_ID }}" \
-                    --discord-avatar-url "https://ai-stats.phaseo.app/png_logo_light.png" \
-                    --skip-hf
+                    --discord-avatar-url "https://ai-stats.phaseo.app/png_logo_light.png"
 
             - name: Check for new external provider models
               env:
@@ -84,10 +83,9 @@ jobs:
                   DISCORD_USER_ID: ${{ secrets.DISCORD_USER_ID }}
                   DISCORD_ROLE_ID: ${{ secrets.DISCORD_ROLE_ID }}
               run: |
-                  pnpm exec tsx scripts/model-discovery/run-internal.ts \
+                  pnpm exec tsx scripts/model-discovery/run-hf-private.ts \
                     --discord-user-id "${{ secrets.DISCORD_USER_ID }}" \
                     --discord-role-id "${{ secrets.DISCORD_ROLE_ID }}" \
-                    --skip-internal \
                     --hf-orgs "${{ vars.HF_WATCH_ORGS }}" \
                     --hf-token "${{ secrets.HF_TOKEN }}"
 

--- a/.github/workflows/check-new-models.yml
+++ b/.github/workflows/check-new-models.yml
@@ -12,6 +12,7 @@ concurrency:
 env:
     NODE_VERSION: 22
     DISCORD_WEBHOOK_NEW_MODELS_PUBLIC: ${{ secrets.DISCORD_WEBHOOK_NEW_MODELS_PUBLIC }}
+    DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
 
 permissions:
     contents: read
@@ -57,11 +58,12 @@ jobs:
                   pnpm exec tsx scripts/model-discovery/run-internal.ts \
                     --discord-user-id "${{ secrets.DISCORD_USER_ID }}" \
                     --discord-role-id "${{ secrets.DISCORD_ROLE_ID }}" \
+                    --discord-avatar-url "https://ai-stats.phaseo.app/png_logo_light.png" \
                     --skip-hf
 
             - name: Check for new external provider models
               env:
-                  DISCORD_WEBHOOK_NEW_MODELS_PUBLIC: ${{ secrets.DISCORD_WEBHOOK_NEW_MODELS_PUBLIC }}
+                  DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
                   DISCORD_USER_ID: ${{ secrets.DISCORD_USER_ID }}
                   DISCORD_ROLE_ID: ${{ secrets.DISCORD_ROLE_ID }}
                   NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.NEXT_PUBLIC_SUPABASE_URL }}
@@ -77,6 +79,10 @@ jobs:
                   pnpm exec tsx scripts/model-discovery/run.ts
 
             - name: Check for new external Hugging Face models
+              env:
+                  DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
+                  DISCORD_USER_ID: ${{ secrets.DISCORD_USER_ID }}
+                  DISCORD_ROLE_ID: ${{ secrets.DISCORD_ROLE_ID }}
               run: |
                   pnpm exec tsx scripts/model-discovery/run-internal.ts \
                     --discord-user-id "${{ secrets.DISCORD_USER_ID }}" \

--- a/.github/workflows/check-new-models.yml
+++ b/.github/workflows/check-new-models.yml
@@ -13,6 +13,7 @@ env:
     NODE_VERSION: 22
     DISCORD_WEBHOOK_NEW_MODELS_PUBLIC: ${{ secrets.DISCORD_WEBHOOK_NEW_MODELS_PUBLIC }}
     DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
+    DISCORD_ROLE_ID_MODEL_UPDATES: "1377690778478055584"
 
 permissions:
     contents: read
@@ -57,14 +58,14 @@ jobs:
               run: |
                   pnpm exec tsx scripts/model-discovery/run-internal-public.ts \
                     --discord-user-id "${{ secrets.DISCORD_USER_ID }}" \
-                    --discord-role-id "${{ secrets.DISCORD_ROLE_ID }}" \
+                    --discord-role-id "${{ env.DISCORD_ROLE_ID_MODEL_UPDATES }}" \
                     --discord-avatar-url "https://ai-stats.phaseo.app/png_logo_light.png"
 
             - name: Check for new external provider models
               env:
                   DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
                   DISCORD_USER_ID: ${{ secrets.DISCORD_USER_ID }}
-                  DISCORD_ROLE_ID: ${{ secrets.DISCORD_ROLE_ID }}
+                  DISCORD_ROLE_ID: ${{ env.DISCORD_ROLE_ID_MODEL_UPDATES }}
                   NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.NEXT_PUBLIC_SUPABASE_URL }}
                   SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
                   AION_LABS_API_KEY: ${{ secrets.AION_LABS_API_KEY }}
@@ -81,11 +82,11 @@ jobs:
               env:
                   DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
                   DISCORD_USER_ID: ${{ secrets.DISCORD_USER_ID }}
-                  DISCORD_ROLE_ID: ${{ secrets.DISCORD_ROLE_ID }}
+                  DISCORD_ROLE_ID: ${{ env.DISCORD_ROLE_ID_MODEL_UPDATES }}
               run: |
                   pnpm exec tsx scripts/model-discovery/run-hf-private.ts \
                     --discord-user-id "${{ secrets.DISCORD_USER_ID }}" \
-                    --discord-role-id "${{ secrets.DISCORD_ROLE_ID }}" \
+                    --discord-role-id "${{ env.DISCORD_ROLE_ID_MODEL_UPDATES }}" \
                     --hf-orgs "${{ vars.HF_WATCH_ORGS }}" \
                     --hf-token "${{ secrets.HF_TOKEN }}"
 

--- a/apps/web/src/app/(dashboard)/internal/model-discovery-notifier/actions.ts
+++ b/apps/web/src/app/(dashboard)/internal/model-discovery-notifier/actions.ts
@@ -221,7 +221,7 @@ export async function testInternalModelDiscoveryNotifierAction(
 		const payload = buildWebhookPayload(models, trimOrNull(input.roleId), {
 			discordUserId: trimOrNull(input.userId),
 			includeMentions: true,
-			avatarUrl: trimOrNull(process.env.DISCORD_MODEL_DISCOVERY_AVATAR_URL),
+			avatarUrl: null,
 			maxModelEmbeds: 10,
 		});
 		const payloadPreview = JSON.stringify(payload, null, 2);

--- a/package.json
+++ b/package.json
@@ -34,6 +34,8 @@
 		"data:update-statuses": "tsx scripts/update-model-statuses.ts",
 		"data:reconcile-api-model-links": "pnpm --filter @ai-stats/web run db:reconcile-api-model-links",
 		"data:check-new-models": "tsx scripts/model-discovery/run.ts",
+		"data:check-new-models:internal-public": "tsx scripts/model-discovery/run-internal-public.ts",
+		"data:check-new-models:hf-private": "tsx scripts/model-discovery/run-hf-private.ts",
 		"data:probe-model-endpoints": "node internal/fetch-provider-model-endpoints.mjs",
 		"oauth:e2e:mini": "tsx internal/oauth-e2e-mini/oauth-e2e-mini.ts",
 		"data:check-new-models:test": "tsx scripts/model-discovery/validate-providers.ts",

--- a/scripts/model-discovery/README.md
+++ b/scripts/model-discovery/README.md
@@ -27,6 +27,7 @@ Already-announced model IDs are persisted to:
 - `scripts/model-discovery/state/internal-announced-models.json`
 
 This avoids duplicate notifications across runs while the GitHub Actions cache is retained.
+Internal model IDs are also marked as announced before sending webhook payloads, preventing duplicate reposts on retry/rerun paths.
 
 Providers marked inactive in `discovery-policy.ts` are skipped explicitly with an `Inactive by policy` reason. Use this for providers without a stable/public models endpoint.
 Providers not present in `discovery-policy.ts` are also treated as inactive by default.
@@ -43,10 +44,11 @@ pnpm run data:check-new-models:test
 
 ## Environment variables
 
-- `DISCORD_WEBHOOK_NEW_MODELS_PUBLIC` (webhook URL for model-discovery alerts)
+- `DISCORD_WEBHOOK_NEW_MODELS_PUBLIC` (public webhook URL for internal website model additions)
+- `DISCORD_WEBHOOK_URL` (private/default webhook URL for provider and Hugging Face tracking alerts)
 - `DISCORD_ROLE_ID` (optional role mention)
 - `DISCORD_USER_ID` (optional mention)
-- `DISCORD_MODEL_DISCOVERY_AVATAR_URL` (optional webhook avatar URL, e.g. `https://ai-stats.phaseo.app/png_logo_light.png`)
+- `DISCORD_MODEL_DISCOVERY_AVATAR_URL` (optional manual override when calling `run-internal.ts` with `--discord-avatar-url`)
 - `NEXT_PUBLIC_SUPABASE_URL` (required for DB allowlist)
 - `SUPABASE_SERVICE_ROLE_KEY` (required for DB allowlist)
 - Provider-specific API keys declared in each provider module.

--- a/scripts/model-discovery/README.md
+++ b/scripts/model-discovery/README.md
@@ -32,6 +32,15 @@ Internal model IDs are also marked as announced before sending webhook payloads,
 Providers marked inactive in `discovery-policy.ts` are skipped explicitly with an `Inactive by policy` reason. Use this for providers without a stable/public models endpoint.
 Providers not present in `discovery-policy.ts` are also treated as inactive by default.
 
+## Script entrypoints
+
+- `scripts/model-discovery/run-internal-public.ts`
+  - Public internal release notifications (website model additions only).
+- `scripts/model-discovery/run.ts`
+  - Private external provider tracking notifications.
+- `scripts/model-discovery/run-hf-private.ts`
+  - Private Hugging Face org tracking notifications.
+
 ## Local run
 
 ```bash
@@ -48,7 +57,7 @@ pnpm run data:check-new-models:test
 - `DISCORD_WEBHOOK_URL` (private/default webhook URL for provider and Hugging Face tracking alerts)
 - `DISCORD_ROLE_ID` (optional role mention)
 - `DISCORD_USER_ID` (optional mention)
-- `DISCORD_MODEL_DISCOVERY_AVATAR_URL` (optional manual override when calling `run-internal.ts` with `--discord-avatar-url`)
+- `DISCORD_MODEL_DISCOVERY_AVATAR_URL` (optional manual override when calling internal runner scripts with `--discord-avatar-url`)
 - `NEXT_PUBLIC_SUPABASE_URL` (required for DB allowlist)
 - `SUPABASE_SERVICE_ROLE_KEY` (required for DB allowlist)
 - Provider-specific API keys declared in each provider module.

--- a/scripts/model-discovery/check-new-models.py
+++ b/scripts/model-discovery/check-new-models.py
@@ -454,7 +454,7 @@ def fetch_all_provider_models() -> list[dict]:
     return results
 
 def send_discord_webhook(message: str):
-    webhook_url = os.getenv('DISCORD_WEBHOOK_NEW_MODELS_PUBLIC')
+    webhook_url = os.getenv('DISCORD_WEBHOOK_URL')
     if not webhook_url:
         return
     user_id = os.getenv('DISCORD_USER_ID')

--- a/scripts/model-discovery/run-hf-private.ts
+++ b/scripts/model-discovery/run-hf-private.ts
@@ -1,0 +1,12 @@
+import { runInternalModelDiscovery } from "./run-internal";
+
+async function main(): Promise<void> {
+    const args = [...process.argv.slice(2), "--skip-internal"];
+    await runInternalModelDiscovery(args);
+}
+
+main().catch((error) => {
+    const message = error instanceof Error ? error.message : String(error);
+    console.error(`[internal-model-check] Fatal error: ${message}`);
+    process.exitCode = 1;
+});

--- a/scripts/model-discovery/run-internal-public.ts
+++ b/scripts/model-discovery/run-internal-public.ts
@@ -1,0 +1,12 @@
+import { runInternalModelDiscovery } from "./run-internal";
+
+async function main(): Promise<void> {
+    const args = [...process.argv.slice(2), "--skip-hf"];
+    await runInternalModelDiscovery(args);
+}
+
+main().catch((error) => {
+    const message = error instanceof Error ? error.message : String(error);
+    console.error(`[internal-model-check] Fatal error: ${message}`);
+    process.exitCode = 1;
+});

--- a/scripts/model-discovery/run-internal.ts
+++ b/scripts/model-discovery/run-internal.ts
@@ -10,6 +10,8 @@ import {
 
 type CliOptions = {
     webhookUrl: string | null;
+    internalWebhookUrl: string | null;
+    hfWebhookUrl: string | null;
     discordUserId: string | null;
     discordRoleId: string | null;
     discordAvatarUrl: string | null;
@@ -84,6 +86,8 @@ function migrateModelRootPrefix(filePath: string): string {
 
 function parseArgs(argv: string[]): CliOptions {
     let webhookUrl: string | null = null;
+    let internalWebhookUrl: string | null = null;
+    let hfWebhookUrl: string | null = null;
     let discordUserId: string | null = null;
     let discordRoleId: string | null = null;
     let discordAvatarUrl: string | null = null;
@@ -111,6 +115,18 @@ function parseArgs(argv: string[]): CliOptions {
 
         if (key === "--webhook-url") {
             webhookUrl = value.trim() || null;
+            index += 1;
+            continue;
+        }
+
+        if (key === "--internal-webhook-url") {
+            internalWebhookUrl = value.trim() || null;
+            index += 1;
+            continue;
+        }
+
+        if (key === "--hf-webhook-url") {
+            hfWebhookUrl = value.trim() || null;
             index += 1;
             continue;
         }
@@ -149,7 +165,18 @@ function parseArgs(argv: string[]): CliOptions {
         }
     }
 
-    return { webhookUrl, discordUserId, discordRoleId, discordAvatarUrl, hfOrgs, hfToken, skipInternal, skipHf };
+    return {
+        webhookUrl,
+        internalWebhookUrl,
+        hfWebhookUrl,
+        discordUserId,
+        discordRoleId,
+        discordAvatarUrl,
+        hfOrgs,
+        hfToken,
+        skipInternal,
+        skipHf,
+    };
 }
 
 function collectModelJsonFiles(rootDir: string): string[] {
@@ -700,9 +727,14 @@ async function sendDiscordWebhook(
 
 async function main(): Promise<void> {
     const options = parseArgs(process.argv.slice(2));
-    const webhookUrl =
+    const internalWebhookUrl =
+        options.internalWebhookUrl ??
         options.webhookUrl ??
         envValue("DISCORD_WEBHOOK_NEW_MODELS_PUBLIC");
+    const hfWebhookUrl =
+        options.hfWebhookUrl ??
+        options.webhookUrl ??
+        envValue("DISCORD_WEBHOOK_URL");
     const shouldCheckInternal = !options.skipInternal;
     const shouldCheckHf = !options.skipHf && options.hfOrgs.length > 0;
     const repoRoot = process.cwd();
@@ -799,16 +831,22 @@ async function main(): Promise<void> {
         return;
     }
 
-    if (!webhookUrl) {
-        const total = internalAdditionsCount + hfAdditionsTotal;
+    if (internalAdditionsCount > 0 && !internalWebhookUrl) {
         console.log(
-            `[internal-model-check] ${total} model change(s) detected (${internalAdditionsCount} internal additions, ${hfAdditionsTotal} HF), but no webhook URL was provided.`
+            `[internal-model-check] ${internalAdditionsCount} internal model addition(s) detected, but DISCORD_WEBHOOK_NEW_MODELS_PUBLIC is missing.`
         );
-        return;
+    }
+    if (hfAdditionsTotal > 0 && !hfWebhookUrl) {
+        console.log(
+            `[internal-model-check] ${hfAdditionsTotal} HF model addition(s) detected, but DISCORD_WEBHOOK_URL is missing.`
+        );
     }
 
-    const shouldSendInternal = shouldCheckInternal && internalAdditionsCount > 0;
-    const shouldSendHf = shouldCheckHf && hfAdditionsTotal > 0;
+    const shouldSendInternal = shouldCheckInternal && internalAdditionsCount > 0 && Boolean(internalWebhookUrl);
+    const shouldSendHf = shouldCheckHf && hfAdditionsTotal > 0 && Boolean(hfWebhookUrl);
+    if (!shouldSendInternal && !shouldSendHf) {
+        return;
+    }
 
     console.log(
         `[internal-model-check] Changes detected (${internalAdditionsCount} internal new, ${diff.removed.length} internal removed, ${hfAdditionsTotal} HF new). Sending Discord notification${shouldSendInternal && shouldSendHf ? "s" : ""}.`
@@ -816,24 +854,15 @@ async function main(): Promise<void> {
 
     let mentionsSent = false;
 
-    if (shouldSendInternal) {
-        const avatarUrl =
-            options.discordAvatarUrl ??
-            (typeof process.env.DISCORD_MODEL_DISCOVERY_AVATAR_URL === "string" && process.env.DISCORD_MODEL_DISCOVERY_AVATAR_URL.trim()
-                ? process.env.DISCORD_MODEL_DISCOVERY_AVATAR_URL.trim()
-                : null);
+    if (shouldSendInternal && internalWebhookUrl) {
+        const avatarUrl = options.discordAvatarUrl ?? null;
         const payload = buildWebhookPayload(newInternalModels, options.discordRoleId, {
             discordUserId: options.discordUserId,
             includeMentions: true,
             avatarUrl,
             maxModelEmbeds: 10,
         });
-        await sendDiscordWebhookPayload(webhookUrl, payload, {
-            maxAttempts: 3,
-            timeoutMs: 10_000,
-            retryDelayMs: 750,
-            logger: console,
-        });
+
         const nextAnnounced = { ...announcedState.announcedByModelId };
         const markedAt = nowIso();
         for (const model of newInternalModels) {
@@ -844,13 +873,20 @@ async function main(): Promise<void> {
             updatedAt: markedAt,
             announcedByModelId: nextAnnounced,
         } satisfies AnnouncedInternalModelsState);
+
+        await sendDiscordWebhookPayload(internalWebhookUrl, payload, {
+            maxAttempts: 3,
+            timeoutMs: 10_000,
+            retryDelayMs: 750,
+            logger: console,
+        });
         mentionsSent = true;
     }
 
-    if (shouldSendHf) {
+    if (shouldSendHf && hfWebhookUrl) {
         const hfMessage = buildHfDiscordMessage(hfAdditionsByOrg);
         await sendDiscordWebhook(hfMessage, {
-            webhookUrl,
+            webhookUrl: hfWebhookUrl,
             discordUserId: options.discordUserId,
             discordRoleId: options.discordRoleId,
             includeMentions: !mentionsSent,

--- a/scripts/model-discovery/run-internal.ts
+++ b/scripts/model-discovery/run-internal.ts
@@ -1,5 +1,6 @@
 import fs from "node:fs";
 import path from "node:path";
+import { fileURLToPath } from "node:url";
 import {
     buildWebhookPayload,
     filterUnannouncedModels,
@@ -725,8 +726,8 @@ async function sendDiscordWebhook(
     }
 }
 
-async function main(): Promise<void> {
-    const options = parseArgs(process.argv.slice(2));
+export async function runInternalModelDiscovery(argv: string[]): Promise<void> {
+    const options = parseArgs(argv);
     const internalWebhookUrl =
         options.internalWebhookUrl ??
         options.webhookUrl ??
@@ -894,8 +895,16 @@ async function main(): Promise<void> {
     }
 }
 
-main().catch((error) => {
-    const message = error instanceof Error ? error.message : String(error);
-    console.error(`[internal-model-check] Fatal error: ${message}`);
-    process.exitCode = 1;
-});
+function isMainModule(): boolean {
+    const entry = process.argv[1];
+    if (!entry) return false;
+    return path.resolve(entry) === path.resolve(fileURLToPath(import.meta.url));
+}
+
+if (isMainModule()) {
+    runInternalModelDiscovery(process.argv.slice(2)).catch((error) => {
+        const message = error instanceof Error ? error.message : String(error);
+        console.error(`[internal-model-check] Fatal error: ${message}`);
+        process.exitCode = 1;
+    });
+}

--- a/scripts/model-discovery/run-internal.ts
+++ b/scripts/model-discovery/run-internal.ts
@@ -350,6 +350,19 @@ function writeJson(filePath: string, value: unknown): void {
     fs.writeFileSync(filePath, `${JSON.stringify(value, null, 2)}\n`, "utf-8");
 }
 
+function writeDiscoveryState(
+    statePath: string,
+    files: Record<string, ModelFileSnapshot>,
+    hfOrgs: Record<string, HuggingFaceOrgSnapshot>
+): void {
+    writeJson(statePath, {
+        version: 2,
+        generatedAt: nowIso(),
+        files,
+        hfOrgs,
+    } satisfies InternalModelsFileState);
+}
+
 function buildCurrentFileMap(repoRoot: string): Record<string, ModelFileSnapshot> {
     const canonicalModelsRoot = path.join(repoRoot, "packages", "data", "catalog", "src", "data", "models");
     const legacyModelsRoot = path.join(repoRoot, "apps", "web", "src", "data", "models");
@@ -752,14 +765,6 @@ export async function runInternalModelDiscovery(argv: string[]): Promise<void> {
         ? await buildCurrentHfOrgMap(options.hfOrgs, options.hfToken, previousState.hfOrgs)
         : { snapshots: previousState.hfOrgs, fetchedOrgs: new Set<string>() };
 
-    const nextState: InternalModelsFileState = {
-        version: 2,
-        generatedAt: nowIso(),
-        files: currentFiles,
-        hfOrgs: currentHf.snapshots,
-    };
-    writeJson(statePath, nextState);
-
     const diff = diffStates(previousState, currentFiles);
     const announcedState = readAnnouncedState(announcedStatePath);
     const detectedInternalModels = shouldCheckInternal
@@ -818,6 +823,7 @@ export async function runInternalModelDiscovery(argv: string[]): Promise<void> {
     }
 
     if (shouldCheckInternal && diff.previousCount === 0) {
+        writeDiscoveryState(statePath, currentFiles, currentHf.snapshots);
         console.log("[internal-model-check] Baseline initialized. Skipping first-run notifications.");
         return;
     }
@@ -828,6 +834,7 @@ export async function runInternalModelDiscovery(argv: string[]): Promise<void> {
 
     const internalAdditionsCount = shouldCheckInternal ? newInternalModels.length : 0;
     if (internalAdditionsCount === 0 && hfAdditionsTotal === 0) {
+        writeDiscoveryState(statePath, currentFiles, currentHf.snapshots);
         console.log("[internal-model-check] No new internal or HF models detected.");
         return;
     }
@@ -845,7 +852,15 @@ export async function runInternalModelDiscovery(argv: string[]): Promise<void> {
 
     const shouldSendInternal = shouldCheckInternal && internalAdditionsCount > 0 && Boolean(internalWebhookUrl);
     const shouldSendHf = shouldCheckHf && hfAdditionsTotal > 0 && Boolean(hfWebhookUrl);
+    const holdInternalBaseline = shouldCheckInternal && internalAdditionsCount > 0 && !shouldSendInternal;
+    const holdHfBaseline = shouldCheckHf && hfAdditionsTotal > 0 && !shouldSendHf;
+
     if (!shouldSendInternal && !shouldSendHf) {
+        writeDiscoveryState(
+            statePath,
+            holdInternalBaseline ? previousState.files : currentFiles,
+            holdHfBaseline ? previousState.hfOrgs : currentHf.snapshots
+        );
         return;
     }
 
@@ -869,18 +884,25 @@ export async function runInternalModelDiscovery(argv: string[]): Promise<void> {
         for (const model of newInternalModels) {
             nextAnnounced[toAnnouncementKey(model)] = markedAt;
         }
-        writeJson(announcedStatePath, {
+        const nextAnnouncedState: AnnouncedInternalModelsState = {
             version: 1,
             updatedAt: markedAt,
             announcedByModelId: nextAnnounced,
-        } satisfies AnnouncedInternalModelsState);
+        };
+        writeJson(announcedStatePath, nextAnnouncedState);
 
-        await sendDiscordWebhookPayload(internalWebhookUrl, payload, {
-            maxAttempts: 3,
-            timeoutMs: 10_000,
-            retryDelayMs: 750,
-            logger: console,
-        });
+        try {
+            await sendDiscordWebhookPayload(internalWebhookUrl, payload, {
+                maxAttempts: 3,
+                timeoutMs: 10_000,
+                retryDelayMs: 750,
+                logger: console,
+            });
+        } catch (error) {
+            // Roll back pre-send mark so failed sends can be retried cleanly.
+            writeJson(announcedStatePath, announcedState);
+            throw error;
+        }
         mentionsSent = true;
     }
 
@@ -893,6 +915,12 @@ export async function runInternalModelDiscovery(argv: string[]): Promise<void> {
             includeMentions: !mentionsSent,
         });
     }
+
+    writeDiscoveryState(
+        statePath,
+        holdInternalBaseline ? previousState.files : currentFiles,
+        holdHfBaseline ? previousState.hfOrgs : currentHf.snapshots
+    );
 }
 
 function isMainModule(): boolean {

--- a/scripts/model-discovery/run.ts
+++ b/scripts/model-discovery/run.ts
@@ -707,14 +707,14 @@ function buildDiscordMessage(changes: ProviderChangeSet[], entries: ProviderChan
 }
 
 async function sendDiscordWebhook(message: string): Promise<void> {
-    const webhookUrl = process.env.DISCORD_WEBHOOK_NEW_MODELS_PUBLIC?.trim() || "";
+    const webhookUrl = process.env.DISCORD_WEBHOOK_URL?.trim() || "";
     if (!webhookUrl) return;
 
     try {
         new URL(webhookUrl);
     } catch {
         console.warn(
-            "[model-discovery] Skipping Discord webhook: DISCORD_WEBHOOK_NEW_MODELS_PUBLIC is not a valid URL."
+            "[model-discovery] Skipping Discord webhook: DISCORD_WEBHOOK_URL is not a valid URL."
         );
         return;
     }


### PR DESCRIPTION
## Summary
- split Discord routing so public model-release notifications stay on `DISCORD_WEBHOOK_NEW_MODELS_PUBLIC`
- route provider-change and Hugging Face tracking notifications to the private/default `DISCORD_WEBHOOK_URL`
- force light-logo avatar for internal release notifications in workflow/tester and harden internal announcement idempotency

## What Changed
- `.github/workflows/check-new-models.yml`
  - added `DISCORD_WEBHOOK_URL` env
  - internal run now passes `--discord-avatar-url "https://ai-stats.phaseo.app/png_logo_light.png"`
  - external provider + HF steps now use `DISCORD_WEBHOOK_URL`
- `scripts/model-discovery/run.ts`
  - switched provider tracking webhook env from `DISCORD_WEBHOOK_NEW_MODELS_PUBLIC` to `DISCORD_WEBHOOK_URL`
- `scripts/model-discovery/check-new-models.py`
  - switched webhook env to `DISCORD_WEBHOOK_URL`
- `scripts/model-discovery/run-internal.ts`
  - added split webhook handling (`internal` vs `hf` targets)
  - default routing: internal -> `DISCORD_WEBHOOK_NEW_MODELS_PUBLIC`, HF -> `DISCORD_WEBHOOK_URL`
  - marks internal model IDs as announced before send to prevent duplicate reposts on retries/reruns
  - removed implicit env-based avatar override in this flow; relies on explicit CLI override or notifier defaults
- `apps/web/src/app/(dashboard)/internal/model-discovery-notifier/actions.ts`
  - internal notifier test action now uses the notifier�s default avatar resolution (light PNG default)
- `scripts/model-discovery/README.md`
  - documented public/private webhook split and stronger duplicate-prevention behavior

## Validation
- `pnpm --filter @ai-stats/web test -- internalModelDiscordNotifier.test.ts`
- `pnpm --filter @ai-stats/web typecheck`
- `pnpm exec tsx scripts/model-discovery/run-internal.ts --skip-internal --skip-hf`
