### PR TITLE
Enforce active-model gating across API and all SDKs

### DIFF
--- a/apps/api/src/pipeline/before/context.sql
+++ b/apps/api/src/pipeline/before/context.sql
@@ -376,9 +376,15 @@ begin
       c.max_input_tokens,
       c.max_output_tokens
     from public.data_api_provider_models m
+    join public.data_models dm
+      on dm.model_id = coalesce(m.model_id, m.api_model_id)
     join public.data_api_provider_model_capabilities c
       on c.provider_api_model_id = m.provider_api_model_id
     where m.api_model_id = resolved_model
+      and coalesce(dm.hidden, false) = false
+      and (dm.status is null or lower(dm.status) in ('active', 'available'))
+      and (dm.deprecation_date is null or dm.deprecation_date > now() at time zone 'utc')
+      and (dm.retirement_date is null or dm.retirement_date > now() at time zone 'utc')
       and c.capability_id = gateway_fetch_request_context.endpoint
       and c.status in ('active', 'deranked', 'deranked_lvl1', 'deranked_lvl2', 'deranked_lvl3')
       and m.is_active_gateway

--- a/apps/api/src/routes/v1/control/models.catalogue.test.ts
+++ b/apps/api/src/routes/v1/control/models.catalogue.test.ts
@@ -96,4 +96,51 @@ describe("fetchCatalogue", () => {
         expect(models).toHaveLength(1);
         expect(models[0]?.model_id).toBe("test/model-1");
     });
+
+    it("filters models by requested statuses", async () => {
+        const state: QueryState = { emptyCapabilityInCalled: false };
+        const responses: Record<string, QueryResult[]> = {
+            data_models: [
+                {
+                    data: [
+                        {
+                            model_id: "test/model-active",
+                            name: "Active Model",
+                            release_date: null,
+                            deprecation_date: null,
+                            retirement_date: null,
+                            status: "active",
+                            organisation_id: null,
+                            input_types: ["text"],
+                            output_types: ["text"],
+                            organisation: null,
+                        },
+                        {
+                            model_id: "test/model-retired",
+                            name: "Retired Model",
+                            release_date: null,
+                            deprecation_date: null,
+                            retirement_date: null,
+                            status: "retired",
+                            organisation_id: null,
+                            input_types: ["text"],
+                            output_types: ["text"],
+                            organisation: null,
+                        },
+                    ],
+                    error: null,
+                },
+            ],
+            data_api_provider_models: [{ data: [], error: null }],
+            data_api_pricing_rules: [{ data: [], error: null }],
+        };
+
+        getSupabaseAdminMock.mockReturnValue(buildSupabaseMock(responses, state));
+        const { fetchCatalogue } = await import("./models.catalogue");
+
+        const models = await fetchCatalogue({ statuses: ["active"] });
+
+        expect(models).toHaveLength(1);
+        expect(models[0]?.model_id).toBe("test/model-active");
+    });
 });

