### PR TITLE
Fix models page skeleton card count

### DIFF
--- a/apps/web/src/components/(data)/models/Models/ModelsPageSkeleton.tsx
+++ b/apps/web/src/components/(data)/models/Models/ModelsPageSkeleton.tsx
@@ -56,7 +56,7 @@ function ModelCardsSkeletonGrid() {
 	return (
 		<div className="bg-border/70">
 			<div className="grid grid-cols-1 gap-px md:grid-cols-2 2xl:grid-cols-3">
-				{Array.from({ length: 8 }).map((_, index) => (
+				{Array.from({ length: 9 }).map((_, index) => (
 					<div key={index} className={getSkeletonCellClass(index)}>
 						<ModelCardSkeleton />
 					</div>


### PR DESCRIPTION
﻿## Summary
- update models page loading skeleton to render 9 placeholder cards instead of 8
- keeps the skeleton visually balanced on the 3-column layout

## Validation
- `pnpm --filter @ai-stats/web typecheck`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Updates**
  * Adjusted the Models page loading skeleton grid to display an additional placeholder card while the page loads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->