### PR TITLE
CI: switch workflow pnpm setup to corepack

### DIFF
--- a/.github/workflows/check-new-models.yml
+++ b/.github/workflows/check-new-models.yml
@@ -33,13 +33,70 @@ jobs:
               with:
                   version: 10.18.3
                   run_install: false
+
+            - name: Inspect lockfile (post-checkout, pre-setup-node)
+              run: |
+                  python - <<'PY'
+                  from pathlib import Path
+                  import hashlib
+
+                  p = Path("pnpm-lock.yaml")
+                  b = p.read_bytes()
+                  t = b.decode("utf-8", errors="replace")
+                  sep = sum(1 for line in t.splitlines() if line.strip() == "---")
+                  end = sum(1 for line in t.splitlines() if line.strip() == "...")
+                  lock = sum(1 for line in t.splitlines() if line.startswith("lockfileVersion:"))
+                  print(f"bytes={len(b)} lockfileVersion_lines={lock} doc_start_lines={sep} doc_end_lines={end}")
+                  print(f"sha256={hashlib.sha256(b).hexdigest()}")
+                  print(f"head_hex={b[:48].hex()}")
+                  PY
             - name: Setup Node.js
               uses: actions/setup-node@v6
               with:
                   node-version: ${{ env.NODE_VERSION }}
 
+            - name: Inspect lockfile (post-setup-node)
+              run: |
+                  python - <<'PY'
+                  from pathlib import Path
+                  import hashlib
+
+                  p = Path("pnpm-lock.yaml")
+                  b = p.read_bytes()
+                  t = b.decode("utf-8", errors="replace")
+                  sep = sum(1 for line in t.splitlines() if line.strip() == "---")
+                  end = sum(1 for line in t.splitlines() if line.strip() == "...")
+                  lock = sum(1 for line in t.splitlines() if line.startswith("lockfileVersion:"))
+                  print(f"bytes={len(b)} lockfileVersion_lines={lock} doc_start_lines={sep} doc_end_lines={end}")
+                  print(f"sha256={hashlib.sha256(b).hexdigest()}")
+                  print(f"head_hex={b[:48].hex()}")
+                  PY
+
             - name: Restore lockfile (guard setup-node cache mutation)
               run: git checkout -- pnpm-lock.yaml
+
+            - name: Rehydrate lockfile directly from HEAD blob
+              run: git show HEAD:pnpm-lock.yaml > pnpm-lock.yaml
+
+            - name: Inspect lockfile (pre-install)
+              run: |
+                  python - <<'PY'
+                  from pathlib import Path
+                  import hashlib
+                  import subprocess
+
+                  p = Path("pnpm-lock.yaml")
+                  b = p.read_bytes()
+                  t = b.decode("utf-8", errors="replace")
+                  sep = sum(1 for line in t.splitlines() if line.strip() == "---")
+                  end = sum(1 for line in t.splitlines() if line.strip() == "...")
+                  lock = sum(1 for line in t.splitlines() if line.startswith("lockfileVersion:"))
+                  blob = subprocess.check_output(["git", "show", "HEAD:pnpm-lock.yaml"])
+                  print(f"bytes={len(b)} lockfileVersion_lines={lock} doc_start_lines={sep} doc_end_lines={end}")
+                  print(f"sha256={hashlib.sha256(b).hexdigest()}")
+                  print(f"matches_head_blob={b == blob}")
+                  print(f"head_hex={b[:48].hex()}")
+                  PY
 
             - name: Install dependencies
               run: pnpm install --frozen-lockfile

--- a/.github/workflows/check-new-models.yml
+++ b/.github/workflows/check-new-models.yml
@@ -34,69 +34,13 @@ jobs:
                   corepack prepare pnpm@10.18.3 --activate
                   pnpm --version
 
