### PR TITLE
ci: fix trusted npm publishing runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
         branches: [main]
     pull_request:
         branches: [main]
+    workflow_dispatch:
 
 permissions:
     contents: read
@@ -566,7 +567,7 @@ jobs:
             - packages
             - sdk-lifecycle-tests
             - apps
-        if: github.ref == 'refs/heads/main'
+        if: github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch'
         env:
             NPM_CONFIG_PROVENANCE: true
         permissions:
@@ -636,9 +637,6 @@ jobs:
                   commitMode: github-api
               env:
                   GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
-                  # Fallback to npm token auth when trusted publishing is not configured for a package.
-                  NPM_TOKEN: ${{ secrets.NPM_AUTOMATION_TOKEN || secrets.NPM_TOKEN }}
-                  NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTOMATION_TOKEN || secrets.NPM_TOKEN }}
 
             - name: Set up Python (for PyPI publish)
               if: github.ref == 'refs/heads/main' && steps.changesets.outputs.published == 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -627,6 +627,14 @@ jobs:
                   GITHUB_SHA: ${{ github.sha }}
               run: pnpm run changeset:validate-sdk-semver
 
+            - name: Force pure OIDC npm auth context
+              run: |
+                  echo "NODE_AUTH_TOKEN=" >> "$GITHUB_ENV"
+                  echo "NPM_TOKEN=" >> "$GITHUB_ENV"
+                  oidc_npmrc="$RUNNER_TEMP/oidc-only.npmrc"
+                  printf "registry=https://registry.npmjs.org\nalways-auth=false\n" > "$oidc_npmrc"
+                  echo "NPM_CONFIG_USERCONFIG=$oidc_npmrc" >> "$GITHUB_ENV"
+
             - name: Create release PR / publish
               id: changesets
               uses: changesets/action@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -595,11 +595,8 @@ jobs:
             - name: Setup Node.js
               uses: actions/setup-node@v6
               with:
-                  node-version: ${{ env.NODE_VERSION }}
+                  node-version: 24
                   registry-url: https://registry.npmjs.org
-
-            - name: Upgrade npm for trusted publishing
-              run: npm install -g npm@11
 
             - name: Check runtime versions (trusted publishing)
               run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -598,6 +598,9 @@ jobs:
                   node-version: ${{ env.NODE_VERSION }}
                   registry-url: https://registry.npmjs.org
 
+            - name: Upgrade npm for trusted publishing
+              run: npm install -g npm@11
+
             - name: Check runtime versions (trusted publishing)
               run: |
                   node -v


### PR DESCRIPTION
## Summary
- run publish job on Node 24 (npm 11.x) to satisfy npm trusted publishing requirements
- keep publish path on OIDC-only auth context (no token fallback in changesets step)
- allow workflow dispatch for CI so publish path can be validated safely

## Validation
- CI workflow_dispatch run succeeded: https://github.com/AI-Stats/AI-Stats/actions/runs/24446473894
- Handle Versions used OIDC trusted publishing and published @ai-stats/sdk@1.1.2


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added manual trigger capability to the publish workflow, allowing on-demand deployments.
  * Updated Node.js version to 24 for CI/CD pipeline.
  * Improved authentication security by implementing OIDC-based npm authentication, removing legacy token fallback mechanisms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->