### PR TITLE
CI: disable setup-node pnpm cache in workflows

### DIFF
--- a/.github/workflows/check-new-models.yml
+++ b/.github/workflows/check-new-models.yml
@@ -37,7 +37,6 @@ jobs:
               uses: actions/setup-node@v6
               with:
                   node-version: ${{ env.NODE_VERSION }}
-                  cache: pnpm
 
             - name: Restore lockfile (guard setup-node cache mutation)
               run: git checkout -- pnpm-lock.yaml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,8 +30,6 @@ jobs:
               with:
                   node-version: ${{ env.NODE_VERSION }}
                   registry-url: https://registry.npmjs.org
-                  cache: pnpm
-                  cache-dependency-path: pnpm-lock.yaml
 
             - name: Restore lockfile (guard setup-node cache mutation)
               run: git checkout -- pnpm-lock.yaml
@@ -76,8 +74,6 @@ jobs:
               with:
                   node-version: ${{ env.NODE_VERSION }}
                   registry-url: https://registry.npmjs.org
-                  cache: pnpm
-                  cache-dependency-path: pnpm-lock.yaml
 
             - name: Restore lockfile (guard setup-node cache mutation)
               run: git checkout -- pnpm-lock.yaml
@@ -124,8 +120,6 @@ jobs:
               uses: actions/setup-node@v6
               with:
                   node-version: ${{ env.NODE_VERSION }}
-                  cache: pnpm
-                  cache-dependency-path: pnpm-lock.yaml
 
             - name: Restore lockfile (guard setup-node cache mutation)
               run: git checkout -- pnpm-lock.yaml
@@ -170,8 +164,6 @@ jobs:
               uses: actions/setup-node@v6
               with:
                   node-version: ${{ env.NODE_VERSION }}
-                  cache: pnpm
-                  cache-dependency-path: pnpm-lock.yaml
 
             - name: Restore lockfile (guard setup-node cache mutation)
               run: git checkout -- pnpm-lock.yaml
@@ -207,8 +199,6 @@ jobs:
               uses: actions/setup-node@v6
               with:
                   node-version: ${{ env.NODE_VERSION }}
-                  cache: pnpm
-                  cache-dependency-path: pnpm-lock.yaml
 
             - name: Restore lockfile (guard setup-node cache mutation)
               run: git checkout -- pnpm-lock.yaml
@@ -275,8 +265,6 @@ jobs:
               uses: actions/setup-node@v6
               with:
                   node-version: ${{ env.NODE_VERSION }}
-                  cache: pnpm
-                  cache-dependency-path: pnpm-lock.yaml
 
             - name: Restore lockfile (guard setup-node cache mutation)
               run: git checkout -- pnpm-lock.yaml
@@ -347,8 +335,6 @@ jobs:
               uses: actions/setup-node@v6
               with:
                   node-version: ${{ env.NODE_VERSION }}
-                  cache: pnpm
-                  cache-dependency-path: pnpm-lock.yaml
 
             - name: Restore lockfile (guard setup-node cache mutation)
               run: git checkout -- pnpm-lock.yaml
@@ -382,8 +368,6 @@ jobs:
               uses: actions/setup-node@v6
               with:
                   node-version: ${{ env.NODE_VERSION }}
-                  cache: pnpm
-                  cache-dependency-path: pnpm-lock.yaml
 
             - name: Restore lockfile (guard setup-node cache mutation)
               run: git checkout -- pnpm-lock.yaml
@@ -447,8 +431,6 @@ jobs:
               uses: actions/setup-node@v6
               with:
                   node-version: ${{ env.NODE_VERSION }}
-                  cache: pnpm
-                  cache-dependency-path: pnpm-lock.yaml
 
             - name: Restore lockfile (guard setup-node cache mutation)
               run: git checkout -- pnpm-lock.yaml
@@ -500,8 +482,6 @@ jobs:
               uses: actions/setup-node@v6
               with:
                   node-version: ${{ env.NODE_VERSION }}
-                  cache: pnpm
-                  cache-dependency-path: pnpm-lock.yaml
 
             # ---------- WEB (Vercel) ----------
 
@@ -616,8 +596,6 @@ jobs:
               with:
                   node-version: ${{ env.NODE_VERSION }}
                   registry-url: https://registry.npmjs.org
-                  cache: pnpm
-                  cache-dependency-path: pnpm-lock.yaml
 
             - name: Check runtime versions (trusted publishing)
               run: |

--- a/.github/workflows/monitor-history.yml
+++ b/.github/workflows/monitor-history.yml
@@ -51,8 +51,6 @@ jobs:
               uses: actions/setup-node@v6
               with:
                   node-version: "22"
-                  cache: pnpm
-                  cache-dependency-path: pnpm-lock.yaml
 
             - name: Restore lockfile (guard setup-node cache mutation)
               run: git checkout -- pnpm-lock.yaml

--- a/.github/workflows/nightly-model-statuses.yml
+++ b/.github/workflows/nightly-model-statuses.yml
@@ -49,7 +49,6 @@ jobs:
               uses: actions/setup-node@v6
               with:
                   node-version: ${{ env.NODE_VERSION }}
-                  cache: pnpm
 
             - name: Restore lockfile (guard setup-node cache mutation)
               run: git checkout -- pnpm-lock.yaml

--- a/.github/workflows/npm-bootstrap-publish.yml
+++ b/.github/workflows/npm-bootstrap-publish.yml
@@ -40,8 +40,6 @@ jobs:
         with:
           node-version: ${{ env.NODE_VERSION }}
           registry-url: https://registry.npmjs.org
-          cache: pnpm
-          cache-dependency-path: pnpm-lock.yaml
 
       - name: Restore lockfile (guard setup-node cache mutation)
         run: git checkout -- pnpm-lock.yaml

--- a/.github/workflows/watchers.yml
+++ b/.github/workflows/watchers.yml
@@ -38,8 +38,6 @@ jobs:
               uses: actions/setup-node@v6
               with:
                   node-version: "20"
-                  cache: "pnpm"
-                  cache-dependency-path: pnpm-lock.yaml
 
             - name: Restore lockfile (guard setup-node cache mutation)
               run: git checkout -- pnpm-lock.yaml


### PR DESCRIPTION
## Summary
- remove `cache: pnpm` from all `actions/setup-node@v6` workflow steps
- remove paired `cache-dependency-path: pnpm-lock.yaml` entries where present
- keep existing lockfile restore guard (`git checkout -- pnpm-lock.yaml`) and install steps unchanged

## Why
Scheduled and CI jobs are intermittently failing at install with:
- `ERR_PNPM_BROKEN_LOCKFILE`
- `expected a single document in the stream, but found more`

This change disables setup-node pnpm caching in workflows to avoid lockfile mutation during CI setup.

## Validation
- workflow YAML changes only
- no runtime/app code changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Streamlined CI/CD workflow configurations by removing redundant caching directives across multiple build pipelines, ensuring consistent dependency management practices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ai-stats/ai-stats/pull/280" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