-            - name: Inspect lockfile (post-checkout, pre-setup-node)
-              run: |
-                  python - <<'PY'
-                  from pathlib import Path
-                  import hashlib
-
-                  p = Path("pnpm-lock.yaml")
-                  b = p.read_bytes()
-                  t = b.decode("utf-8", errors="replace")
-                  sep = sum(1 for line in t.splitlines() if line.strip() == "---")
-                  end = sum(1 for line in t.splitlines() if line.strip() == "...")
-                  lock = sum(1 for line in t.splitlines() if line.startswith("lockfileVersion:"))
-                  print(f"bytes={len(b)} lockfileVersion_lines={lock} doc_start_lines={sep} doc_end_lines={end}")
-                  print(f"sha256={hashlib.sha256(b).hexdigest()}")
-                  print(f"head_hex={b[:48].hex()}")
-                  PY
             - name: Setup Node.js
               uses: actions/setup-node@v6
               with:
                   node-version: ${{ env.NODE_VERSION }}
 
-            - name: Inspect lockfile (post-setup-node)
-              run: |
-                  python - <<'PY'
-                  from pathlib import Path
-                  import hashlib
-
-                  p = Path("pnpm-lock.yaml")
-                  b = p.read_bytes()
-                  t = b.decode("utf-8", errors="replace")
-                  sep = sum(1 for line in t.splitlines() if line.strip() == "---")
-                  end = sum(1 for line in t.splitlines() if line.strip() == "...")
-                  lock = sum(1 for line in t.splitlines() if line.startswith("lockfileVersion:"))
-                  print(f"bytes={len(b)} lockfileVersion_lines={lock} doc_start_lines={sep} doc_end_lines={end}")
-                  print(f"sha256={hashlib.sha256(b).hexdigest()}")
-                  print(f"head_hex={b[:48].hex()}")
-                  PY
-
             - name: Restore lockfile (guard setup-node cache mutation)
               run: git checkout -- pnpm-lock.yaml
-
-            - name: Rehydrate lockfile directly from HEAD blob
-              run: git show HEAD:pnpm-lock.yaml > pnpm-lock.yaml
-
-            - name: Inspect lockfile (pre-install)
-              run: |
-                  python - <<'PY'
-                  from pathlib import Path
-                  import hashlib
-                  import subprocess
-
-                  p = Path("pnpm-lock.yaml")
-                  b = p.read_bytes()
-                  t = b.decode("utf-8", errors="replace")
-                  sep = sum(1 for line in t.splitlines() if line.strip() == "---")
-                  end = sum(1 for line in t.splitlines() if line.strip() == "...")
-                  lock = sum(1 for line in t.splitlines() if line.startswith("lockfileVersion:"))
-                  blob = subprocess.check_output(["git", "show", "HEAD:pnpm-lock.yaml"])
-                  print(f"bytes={len(b)} lockfileVersion_lines={lock} doc_start_lines={sep} doc_end_lines={end}")
-                  print(f"sha256={hashlib.sha256(b).hexdigest()}")
-                  print(f"matches_head_blob={b == blob}")
-                  print(f"head_hex={b[:48].hex()}")
-                  PY
 
             - name: Install dependencies
               run: pnpm install --frozen-lockfile

--- a/.github/workflows/check-new-models.yml
+++ b/.github/workflows/check-new-models.yml
@@ -28,11 +28,11 @@ jobs:
                   fetch-depth: 0
                   persist-credentials: false
 
-            - name: Setup pnpm
-              uses: pnpm/action-setup@v6
-              with:
-                  version: 10.18.3
-                  run_install: false
+            - name: Setup pnpm (corepack)
+              run: |
+                  corepack enable
+                  corepack prepare pnpm@10.18.3 --activate
+                  pnpm --version
 
             - name: Inspect lockfile (post-checkout, pre-setup-node)
               run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,12 +19,11 @@ jobs:
         steps:
             - uses: actions/checkout@v6
 
-            - name: Setup pnpm
-              uses: pnpm/action-setup@v6
-              with:
-                  version: 10.18.3
-                  run_install: false
-                  standalone: true
+            - name: Setup pnpm (corepack)
+              run: |
+                  corepack enable
+                  corepack prepare pnpm@10.18.3 --activate
+                  pnpm --version
             - name: Setup Node.js
               uses: actions/setup-node@v6
               with:
@@ -63,12 +62,11 @@ jobs:
         steps:
             - uses: actions/checkout@v6
 
