### PR TITLE
fix(web): restore mobile padding on support contact page

### DIFF
--- a/apps/web/src/components/contact/ContactClient.tsx
+++ b/apps/web/src/components/contact/ContactClient.tsx
@@ -277,7 +277,7 @@ export function ContactClient({
 	};
 
 	return (
-		<div className="container mx-auto py-10 space-y-8">
+		<div className="container mx-auto space-y-8 px-4 py-10 sm:px-6 lg:px-8">
 			<div className="flex flex-wrap items-start justify-between gap-4">
 				<div className="space-y-2">
 					<Badge variant="secondary" className="w-fit">


### PR DESCRIPTION
### Motivation
- Fix the support/contact page layout on small viewports so content is not edge-to-edge by adding responsive horizontal padding to the page wrapper.

### Description
- Updated the top-level container in `apps/web/src/components/contact/ContactClient.tsx` to include responsive padding classes (`px-4 sm:px-6 lg:px-8`) so mobile viewports receive horizontal padding while desktop spacing remains unchanged.

### Testing
- Ran `pnpm --filter @ai-stats/web lint`, `pnpm --filter @ai-stats/web test`, and `pnpm --filter @ai-stats/web build`; lint failed due to an existing ESLint/react plugin runtime error, tests failed because a Playwright spec is being picked up by Jest, and the build failed in this environment because Next.js could not fetch the Google Font `Montserrat` from `fonts.googleapis.com`.

------
Fixes #265

[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc1e20c26083339e87393c64cf576a)