### PR TITLE
fix: preserve withheld model status during refresh

### DIFF
--- a/scripts/update-model-statuses.ts
+++ b/scripts/update-model-statuses.ts
@@ -2,7 +2,7 @@ import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
-type ModelStatus = "Rumoured" | "Announced" | "Available" | "Deprecated" | "Retired" | null;
+type ModelStatus = "Rumoured" | "Announced" | "Withheld" | "Available" | "Deprecated" | "Retired" | null;
 
 type ModelDates = {
     announced_date?: unknown;
@@ -19,6 +19,7 @@ type DerivedStatus = {
 const STATUS_ORDER: Record<Exclude<ModelStatus, null>, number> = {
     Rumoured: 0,
     Announced: 1,
+    Withheld: 1.5,
     Available: 2,
     Deprecated: 3,
     Retired: 4,
@@ -50,6 +51,7 @@ function normalizeStatus(value: unknown): ModelStatus {
     const trimmed = value.trim();
     return (trimmed === "Rumoured" ||
         trimmed === "Announced" ||
+        trimmed === "Withheld" ||
         trimmed === "Available" ||
         trimmed === "Deprecated" ||
         trimmed === "Retired")
@@ -83,6 +85,9 @@ function deriveStatusFromDates(dates: ModelDates, now: Date): DerivedStatus | nu
 
 function pickStatus(current: ModelStatus, derived: DerivedStatus | null): ModelStatus {
     if (!derived) return current;
+    if (current === "Withheld" && (derived.status === "Announced" || derived.status === "Available")) {
+        return current;
+    }
     const currentRank = current ? STATUS_ORDER[current] ?? -1 : -1;
     const derivedRank = STATUS_ORDER[derived.status];
     return derivedRank > currentRank ? derived.status : current;


### PR DESCRIPTION
## Summary
- treat Withheld as a first-class status in scripts/update-model-statuses.ts
- preserve Withheld when date-derived status is Announced or Available
- still allow progression to terminal statuses (Deprecated/Retired) when applicable

## Why
PR #286 surfaced that refresh logic could reclassify withheld models (e.g. openai/o3-preview, nthropic/claude-mythos-preview) as standard announced models, which breaks withheld-specific UI semantics.

## Validation
- pnpm tsx scripts/update-model-statuses.ts --dry-run


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for a new "Withheld" model status with defined precedence in the status hierarchy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->