### PR TITLE
Refine homepage hero subtitle and gateway card copy

### DIFF
--- a/apps/web/src/app/(dashboard)/page.tsx
+++ b/apps/web/src/app/(dashboard)/page.tsx
@@ -76,7 +76,7 @@ export default function Page() {
 								<span className="mt-2 block">One Open Model Database</span>
 							</h1>
 							<p className="mx-auto max-w-2xl text-lg leading-8 text-zinc-600 dark:text-zinc-300">
-								Access 300+ AI models through a unified API, with open benchmarks, pricing data, and reliability insights.
+								Open-source AI gateway and open model database, with OpenAI-compatible drop-in access to 300+ models plus benchmarks, pricing, and reliability data.
 							</p>
 						</div>
 						<div className="mx-auto grid w-full max-w-2xl grid-cols-1 gap-3 sm:grid-cols-2">

--- a/apps/web/src/components/landingPage/Home/HomeQuickstartSection.tsx
+++ b/apps/web/src/components/landingPage/Home/HomeQuickstartSection.tsx
@@ -22,7 +22,7 @@ const BENEFITS: Benefit[] = [
 	},
 	{
 		title: "Unified AI Gateway",
-		body: "Integrate once and access hundreds of models across major providers through a single OpenAI-compatible API.",
+		body: "Integrate once and access hundreds of models through one OpenAI-compatible API.",
 		href: "/models",
 		cta: "Browse models",
 		visual: "models",


### PR DESCRIPTION
## Summary
- tighten the homepage subtitle copy to clearly position AI Stats as an open-source AI gateway + open model database
- keep the existing hero heading wording (`One API for Every AI Model` / `One Open Model Database`)
- shorten the `Unified AI Gateway` quickstart card description so it wraps more consistently with peer cards
- keep CTA button row width aligned with the two-button layout pattern used below on the page

## User Impact
- clearer top-of-page value proposition without adding visual clutter
- more consistent card text wrapping in the quickstart grid

## Files Changed
- `apps/web/src/app/(dashboard)/page.tsx`
- `apps/web/src/components/landingPage/Home/HomeQuickstartSection.tsx`

## Validation
- no functional logic changed (copy/layout-class adjustments only)
- tests not run for this copy-only update


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Refreshed landing page messaging to emphasize the open-source AI gateway and open model database, highlighting OpenAI-compatible access to 300+ models
  * Updated product benefit descriptions for improved clarity and positioning

<!-- end of auto-generated comment: release notes by coderabbit.ai -->