-            - name: Setup pnpm
-              uses: pnpm/action-setup@v6
-              with:
-                  version: 10.18.3
-                  run_install: false
-                  standalone: true
+            - name: Setup pnpm (corepack)
+              run: |
+                  corepack enable
+                  corepack prepare pnpm@10.18.3 --activate
+                  pnpm --version
             - name: Setup Node.js
               uses: actions/setup-node@v6
               with:
@@ -110,12 +108,11 @@ jobs:
         steps:
             - uses: actions/checkout@v6
 
-            - name: Setup pnpm
-              uses: pnpm/action-setup@v6
-              with:
-                  version: 10.18.3
-                  run_install: false
-                  standalone: true
+            - name: Setup pnpm (corepack)
+              run: |
+                  corepack enable
+                  corepack prepare pnpm@10.18.3 --activate
+                  pnpm --version
             - name: Setup Node.js
               uses: actions/setup-node@v6
               with:
@@ -154,12 +151,11 @@ jobs:
         steps:
             - uses: actions/checkout@v6
 
-            - name: Setup pnpm
-              uses: pnpm/action-setup@v6
-              with:
-                  version: 10.18.3
-                  run_install: false
-                  standalone: true
+            - name: Setup pnpm (corepack)
+              run: |
+                  corepack enable
+                  corepack prepare pnpm@10.18.3 --activate
+                  pnpm --version
             - name: Setup Node.js
               uses: actions/setup-node@v6
               with:
@@ -189,12 +185,11 @@ jobs:
         steps:
             - uses: actions/checkout@v6
 
-            - name: Setup pnpm
-              uses: pnpm/action-setup@v6
-              with:
-                  version: 10.18.3
-                  run_install: false
-                  standalone: true
+            - name: Setup pnpm (corepack)
+              run: |
+                  corepack enable
+                  corepack prepare pnpm@10.18.3 --activate
+                  pnpm --version
             - name: Setup Node.js
               uses: actions/setup-node@v6
               with:
@@ -255,12 +250,11 @@ jobs:
               with:
                   fetch-depth: 0
 
-            - name: Setup pnpm
-              uses: pnpm/action-setup@v6
-              with:
-                  version: 10.18.3
-                  run_install: false
-                  standalone: true
+            - name: Setup pnpm (corepack)
+              run: |
+                  corepack enable
+                  corepack prepare pnpm@10.18.3 --activate
+                  pnpm --version
             - name: Setup Node.js
               uses: actions/setup-node@v6
               with:
@@ -325,12 +319,11 @@ jobs:
                   python -m pip install build pytest
                   python -m pip install -e packages/sdk/sdk-py
 
-            - name: Setup pnpm
-              uses: pnpm/action-setup@v6
-              with:
-                  version: 10.18.3
-                  run_install: false
-                  standalone: true
+            - name: Setup pnpm (corepack)
+              run: |
+                  corepack enable
+                  corepack prepare pnpm@10.18.3 --activate
+                  pnpm --version
             - name: Setup Node.js
               uses: actions/setup-node@v6
               with:
@@ -357,12 +350,11 @@ jobs:
         steps:
             - uses: actions/checkout@v6
 
-            - name: Setup pnpm
-              uses: pnpm/action-setup@v6
-              with:
-                  version: 10.18.3
-                  run_install: false
-                  standalone: true
+            - name: Setup pnpm (corepack)
+              run: |
+                  corepack enable
+                  corepack prepare pnpm@10.18.3 --activate
+                  pnpm --version
 
             - name: Setup Node.js
               uses: actions/setup-node@v6
@@ -421,12 +413,11 @@ jobs:
         steps:
             - uses: actions/checkout@v6
 
-            - name: Setup pnpm
-              uses: pnpm/action-setup@v6
-              with:
-                  version: 10.18.3
-                  run_install: false
-                  standalone: true
+            - name: Setup pnpm (corepack)
+              run: |
+                  corepack enable
+                  corepack prepare pnpm@10.18.3 --activate
+                  pnpm --version
             - name: Setup Node.js
               uses: actions/setup-node@v6
               with:
@@ -472,12 +463,11 @@ jobs:
         steps:
             - uses: actions/checkout@v6
 
