### PR TITLE
fix: preserve withheld statuses in refresh script

### DIFF
--- a/packages/data/catalog/src/data/models/anthropic/claude-mythos-preview/model.json
+++ b/packages/data/catalog/src/data/models/anthropic/claude-mythos-preview/model.json
@@ -2,7 +2,7 @@
   "model_id": "anthropic/claude-mythos-preview",
   "organisation_id": "anthropic",
   "name": "Claude Mythos Preview",
-  "status": "Announced",
+  "status": "Withheld",
   "previous_model_id": null,
   "announced_date": "2026-04-07T00:00:00",
   "release_date": null,

--- a/packages/data/catalog/src/data/models/openai/o3-preview/model.json
+++ b/packages/data/catalog/src/data/models/openai/o3-preview/model.json
@@ -2,7 +2,7 @@
   "model_id": "openai/o3-preview",
   "organisation_id": "openai",
   "name": "o3 Preview",
-  "status": "Announced",
+  "status": "Withheld",
   "previous_model_id": "openai/o1-preview-2024-09-12",
   "announced_date": "2024-12-20T00:00:00",
   "release_date": null,

--- a/scripts/update-model-statuses.ts
+++ b/scripts/update-model-statuses.ts
@@ -2,7 +2,7 @@ import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
-type ModelStatus = "Rumoured" | "Announced" | "Available" | "Deprecated" | "Retired" | null;
+type ModelStatus = "Rumoured" | "Announced" | "Withheld" | "Available" | "Deprecated" | "Retired" | null;
 
 type ModelDates = {
     announced_date?: unknown;
@@ -19,6 +19,7 @@ type DerivedStatus = {
 const STATUS_ORDER: Record<Exclude<ModelStatus, null>, number> = {
     Rumoured: 0,
     Announced: 1,
+    Withheld: 1.5,
     Available: 2,
     Deprecated: 3,
     Retired: 4,
@@ -50,6 +51,7 @@ function normalizeStatus(value: unknown): ModelStatus {
     const trimmed = value.trim();
     return (trimmed === "Rumoured" ||
         trimmed === "Announced" ||
+        trimmed === "Withheld" ||
         trimmed === "Available" ||
         trimmed === "Deprecated" ||
         trimmed === "Retired")
@@ -83,6 +85,9 @@ function deriveStatusFromDates(dates: ModelDates, now: Date): DerivedStatus | nu
 
 function pickStatus(current: ModelStatus, derived: DerivedStatus | null): ModelStatus {
     if (!derived) return current;
+    if (current === "Withheld" && (derived.status === "Announced" || derived.status === "Available")) {
+        return current;
+    }
     const currentRank = current ? STATUS_ORDER[current] ?? -1 : -1;
     const derivedRank = STATUS_ORDER[derived.status];
     return derivedRank > currentRank ? derived.status : current;


### PR DESCRIPTION
## Summary
- restore Withheld status for openai/o3-preview and nthropic/claude-mythos-preview
- update scripts/update-model-statuses.ts to recognize Withheld
- prevent automatic transitions from Withheld to Announced/Available during status refresh

## Validation
- pnpm tsx scripts/update-model-statuses.ts --dry-run
  - output: [update-model-statuses] No status changes found.

Addresses the unresolved review thread on #286 about preserving withheld model status semantics.
