### PR TITLE
Fix API credit gating for free models and missing pricing rules

### DIFF
--- a/apps/api/src/pipeline/before/guards.credit.test.ts
+++ b/apps/api/src/pipeline/before/guards.credit.test.ts
@@ -1,0 +1,152 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { guardContext } from "./guards";
+import { fetchGatewayContext } from "./context";
+
+vi.mock("./context", () => ({
+	fetchGatewayContext: vi.fn(),
+}));
+
+const fetchGatewayContextMock = vi.mocked(fetchGatewayContext);
+
+function makeContext(args: {
+	model?: string;
+	creditOk?: boolean;
+	creditReason?: string | null;
+	pricingRules?: Array<{
+		pricing_plan?: string;
+		price_per_unit?: string | number;
+	}>;
+}) {
+	const rules = args.pricingRules ?? [
+		{
+			pricing_plan: "standard",
+			price_per_unit: "0.01",
+		},
+	];
+
+	return {
+		teamId: "team_123",
+		resolvedModel: args.model ?? "openai/gpt-4.1-mini",
+		key: { ok: true, reason: null, resetAt: null },
+		keyLimit: { ok: true, reason: null, resetAt: null },
+		credit: {
+			ok: args.creditOk ?? false,
+			reason: args.creditReason ?? "insufficient_funds",
+			resetAt: null,
+			balanceNanos: 0,
+		},
+		providers: [
+			{
+				providerId: "openai",
+				supportsEndpoint: true,
+				baseWeight: 1,
+				byokMeta: [],
+				providerModelSlug: null,
+				capabilityParams: {},
+			},
+		],
+		pricing: {
+			openai: {
+				provider: "openai",
+				model: args.model ?? "openai/gpt-4.1-mini",
+				endpoint: "text.generate",
+				effective_from: null,
+				effective_to: null,
+				currency: "USD",
+				version: null,
+				rules: rules.map((rule) => ({
+					pricing_plan: rule.pricing_plan ?? "standard",
+					meter: "requests",
+					unit: "request",
+					unit_size: 1,
+					price_per_unit: String(rule.price_per_unit ?? "0.01"),
+					currency: "USD",
+					match: [],
+					priority: 100,
+				})),
+			},
+		},
+		teamSettings: {
+			routingMode: null,
+			byokFallbackEnabled: null,
+			betaChannelEnabled: false,
+			alphaChannelEnabled: false,
+			cacheAwareRoutingEnabled: null,
+			billingMode: "wallet",
+		},
+	};
+}
+
+describe("guardContext credit gating for free models", () => {
+	beforeEach(() => {
+		fetchGatewayContextMock.mockReset();
+	});
+
+	it("keeps insufficient_funds for paid pricing when credits are insufficient", async () => {
+		fetchGatewayContextMock.mockResolvedValue(
+			makeContext({
+				model: "openai/gpt-4.1-mini",
+				creditOk: false,
+				pricingRules: [{ pricing_plan: "standard", price_per_unit: "0.01" }],
+			}) as any,
+		);
+
+		const result = await guardContext({
+			teamId: "team_123",
+			apiKeyId: "key_123",
+			endpoint: "responses",
+			capability: "text.generate",
+			model: "openai/gpt-4.1-mini",
+			requestId: "req_paid_1",
+		});
+
+		expect(result.ok).toBe(false);
+		if (result.ok) return;
+		expect(result.response.status).toBe(402);
+		const payload = await result.response.json();
+		expect(payload.error).toBe("insufficient_funds");
+	});
+
+	it("allows :free model requests with zero credits", async () => {
+		fetchGatewayContextMock.mockResolvedValue(
+			makeContext({
+				model: "google/gemma-3-27b:free",
+				creditOk: false,
+				pricingRules: [{ pricing_plan: "free", price_per_unit: "0" }],
+			}) as any,
+		);
+
+		const result = await guardContext({
+			teamId: "team_123",
+			apiKeyId: "key_123",
+			endpoint: "responses",
+			capability: "text.generate",
+			model: "google/gemma-3-27b:free",
+			requestId: "req_free_1",
+		});
+
+		expect(result.ok).toBe(true);
+	});
+
+	it("allows zero-credit requests when all routable pricing cards are free/zero-cost", async () => {
+		fetchGatewayContextMock.mockResolvedValue(
+			makeContext({
+				model: "provider/model-no-suffix",
+				creditOk: false,
+				pricingRules: [{ pricing_plan: "standard", price_per_unit: "0" }],
+			}) as any,
+		);
+
+		const result = await guardContext({
+			teamId: "team_123",
+			apiKeyId: "key_123",
+			endpoint: "responses",
+			capability: "text.generate",
+			model: "provider/model-no-suffix",
+			requestId: "req_free_2",
+		});
+
+		expect(result.ok).toBe(true);
+	});
+});
+