--- a/apps/api/src/routes/v1/control/models.catalogue.ts
+++ b/apps/api/src/routes/v1/control/models.catalogue.ts
@@ -113,6 +113,7 @@ export type CatalogueFilters = {
     inputTypes?: string[];
     outputTypes?: string[];
     params?: string[];
+    statuses?: string[];
 };
 
 const PRICING_METERS = [
@@ -208,6 +209,40 @@ function normalizeStringSet(values?: string[]): string[] | undefined {
     if (!values || !values.length) return undefined;
     const normalized = Array.from(new Set(values.map((value) => value.trim()).filter((value) => value.length > 0)));
     return normalized.length ? normalized : undefined;
+}
+
+function toNormalizedStatus(value: string | null | undefined): string | null {
+    if (!value) return null;
+    const normalized = value.trim().toLowerCase();
+    return normalized.length > 0 ? normalized : null;
+}
+
+function matchesRequestedStatus(args: {
+    requestedStatus: string;
+    modelStatus: string | null;
+    deprecationDate: string | null;
+    retirementDate: string | null;
+}): boolean {
+    const requested = args.requestedStatus.trim().toLowerCase();
+    const modelStatus = toNormalizedStatus(args.modelStatus);
+    const now = Date.now();
+
+    const retirementAt = parseDate(args.retirementDate);
+    if (retirementAt !== null && retirementAt <= now) {
+        return requested === "retired";
+    }
+
+    const deprecationAt = parseDate(args.deprecationDate);
+    if (deprecationAt !== null && deprecationAt <= now) {
+        return requested === "deprecated";
+    }
+
+    if (requested === "active") {
+        if (!modelStatus) return true;
+        return modelStatus === "active" || modelStatus === "available";
+    }
+
+    return modelStatus === requested;
 }
 
 function chunkArray<T>(values: T[], size: number): T[][] {
@@ -539,9 +574,22 @@ export async function fetchCatalogue(filter: CatalogueFilters): Promise<Catalogu
     const inputTypesFilter = normalizeStringSet(filter.inputTypes)?.map((value) => value.toLowerCase());
     const outputTypesFilter = normalizeStringSet(filter.outputTypes)?.map((value) => value.toLowerCase());
     const paramsFilter = normalizeStringSet(filter.params);
+    const statusesFilter = normalizeStringSet(filter.statuses)?.map((value) => value.toLowerCase());
 
     const models: CatalogueModel[] = [];
     for (const [modelId, info] of baseModels) {
+        if (statusesFilter?.length) {
+            const matchesAny = statusesFilter.some((requestedStatus) =>
+                matchesRequestedStatus({
+                    requestedStatus,
+                    modelStatus: info.status,
+                    deprecationDate: info.deprecation_date,
+                    retirementDate: info.retirement_date,
+                })
+            );
+            if (!matchesAny) continue;
+        }
+
         if (organisationIds?.length) {
             const organisationId = info.organisation?.organisation_id ?? info.organisation_id ?? null;
             if (!organisationId || !organisationIds.includes(organisationId)) continue;

--- a/apps/api/src/routes/v1/data/videos.ts
+++ b/apps/api/src/routes/v1/data/videos.ts
@@ -213,7 +213,10 @@ videosRoutes.get("/", withRuntime(async (req) => {
 videosRoutes.get("/models", withRuntime(async (req) => {
 	const auth = await guardAuth(req);
 	if (!auth.ok) return (auth as { ok: false; response: Response }).response;
-	const catalogue = await fetchCatalogue({ endpoints: ["video.generation"] });
+	const catalogue = await fetchCatalogue({
+		endpoints: ["video.generation"],
+		statuses: ["active"],
+	});
 	return new Response(JSON.stringify({
 		object: "list",
 		data: catalogue.map((model) => ({

--- a/packages/sdk/sdk-csharp/Client.cs
+++ b/packages/sdk/sdk-csharp/Client.cs
@@ -172,7 +172,7 @@ namespace AiStatsSdk
             }
 
             var lifecycle = await GetModelDeprecationInfo(normalized).ConfigureAwait(false);
-            if (lifecycle is null || lifecycle.Status == "active")
+            if (lifecycle is null || string.Equals(NormalizeRequestabilityStatus(lifecycle.Status), "active", StringComparison.Ordinal))
             {
                 return;
             }
@@ -553,9 +553,20 @@ namespace AiStatsSdk
             return value.Trim().ToLowerInvariant();
         }
 
+        private static string NormalizeRequestabilityStatus(string? value)
+        {
+            return NormalizeSourceStatus(value) switch
+            {
+                "active" or "available" => "active",
+                "deprecated" => "deprecated",
+                "retired" => "retired",
+                _ => string.Empty
+            };
+        }
+
         private static bool IsModelRequestableForInference(ModelLifecycleInfo info)
         {
-            if (!string.Equals(info.Status, "active", StringComparison.Ordinal))
+            if (!string.Equals(NormalizeRequestabilityStatus(info.Status), "active", StringComparison.Ordinal))
             {
                 return false;
             }
@@ -578,10 +589,14 @@ namespace AiStatsSdk
 
         private static string BuildInactiveModelRequestMessage(ModelLifecycleInfo info)
         {
-            if (!string.Equals(info.Status, "active", StringComparison.Ordinal))
+            var normalizedStatus = NormalizeRequestabilityStatus(info.Status);
+            if (!string.Equals(normalizedStatus, "active", StringComparison.Ordinal))
             {
+                var lifecycleStatusForMessage = string.IsNullOrWhiteSpace(normalizedStatus)
+                    ? (NormalizeSourceStatus(info.Status) ?? info.Status)
+                    : normalizedStatus;
                 var fallback = BuildLifecycleMessage(
-                    info.Status,
+                    lifecycleStatusForMessage,
                     info.ModelId,
                     info.DeprecationDate,
                     info.RetirementDate,

--- a/packages/sdk/sdk-csharp/Client.cs
+++ b/packages/sdk/sdk-csharp/Client.cs
@@ -15,6 +15,7 @@ namespace AiStatsSdk
     {
         public required string ModelId { get; init; }
         public required string Status { get; init; }
+        public string? SourceStatus { get; init; }
         public string? DeprecationDate { get; init; }
         public string? RetirementDate { get; init; }
         public string? ReplacementModelId { get; init; }
@@ -33,6 +34,29 @@ namespace AiStatsSdk
         private readonly Func<string, Task<ModelLifecycleInfo?>> _lifecycleResolver;
         private readonly HashSet<string> _warnedModels = new(StringComparer.Ordinal);
         private readonly Dictionary<string, ModelLifecycleInfo?> _lifecycleCache = new(StringComparer.Ordinal);
+        private static readonly HashSet<string> ActiveModelSourceStatuses = new(StringComparer.Ordinal)
+        {
+            "active",
+            "available"
+        };
+        private static readonly HashSet<string> InactiveModelSourceStatuses = new(StringComparer.Ordinal)
+        {
+            "deprecated",
+            "retired",
+            "withheld",
+            "announced",
+            "rumoured",
+            "rumored",
+            "unavailable",
+            "disabled",
+            "internal",
+            "private",
+            "removed",
+            "sunset",
+            "eol",
+            "end_of_life",
+            "end-of-life"
+        };
 
         public AiStats.Gen.Client RawClient => _client;
 
@@ -87,13 +111,13 @@ namespace AiStatsSdk
                 return new Dictionary<string, object?> { ["ok"] = true, ["info"] = null };
             }
 
-            if (string.Equals(info.Status, "retired", StringComparison.Ordinal))
+            if (!IsModelRequestableForInference(info))
             {
                 return new Dictionary<string, object?>
                 {
                     ["ok"] = false,
                     ["info"] = info,
-                    ["reason"] = info.Message ?? $"Model \"{modelId}\" is retired."
+                    ["reason"] = BuildInactiveModelRequestMessage(info)
                 };
             }
 
@@ -108,7 +132,30 @@ namespace AiStatsSdk
                 return;
             }
 
+            await EnsureModelRequestable(modelId).ConfigureAwait(false);
             await MaybeWarnForModel(modelId).ConfigureAwait(false);
+        }
+
+        private async Task EnsureModelRequestable(string modelId)
+        {
+            var normalized = modelId.Trim();
+            if (normalized.Length == 0)
+            {
+                return;
+            }
+
+            var lifecycle = await GetModelDeprecationInfo(normalized).ConfigureAwait(false);
+            if (lifecycle is null)
+            {
+                return;
+            }
+
+            if (IsModelRequestableForInference(lifecycle))
+            {
+                return;
+            }
+
+            throw new InvalidOperationException(BuildInactiveModelRequestMessage(lifecycle));
         }
 
         private async Task MaybeWarnForModel(string modelId)
@@ -417,6 +464,7 @@ namespace AiStatsSdk
         {
             var lifecycle = GetObject(model, "lifecycle");
             var modelId = FirstNonEmpty(GetString(model, "model_id"), fallbackModelId) ?? fallbackModelId;
+            var sourceStatus = FirstNonEmpty(GetString(model, "status"), GetString(lifecycle, "status"));
             var deprecationDate = FirstNonEmpty(GetString(lifecycle, "deprecation_date"), GetString(model, "deprecation_date"));
             var retirementDate = FirstNonEmpty(GetString(lifecycle, "retirement_date"), GetString(model, "retirement_date"));
             var status = NormalizeLifecycleStatus(
@@ -432,6 +480,7 @@ namespace AiStatsSdk
             {
                 ModelId = modelId,
                 Status = status,
+                SourceStatus = sourceStatus,
                 DeprecationDate = deprecationDate,
                 RetirementDate = retirementDate,
                 ReplacementModelId = replacementModelId,
@@ -493,6 +542,66 @@ namespace AiStatsSdk
                     => $"[ai-stats] Model \"{modelId}\" is deprecated.{replacement}",
                 _ => string.Empty
             };
+        }
+
+        private static string? NormalizeSourceStatus(string? value)
+        {
+            if (string.IsNullOrWhiteSpace(value))
+            {
+                return null;
+            }
+            return value.Trim().ToLowerInvariant();
+        }
+
+        private static bool IsModelRequestableForInference(ModelLifecycleInfo info)
+        {
+            if (!string.Equals(info.Status, "active", StringComparison.Ordinal))
+            {
+                return false;
+            }
+
+            var sourceStatus = NormalizeSourceStatus(info.SourceStatus);
+            if (sourceStatus is null)
+            {
+                return true;
+            }
+            if (ActiveModelSourceStatuses.Contains(sourceStatus))
+            {
+                return true;
+            }
+            if (InactiveModelSourceStatuses.Contains(sourceStatus))
+            {
+                return false;
+            }
+            return false;
+        }
+
+        private static string BuildInactiveModelRequestMessage(ModelLifecycleInfo info)
+        {
+            if (!string.Equals(info.Status, "active", StringComparison.Ordinal))
+            {
+                var fallback = BuildLifecycleMessage(
+                    info.Status,
+                    info.ModelId,
+                    info.DeprecationDate,
+                    info.RetirementDate,
+                    info.ReplacementModelId);
+                if (!string.IsNullOrWhiteSpace(info.Message))
+                {
+                    return info.Message!;
+                }
+                if (!string.IsNullOrWhiteSpace(fallback))
+                {
+                    return fallback;
+                }
+                return $"[ai-stats] Model \"{info.ModelId}\" is not active for inference.";
+            }
+
+            var sourceStatus = NormalizeSourceStatus(info.SourceStatus) ?? "unknown";
+            var replacement = string.IsNullOrWhiteSpace(info.ReplacementModelId)
+                ? string.Empty
+                : $" Use \"{info.ReplacementModelId}\" instead.";
+            return $"[ai-stats] Model \"{info.ModelId}\" is not active for inference (status: {sourceStatus}).{replacement}";
         }
 
         private static JsonElement GetObject(JsonElement source, string property)

--- a/packages/sdk/sdk-csharp/tests/AIStats.Sdk.Tests/LifecycleTests.cs
+++ b/packages/sdk/sdk-csharp/tests/AIStats.Sdk.Tests/LifecycleTests.cs
@@ -9,7 +9,7 @@ namespace AIStats.Sdk.Tests;
 public class LifecycleTests
 {
     [Fact]
-    public async Task DeprecatedModelWarnsOncePerModel()
+    public async Task DeprecatedModelBlocksRequest()
     {
         var warnings = new List<string>();
         var handler = new StubHttpHandler((request) =>
@@ -58,17 +58,16 @@ public class LifecycleTests
             ["model"] = "provider/old-model",
             ["input"] = "Hello"
         };
-        await client.CreateResponse(payload);
-        await client.CreateResponse(payload);
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(() => client.CreateResponse(payload));
 
-        Assert.Single(warnings);
-        Assert.Contains("provider/new-model", warnings[0]);
+        Assert.Contains("provider/new-model", ex.Message);
+        Assert.Empty(warnings);
         Assert.Equal(1, handler.Count("/data/models"));
-        Assert.Equal(2, handler.Count("/responses"));
+        Assert.Equal(0, handler.Count("/responses"));
     }
 
     [Fact]
-    public async Task WarningsAsErrorsBlocksRequestForRetiredModels()
+    public async Task RetiredModelBlocksRequestWithoutWarningsAsErrors()
     {
         var handler = new StubHttpHandler((request) =>
         {
@@ -101,7 +100,7 @@ public class LifecycleTests
         var client = new AiStatsSdk.AIStats(
             apiKey: "test",
             basePath: "http://localhost",
-            warningsAsErrors: true,
+            warningsAsErrors: false,
             httpClient: httpClient);
 
         var ex = await Assert.ThrowsAsync<InvalidOperationException>(() =>

--- a/packages/sdk/sdk-go/devtools_test.go
+++ b/packages/sdk/sdk-go/devtools_test.go
@@ -16,6 +16,18 @@ import (
 func TestDevtoolsCapturesResponsesRequests(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
+		case "/data/models":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"models": []map[string]any{
+					{
+						"model_id": "openai/gpt-5-nano",
+						"status":   "Available",
+						"lifecycle": map[string]any{
+							"status": "active",
+						},
+					},
+				},
+			})
 		case "/responses":
 			_ = json.NewEncoder(w).Encode(map[string]any{
 				"id":    "resp_1",

--- a/packages/sdk/sdk-go/index.go
+++ b/packages/sdk/sdk-go/index.go
@@ -30,6 +30,7 @@ type Option func(*AIStats)
 type ModelLifecycleInfo struct {
 	ModelID            string
 	Status             string
+	SourceStatus       *string
 	DeprecationDate    *string
 	RetirementDate     *string
 	ReplacementModelID *string
@@ -40,6 +41,29 @@ type ModelValidationResult struct {
 	OK     bool
 	Info   *ModelLifecycleInfo
 	Reason string
+}
+
+var activeModelSourceStatuses = map[string]struct{}{
+	"active":    {},
+	"available": {},
+}
+
+var inactiveModelSourceStatuses = map[string]struct{}{
+	"deprecated":  {},
+	"retired":     {},
+	"withheld":    {},
+	"announced":   {},
+	"rumoured":    {},
+	"rumored":     {},
+	"unavailable": {},
+	"disabled":    {},
+	"internal":    {},
+	"private":     {},
+	"removed":     {},
+	"sunset":      {},
+	"eol":         {},
+	"end_of_life": {},
+	"end-of-life": {},
 }
 
 // AIStats is a thin facade over the generated Go client in src/gen.
@@ -210,12 +234,12 @@ func (c *AIStats) ValidateModel(ctx context.Context, modelID string) (ModelValid
 	if info == nil {
 		return ModelValidationResult{OK: true, Info: nil}, nil
 	}
-	if info.Status == "retired" {
-		reason := fmt.Sprintf(`Model "%s" is retired.`, modelID)
-		if info.Message != nil {
-			reason = *info.Message
-		}
-		return ModelValidationResult{OK: false, Info: info, Reason: reason}, nil
+	if !isModelRequestableForInference(info) {
+		return ModelValidationResult{
+			OK:     false,
+			Info:   info,
+			Reason: buildInactiveModelRequestMessage(info),
+		}, nil
 	}
 	return ModelValidationResult{OK: true, Info: info}, nil
 }
@@ -225,7 +249,28 @@ func (c *AIStats) maybeWarnForPayload(ctx context.Context, payload any) error {
 	if modelID == "" {
 		return nil
 	}
+	if err := c.ensureModelRequestable(ctx, modelID); err != nil {
+		return err
+	}
 	return c.maybeWarnForModel(ctx, modelID)
+}
+
+func (c *AIStats) ensureModelRequestable(ctx context.Context, modelID string) error {
+	normalizedModelID := strings.TrimSpace(modelID)
+	if normalizedModelID == "" {
+		return nil
+	}
+
+	lifecycle, err := c.GetModelDeprecationInfo(ctx, normalizedModelID)
+	if err != nil || lifecycle == nil {
+		return err
+	}
+
+	if isModelRequestableForInference(lifecycle) {
+		return nil
+	}
+
+	return errors.New(buildInactiveModelRequestMessage(lifecycle))
 }
 
 func (c *AIStats) maybeWarnForModel(ctx context.Context, modelID string) error {
@@ -296,7 +341,7 @@ func (c *AIStats) fetchModelLifecycle(
 		nil,
 	)
 	if err != nil {
-		return nil, err
+		return nil, nil
 	}
 
 	models, ok := payload["models"]
@@ -609,6 +654,7 @@ func firstNonEmpty(values ...string) string {
 func toModelLifecycleInfo(model map[string]any, fallbackModelID string) *ModelLifecycleInfo {
 	lifecycle := asMap(model["lifecycle"])
 	modelID := firstNonEmpty(asString(model["model_id"]), fallbackModelID)
+	sourceStatus := firstNonEmpty(asString(model["status"]), asString(lifecycle["status"]))
 	deprecationDate := firstNonEmpty(asString(lifecycle["deprecation_date"]), asString(model["deprecation_date"]))
 	retirementDate := firstNonEmpty(asString(lifecycle["retirement_date"]), asString(model["retirement_date"]))
 	status := normalizeLifecycleStatus(
@@ -625,6 +671,7 @@ func toModelLifecycleInfo(model map[string]any, fallbackModelID string) *ModelLi
 	return &ModelLifecycleInfo{
 		ModelID:            modelID,
 		Status:             status,
+		SourceStatus:       stringPtr(sourceStatus),
 		DeprecationDate:    stringPtr(deprecationDate),
 		RetirementDate:     stringPtr(retirementDate),
 		ReplacementModelID: stringPtr(replacementModelID),
@@ -675,4 +722,66 @@ func buildLifecycleMessage(
 	default:
 		return ""
 	}
+}
+
+func normalizeSourceStatus(value *string) string {
+	if value == nil {
+		return ""
+	}
+	return strings.ToLower(strings.TrimSpace(*value))
+}
+
+func isModelRequestableForInference(info *ModelLifecycleInfo) bool {
+	if info == nil || info.Status != "active" {
+		return false
+	}
+	sourceStatus := normalizeSourceStatus(info.SourceStatus)
+	if sourceStatus == "" {
+		return true
+	}
+	if _, ok := activeModelSourceStatuses[sourceStatus]; ok {
+		return true
+	}
+	if _, ok := inactiveModelSourceStatuses[sourceStatus]; ok {
+		return false
+	}
+	return false
+}
+
+func buildInactiveModelRequestMessage(info *ModelLifecycleInfo) string {
+	if info == nil {
+		return `[ai-stats] Model "unknown-model" is not active for inference.`
+	}
+
+	if info.Status != "active" {
+		if info.Message != nil && strings.TrimSpace(*info.Message) != "" {
+			return *info.Message
+		}
+		fallback := buildLifecycleMessage(
+			info.Status,
+			info.ModelID,
+			info.DeprecationDate,
+			info.RetirementDate,
+			info.ReplacementModelID,
+		)
+		if strings.TrimSpace(fallback) != "" {
+			return fallback
+		}
+		return fmt.Sprintf(`[ai-stats] Model "%s" is not active for inference.`, info.ModelID)
+	}
+
+	sourceStatus := normalizeSourceStatus(info.SourceStatus)
+	if sourceStatus == "" {
+		sourceStatus = "unknown"
+	}
+	replacement := ""
+	if info.ReplacementModelID != nil {
+		replacement = fmt.Sprintf(` Use "%s" instead.`, *info.ReplacementModelID)
+	}
+	return fmt.Sprintf(
+		`[ai-stats] Model "%s" is not active for inference (status: %s).%s`,
+		info.ModelID,
+		sourceStatus,
+		replacement,
+	)
 }

--- a/packages/sdk/sdk-go/index.go
+++ b/packages/sdk/sdk-go/index.go
@@ -341,7 +341,7 @@ func (c *AIStats) fetchModelLifecycle(
 		nil,
 	)
 	if err != nil {
-		return nil, nil
+		return nil, fmt.Errorf("list model lifecycle for %q: %w", modelID, err)
 	}
 
 	models, ok := payload["models"]

--- a/packages/sdk/sdk-go/lifecycle_test.go
+++ b/packages/sdk/sdk-go/lifecycle_test.go
@@ -12,7 +12,7 @@ import (
 	gen "github.com/AI-Stats/AI-Stats/packages/sdk/sdk-go/src/gen"
 )
 
-func TestLifecycleWarningEmitsOncePerModel(t *testing.T) {
+func TestInactiveModelBlocksRequest(t *testing.T) {
 	var dataModelsCalls int32
 	var responsesCalls int32
 
@@ -43,39 +43,31 @@ func TestLifecycleWarningEmitsOncePerModel(t *testing.T) {
 	}))
 	defer server.Close()
 
-	var warnings []string
 	client := New("test", server.URL, WithLogger(func(level AIStatsLogLevel, message string, _ map[string]any) {
-		if level == AIStatsLogLevelWarn {
-			warnings = append(warnings, message)
-		}
+		_ = level
+		_ = message
 	}))
 
 	req := gen.ResponsesRequest{
 		Model: "provider/old-model",
 		Input: "hello",
 	}
-	if _, err := client.CreateResponse(context.Background(), req); err != nil {
-		t.Fatalf("first CreateResponse failed: %v", err)
+	_, err := client.CreateResponse(context.Background(), req)
+	if err == nil {
+		t.Fatal("expected error for inactive model")
 	}
-	if _, err := client.CreateResponse(context.Background(), req); err != nil {
-		t.Fatalf("second CreateResponse failed: %v", err)
-	}
-
-	if len(warnings) != 1 {
-		t.Fatalf("expected 1 warning, got %d (%v)", len(warnings), warnings)
-	}
-	if !strings.Contains(warnings[0], "provider/new-model") {
-		t.Fatalf("expected replacement model in warning, got %q", warnings[0])
+	if !strings.Contains(err.Error(), "provider/new-model") {
+		t.Fatalf("expected replacement model in inactive-model error, got %q", err.Error())
 	}
 	if atomic.LoadInt32(&dataModelsCalls) != 1 {
 		t.Fatalf("expected 1 /data/models lookup due to cache, got %d", dataModelsCalls)
 	}
-	if atomic.LoadInt32(&responsesCalls) != 2 {
-		t.Fatalf("expected 2 /responses calls, got %d", responsesCalls)
+	if atomic.LoadInt32(&responsesCalls) != 0 {
+		t.Fatalf("expected 0 /responses calls when lifecycle blocks request, got %d", responsesCalls)
 	}
 }
 
-func TestLifecycleWarningsAsErrorsBlocksRequest(t *testing.T) {
+func TestRetiredModelBlocksRequestWithoutWarningsAsErrors(t *testing.T) {
 	var responsesCalls int32
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -103,13 +95,16 @@ func TestLifecycleWarningsAsErrorsBlocksRequest(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := New("test", server.URL, WithWarningsAsErrors(true))
+	client := New("test", server.URL, WithWarningsAsErrors(false))
 	_, err := client.CreateResponse(context.Background(), gen.ResponsesRequest{
 		Model: "provider/retired-model",
 		Input: "hello",
 	})
 	if err == nil {
-		t.Fatal("expected error when warningsAsErrors is enabled")
+		t.Fatal("expected error when model is retired")
+	}
+	if !strings.Contains(strings.ToLower(err.Error()), "retired") {
+		t.Fatalf("expected retired model error, got %q", err.Error())
 	}
 	if atomic.LoadInt32(&responsesCalls) != 0 {
 		t.Fatalf("expected no /responses call when blocked by lifecycle warning, got %d", responsesCalls)

--- a/packages/sdk/sdk-java/src/ai/stats/sdk/AIStats.java
+++ b/packages/sdk/sdk-java/src/ai/stats/sdk/AIStats.java
@@ -430,12 +430,7 @@ public final class AIStats {
 		Map<String, String> query = new HashMap<>();
 		query.put("model_id", modelId);
 		query.put("limit", "1");
-		JsonNode response;
-		try {
-			response = parse(Operations.listDataModels(rawClient, null, query, null, null));
-		} catch (RuntimeException | IOException | InterruptedException ex) {
-			return null;
-		}
+		JsonNode response = parse(Operations.listDataModels(rawClient, null, query, null, null));
 		JsonNode models = response.path("models");
 		if (!models.isArray()) {
 			return null;

--- a/packages/sdk/sdk-java/src/ai/stats/sdk/AIStats.java
+++ b/packages/sdk/sdk-java/src/ai/stats/sdk/AIStats.java
@@ -29,6 +29,7 @@ public final class AIStats {
 	public static final class ModelLifecycleInfo {
 		public final String modelId;
 		public final String status;
+		public final String sourceStatus;
 		public final String deprecationDate;
 		public final String retirementDate;
 		public final String replacementModelId;
@@ -37,6 +38,7 @@ public final class AIStats {
 		public ModelLifecycleInfo(
 			String modelId,
 			String status,
+			String sourceStatus,
 			String deprecationDate,
 			String retirementDate,
 			String replacementModelId,
@@ -44,6 +46,7 @@ public final class AIStats {
 		) {
 			this.modelId = modelId;
 			this.status = status;
+			this.sourceStatus = sourceStatus;
 			this.deprecationDate = deprecationDate;
 			this.retirementDate = retirementDate;
 			this.replacementModelId = replacementModelId;
@@ -53,6 +56,24 @@ public final class AIStats {
 
 	private static final ObjectMapper MAPPER = new ObjectMapper();
 	private static final String DEFAULT_BASE_URL = "https://api.phaseo.app/v1";
+	private static final Set<String> ACTIVE_MODEL_SOURCE_STATUSES = Set.of("active", "available");
+	private static final Set<String> INACTIVE_MODEL_SOURCE_STATUSES = Set.of(
+		"deprecated",
+		"retired",
+		"withheld",
+		"announced",
+		"rumoured",
+		"rumored",
+		"unavailable",
+		"disabled",
+		"internal",
+		"private",
+		"removed",
+		"sunset",
+		"eol",
+		"end_of_life",
+		"end-of-life"
+	);
 	private final Client rawClient;
 	private final boolean enableDeprecationWarnings;
 	private final boolean warningsAsErrors;
@@ -157,10 +178,10 @@ public final class AIStats {
 			out.put("info", null);
 			return out;
 		}
-		if ("retired".equals(info.status)) {
+		if (!isModelRequestableForInference(info)) {
 			out.put("ok", false);
 			out.put("info", info);
-			out.put("reason", info.message != null ? info.message : "Model \"" + modelId + "\" is retired.");
+			out.put("reason", buildInactiveModelRequestMessage(info));
 			return out;
 		}
 		out.put("ok", true);
@@ -335,7 +356,26 @@ public final class AIStats {
 		if (modelId == null) {
 			return;
 		}
+		ensureModelRequestable(modelId);
 		maybeWarnForModel(modelId);
+	}
+
+	private void ensureModelRequestable(String modelId) throws IOException, InterruptedException {
+		String normalized = asTrimmedString(modelId);
+		if (normalized == null) {
+			return;
+		}
+
+		ModelLifecycleInfo lifecycle = getModelDeprecationInfo(normalized);
+		if (lifecycle == null) {
+			return;
+		}
+
+		if (isModelRequestableForInference(lifecycle)) {
+			return;
+		}
+
+		throw new IllegalStateException(buildInactiveModelRequestMessage(lifecycle));
 	}
 
 	private void maybeWarnForModel(String modelId) throws IOException, InterruptedException {
@@ -390,7 +430,12 @@ public final class AIStats {
 		Map<String, String> query = new HashMap<>();
 		query.put("model_id", modelId);
 		query.put("limit", "1");
-		JsonNode response = parse(Operations.listDataModels(rawClient, null, query, null, null));
+		JsonNode response;
+		try {
+			response = parse(Operations.listDataModels(rawClient, null, query, null, null));
+		} catch (RuntimeException | IOException | InterruptedException ex) {
+			return null;
+		}
 		JsonNode models = response.path("models");
 		if (!models.isArray()) {
 			return null;
@@ -413,6 +458,10 @@ public final class AIStats {
 			asTrimmedString(model.path("model_id").asText(null)),
 			fallbackModelId
 		);
+		String sourceStatus = firstNonEmpty(
+			asTrimmedString(model.path("status").asText(null)),
+			asTrimmedString(lifecycle.path("status").asText(null))
+		);
 		String deprecationDate = firstNonEmpty(
 			asTrimmedString(lifecycle.path("deprecation_date").asText(null)),
 			asTrimmedString(model.path("deprecation_date").asText(null))
@@ -434,7 +483,7 @@ public final class AIStats {
 			asTrimmedString(lifecycle.path("message").asText(null)),
 			buildLifecycleMessage(status, modelId, deprecationDate, retirementDate, replacement)
 		);
-		return new ModelLifecycleInfo(modelId, status, deprecationDate, retirementDate, replacement, message);
+		return new ModelLifecycleInfo(modelId, status, sourceStatus, deprecationDate, retirementDate, replacement, message);
 	}
 
 	private static String normalizeLifecycleStatus(String status, String deprecationDate, String retirementDate) {
@@ -492,6 +541,59 @@ public final class AIStats {
 			return "[ai-stats] Model \"" + modelId + "\" is deprecated." + replacement;
 		}
 		return "";
+	}
+
+	private static String normalizeSourceStatus(String value) {
+		String normalized = asTrimmedString(value);
+		return normalized == null ? null : normalized.toLowerCase();
+	}
+
+	private static boolean isModelRequestableForInference(ModelLifecycleInfo info) {
+		if (info == null || !"active".equals(info.status)) {
+			return false;
+		}
+
+		String sourceStatus = normalizeSourceStatus(info.sourceStatus);
+		if (sourceStatus == null) {
+			return true;
+		}
+		if (ACTIVE_MODEL_SOURCE_STATUSES.contains(sourceStatus)) {
+			return true;
+		}
+		if (INACTIVE_MODEL_SOURCE_STATUSES.contains(sourceStatus)) {
+			return false;
+		}
+		return false;
+	}
+
+	private static String buildInactiveModelRequestMessage(ModelLifecycleInfo info) {
+		if (info == null) {
+			return "[ai-stats] Model \"unknown-model\" is not active for inference.";
+		}
+
+		if (!"active".equals(info.status)) {
+			String fallback = buildLifecycleMessage(
+				info.status,
+				info.modelId,
+				info.deprecationDate,
+				info.retirementDate,
+				info.replacementModelId
+			);
+			if (info.message != null && !info.message.isBlank()) {
+				return info.message;
+			}
+			if (fallback != null && !fallback.isBlank()) {
+				return fallback;
+			}
+			return "[ai-stats] Model \"" + info.modelId + "\" is not active for inference.";
+		}
+
+		String sourceStatus = normalizeSourceStatus(info.sourceStatus);
+		if (sourceStatus == null) {
+			sourceStatus = "unknown";
+		}
+		String replacement = info.replacementModelId == null ? "" : " Use \"" + info.replacementModelId + "\" instead.";
+		return "[ai-stats] Model \"" + info.modelId + "\" is not active for inference (status: " + sourceStatus + ")." + replacement;
 	}
 
 	private static String extractModelIdFromPayload(Object payload) {

--- a/packages/sdk/sdk-java/tests/AIStatsDevtoolsTest.java
+++ b/packages/sdk/sdk-java/tests/AIStatsDevtoolsTest.java
@@ -20,6 +20,9 @@ public class AIStatsDevtoolsTest {
 	void capturesResponsesEntriesToDevtoolsDirectory() throws Exception {
 		AtomicInteger responseCalls = new AtomicInteger(0);
 		HttpServer server = HttpServer.create(new InetSocketAddress(0), 0);
+		server.createContext("/data/models", jsonHandler(new AtomicInteger(0), """
+			{"models":[{"model_id":"openai/gpt-5-nano","status":"Available","lifecycle":{"status":"active"}}]}
+			"""));
 		server.createContext("/responses", jsonHandler(responseCalls, """
 			{"id":"resp_1","model":"openai/gpt-5-nano","usage":{"input_tokens":2,"output_tokens":1,"total_tokens":3}}
 			"""));

--- a/packages/sdk/sdk-java/tests/AIStatsLifecycleTest.java
+++ b/packages/sdk/sdk-java/tests/AIStatsLifecycleTest.java
@@ -18,7 +18,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class AIStatsLifecycleTest {
 	@Test
-	void deprecatedModelWarnsOncePerModel() throws Exception {
+	void deprecatedModelBlocksRequest() throws Exception {
 		AtomicInteger dataModelsCalls = new AtomicInteger(0);
 		AtomicInteger responseCalls = new AtomicInteger(0);
 		List<String> warnings = new ArrayList<>();
@@ -48,20 +48,19 @@ public class AIStatsLifecycleTest {
 			Map<String, Object> request = new HashMap<>();
 			request.put("model", "provider/old-model");
 			request.put("input", "hello");
-			client.createResponse(request);
-			client.createResponse(request);
+			IllegalStateException ex = assertThrows(IllegalStateException.class, () -> client.createResponse(request));
 
-			assertEquals(1, warnings.size());
-			assertTrue(warnings.get(0).contains("provider/new-model"));
+			assertTrue(ex.getMessage().contains("provider/new-model"));
+			assertEquals(0, warnings.size());
 			assertEquals(1, dataModelsCalls.get());
-			assertEquals(2, responseCalls.get());
+			assertEquals(0, responseCalls.get());
 		} finally {
 			server.stop(0);
 		}
 	}
 
 	@Test
-	void warningsAsErrorsBlocksRequestWhenRetired() throws Exception {
+	void retiredModelBlocksRequestWithoutWarningsAsErrors() throws Exception {
 		AtomicInteger responseCalls = new AtomicInteger(0);
 
 		HttpServer server = HttpServer.create(new InetSocketAddress(0), 0);
@@ -74,7 +73,7 @@ public class AIStatsLifecycleTest {
 		server.start();
 		try {
 			String baseUrl = "http://127.0.0.1:" + server.getAddress().getPort();
-			AIStats client = new AIStats("test", baseUrl, true, true, null);
+			AIStats client = new AIStats("test", baseUrl, true, false, null);
 			Map<String, Object> request = new HashMap<>();
 			request.put("model", "provider/retired-model");
 			request.put("input", "hello");

--- a/packages/sdk/sdk-php/src/index.php
+++ b/packages/sdk/sdk-php/src/index.php
@@ -16,6 +16,25 @@ use RuntimeException;
 
 class AIStats
 {
+    private const ACTIVE_MODEL_SOURCE_STATUSES = ["active", "available"];
+    private const INACTIVE_MODEL_SOURCE_STATUSES = [
+        "deprecated",
+        "retired",
+        "withheld",
+        "announced",
+        "rumoured",
+        "rumored",
+        "unavailable",
+        "disabled",
+        "internal",
+        "private",
+        "removed",
+        "sunset",
+        "eol",
+        "end_of_life",
+        "end-of-life",
+    ];
+
     private GenClient $client;
     private bool $enableDeprecationWarnings;
     private bool $warningsAsErrors;
@@ -83,11 +102,11 @@ class AIStats
         if ($info === null) {
             return ["ok" => true, "info" => null];
         }
-        if (($info["status"] ?? "active") === "retired") {
+        if (!$this->isModelRequestableForInference($info)) {
             return [
                 "ok" => false,
                 "info" => $info,
-                "reason" => (string) ($info["message"] ?? sprintf('Model "%s" is retired.', $modelId)),
+                "reason" => $this->buildInactiveModelRequestMessage($info),
             ];
         }
         return ["ok" => true, "info" => $info];
@@ -354,7 +373,27 @@ class AIStats
         if ($modelId === null) {
             return;
         }
+        $this->ensureModelRequestable($modelId);
         $this->maybeWarnForModel($modelId);
+    }
+
+    private function ensureModelRequestable(string $modelId): void
+    {
+        $normalizedModelId = $this->asTrimmedString($modelId);
+        if ($normalizedModelId === null) {
+            return;
+        }
+
+        $lifecycle = $this->getModelDeprecationInfo($normalizedModelId);
+        if ($lifecycle === null) {
+            return;
+        }
+
+        if ($this->isModelRequestableForInference($lifecycle)) {
+            return;
+        }
+
+        throw new RuntimeException($this->buildInactiveModelRequestMessage($lifecycle));
     }
 
     private function withLifecycleAndTelemetry(string $endpoint, mixed $payload, bool $checkLifecycle, callable $operation): mixed
@@ -478,6 +517,10 @@ class AIStats
             $this->asTrimmedString((string) ($model["model_id"] ?? "")),
             $fallbackModelId
         ) ?? $fallbackModelId;
+        $sourceStatus = $this->firstNonEmpty(
+            $this->asTrimmedString((string) ($model["status"] ?? "")),
+            $this->asTrimmedString((string) ($lifecycle["status"] ?? ""))
+        );
         $deprecationDate = $this->firstNonEmpty(
             $this->asTrimmedString((string) ($lifecycle["deprecation_date"] ?? "")),
             $this->asTrimmedString((string) ($model["deprecation_date"] ?? ""))
@@ -505,6 +548,7 @@ class AIStats
         return [
             "model_id" => $modelId,
             "status" => $status,
+            "source_status" => $sourceStatus,
             "deprecation_date" => $deprecationDate,
             "retirement_date" => $retirementDate,
             "replacement_model_id" => $replacementModelId,
@@ -570,6 +614,60 @@ class AIStats
             return sprintf('[ai-stats] Model "%s" is deprecated.%s', $modelId, $replacement);
         }
         return "";
+    }
+
+    private function normalizeSourceStatus(?string $status): ?string
+    {
+        $normalized = $this->asTrimmedString($status);
+        return $normalized !== null ? strtolower($normalized) : null;
+    }
+
+    /** @param array<string,mixed> $info */
+    private function isModelRequestableForInference(array $info): bool
+    {
+        if (($info["status"] ?? "active") !== "active") {
+            return false;
+        }
+
+        $sourceStatus = $this->normalizeSourceStatus(isset($info["source_status"]) ? (string) $info["source_status"] : null);
+        if ($sourceStatus === null) {
+            return true;
+        }
+        if (in_array($sourceStatus, self::ACTIVE_MODEL_SOURCE_STATUSES, true)) {
+            return true;
+        }
+        if (in_array($sourceStatus, self::INACTIVE_MODEL_SOURCE_STATUSES, true)) {
+            return false;
+        }
+        return false;
+    }
+
+    /** @param array<string,mixed> $info */
+    private function buildInactiveModelRequestMessage(array $info): string
+    {
+        $status = (string) ($info["status"] ?? "active");
+        $modelId = (string) ($info["model_id"] ?? "unknown-model");
+        if ($status !== "active") {
+            $fallback = $this->buildLifecycleMessage(
+                $status,
+                $modelId,
+                isset($info["deprecation_date"]) ? (string) $info["deprecation_date"] : null,
+                isset($info["retirement_date"]) ? (string) $info["retirement_date"] : null,
+                isset($info["replacement_model_id"]) ? (string) $info["replacement_model_id"] : null
+            );
+            $message = $this->asTrimmedString(isset($info["message"]) ? (string) $info["message"] : null);
+            return $message ?? $fallback ?? sprintf('[ai-stats] Model "%s" is not active for inference.', $modelId);
+        }
+
+        $sourceStatus = $this->normalizeSourceStatus(isset($info["source_status"]) ? (string) $info["source_status"] : null) ?? "unknown";
+        $replacementModelId = $this->asTrimmedString(isset($info["replacement_model_id"]) ? (string) $info["replacement_model_id"] : null);
+        $replacement = $replacementModelId !== null ? sprintf(' Use "%s" instead.', $replacementModelId) : "";
+        return sprintf(
+            '[ai-stats] Model "%s" is not active for inference (status: %s).%s',
+            $modelId,
+            $sourceStatus,
+            $replacement
+        );
     }
 
     private function extractModelIdFromPayload(mixed $payload): ?string

--- a/packages/sdk/sdk-php/tests/lifecycle_test.php
+++ b/packages/sdk/sdk-php/tests/lifecycle_test.php
@@ -42,16 +42,24 @@ $deprecatedClient = new AIStats(
     }
 );
 
-invoke_private($deprecatedClient, "maybeWarnForModel", ["provider/old-model"]);
-invoke_private($deprecatedClient, "maybeWarnForModel", ["provider/old-model"]);
-assert_true(count($warnings) === 1, "expected warn-once behavior for deprecated model");
-assert_true(str_contains($warnings[0][0], "provider/new-model"), "expected replacement model in warning message");
+$validation = $deprecatedClient->validateModel("provider/old-model");
+assert_true($validation["ok"] === false, "expected validateModel to reject deprecated model");
+assert_true(str_contains((string) $validation["reason"], "provider/new-model"), "expected replacement model in validation reason");
+
+$threw = false;
+try {
+    invoke_private($deprecatedClient, "maybeWarnForPayload", [["model" => "provider/old-model"]]);
+} catch (RuntimeException $e) {
+    $threw = str_contains($e->getMessage(), "provider/new-model");
+}
+assert_true($threw, "expected inactive model preflight to throw before dispatch");
+assert_true(count($warnings) === 0, "expected no warning callback when request is blocked");
 
 $retiredClient = new AIStats(
     apiKey: "test",
     basePath: "https://api.phaseo.app/v1",
     enableDeprecationWarnings: true,
-    warningsAsErrors: true,
+    warningsAsErrors: false,
     lifecycleResolver: function (string $modelId): array {
         return [
             "model_id" => $modelId,
@@ -64,10 +72,10 @@ $retiredClient = new AIStats(
 
 $threw = false;
 try {
-    invoke_private($retiredClient, "maybeWarnForModel", ["provider/retired-model"]);
+    invoke_private($retiredClient, "maybeWarnForPayload", [["model" => "provider/retired-model"]]);
 } catch (RuntimeException $e) {
     $threw = str_contains($e->getMessage(), "retired");
 }
-assert_true($threw, "expected warningsAsErrors to throw for retired model");
+assert_true($threw, "expected retired model preflight to throw regardless of warning mode");
 
 echo "php lifecycle tests ok" . PHP_EOL;

--- a/packages/sdk/sdk-py/src/ai_stats/__init__.py
+++ b/packages/sdk/sdk-py/src/ai_stats/__init__.py
@@ -178,6 +178,7 @@ AIStatsLogger: TypeAlias = Callable[[AIStatsLogLevel, str, dict[str, Any]], None
 class ModelLifecycleInfo(TypedDict):
     model_id: str
     status: Literal["active", "deprecated", "retired"]
+    source_status: Optional[str]
     deprecation_date: Optional[str]
     retirement_date: Optional[str]
     replacement_model_id: Optional[str]
@@ -305,19 +306,27 @@ class AIStats:
         info = self.get_model_deprecation_info(model_id)
         if not info:
             return {"ok": True, "info": None}
-        if info["status"] == "retired":
-            return {
-                "ok": False,
-                "info": info,
-                "reason": info.get("message") or f'Model "{model_id}" is retired.',
-            }
+        if not _is_model_requestable_for_inference(info):
+            return {"ok": False, "info": info, "reason": _build_inactive_model_request_message(info)}
         return {"ok": True, "info": info}
 
     def _maybe_warn_for_payload(self, payload: dict[str, Any] | None) -> None:
         model_id = _extract_model_id_from_payload(payload)
         if not model_id:
             return
+        self._ensure_model_requestable(model_id)
         self._maybe_warn_for_model(model_id)
+
+    def _ensure_model_requestable(self, model_id: str) -> None:
+        normalized_model_id = _as_trimmed_string(model_id)
+        if not normalized_model_id:
+            return
+        lifecycle = self._resolve_model_lifecycle(normalized_model_id)
+        if not lifecycle:
+            return
+        if _is_model_requestable_for_inference(lifecycle):
+            return
+        raise ValueError(_build_inactive_model_request_message(lifecycle))
 
     def _maybe_warn_for_model(self, model_id: str) -> None:
         if not self._enable_deprecation_warnings:
@@ -808,6 +817,7 @@ def _to_model_lifecycle_info(model: dict[str, Any], fallback_model_id: str) -> M
     lifecycle_obj = model.get("lifecycle")
     lifecycle = lifecycle_obj if isinstance(lifecycle_obj, dict) else {}
     model_id = _as_trimmed_string(model.get("model_id")) or fallback_model_id
+    source_status = _as_trimmed_string(model.get("status")) or _as_trimmed_string(lifecycle.get("status"))
 
     deprecation_date = _as_trimmed_string(lifecycle.get("deprecation_date")) or _as_trimmed_string(
         model.get("deprecation_date")
@@ -828,6 +838,7 @@ def _to_model_lifecycle_info(model: dict[str, Any], fallback_model_id: str) -> M
     return {
         "model_id": model_id,
         "status": status,
+        "source_status": source_status,
         "deprecation_date": deprecation_date,
         "retirement_date": retirement_date,
         "replacement_model_id": replacement_model_id,
@@ -879,6 +890,70 @@ def _build_lifecycle_message(
             return f'[ai-stats] Model "{model_id}" has been deprecated since {deprecation_date}.{replacement}'
         return f'[ai-stats] Model "{model_id}" is deprecated.{replacement}'
     return None
+
+
+_ACTIVE_MODEL_SOURCE_STATUSES = {"active", "available"}
+_INACTIVE_MODEL_SOURCE_STATUSES = {
+    "deprecated",
+    "retired",
+    "withheld",
+    "announced",
+    "rumoured",
+    "rumored",
+    "unavailable",
+    "disabled",
+    "internal",
+    "private",
+    "removed",
+    "sunset",
+    "eol",
+    "end_of_life",
+    "end-of-life",
+}
+
+
+def _normalize_source_status(value: Optional[str]) -> Optional[str]:
+    if not value:
+        return None
+    normalized = value.strip().lower()
+    return normalized or None
+
+
+def _is_model_requestable_for_inference(info: ModelLifecycleInfo) -> bool:
+    if info.get("status") != "active":
+        return False
+    source_status = _normalize_source_status(info.get("source_status"))
+    if not source_status:
+        return True
+    if source_status in _ACTIVE_MODEL_SOURCE_STATUSES:
+        return True
+    if source_status in _INACTIVE_MODEL_SOURCE_STATUSES:
+        return False
+    return False
+
+
+def _build_inactive_model_request_message(info: ModelLifecycleInfo) -> str:
+    status = info.get("status")
+    if status != "active":
+        fallback = _build_lifecycle_message(
+            status or "retired",
+            info.get("model_id") or "unknown-model",
+            info.get("deprecation_date"),
+            info.get("retirement_date"),
+            info.get("replacement_model_id"),
+        )
+        return info.get("message") or fallback or f'Model "{info.get("model_id")}" is not active for inference.'
+
+    source_status = _normalize_source_status(info.get("source_status")) or "unknown"
+    replacement = (
+        f' Use "{info.get("replacement_model_id")}" instead.'
+        if info.get("replacement_model_id")
+        else ""
+    )
+    return (
+        f'[ai-stats] Model "{info.get("model_id")}" is not active for inference '
+        f"(status: {source_status}).{replacement}"
+    )
 
 
 def _parse_iso_datetime(value: Optional[str]) -> Optional[datetime]:

--- a/packages/sdk/sdk-py/tests/test_client.py
+++ b/packages/sdk/sdk-py/tests/test_client.py
@@ -49,43 +49,34 @@ def test_chat_completions_propagates_errors(monkeypatch):
         )
 
 
-def test_deprecation_warning_emits_once_per_model(monkeypatch):
-    warning_events = []
-    response_calls = []
+def test_non_active_status_blocks_request_dispatch(monkeypatch):
+    called = False
 
     def fake_create_response(_client, body):
-        response_calls.append(body["model"])
+        nonlocal called
+        called = True
         return {"id": "resp_123", "output_text": "ok"}
 
     def fake_request(method, path, *, query=None, headers=None, body=None):
         assert method == "GET"
         assert path == "/data/models"
-        assert query == {"model_id": "openai/legacy-model", "limit": 1}
+        assert query == {"model_id": "openai/rumoured-model", "limit": 1}
         return {
             "models": [
                 {
-                    "model_id": "openai/legacy-model",
-                    "status": "deprecated",
-                    "retirement_date": "2099-01-01T00:00:00Z",
+                    "model_id": "openai/rumoured-model",
+                    "status": "rumoured",
                 }
             ]
         }
 
     monkeypatch.setattr(ops, "createResponse", fake_create_response)
-    client = AIStats(
-        api_key="sk_test_123",
-        base_url="https://example.test",
-        logger=lambda level, message, meta: warning_events.append((level, message, meta)),
-    )
+    client = AIStats(api_key="sk_test_123", base_url="https://example.test")
     monkeypatch.setattr(client, "request", fake_request)
 
-    client.generate_response({"model": "openai/legacy-model", "input": "first"})
-    client.generate_response({"model": "openai/legacy-model", "input": "second"})
-
-    assert len(response_calls) == 2
-    assert len(warning_events) == 1
-    assert warning_events[0][0] == "warn"
-    assert "deprecated" in warning_events[0][1]
+    with pytest.raises(ValueError, match="not active for inference"):
+        client.generate_response({"model": "openai/rumoured-model", "input": "first"})
+    assert called is False
 
 
 def test_warnings_as_errors_blocks_request_for_retired_models(monkeypatch):
@@ -122,14 +113,23 @@ def test_warnings_as_errors_blocks_request_for_retired_models(monkeypatch):
 
 def test_can_disable_deprecation_warnings(monkeypatch):
     called = False
+    lifecycle_lookups = []
 
     def fake_create_response(_client, body):
         nonlocal called
         called = True
         return {"id": "resp_123"}
 
-    def fail_if_called(*args, **kwargs):
-        raise AssertionError("Lifecycle lookup should not run when warnings are disabled")
+    def fake_request(method, path, *, query=None, headers=None, body=None):
+        lifecycle_lookups.append((method, path, query))
+        return {
+            "models": [
+                {
+                    "model_id": "openai/new-model",
+                    "status": "active",
+                }
+            ]
+        }
 
     monkeypatch.setattr(ops, "createResponse", fake_create_response)
     client = AIStats(
@@ -137,8 +137,9 @@ def test_can_disable_deprecation_warnings(monkeypatch):
         base_url="https://example.test",
         enable_deprecation_warnings=False,
     )
-    monkeypatch.setattr(client, "request", fail_if_called)
+    monkeypatch.setattr(client, "request", fake_request)
 
     response = client.generate_response({"model": "openai/new-model", "input": "hi"})
     assert called is True
     assert response["id"] == "resp_123"
+    assert lifecycle_lookups == [("GET", "/data/models", {"model_id": "openai/new-model", "limit": 1})]

--- a/packages/sdk/sdk-ruby/lib/index.rb
+++ b/packages/sdk/sdk-ruby/lib/index.rb
@@ -11,6 +11,25 @@ module AIStatsSdk
   # Thin wrapper around the in-house generated Ruby SDK.
   # Regenerate with: `pnpm openapi:gen:ruby`
   class AIStats
+    ACTIVE_MODEL_SOURCE_STATUSES = %w[active available].freeze
+    INACTIVE_MODEL_SOURCE_STATUSES = %w[
+      deprecated
+      retired
+      withheld
+      announced
+      rumoured
+      rumored
+      unavailable
+      disabled
+      internal
+      private
+      removed
+      sunset
+      eol
+      end_of_life
+      end-of-life
+    ].freeze
+
     attr_reader :raw_client
 
     def initialize(
@@ -51,7 +70,9 @@ module AIStatsSdk
     def validate_model(model_id)
       info = get_model_deprecation_info(model_id)
       return { ok: true, info: nil } unless info
-      return { ok: false, info: info, reason: info[:message] || %(Model "#{model_id}" is retired.) } if info[:status] == "retired"
+      unless is_model_requestable_for_inference?(info)
+        return { ok: false, info: info, reason: build_inactive_model_request_message(info) }
+      end
 
       { ok: true, info: info }
     end
@@ -227,7 +248,19 @@ module AIStatsSdk
     def maybe_warn_for_payload(payload)
       model_id = extract_model_id(payload)
       return unless model_id
+      ensure_model_requestable(model_id)
       maybe_warn_for_model(model_id)
+    end
+
+    def ensure_model_requestable(model_id)
+      normalized = as_trimmed_string(model_id)
+      return unless normalized
+
+      lifecycle = get_model_deprecation_info(normalized)
+      return unless lifecycle
+      return if is_model_requestable_for_inference?(lifecycle)
+
+      raise RuntimeError, build_inactive_model_request_message(lifecycle)
     end
 
     def with_lifecycle_and_telemetry(endpoint:, payload:, check_lifecycle:)
@@ -314,6 +347,7 @@ module AIStatsSdk
     def to_model_lifecycle_info(model, fallback_model_id)
       lifecycle = normalize_hash(model[:lifecycle]) || {}
       model_id = first_non_empty(as_trimmed_string(model[:model_id]), fallback_model_id) || fallback_model_id
+      source_status = first_non_empty(as_trimmed_string(model[:status]), as_trimmed_string(lifecycle[:status]))
       deprecation_date = first_non_empty(as_trimmed_string(lifecycle[:deprecation_date]), as_trimmed_string(model[:deprecation_date]))
       retirement_date = first_non_empty(as_trimmed_string(lifecycle[:retirement_date]), as_trimmed_string(model[:retirement_date]))
       status = normalize_lifecycle_status(
@@ -330,6 +364,7 @@ module AIStatsSdk
       {
         model_id: model_id,
         status: status,
+        source_status: source_status,
         deprecation_date: deprecation_date,
         retirement_date: retirement_date,
         replacement_model_id: replacement_model_id,
@@ -371,6 +406,42 @@ module AIStatsSdk
         return %[ [ai-stats] Model "#{model_id}" is deprecated.#{replacement} ].strip
       end
       ""
+    end
+
+    def normalize_source_status(value)
+      normalized = as_trimmed_string(value)
+      normalized&.downcase
+    end
+
+    def is_model_requestable_for_inference?(info)
+      return false unless info[:status] == "active"
+
+      source_status = normalize_source_status(info[:source_status])
+      return true unless source_status
+      return true if ACTIVE_MODEL_SOURCE_STATUSES.include?(source_status)
+      return false if INACTIVE_MODEL_SOURCE_STATUSES.include?(source_status)
+
+      false
+    end
+
+    def build_inactive_model_request_message(info)
+      if info[:status] != "active"
+        fallback = build_lifecycle_message(
+          info[:status] || "retired",
+          info[:model_id] || "unknown-model",
+          info[:deprecation_date],
+          info[:retirement_date],
+          info[:replacement_model_id]
+        )
+        return info[:message] if as_trimmed_string(info[:message])
+        return fallback if as_trimmed_string(fallback)
+
+        return %[ [ai-stats] Model "#{info[:model_id]}" is not active for inference. ].strip
+      end
+
+      source_status = normalize_source_status(info[:source_status]) || "unknown"
+      replacement = info[:replacement_model_id] ? %( Use "#{info[:replacement_model_id]}" instead.) : ""
+      %[ [ai-stats] Model "#{info[:model_id]}" is not active for inference (status: #{source_status}).#{replacement} ].strip
     end
 
     def extract_model_id(payload)

--- a/packages/sdk/sdk-ruby/tests/lifecycle_test.rb
+++ b/packages/sdk/sdk-ruby/tests/lifecycle_test.rb
@@ -2,7 +2,7 @@ require "minitest/autorun"
 require_relative "../lib/index"
 
 class LifecycleTest < Minitest::Test
-  def test_warns_once_per_model
+  def test_inactive_model_is_blocked_before_dispatch
     warnings = []
     logger = lambda do |level, message, _meta|
       warnings << message if level == "warn"
@@ -22,17 +22,21 @@ class LifecycleTest < Minitest::Test
       end
     )
 
-    client.send(:maybe_warn_for_model, "provider/old-model")
-    client.send(:maybe_warn_for_model, "provider/old-model")
+    validation = client.validate_model("provider/old-model")
+    assert_equal false, validation[:ok]
+    assert_includes validation[:reason], "provider/new-model"
 
-    assert_equal 1, warnings.length
-    assert_includes warnings[0], "provider/new-model"
+    error = assert_raises(RuntimeError) do
+      client.send(:maybe_warn_for_payload, { model: "provider/old-model" })
+    end
+    assert_includes error.message, "provider/new-model"
+    assert_equal 0, warnings.length
   end
 
-  def test_warnings_as_errors_for_retired_model
+  def test_retired_model_is_blocked_without_warnings_as_errors
     client = AIStatsSdk::AIStats.new(
       api_key: "test",
-      warnings_as_errors: true,
+      warnings_as_errors: false,
       lifecycle_resolver: lambda do |model_id|
         {
           model_id: model_id,
@@ -44,7 +48,7 @@ class LifecycleTest < Minitest::Test
     )
 
     error = assert_raises(RuntimeError) do
-      client.send(:maybe_warn_for_model, "provider/retired-model")
+      client.send(:maybe_warn_for_payload, { model: "provider/retired-model" })
     end
     assert_includes error.message, "retired"
   end

--- a/packages/sdk/sdk-ts/src/index.ts
+++ b/packages/sdk/sdk-ts/src/index.ts
@@ -58,6 +58,7 @@ export type AIStatsLogger = (level: AIStatsLogLevel, message: string, meta?: Rec
 export type ModelLifecycleInfo = {
   modelId: string;
   status: "active" | "deprecated" | "retired";
+  sourceStatus: string | null;
   deprecationDate: string | null;
   retirementDate: string | null;
   replacementModelId: string | null;
@@ -305,8 +306,8 @@ export class AIStats {
   async validateModel(modelId: string): Promise<{ ok: boolean; info: ModelLifecycleInfo | null; reason?: string }> {
     const info = await this.getModelDeprecationInfo(modelId);
     if (!info) return { ok: true, info: null };
-    if (info.status === "retired") {
-      return { ok: false, info, reason: info.message ?? `Model "${modelId}" is retired.` };
+    if (!isModelRequestableForInference(info)) {
+      return { ok: false, info, reason: buildInactiveModelRequestMessage(info) };
     }
     return { ok: true, info };
   }
@@ -319,7 +320,17 @@ export class AIStats {
   private async maybeWarnForPayload(payload: unknown): Promise<void> {
     const modelId = extractModelIdFromPayload(payload);
     if (!modelId) return;
+    await this.ensureModelRequestable(modelId);
     await this.maybeWarnForModel(modelId);
+  }
+
+  private async ensureModelRequestable(modelId: string): Promise<void> {
+    const normalizedModelId = modelId.trim();
+    if (!normalizedModelId) return;
+    const lifecycle = await this.resolveModelLifecycle(normalizedModelId);
+    if (!lifecycle) return;
+    if (isModelRequestableForInference(lifecycle)) return;
+    throw new Error(buildInactiveModelRequestMessage(lifecycle));
   }
 
   private async maybeWarnForModel(modelId: string): Promise<void> {
@@ -809,6 +820,10 @@ function toModelLifecycleInfo(
 ): ModelLifecycleInfo {
   const lifecycle = (model.lifecycle ?? {}) as Record<string, unknown>;
   const modelId = asTrimmedString(model.model_id) ?? fallbackModelId;
+  const sourceStatus =
+    asTrimmedString(model.status) ??
+    asTrimmedString(lifecycle.status) ??
+    null;
 
   const deprecationDate =
     asTrimmedString(lifecycle.deprecation_date) ??
@@ -832,6 +847,7 @@ function toModelLifecycleInfo(
   return {
     modelId,
     status,
+    sourceStatus,
     deprecationDate,
     retirementDate,
     replacementModelId,
@@ -882,6 +898,60 @@ function buildLifecycleMessage(
     return `[ai-stats] Model "${modelId}" is deprecated.${replacement}`;
   }
   return null;
+}
+
+const ACTIVE_MODEL_SOURCE_STATUSES = new Set(["active", "available"]);
+const INACTIVE_MODEL_SOURCE_STATUSES = new Set([
+  "deprecated",
+  "retired",
+  "withheld",
+  "announced",
+  "rumoured",
+  "rumored",
+  "unavailable",
+  "disabled",
+  "internal",
+  "private",
+  "removed",
+  "sunset",
+  "eol",
+  "end_of_life",
+  "end-of-life",
+]);
+
+function normalizeSourceStatus(value: string | null | undefined): string | null {
+  if (!value) return null;
+  const normalized = value.trim().toLowerCase();
+  return normalized.length > 0 ? normalized : null;
+}
+
+function isModelRequestableForInference(info: ModelLifecycleInfo): boolean {
+  if (info.status !== "active") return false;
+  const sourceStatus = normalizeSourceStatus(info.sourceStatus);
+  if (!sourceStatus) return true;
+  if (ACTIVE_MODEL_SOURCE_STATUSES.has(sourceStatus)) return true;
+  if (INACTIVE_MODEL_SOURCE_STATUSES.has(sourceStatus)) return false;
+  return false;
+}
+
+function buildInactiveModelRequestMessage(info: ModelLifecycleInfo): string {
+  if (info.status !== "active") {
+    return (
+      info.message ??
+      buildLifecycleMessage(
+        info.status,
+        info.modelId,
+        info.deprecationDate,
+        info.retirementDate,
+        info.replacementModelId
+      ) ??
+      `[ai-stats] Model "${info.modelId}" is not active for inference.`
+    );
+  }
+
+  const sourceStatus = normalizeSourceStatus(info.sourceStatus) ?? "unknown";
+  const replacement = info.replacementModelId ? ` Use "${info.replacementModelId}" instead.` : "";
+  return `[ai-stats] Model "${info.modelId}" is not active for inference (status: ${sourceStatus}).${replacement}`;
 }
 
 function asTrimmedString(value: unknown): string | null {


### PR DESCRIPTION
## Summary
- enforce active-only inference gating in API routing and model-catalog filters
- apply the same preflight lifecycle enforcement across all maintained SDK wrappers (TS, Python, Go, Java, C#, PHP, Ruby)
- make `validateModel` return `ok: false` for any non-requestable model (not only retired)
- block inference dispatch early when source status is non-active (for example `withheld`, `announced`, `deprecated`, `retired`)
- update lifecycle tests in each SDK wrapper to reflect blocked non-active requests

## API changes
- `apps/api/src/pipeline/before/context.sql`
  - provider candidate selection now filters to active/available and excludes retired/deprecated-by-date models
- `apps/api/src/routes/v1/control/models.catalogue.ts`
  - add `statuses` filter support (`active`, `deprecated`, `retired`) with date-aware normalization
- `apps/api/src/routes/v1/data/videos.ts`
  - `/videos/models` now requests only active models from the catalogue loader
- `apps/api/src/routes/v1/control/models.catalogue.test.ts`
  - add status-filter coverage

## SDK coverage
- TypeScript: `packages/sdk/sdk-ts/src/index.ts`
- Python: `packages/sdk/sdk-py/src/ai_stats/__init__.py`
- Go: `packages/sdk/sdk-go/index.go`, `packages/sdk/sdk-go/lifecycle_test.go`
- Java: `packages/sdk/sdk-java/src/ai/stats/sdk/AIStats.java`, `packages/sdk/sdk-java/tests/AIStatsLifecycleTest.java`
- C#: `packages/sdk/sdk-csharp/Client.cs`, `packages/sdk/sdk-csharp/tests/AIStats.Sdk.Tests/LifecycleTests.cs`
- PHP: `packages/sdk/sdk-php/src/index.php`, `packages/sdk/sdk-php/tests/lifecycle_test.php`
- Ruby: `packages/sdk/sdk-ruby/lib/index.rb`, `packages/sdk/sdk-ruby/tests/lifecycle_test.rb`

## Validation
- `pnpm --filter @ai-stats/gateway-api exec vitest run src/routes/v1/control/models.catalogue.test.ts`
- `pnpm --filter @ai-stats/gateway-api typecheck`
- `pnpm --filter @ai-stats/sdk build`
- `pnpm test:sdk-py`
- `pnpm --filter @ai-stats/go-sdk test`
- `pnpm --filter @ai-stats/java-sdk test`
- `pnpm --filter @ai-stats/csharp-sdk test`
- `pnpm --filter @ai-stats/php-sdk test`
- `pnpm --filter @ai-stats/ruby-sdk test`

### Live TS SDK smoke checks (hosted API)
- pass: `openai/gpt-5.4-nano` via `responses.create`
- blocked as expected: `anthropic/claude-mythos-preview` with
  - `[ai-stats] Model "anthropic/claude-mythos-preview" is not active for inference (status: withheld).`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Models that are deprecated, retired, or otherwise not requestable are now blocked from inference and return a clear error instead of allowing requests with warnings.

* **Improvements**
  * SDKs and API now enforce lifecycle and source-status eligibility earlier in request flow, giving clearer rejection reasons and preventing dispatch for ineligible models.

* **Tests**
  * Test suites and test server behavior updated to assert blocking behavior and exercise model-list lookups.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->