### PR TITLE
Fix main release publish fallback for npm auth

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -636,6 +636,9 @@ jobs:
                   commitMode: github-api
               env:
                   GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+                  # Fallback to npm token auth when trusted publishing is not configured for a package.
+                  NPM_TOKEN: ${{ secrets.NPM_AUTOMATION_TOKEN || secrets.NPM_TOKEN }}
+                  NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTOMATION_TOKEN || secrets.NPM_TOKEN }}
 
             - name: Set up Python (for PyPI publish)
               if: github.ref == 'refs/heads/main' && steps.changesets.outputs.published == 'true'


### PR DESCRIPTION
## Summary
- investigate main CI failure from merge commit `b49dd24f` (`Version Packages #253`)
- root cause: `Handle Versions` failed at `Create release PR / publish` when publishing `@ai-stats/sdk@1.1.2` via OIDC-only npm auth (`E404` from npm)
- restore npm token fallback for changesets publish (`NPM_AUTOMATION_TOKEN`/`NPM_TOKEN`) while keeping trusted publishing as default

## Why this fixes it
- when trusted publishing is not configured/authorized for a specific package, changesets can now use configured npm token auth instead of failing release CI on main

## Validation
- workflow-only change (no local runtime test)
- verified failing run/job and exact error in logs:
  - run: `24425873615`
  - job: `71360105717`
  - error: `E404 Not Found - PUT https://registry.npmjs.org/@ai-stats%2fsdk`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated publishing workflow configuration to enhance npm authentication credential handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->