### PR TITLE
Add Gemini Robotics ER 1.6 and rumoured Claude Opus 4.7

### DIFF
--- a/packages/data/catalog/src/data/models/anthropic/claude-opus-4.7/model.json
+++ b/packages/data/catalog/src/data/models/anthropic/claude-opus-4.7/model.json
@@ -1,0 +1,18 @@
+{
+  "model_id": "anthropic/claude-opus-4.7",
+  "organisation_id": "anthropic",
+  "name": "Claude Opus 4.7",
+  "status": "Rumoured",
+  "previous_model_id": "anthropic/claude-opus-4.6",
+  "announced_date": null,
+  "release_date": null,
+  "deprecation_date": null,
+  "retirement_date": null,
+  "license": null,
+  "input_types": null,
+  "output_types": null,
+  "api_model_id": "anthropic/claude-opus-4.7",
+  "links": [],
+  "details": [],
+  "benchmarks": []
+}

--- a/packages/data/catalog/src/data/models/google/gemini-robotics-er-1.6-preview/model.json
+++ b/packages/data/catalog/src/data/models/google/gemini-robotics-er-1.6-preview/model.json
@@ -18,7 +18,7 @@
       "url": "https://deepmind.google/blog/gemini-robotics-er-1-6/"
     },
     {
-      "platform": "docs",
+      "platform": "api_reference",
       "url": "https://ai.google.dev/gemini-api/docs/robotics-overview"
     }
   ],

--- a/packages/data/catalog/src/data/models/google/gemini-robotics-er-1.6-preview/model.json
+++ b/packages/data/catalog/src/data/models/google/gemini-robotics-er-1.6-preview/model.json
@@ -1,0 +1,27 @@
+{
+  "model_id": "google/gemini-robotics-er-1.6-preview",
+  "organisation_id": "google",
+  "name": "Gemini Robotics ER 1.6 Preview",
+  "status": "Available",
+  "previous_model_id": "google/gemini-robotics-er-1.5-preview",
+  "announced_date": "2026-04-14T00:00:00",
+  "release_date": "2026-04-14T00:00:00",
+  "deprecation_date": null,
+  "retirement_date": null,
+  "license": "Proprietary",
+  "input_types": "text,image,video,audio",
+  "output_types": "text",
+  "api_model_id": "google/gemini-robotics-er-1.6-preview",
+  "links": [
+    {
+      "platform": "announcement",
+      "url": "https://deepmind.google/blog/gemini-robotics-er-1-6/"
+    },
+    {
+      "platform": "docs",
+      "url": "https://ai.google.dev/gemini-api/docs/robotics-overview"
+    }
+  ],
+  "details": [],
+  "benchmarks": []
+}


### PR DESCRIPTION
﻿## Summary
- add `google/gemini-robotics-er-1.6-preview` to the model catalog
- set announced/release date to `2026-04-14` (today)
- add rumoured `anthropic/claude-opus-4.7` model entry with `status: "Rumoured"`

## Source (Gemini 1.6)
- https://deepmind.google/blog/gemini-robotics-er-1-6/
- https://ai.google.dev/gemini-api/docs/robotics-overview

## Validation
- `pnpm validate:data`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Google Gemini Robotics ER 1.6 Preview to the catalog with multi-modal input support (text, image, video, audio), marked Available and announced/released 2026-04-14.
  * Added Anthropic Claude Opus 4.7 to the catalog as Rumoured, linked to the prior Opus 4.6 entry.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->