-            - name: Setup pnpm
-              uses: pnpm/action-setup@v6
-              with:
-                  version: 10.18.3
-                  run_install: false
-                  standalone: true
+            - name: Setup pnpm (corepack)
+              run: |
+                  corepack enable
+                  corepack prepare pnpm@10.18.3 --activate
+                  pnpm --version
             - name: Setup Node.js
               uses: actions/setup-node@v6
               with:
@@ -585,12 +575,11 @@ jobs:
                   app-id: ${{ secrets.AI_STATS_APP_ID }}
                   private-key: ${{ secrets.AI_STATS_APP_PRIVATE_KEY }}
 
-            - name: Setup pnpm
-              uses: pnpm/action-setup@v6
-              with:
-                  version: 10.18.3
-                  run_install: false
-                  standalone: true
+            - name: Setup pnpm (corepack)
+              run: |
+                  corepack enable
+                  corepack prepare pnpm@10.18.3 --activate
+                  pnpm --version
             - name: Setup Node.js
               uses: actions/setup-node@v6
               with:

--- a/.github/workflows/monitor-history.yml
+++ b/.github/workflows/monitor-history.yml
@@ -42,11 +42,11 @@ jobs:
                   echo "name=${bot}" >> "$GITHUB_OUTPUT"
                   echo "email=${email}" >> "$GITHUB_OUTPUT"
 
-            - name: Setup pnpm
-              uses: pnpm/action-setup@v6
-              with:
-                  version: 10.18.3
-                  run_install: false
+            - name: Setup pnpm (corepack)
+              run: |
+                  corepack enable
+                  corepack prepare pnpm@10.18.3 --activate
+                  pnpm --version
             - name: Setup Node.js
               uses: actions/setup-node@v6
               with:

--- a/.github/workflows/nightly-model-statuses.yml
+++ b/.github/workflows/nightly-model-statuses.yml
@@ -40,11 +40,11 @@ jobs:
                   email="${id}+${bot}@users.noreply.github.com"
                   echo "committer=${bot} <${email}>" >> "$GITHUB_OUTPUT"
 
-            - name: Setup pnpm
-              uses: pnpm/action-setup@v6
-              with:
-                  version: 10.18.3
-                  run_install: false
+            - name: Setup pnpm (corepack)
+              run: |
+                  corepack enable
+                  corepack prepare pnpm@10.18.3 --activate
+                  pnpm --version
             - name: Setup Node.js
               uses: actions/setup-node@v6
               with:

--- a/.github/workflows/npm-bootstrap-publish.yml
+++ b/.github/workflows/npm-bootstrap-publish.yml
@@ -29,11 +29,11 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v6
-        with:
-          version: 10.18.3
-          run_install: false
+      - name: Setup pnpm (corepack)
+        run: |
+          corepack enable
+          corepack prepare pnpm@10.18.3 --activate
+          pnpm --version
 
       - name: Setup Node.js
         uses: actions/setup-node@v6

--- a/.github/workflows/watchers.yml
+++ b/.github/workflows/watchers.yml
@@ -29,11 +29,11 @@ jobs:
         steps:
             - uses: actions/checkout@v6
 
-            - name: Setup pnpm
-              uses: pnpm/action-setup@v6
-              with:
-                  version: 10.18.3
-                  run_install: false
+            - name: Setup pnpm (corepack)
+              run: |
+                  corepack enable
+                  corepack prepare pnpm@10.18.3 --activate
+                  pnpm --version
             - name: Setup Node 20
               uses: actions/setup-node@v6
               with:


### PR DESCRIPTION
## Summary
- replace `pnpm/action-setup@v6` with `corepack`-managed pnpm setup in CI workflows
- keep `pnpm` version pinned to `10.18.3`
- keep existing install + lockfile-restore steps unchanged

## Files
- `.github/workflows/check-new-models.yml`
- `.github/workflows/ci.yml`
- `.github/workflows/monitor-history.yml`
- `.github/workflows/nightly-model-statuses.yml`
- `.github/workflows/npm-bootstrap-publish.yml`
- `.github/workflows/watchers.yml`

## Validation
- `Check New Models` workflow_dispatch passed on this branch:
  - https://github.com/AI-Stats/AI-Stats/actions/runs/24386780957


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Modernized package manager provisioning in CI/CD workflows across development, testing, validation, and deployment stages to improve consistency and reliability of the build infrastructure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->