--- a/apps/api/src/pipeline/before/guards.credit.test.ts
+++ b/apps/api/src/pipeline/before/guards.credit.test.ts
@@ -12,6 +12,18 @@ function makeContext(args: {
 	model?: string;
 	creditOk?: boolean;
 	creditReason?: string | null;
+	providers?: Array<{
+		providerId: string;
+		supportsEndpoint?: boolean;
+	}>;
+	pricingByProvider?: Record<
+		string,
+		| Array<{
+				pricing_plan?: string;
+				price_per_unit?: string | number;
+		  }>
+		| undefined
+	>;
 	pricingRules?: Array<{
 		pricing_plan?: string;
 		price_per_unit?: string | number;
@@ -23,6 +35,43 @@ function makeContext(args: {
 			price_per_unit: "0.01",
 		},
 	];
+	const providers =
+		args.providers ??
+		([
+			{
+				providerId: "openai",
+				supportsEndpoint: true,
+			},
+		] as const);
+	const pricingByProvider = args.pricingByProvider ?? {
+		openai: rules,
+	};
+	const pricing = Object.fromEntries(
+		Object.entries(pricingByProvider)
+			.filter(([, providerRules]) => Array.isArray(providerRules))
+			.map(([providerId, providerRules]) => [
+				providerId,
+				{
+					provider: providerId,
+					model: args.model ?? "openai/gpt-4.1-mini",
+					endpoint: "text.generate",
+					effective_from: null,
+					effective_to: null,
+					currency: "USD",
+					version: null,
+					rules: (providerRules ?? []).map((rule) => ({
+						pricing_plan: rule.pricing_plan ?? "standard",
+						meter: "requests",
+						unit: "request",
+						unit_size: 1,
+						price_per_unit: String(rule.price_per_unit ?? "0.01"),
+						currency: "USD",
+						match: [],
+						priority: 100,
+					})),
+				},
+			]),
+	);
 
 	return {
 		teamId: "team_123",
@@ -35,37 +84,15 @@ function makeContext(args: {
 			resetAt: null,
 			balanceNanos: 0,
 		},
-		providers: [
-			{
-				providerId: "openai",
-				supportsEndpoint: true,
-				baseWeight: 1,
-				byokMeta: [],
-				providerModelSlug: null,
-				capabilityParams: {},
-			},
-		],
-		pricing: {
-			openai: {
-				provider: "openai",
-				model: args.model ?? "openai/gpt-4.1-mini",
-				endpoint: "text.generate",
-				effective_from: null,
-				effective_to: null,
-				currency: "USD",
-				version: null,
-				rules: rules.map((rule) => ({
-					pricing_plan: rule.pricing_plan ?? "standard",
-					meter: "requests",
-					unit: "request",
-					unit_size: 1,
-					price_per_unit: String(rule.price_per_unit ?? "0.01"),
-					currency: "USD",
-					match: [],
-					priority: 100,
-				})),
-			},
-		},
+		providers: providers.map((provider) => ({
+			providerId: provider.providerId,
+			supportsEndpoint: provider.supportsEndpoint ?? true,
+			baseWeight: 1,
+			byokMeta: [],
+			providerModelSlug: null,
+			capabilityParams: {},
+		})),
+		pricing,
 		teamSettings: {
 			routingMode: null,
 			byokFallbackEnabled: null,
@@ -144,6 +171,65 @@ describe("guardContext credit gating for free models", () => {
 			capability: "text.generate",
 			model: "provider/model-no-suffix",
 			requestId: "req_free_2",
+		});
+
+		expect(result.ok).toBe(true);
+	});
+
+	it("fails closed when a routable provider has missing pricing", async () => {
+		fetchGatewayContextMock.mockResolvedValue(
+			makeContext({
+				model: "provider/model-no-suffix",
+				creditOk: false,
+				providers: [
+					{ providerId: "openai" },
+					{ providerId: "anthropic" },
+				],
+				pricingByProvider: {
+					openai: [{ pricing_plan: "free", price_per_unit: "0" }],
+				},
+			}) as any,
+		);
+
+		const result = await guardContext({
+			teamId: "team_123",
+			apiKeyId: "key_123",
+			endpoint: "responses",
+			capability: "text.generate",
+			model: "provider/model-no-suffix",
+			requestId: "req_free_missing_pricing",
+		});
+
+		expect(result.ok).toBe(false);
+		if (result.ok) return;
+		expect(result.response.status).toBe(402);
+		const payload = await result.response.json();
+		expect(payload.error).toBe("insufficient_funds");
+	});
+
+	it("ignores providers that are not routable for free-credit bypass", async () => {
+		fetchGatewayContextMock.mockResolvedValue(
+			makeContext({
+				model: "provider/model-no-suffix",
+				creditOk: false,
+				providers: [
+					{ providerId: "openai" },
+					{ providerId: "non-existent-provider" },
+				],
+				pricingByProvider: {
+					openai: [{ pricing_plan: "free", price_per_unit: "0" }],
+					"non-existent-provider": [{ pricing_plan: "standard", price_per_unit: "0.2" }],
+				},
+			}) as any,
+		);
+
+		const result = await guardContext({
+			teamId: "team_123",
+			apiKeyId: "key_123",
+			endpoint: "responses",
+			capability: "text.generate",
+			model: "provider/model-no-suffix",
+			requestId: "req_free_non_routable",
 		});
 
 		expect(result.ok).toBe(true);

--- a/apps/api/src/pipeline/before/guards.ts
+++ b/apps/api/src/pipeline/before/guards.ts
@@ -15,11 +15,49 @@ import type { DebugOptions } from "@core/types";
 import { authenticate, type AuthFailure } from "./auth";
 import { readAttributionHeaders } from "../after/attribution";
 import type { ProviderCandidateBuildDiagnostics } from "./types";
+import type { PriceCard } from "../pricing";
 
 const MIN_CREDIT_AMOUNT = 1.0;
 const TRUTHY_VALUES = new Set(["1", "true", "yes"]);
 const FORM_JSON_FIELDS = new Set(["provider", "debug", "include", "timestamp_granularities"]);
 const FORM_FORCE_ARRAY_FIELDS = new Set(["include", "timestamp_granularities"]);
+
+function isLikelyFreeModelId(value: unknown): boolean {
+    if (typeof value !== "string") return false;
+    return value.trim().toLowerCase().includes(":free");
+}
+
+function isFreePriceCard(card: PriceCard | null | undefined): boolean {
+    if (!card || !Array.isArray(card.rules) || card.rules.length === 0) return false;
+    return card.rules.every((rule) => {
+        const pricingPlan = String(rule.pricing_plan ?? "")
+            .trim()
+            .toLowerCase();
+        if (pricingPlan === "free") return true;
+        const numericPrice = Number(rule.price_per_unit);
+        return Number.isFinite(numericPrice) && numericPrice <= 0;
+    });
+}
+
+function allowsNoCreditForFreeRequest(args: { model: string; context: any }): boolean {
+    if (isLikelyFreeModelId(args.model) || isLikelyFreeModelId(args.context?.resolvedModel)) {
+        return true;
+    }
+
+    const supportsEndpointProviders = Array.isArray(args.context?.providers)
+        ? args.context.providers
+            .filter((provider: any) => provider?.supportsEndpoint && typeof provider?.providerId === "string")
+            .map((provider: any) => String(provider.providerId))
+        : [];
+    if (!supportsEndpointProviders.length) return false;
+
+    const pricedCards = supportsEndpointProviders
+        .map((providerId) => args.context?.pricing?.[providerId] as PriceCard | undefined)
+        .filter((card): card is PriceCard => Boolean(card));
+    if (!pricedCards.length) return false;
+
+    return pricedCards.every((card) => isFreePriceCard(card));
+}
 
 function normalizeFormKey(key: string): { key: string; array: boolean } {
     if (/\[\]$/.test(key)) {
@@ -255,8 +293,17 @@ export async function guardContext(args: {
             .toLowerCase();
         const bypassWalletCreditCheck =
             teamTier === "enterprise" && billingMode === "invoice";
+        const allowFreeWithoutCredits = allowsNoCreditForFreeRequest({
+            model: args.model,
+            context,
+        });
 
-        if (!args.internal && !context.credit.ok && !bypassWalletCreditCheck) {
+        if (
+            !args.internal &&
+            !context.credit.ok &&
+            !bypassWalletCreditCheck &&
+            !allowFreeWithoutCredits
+        ) {
             return {
                 ok: false,
                 response: err("insufficient_funds", {

--- a/apps/api/src/pipeline/before/guards.ts
+++ b/apps/api/src/pipeline/before/guards.ts
@@ -39,21 +39,21 @@ function isFreePriceCard(card: PriceCard | null | undefined): boolean {
     });
 }
 
-function allowsNoCreditForFreeRequest(args: { model: string; context: any }): boolean {
+function allowsNoCreditForFreeRequest(args: { model: string; context: any; providers: any[] }): boolean {
     if (isLikelyFreeModelId(args.model) || isLikelyFreeModelId(args.context?.resolvedModel)) {
         return true;
     }
 
-    const supportsEndpointProviders = Array.isArray(args.context?.providers)
-        ? args.context.providers
-            .filter((provider: any) => provider?.supportsEndpoint && typeof provider?.providerId === "string")
-            .map((provider: any) => String(provider.providerId))
+    const routableProviders = Array.isArray(args.providers)
+        ? args.providers
+            .filter((provider: any) => typeof provider?.providerId === "string")
         : [];
-    if (!supportsEndpointProviders.length) return false;
+    if (!routableProviders.length) return false;
 
-    const pricedCards = supportsEndpointProviders
-        .map((providerId) => args.context?.pricing?.[providerId] as PriceCard | undefined)
+    const pricedCards = routableProviders
+        .map((provider: any) => provider?.pricingCard as PriceCard | undefined)
         .filter((card): card is PriceCard => Boolean(card));
+    if (pricedCards.length !== routableProviders.length) return false;
     if (!pricedCards.length) return false;
 
     return pricedCards.every((card) => isFreePriceCard(card));
@@ -285,6 +285,20 @@ export async function guardContext(args: {
             };
         }
 
+        const { candidates: providers, diagnostics: candidateDiagnostics } = buildProviderCandidatesWithDiagnostics(context);
+        if (!providers.length) {
+            return {
+                ok: false,
+                response: err("unsupported_model_or_endpoint", {
+                    model: args.model,
+                    endpoint: args.endpoint,
+                    request_id: args.requestId,
+                    team_id: args.teamId,
+                    provider_candidate_diagnostics: candidateDiagnostics,
+                }),
+            };
+        }
+
         const teamTier = String(context.teamEnrichment?.tier ?? "")
             .trim()
             .toLowerCase();
@@ -296,6 +310,7 @@ export async function guardContext(args: {
         const allowFreeWithoutCredits = allowsNoCreditForFreeRequest({
             model: args.model,
             context,
+            providers,
         });
 
         if (
@@ -311,20 +326,6 @@ export async function guardContext(args: {
                     min_usd: MIN_CREDIT_AMOUNT,
                     request_id: args.requestId,
                     team_id: args.teamId,
-                }),
-            };
-        }
-
-        const { candidates: providers, diagnostics: candidateDiagnostics } = buildProviderCandidatesWithDiagnostics(context);
-        if (!providers.length) {
-            return {
-                ok: false,
-                response: err("unsupported_model_or_endpoint", {
-                    model: args.model,
-                    endpoint: args.endpoint,
-                    request_id: args.requestId,
-                    team_id: args.teamId,
-                    provider_candidate_diagnostics: candidateDiagnostics,
                 }),
             };
         }

--- a/apps/api/src/pipeline/before/index.pricing.test.ts
+++ b/apps/api/src/pipeline/before/index.pricing.test.ts
@@ -1,0 +1,229 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const guardAuthMock = vi.fn();
+const guardJsonMock = vi.fn();
+const guardZodMock = vi.fn();
+const guardModelMock = vi.fn();
+const guardContextMock = vi.fn();
+const makeMetaMock = vi.fn();
+
+const validateCapabilitiesMock = vi.fn();
+const isTestingModeRequestedMock = vi.fn();
+const resolveTestingModeMock = vi.fn();
+const isProviderCapabilityEnabledMock = vi.fn();
+const normalizeCapabilityMock = vi.fn();
+const resolveCapabilityFromEndpointMock = vi.fn();
+
+vi.mock("@core/schemas", () => ({
+	schemaFor: vi.fn(() => null),
+}));
+
+vi.mock("./guards", () => ({
+	guardAuth: (...args: any[]) => guardAuthMock(...args),
+	guardJson: (...args: any[]) => guardJsonMock(...args),
+	guardZod: (...args: any[]) => guardZodMock(...args),
+	guardModel: (...args: any[]) => guardModelMock(...args),
+	guardContext: (...args: any[]) => guardContextMock(...args),
+	makeMeta: (...args: any[]) => makeMetaMock(...args),
+	normalizeReturnFlag: (value: unknown) => value === true || value === "true" || value === "1",
+}));
+
+vi.mock("./capabilityValidation", () => ({
+	validateCapabilities: (...args: any[]) => validateCapabilitiesMock(...args),
+}));
+
+vi.mock("./testingMode", () => ({
+	isTestingModeRequested: (...args: any[]) => isTestingModeRequestedMock(...args),
+	resolveTestingMode: (...args: any[]) => resolveTestingModeMock(...args),
+}));
+
+vi.mock("@/executors", () => ({
+	isProviderCapabilityEnabled: (...args: any[]) => isProviderCapabilityEnabledMock(...args),
+	normalizeCapability: (...args: any[]) => normalizeCapabilityMock(...args),
+}));
+
+vi.mock("@/lib/config/capabilityToEndpoints", () => ({
+	resolveCapabilityFromEndpoint: (...args: any[]) => resolveCapabilityFromEndpointMock(...args),
+}));
+
+import { beforeRequest } from "./index";
+import { Timer } from "../telemetry/timer";
+
+function providerWithPricingRules(ruleCount: number): any {
+	return {
+		providerId: "openai",
+		providerStatus: "active",
+		providerRoutingStatus: "active",
+		modelRoutingStatus: "active",
+		capabilityStatus: "active",
+		adapter: {
+			name: "openai",
+			supports: () => true,
+			execute: async () => new Response("{}"),
+		},
+		baseWeight: 1,
+		byokMeta: [],
+		pricingCard: {
+			provider: "openai",
+			model: "openai/gpt-4.1-mini",
+			endpoint: "text.generate",
+			effective_from: null,
+			effective_to: null,
+			currency: "USD",
+			version: null,
+			rules: Array.from({ length: ruleCount }, () => ({
+				pricing_plan: "standard",
+				meter: "requests",
+				unit: "request",
+				unit_size: 1,
+				price_per_unit: "0.01",
+				currency: "USD",
+				match: [],
+				priority: 100,
+			})),
+		},
+		providerModelSlug: null,
+		inputModalities: ["text"],
+		outputModalities: ["text"],
+		capabilityParams: {},
+		maxInputTokens: null,
+		maxOutputTokens: null,
+	};
+}
+
+describe("beforeRequest pricing loss-prevention", () => {
+	beforeEach(() => {
+		guardAuthMock.mockReset();
+		guardJsonMock.mockReset();
+		guardZodMock.mockReset();
+		guardModelMock.mockReset();
+		guardContextMock.mockReset();
+		makeMetaMock.mockReset();
+		validateCapabilitiesMock.mockReset();
+		isTestingModeRequestedMock.mockReset();
+		resolveTestingModeMock.mockReset();
+		isProviderCapabilityEnabledMock.mockReset();
+		normalizeCapabilityMock.mockReset();
+		resolveCapabilityFromEndpointMock.mockReset();
+
+		guardAuthMock.mockResolvedValue({
+			ok: true,
+			value: {
+				requestId: "req_123",
+				teamId: "team_123",
+				apiKeyId: "key_123",
+				apiKeyRef: "kid_123",
+				apiKeyKid: "kid_123",
+				userId: null,
+				internal: false,
+			},
+		});
+		guardJsonMock.mockResolvedValue({ ok: true, value: { model: "openai/gpt-4.1-mini" } });
+		guardZodMock.mockReturnValue({ ok: true, value: { model: "openai/gpt-4.1-mini" } });
+		guardModelMock.mockReturnValue({
+			ok: true,
+			value: { body: { model: "openai/gpt-4.1-mini" }, model: "openai/gpt-4.1-mini", stream: false },
+		});
+		makeMetaMock.mockReturnValue({
+			apiKeyId: "key_123",
+			apiKeyRef: "kid_123",
+			apiKeyKid: "kid_123",
+			requestId: "req_123",
+			stream: false,
+			startedAtMs: Date.now(),
+		});
+		validateCapabilitiesMock.mockImplementation((args: any) => ({
+			ok: true,
+			body: args.body,
+			providers: args.providers,
+			requestedParams: [],
+			paramRoutingDiagnostics: {
+				requestedParams: [],
+				unknownParams: [],
+				providerCountBefore: args.providers.length,
+				providerCountAfter: args.providers.length,
+				perParamSupport: [],
+				droppedProviders: [],
+				filteringStages: [],
+			},
+		}));
+		isTestingModeRequestedMock.mockReturnValue(false);
+		resolveTestingModeMock.mockResolvedValue({ enabled: false, reason: "not_requested" });
+		isProviderCapabilityEnabledMock.mockReturnValue(true);
+		normalizeCapabilityMock.mockImplementation((value: string) => value);
+		resolveCapabilityFromEndpointMock.mockReturnValue("text.generate");
+	});
+
+	it("allows request when pricing rules are present", async () => {
+		const provider = providerWithPricingRules(1);
+		guardContextMock.mockResolvedValue({
+			ok: true,
+			value: {
+				context: {
+					pricing: { openai: provider.pricingCard },
+					key: { ok: true, reason: null, resetAt: null },
+					keyLimit: { ok: true, reason: null, resetAt: null },
+					credit: { ok: true, reason: null, resetAt: null },
+					teamSettings: { billingMode: "wallet" },
+				},
+				providers: [provider],
+				resolvedModel: "openai/gpt-4.1-mini",
+				candidateDiagnostics: {
+					totalProviders: 1,
+					supportsEndpointCount: 1,
+					droppedUnsupportedEndpoint: [],
+					droppedMissingAdapter: [],
+					candidateCount: 1,
+				},
+			},
+		});
+
+		const req = new Request("https://gateway.local/v1/responses", {
+			method: "POST",
+			headers: { "content-type": "application/json" },
+			body: JSON.stringify({ model: "openai/gpt-4.1-mini" }),
+		});
+		const result = await beforeRequest(req, "responses", new Timer(), null);
+		expect(result.ok).toBe(true);
+	});
+
+	it("rejects request when pricing card has zero rules", async () => {
+		const provider = providerWithPricingRules(0);
+		guardContextMock.mockResolvedValue({
+			ok: true,
+			value: {
+				context: {
+					pricing: { openai: provider.pricingCard },
+					key: { ok: true, reason: null, resetAt: null },
+					keyLimit: { ok: true, reason: null, resetAt: null },
+					credit: { ok: true, reason: null, resetAt: null },
+					teamSettings: { billingMode: "wallet" },
+				},
+				providers: [provider],
+				resolvedModel: "openai/gpt-4.1-mini",
+				candidateDiagnostics: {
+					totalProviders: 1,
+					supportsEndpointCount: 1,
+					droppedUnsupportedEndpoint: [],
+					droppedMissingAdapter: [],
+					candidateCount: 1,
+				},
+			},
+		});
+
+		const req = new Request("https://gateway.local/v1/responses", {
+			method: "POST",
+			headers: { "content-type": "application/json" },
+			body: JSON.stringify({ model: "openai/gpt-4.1-mini" }),
+		});
+		const result = await beforeRequest(req, "responses", new Timer(), null);
+		expect(result.ok).toBe(false);
+		if (result.ok) return;
+		expect(result.response.status).toBe(400);
+		const payload = await result.response.json();
+		expect(payload.error).toBe("unsupported_model_or_endpoint");
+		expect(payload.reason).toBe("pricing_not_configured");
+		expect(payload.missing_pricing_providers).toEqual(["openai"]);
+	});
+});
+

--- a/apps/api/src/pipeline/before/index.ts
+++ b/apps/api/src/pipeline/before/index.ts
@@ -205,7 +205,11 @@ export async function beforeRequest(
         return hasAdapter;
     });
     const missingPricingProviders = enabledProviders
-        .filter((provider) => !provider.pricingCard)
+        .filter((provider) =>
+            !provider.pricingCard ||
+            !Array.isArray(provider.pricingCard.rules) ||
+            provider.pricingCard.rules.length === 0
+        )
         .map((provider) => provider.providerId);
     if (missingPricingProviders.length) {
         for (const providerId of missingPricingProviders) {
@@ -214,7 +218,13 @@ export async function beforeRequest(
                 reason: "pricing_missing",
             });
         }
-        enabledProviders = enabledProviders.filter((provider) => Boolean(provider.pricingCard));
+        enabledProviders = enabledProviders.filter((provider) =>
+            Boolean(
+                provider.pricingCard &&
+                Array.isArray(provider.pricingCard.rules) &&
+                provider.pricingCard.rules.length > 0
+            )
+        );
     }
     const providerEnablementDiagnostics: ProviderEnablementDiagnostics = {
         capability: normalizedCapability,


### PR DESCRIPTION
## Summary
This PR implements the API gating changes discussed for loss prevention and free-tier usability:

- allow requests with zero credits when the request is clearly free:
  - model id includes `:free`, or
  - all routable provider pricing cards resolve to zero/free pricing
- continue enforcing minimum wallet credits for paid requests (`$1` threshold remains unchanged)
- fail closed when pricing configuration is missing or empty by rejecting providers with missing/empty pricing rules
- return `unsupported_model_or_endpoint` + `reason: pricing_not_configured` when no eligible priced providers remain

## Why
- Users should be able to start on free models without pre-funding credits.
- If pricing metadata is absent or incomplete, requests should be blocked to avoid accidental unpriced traffic.

## Files Changed
- `apps/api/src/pipeline/before/guards.ts`
- `apps/api/src/pipeline/before/index.ts`
- `apps/api/src/pipeline/before/guards.credit.test.ts`
- `apps/api/src/pipeline/before/index.pricing.test.ts`

## Validation
- `pnpm --filter @ai-stats/gateway-api test -- src/pipeline/before/guards.credit.test.ts src/pipeline/before/index.pricing.test.ts`

All targeted tests pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Free models (identified by name or zero-cost provider pricing) can be accessed without requiring credits.

* **Bug Fixes**
  * More strict pricing validation: providers with missing or empty pricing rules are treated as unconfigured and blocked.

* **Tests**
  * Added extensive tests covering credit gating, free-model bypasses, and pricing-based request rejection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->