### PR TITLE
Switch model apps to gateway usage and polish pricing layout

### DIFF
--- a/apps/web/src/app/(dashboard)/models/[organisationId]/[modelId]/apps/page.tsx
+++ b/apps/web/src/app/(dashboard)/models/[organisationId]/[modelId]/apps/page.tsx
@@ -39,17 +39,17 @@ export async function generateMetadata(props: {
 		return buildMetadata({
 			title: "Model Apps and Distribution",
 			description:
-				"See where this model is available across apps and subscription plans on AI Stats, including plan-level pricing context and provider coverage.",
+				"See which public apps are actively sending gateway requests to this model on AI Stats.",
 			path,
-			keywords: ["AI model apps", "subscription plans", "AI distribution", "AI Stats"],
+			keywords: ["AI model apps", "gateway app usage", "AI distribution", "AI Stats"],
 			imagePath,
 		});
 	}
 
 	const organisationName = model.organisation?.name ?? "AI provider";
 	const description = [
-		`${model.name} app and plan availability by ${organisationName} on AI Stats.`,
-		"Review where this model ships across products and subscription tiers.",
+		`${model.name} app usage by ${organisationName} on AI Stats.`,
+		"Review which public apps are actively using this model through gateway requests.",
 	]
 		.filter(Boolean)
 		.join(" ");
@@ -61,9 +61,9 @@ export async function generateMetadata(props: {
 		keywords: [
 			model.name,
 			`${model.name} apps`,
-			`${model.name} subscription plans`,
+			`${model.name} app usage`,
 			`${organisationName} AI`,
-			"AI app availability",
+			"gateway request usage",
 			"AI Stats",
 		],
 		imagePath,

--- a/apps/web/src/components/(data)/model/overview/ModelOverviewSections.tsx
+++ b/apps/web/src/components/(data)/model/overview/ModelOverviewSections.tsx
@@ -26,7 +26,7 @@ import { getModelTokenTrajectoryCached } from "@/lib/fetchers/models/getModelTok
 import { getModelGatewayMetadataCached } from "@/lib/fetchers/models/getModelGatewayMetadata";
 import { getModelBenchmarkHighlights } from "@/lib/fetchers/models/getModelBenchmarkData";
 import { getModelPricingCached } from "@/lib/fetchers/models/getModelPricing";
-import { getModelSubscriptionPlansCached } from "@/lib/fetchers/models/getModelSubscriptionPlans";
+import { getModelAppsCached } from "@/lib/fetchers/models/getModelApps";
 import { getOrganisationModelsCached } from "@/lib/fetchers/organisations/getOrganisation";
 import { Badge } from "@/components/ui/badge";
 import {
@@ -74,20 +74,6 @@ function Section({
 			{children}
 		</section>
 	);
-}
-
-function formatPrice(
-	prices:
-		| Array<{ price: number; currency: string; frequency: string }>
-		| undefined,
-): string {
-	if (!prices || prices.length === 0) return "Pricing unavailable";
-	const sorted = [...prices].sort((a, b) => a.price - b.price);
-	const first = sorted[0];
-	const currency = (first.currency || "USD").toUpperCase();
-	return `${currency} ${first.price.toFixed(first.price % 1 === 0 ? 0 : 2)} / ${
-		first.frequency || "period"
-	}`;
 }
 
 function formatPercent(value: number | null): string {
@@ -234,7 +220,7 @@ export async function ModelAppsSection({
 	modelId,
 	includeHidden,
 }: ModelSectionSharedProps) {
-	const subscriptionPlans = await getModelSubscriptionPlansCached(
+	const modelApps = await getModelAppsCached(
 		modelId,
 		includeHidden,
 	).catch(() => []);
@@ -246,24 +232,29 @@ export async function ModelAppsSection({
 					Apps Using This Model
 				</h2>
 				<p className="text-sm text-muted-foreground">
-					Products and plans where this model is currently available.
+					Public apps observed in gateway request traffic for this model.
 				</p>
 			</div>
-			{subscriptionPlans.length > 0 ? (
+			{modelApps.length > 0 ? (
 				<div className="grid gap-3 md:grid-cols-2">
-					{subscriptionPlans.map((plan) => (
+					{modelApps.map((app) => (
 						<Link
-							key={plan.plan_id}
-							href={`/subscription-plans/${plan.plan_id}`}
+							key={app.appId}
+							href={`/apps/${encodeURIComponent(app.appId)}`}
 							className="rounded-lg border border-border/70 px-4 py-3 transition-colors hover:bg-muted/40"
 						>
-							<p className="text-sm font-semibold">{plan.name}</p>
+							<p className="text-sm font-semibold">{app.title}</p>
 							<p className="text-xs text-muted-foreground">
-								{plan.organisation?.name ?? "Unknown organisation"}
+								{app.appId}
 							</p>
-							<p className="mt-1 text-xs text-muted-foreground">
-								{formatPrice(plan.prices)}
-							</p>
+							<div className="mt-2 flex flex-wrap items-center gap-2">
+								<Badge variant="outline" className="text-[11px]">
+									{app.totalRequests.toLocaleString()} requests
+								</Badge>
+								<Badge variant="outline" className="text-[11px]">
+									{app.totalTokens.toLocaleString()} tokens
+								</Badge>
+							</div>
 						</Link>
 					))}
 				</div>
@@ -275,8 +266,7 @@ export async function ModelAppsSection({
 						</EmptyMedia>
 						<EmptyTitle>No app distribution yet</EmptyTitle>
 						<EmptyDescription>
-							No app or subscription distribution data is available for this
-							model yet.
+							No gateway request app data is available for this model yet.
 						</EmptyDescription>
 					</EmptyHeader>
 				</Empty>

--- a/apps/web/src/components/(data)/model/pricing/ProviderCard.tsx
+++ b/apps/web/src/components/(data)/model/pricing/ProviderCard.tsx
@@ -11,7 +11,7 @@ import {
 	HoverCardTrigger,
 } from "@/components/ui/hover-card";
 import {
-	TokenTripleSection,
+	TierTiles,
 	ImageGenSection,
 	VideoGenSection,
 	InputsSection,
@@ -23,6 +23,8 @@ import ProviderModelParameters from "@/components/(data)/model/pricing/ProviderM
 import {
 	buildProviderSections,
 	fmtUSD,
+	type TokenTier,
+	type TokenTriple,
 } from "@/components/(data)/model/pricing/pricingHelpers";
 import type { ProviderPricing } from "@/lib/fetchers/models/getModelPricing";
 import type { ProviderRuntimeStats } from "@/lib/fetchers/models/getModelProviderRuntimeStats";
@@ -320,16 +322,6 @@ export default function ProviderCard({
 	const textProviderModels = providerModelsInScope.filter(
 		(pm) => pm.endpoint === "text.generate"
 	);
-	const hasTextLikeEndpoint = providerModelsInScope.some(
-		(pm) => pm.endpoint === "text.generate" || pm.endpoint === "text.embed"
-	);
-	const hasTextSection = Boolean(sec.textTokens) || hasTextLikeEndpoint;
-	const textTripleForDisplay = sec.textTokens ?? {
-		in: [],
-		cached: [],
-		write: [],
-		out: [],
-	};
 	const maxFrom = (values: Array<number | null | undefined>) => {
 		const nums = values.filter(
 			(v): v is number => typeof v === "number" && Number.isFinite(v) && v > 0
@@ -363,6 +355,87 @@ export default function ProviderCard({
 				value: string;
 			} => Boolean(metric)
 		);
+	type TokenMetricTile = {
+		key: string;
+		title: string;
+		tiers?: TokenTier[];
+		unitLabel?: string;
+	};
+	type TokenMetricGroup = {
+		key: string;
+		title: string;
+		tiles: TokenMetricTile[];
+	};
+	const createTokenTiles = (
+		modalityLabel: "Text" | "Audio" | "Image" | "Video",
+		modalityKey: "text" | "audio" | "image" | "video",
+		triple: TokenTriple | undefined,
+	): TokenMetricTile[] => {
+		if (!triple) return [];
+		const sections: Array<{
+			key: string;
+			title: string;
+			tiers: TokenTier[];
+		}> = [
+			{
+				key: `${modalityKey}-input`,
+				title: `${modalityLabel} Input`,
+				tiers: triple.in,
+			},
+			{
+				key: `${modalityKey}-output`,
+				title: `${modalityLabel} Output`,
+				tiers: triple.out,
+			},
+			{
+				key: `${modalityKey}-cache-read`,
+				title: `${modalityLabel} Cache Reads`,
+				tiers: triple.cached,
+			},
+			{
+				key: `${modalityKey}-cache-write`,
+				title: `${modalityLabel} Cache Writes`,
+				tiers: triple.write,
+			},
+		];
+		return sections
+			.filter((section) => section.tiers.length > 0)
+			.map((section) => ({
+				key: section.key,
+				title: section.title,
+				tiers: section.tiers,
+				unitLabel: "Per 1M tokens",
+			}));
+	};
+	const tokenMetricGroups: TokenMetricGroup[] = [
+		{
+			key: "text",
+			title: "Text",
+			tiles: createTokenTiles("Text", "text", sec.textTokens),
+		},
+		{
+			key: "audio",
+			title: "Audio",
+			tiles: createTokenTiles("Audio", "audio", sec.audioTokens),
+		},
+		{
+			key: "image",
+			title: "Image",
+			tiles: createTokenTiles("Image", "image", sec.imageTokens),
+		},
+		{
+			key: "video",
+			title: "Video",
+			tiles: createTokenTiles("Video", "video", sec.videoTokens),
+		},
+	].filter((group) => group.tiles.length > 0);
+	const showTokenGroupHeaders = tokenMetricGroups.length > 1;
+	const upcomingTokenChanges = [
+		...upcomingFor("textTokens"),
+		...upcomingFor("imageTokens"),
+		...upcomingFor("audioTokens"),
+		...upcomingFor("videoTokens"),
+	];
 	const infoScope = providerModelsInScope;
 	const providerModelSlugs = infoScope.map((pm) => pm.provider_model_slug);
 	const videoAudioRuleHints = planRules.flatMap((rule) => {
@@ -642,6 +715,32 @@ export default function ProviderCard({
 								</div>
 							))}
 						</div>
+						{capacityMetrics.length > 0 ? (
+							<div className="mt-2 border-t border-zinc-200/70 pt-2 dark:border-zinc-800">
+								<div
+									className={cn(
+										"grid divide-zinc-200/70 dark:divide-zinc-800",
+										capacityMetrics.length > 1
+											? "grid-cols-2 divide-x"
+											: "grid-cols-1",
+									)}
+								>
+									{capacityMetrics.map((metric) => (
+										<div
+											key={metric.label}
+											className="flex min-w-0 flex-col items-center justify-center px-3 text-center"
+										>
+											<p className="text-[10px] font-medium text-muted-foreground">
+												{metric.label}
+											</p>
+											<div className="text-xs font-semibold leading-tight text-foreground tabular-nums">
+												{metric.value}
+											</div>
+										</div>
+									))}
+								</div>
+							</div>
+						) : null}
 					</div>
 				</div>
 			</CardHeader>
@@ -662,18 +761,40 @@ export default function ProviderCard({
 							</div>
 						</div>
 					)}
-					{!isFreePlan && hasTextSection && (
-						<TokenTripleSection
-							title="Text Tokens"
-							triple={textTripleForDisplay}
-							hideHeader={false}
-							leadingTiles={capacityMetrics}
-							minimumSegments={["Input", "Output"]}
+					{!isFreePlan && tokenMetricGroups.length > 0 && (
+						<div className="space-y-1.5">
+							{tokenMetricGroups.map((group) => (
+								<div key={group.key} className="space-y-1.5">
+									{showTokenGroupHeaders ? (
+										<h4 className="text-xs font-semibold tracking-wide text-foreground">
+											{group.title}
+										</h4>
+									) : null}
+									<div className="w-full overflow-visible sm:overflow-x-auto">
+										<div className="grid grid-cols-2 gap-x-3 gap-y-2 sm:flex sm:w-full sm:min-w-max sm:gap-0 sm:divide-x sm:divide-zinc-200/70 sm:dark:divide-zinc-800">
+											{group.tiles.map((tile) => (
+												<div
+													key={tile.key}
+													className="min-w-0 px-1 py-1 sm:min-w-[140px] sm:flex-1 sm:px-3 sm:py-2"
+												>
+													<div className="mb-0.5 text-xs text-muted-foreground">{tile.title}</div>
+													{tile.tiers ? (
+														<TierTiles tiers={tile.tiers} dense unitLabel={tile.unitLabel} />
+													) : null}
+												</div>
+											))}
+										</div>
+									</div>
+								</div>
+							))}
+						</div>
+					)}
+					{!isFreePlan && upcomingTokenChanges.length > 0 && (
+						<UpcomingPricingSection
+							rows={upcomingTokenChanges}
+							title="Upcoming Token Pricing"
 							compact
 						/>
-					)}
-					{!isFreePlan && upcomingFor("textTokens").length > 0 && (
-						<UpcomingPricingSection rows={upcomingFor("textTokens")} title="Upcoming" compact />
 					)}
 					{!isFreePlan && sec.requests && sec.requests.length > 0 && (
 						<RequestsSection rows={sec.requests} />
@@ -682,38 +803,20 @@ export default function ProviderCard({
 						<UpcomingPricingSection rows={upcomingFor("requests")} title="Upcoming" compact />
 					)}
 					{!isFreePlan && imageInputs.length > 0 && (
-						<InputsSection title="Image inputs" rows={imageInputs} />
+						<InputsSection title="Image Inputs" rows={imageInputs} />
 					)}
 					{!isFreePlan && upcomingFor("imageInputs").length > 0 && (
 						<UpcomingPricingSection rows={upcomingFor("imageInputs")} title="Upcoming" compact />
 					)}
 					{!isFreePlan && videoInputs.length > 0 && (
-						<InputsSection title="Video inputs" rows={videoInputs} />
+						<InputsSection title="Video Inputs" rows={videoInputs} />
 					)}
 					{!isFreePlan && upcomingFor("videoInputs").length > 0 && (
 						<UpcomingPricingSection rows={upcomingFor("videoInputs")} title="Upcoming" compact />
 					)}
-					{!isFreePlan && sec.imageTokens && (
-						<TokenTripleSection title="Image Tokens" triple={sec.imageTokens} compact />
-					)}
-					{!isFreePlan && upcomingFor("imageTokens").length > 0 && (
-						<UpcomingPricingSection rows={upcomingFor("imageTokens")} title="Upcoming" compact />
-					)}
 					{!isFreePlan && sec.imageGen && <ImageGenSection rows={sec.imageGen} />}
 					{!isFreePlan && upcomingFor("imageGen").length > 0 && (
 						<UpcomingPricingSection rows={upcomingFor("imageGen")} title="Upcoming" compact />
-					)}
-					{!isFreePlan && sec.audioTokens && (
-						<TokenTripleSection title="Audio Tokens" triple={sec.audioTokens} compact />
-					)}
-					{!isFreePlan && upcomingFor("audioTokens").length > 0 && (
-						<UpcomingPricingSection rows={upcomingFor("audioTokens")} title="Upcoming" compact />
-					)}
-					{!isFreePlan && sec.videoTokens && (
-						<TokenTripleSection title="Video Tokens" triple={sec.videoTokens} compact />
-					)}
-					{!isFreePlan && upcomingFor("videoTokens").length > 0 && (
-						<UpcomingPricingSection rows={upcomingFor("videoTokens")} title="Upcoming" compact />
 					)}
 					{!isFreePlan && sec.videoGen && (
 						<VideoGenSection

--- a/apps/web/src/components/(data)/model/pricing/sections.tsx
+++ b/apps/web/src/components/(data)/model/pricing/sections.tsx
@@ -178,12 +178,66 @@ function formatUsdAligned(value: number, decimals: number): string {
 	return `$${value.toFixed(decimals)}`;
 }
 
+function formatTierConditionLabel(label: string): {
+	shortLabel: string;
+	tooltipLabel?: string;
+} | null {
+	const raw = String(label ?? "").trim();
+	if (!raw || raw.toLowerCase() === "all usage") return null;
+
+	const ttlMatch = raw.match(/^(.+?)\s+cache\s+ttl$/i);
+	if (!ttlMatch) return { shortLabel: raw };
+
+	const durationRaw = ttlMatch[1]?.trim() ?? "";
+	const parseDuration = (
+		value: string,
+		re: RegExp,
+		unitShort: string,
+		unitLong: string,
+	): { shortLabel: string; tooltipLabel: string } | null => {
+		const m = value.match(re);
+		if (!m?.[1]) return null;
+		const amount = Number(m[1]);
+		if (!Number.isFinite(amount) || amount <= 0) return null;
+		const plural = amount === 1 ? unitLong : `${unitLong}s`;
+		return {
+			shortLabel: `${amount}${unitShort}`,
+			tooltipLabel: `${amount} ${plural} cache TTL`,
+		};
+	};
+
+	const minute =
+		parseDuration(durationRaw, /^(\d+)\s*(?:m|min|mins|minute|minutes)$/i, "m", "minute") ??
+		parseDuration(durationRaw, /^(\d+)\s*$/i, "m", "minute");
+	if (minute) return minute;
+
+	const hour = parseDuration(
+		durationRaw,
+		/^(\d+)\s*(?:h|hr|hrs|hour|hours)$/i,
+		"h",
+		"hour",
+	);
+	if (hour) return hour;
+
+	const day = parseDuration(
+		durationRaw,
+		/^(\d+)\s*(?:d|day|days)$/i,
+		"d",
+		"day",
+	);
+	if (day) return day;
+
+	return { shortLabel: durationRaw, tooltipLabel: raw };
+}
+
 export function TierTiles({
 	tiers,
 	dense = false,
+	unitLabel,
 }: {
 	tiers: TokenTier[];
 	dense?: boolean;
+	unitLabel?: string;
 }) {
 	if (!tiers?.length) {
 		return <div className="text-sm text-muted-foreground">--</div>;
@@ -192,32 +246,58 @@ export function TierTiles({
 		(max, tier) => Math.max(max, countUsdDecimals(tier.per1M)),
 		0,
 	);
+	const [primaryTier, ...additionalTiers] = tiers;
+	const hasAdditionalTiers = additionalTiers.length > 0;
+	const renderTierRow = (tier: TokenTier, key: string | number) => (
+		<div key={key} className="space-y-0.5">
+			<div className="flex items-baseline gap-1">
+				<span
+					className={
+						tier.basePer1M != null
+							? "text-xs font-semibold text-emerald-600 tabular-nums"
+							: "text-xs font-semibold text-foreground tabular-nums"
+					}
+				>
+					{formatUsdAligned(tier.per1M, sharedDecimals)}
+				</span>
+				{(() => {
+					const condition = formatTierConditionLabel(tier.label);
+					if (!condition) return null;
+					const hasTooltip =
+						condition.tooltipLabel &&
+						condition.tooltipLabel !== condition.shortLabel;
+					return (
+						<span
+							className="text-xs text-muted-foreground"
+							title={hasTooltip ? condition.tooltipLabel : undefined}
+						>
+							({condition.shortLabel})
+						</span>
+					);
+				})()}
+			</div>
+			{tier.basePer1M != null ? (
+				<div className="text-xs text-muted-foreground">
+					{renderDiscountFooter(tier.basePer1M, tier.discountEndsAt)}
+				</div>
+			) : null}
+		</div>
+	);
 
 	return (
 		<div className={dense ? "space-y-0.5" : "space-y-1.5"}>
-			{tiers.map((t, i) => (
-				<div key={i} className="space-y-0.5">
-					<div className="flex items-baseline gap-1">
-						<span
-							className={
-								t.basePer1M != null
-									? "text-xs font-semibold text-emerald-600 tabular-nums"
-									: "text-xs font-semibold text-foreground tabular-nums"
-							}
-						>
-							{formatUsdAligned(t.per1M, sharedDecimals)}
-						</span>
-						{t.label !== "All usage" ? (
-							<span className="text-xs text-muted-foreground">{t.label}</span>
-						) : null}
-					</div>
-					{t.basePer1M != null ? (
-						<div className="text-xs text-muted-foreground">
-							{renderDiscountFooter(t.basePer1M, t.discountEndsAt)}
-						</div>
-					) : null}
-				</div>
-			))}
+			<div className="space-y-0.5">
+				{renderTierRow(primaryTier, "primary")}
+				{!hasAdditionalTiers && unitLabel ? (
+					<div className="text-[11px] text-muted-foreground">{unitLabel}</div>
+				) : null}
+			</div>
+			{additionalTiers.map((tier, index) =>
+				renderTierRow(tier, `additional-${index}`),
+			)}
+			{hasAdditionalTiers && unitLabel ? (
+				<div className="text-[11px] text-muted-foreground">{unitLabel}</div>
+			) : null}
 		</div>
 	);
 }
@@ -332,7 +412,7 @@ export function ImageGenSection({
 	return (
 		<div className={wrapperClass}>
 			<div className="flex items-center justify-between">
-				<h4 className="text-xs font-semibold tracking-wide text-foreground">Image Generation</h4>
+				<h4 className="text-xs font-semibold tracking-wide text-foreground">Image Quality</h4>
 				<span className="text-xs text-muted-foreground">Per image</span>
 			</div>
 					<div className={vertical ? "" : "w-full overflow-visible sm:overflow-x-auto"}>
@@ -396,7 +476,6 @@ export function VideoGenSection({
 		(byUnit[r.unitLabel] ??= []).push(r);
 	}
 	const unitEntries = Object.entries(byUnit);
-	const hasSingleUnit = unitEntries.length === 1;
 	const audioHintMap = new Map<string, "with-audio" | "without-audio">();
 	for (const hint of audioHints) {
 		audioHintMap.set(
@@ -491,13 +570,20 @@ export function VideoGenSection({
 		: "min-w-0 px-1 py-1 sm:min-w-[220px] sm:flex-1 sm:px-3 sm:py-2";
 	const wrapperClass = vertical ? "space-y-1" : "space-y-1.5";
 	const itemStackClass = vertical ? "space-y-0.5" : "space-y-1";
+	const unitSummaryForItems = (list: Array<{ unit: string }>): string | null => {
+		const uniqueUnits = Array.from(
+			new Set(
+				list
+					.map((item) => String(item.unit ?? "").trim())
+					.filter(Boolean),
+			),
+		);
+		if (!uniqueUnits.length) return null;
+		return uniqueUnits.join(" / ");
+	};
 
 	return (
 		<div className={wrapperClass}>
-			<div className="flex items-center justify-between">
-				<h4 className="text-xs font-semibold tracking-wide text-foreground">Video Generation</h4>
-				{hasSingleUnit ? <span className="text-xs text-muted-foreground">{unitEntries[0][0]}</span> : null}
-			</div>
 				{showAudioVariants ? (
 						<div className={vertical ? "" : "w-full overflow-visible sm:overflow-x-auto"}>
 							{(() => {
@@ -505,49 +591,42 @@ export function VideoGenSection({
 						const withoutAudioItems = items.filter((item) => item.audioMode === "without-audio");
 						const hasExplicitSplit = withAudioItems.length > 0 || withoutAudioItems.length > 0;
 						if (!hasExplicitSplit) {
+							const sortedItems = [...items].sort((a, b) => {
+								const byResolution = compareResolutionLabels(a.resolution, b.resolution);
+								if (byResolution !== 0) return byResolution;
+								return a.price - b.price;
+							});
+							const unitSummary = unitSummaryForItems(sortedItems);
 							return (
-										<div className={columnsWrapClass}>
-										{Array.from(
-										items.reduce((acc, item) => {
-											const list = acc.get(item.resolution) ?? [];
-											list.push(item);
-											acc.set(item.resolution, list);
-											return acc;
-										}, new Map<string, typeof items>()),
-									)
-										.sort(([a], [b]) => compareResolutionLabels(a, b))
-										.map(([resolution, resolutionItems]) => (
-													<div key={resolution} className={resolutionColumnClass}>
-													<div className="mb-0.5 text-xs text-muted-foreground">{resolution}</div>
-													<div className={itemStackClass}>
-													{resolutionItems
-														.sort((a, b) => a.price - b.price)
-														.map((item, index) => (
-															<div key={`${item.unit}-${item.price}-${index}`} className="space-y-0.5">
-																<div className="flex items-baseline gap-1">
-																	<span
-																		className={
-																			item.basePrice != null
-																				? "text-xs font-semibold text-emerald-600 tabular-nums"
-																				: "text-xs font-semibold text-foreground tabular-nums"
-																		}
-																	>
-																		{formatUsdAligned(item.price, sharedDecimals)}
-																	</span>
-																	{hasSingleUnit ? null : (
-																		<span className="text-xs text-muted-foreground/80">({item.unit})</span>
-																	)}
-																</div>
-																{item.basePrice != null ? (
-																	<div className="text-xs text-muted-foreground">
-																		{renderDiscountFooter(item.basePrice, item.discountEndsAt)}
-																	</div>
-																) : null}
-															</div>
-														))}
+								<div className={columnsWrapClass}>
+									<div className={resolutionColumnClass}>
+										<div className={itemStackClass}>
+											{sortedItems.map((item, index) => (
+												<div key={`${item.unit}-${item.resolution}-${item.price}-${index}`} className="space-y-0.5">
+													<div className="flex items-baseline gap-1">
+														<span
+															className={
+																item.basePrice != null
+																	? "text-xs font-semibold text-emerald-600 tabular-nums"
+																	: "text-xs font-semibold text-foreground tabular-nums"
+															}
+														>
+															{formatUsdAligned(item.price, sharedDecimals)}
+														</span>
+														<span className="text-xs text-muted-foreground">{item.resolution}</span>
+													</div>
+													{item.basePrice != null ? (
+														<div className="text-xs text-muted-foreground">
+															{renderDiscountFooter(item.basePrice, item.discountEndsAt)}
+														</div>
+													) : null}
 												</div>
-											</div>
-										))}
+											))}
+										</div>
+										{unitSummary ? (
+											<div className="pt-0.5 text-[11px] text-muted-foreground">{unitSummary}</div>
+										) : null}
+									</div>
 								</div>
 							);
 						}
@@ -556,20 +635,32 @@ export function VideoGenSection({
 									{[
 									{
 										key: "with-audio",
-										title: "With Audio",
+										title: "Video (With Audio)",
 										items: withAudioItems,
 									},
 									{
 										key: "without-audio",
-										title: "No Audio",
+										title: "Video (Without Audio)",
 										items: withoutAudioItems,
 									},
 								].map((column) => (
+									(() => {
+										const sortedColumnItems = [...column.items].sort((a, b) => {
+											const byResolution = compareResolutionLabels(
+												a.resolution,
+												b.resolution,
+											);
+											if (byResolution !== 0) return byResolution;
+											return a.price - b.price;
+										});
+										const unitSummary = unitSummaryForItems(sortedColumnItems);
+										return (
 									<div key={column.key} className={audioColumnClass}>
 									<div className="mb-0.5 text-xs text-muted-foreground">{column.title}</div>
-									{column.items.length ? (
+									{sortedColumnItems.length ? (
+										<>
 										<div className={itemStackClass}>
-										{column.items.map((item, index) => (
+										{sortedColumnItems.map((item, index) => (
 											<div key={`${column.key}-${item.unit}-${item.resolution}-${index}`} className="space-y-0.5">
 												<div className="flex items-baseline gap-1">
 													<span
@@ -582,9 +673,6 @@ export function VideoGenSection({
 														{formatUsdAligned(item.price, sharedDecimals)}
 													</span>
 													<span className="text-xs text-muted-foreground">{item.resolution}</span>
-													{hasSingleUnit ? null : (
-														<span className="text-xs text-muted-foreground/80">({item.unit})</span>
-													)}
 												</div>
 												{item.basePrice != null ? (
 													<div className="text-xs text-muted-foreground">
@@ -594,10 +682,16 @@ export function VideoGenSection({
 											</div>
 										))}
 									</div>
+									{unitSummary ? (
+										<div className="pt-0.5 text-[11px] text-muted-foreground">{unitSummary}</div>
+									) : null}
+									</>
 								) : (
 									<div className="text-xs text-muted-foreground">--</div>
 								)}
 							</div>
+									);
+									})()
 						))}
 							</div>
 						);
@@ -606,23 +700,18 @@ export function VideoGenSection({
 				) : (
 					<div className={vertical ? "" : "w-full overflow-visible sm:overflow-x-auto"}>
 						<div className={columnsWrapClass}>
-							{Array.from(
-							items.reduce((acc, item) => {
-								const list = acc.get(item.resolution) ?? [];
-								list.push(item);
-								acc.set(item.resolution, list);
-								return acc;
-							}, new Map<string, typeof items>()),
-						)
-							.sort(([a], [b]) => compareResolutionLabels(a, b))
-							.map(([resolution, resolutionItems]) => (
-										<div key={resolution} className={resolutionColumnClass}>
-										<div className="mb-0.5 text-xs text-muted-foreground">{resolution}</div>
+							{(() => {
+								const sortedItems = [...items].sort((a, b) => {
+									const byResolution = compareResolutionLabels(a.resolution, b.resolution);
+									if (byResolution !== 0) return byResolution;
+									return a.price - b.price;
+								});
+								const unitSummary = unitSummaryForItems(sortedItems);
+								return (
+									<div className={resolutionColumnClass}>
 										<div className={itemStackClass}>
-										{resolutionItems
-											.sort((a, b) => a.price - b.price)
-											.map((item, index) => (
-												<div key={`${item.unit}-${item.price}-${index}`} className="space-y-0.5">
+											{sortedItems.map((item, index) => (
+												<div key={`${item.unit}-${item.resolution}-${item.price}-${index}`} className="space-y-0.5">
 													<div className="flex items-baseline gap-1">
 														<span
 															className={
@@ -633,9 +722,7 @@ export function VideoGenSection({
 														>
 															{formatUsdAligned(item.price, sharedDecimals)}
 														</span>
-														{hasSingleUnit ? null : (
-															<span className="text-xs text-muted-foreground/80">({item.unit})</span>
-														)}
+														<span className="text-xs text-muted-foreground">{item.resolution}</span>
 													</div>
 													{item.basePrice != null ? (
 														<div className="text-xs text-muted-foreground">
@@ -644,9 +731,13 @@ export function VideoGenSection({
 													) : null}
 												</div>
 											))}
+										</div>
+										{unitSummary ? (
+											<div className="pt-0.5 text-[11px] text-muted-foreground">{unitSummary}</div>
+										) : null}
 									</div>
-								</div>
-							))}
+								);
+							})()}
 					</div>
 				</div>
 			)}

--- a/apps/web/src/lib/fetchers/models/getModelApps.ts
+++ b/apps/web/src/lib/fetchers/models/getModelApps.ts
@@ -1,0 +1,200 @@
+import { cacheLife, cacheTag } from "next/cache";
+import { createAdminClient } from "@/utils/supabase/admin";
+
+const PAGE_SIZE = 5000;
+const MAX_PAGES = 12;
+
+export type ModelAppUsage = {
+	appId: string;
+	title: string;
+	imageUrl: string | null;
+	url: string | null;
+	lastSeen: string | null;
+	totalRequests: number;
+	successfulRequests: number;
+	totalTokens: number;
+};
+
+function toNumber(value: unknown): number {
+	const parsed = Number(value ?? 0);
+	return Number.isFinite(parsed) ? parsed : 0;
+}
+
+async function getModelAliases(client: ReturnType<typeof createAdminClient>, modelId: string): Promise<string[]> {
+	const aliases = new Set<string>([modelId]);
+
+	const [byModelId, byApiModelId] = await Promise.all([
+		client
+			.from("data_api_provider_models")
+			.select("model_id, api_model_id")
+			.eq("model_id", modelId),
+		client
+			.from("data_api_provider_models")
+			.select("model_id, api_model_id")
+			.eq("api_model_id", modelId),
+	]);
+
+	for (const query of [byModelId, byApiModelId]) {
+		if (query.error) {
+			console.warn("[model-apps] failed to resolve aliases", {
+				modelId,
+				error: query.error,
+			});
+			continue;
+		}
+		for (const row of query.data ?? []) {
+			const canonical = String(row?.model_id ?? "").trim();
+			const apiModel = String(row?.api_model_id ?? "").trim();
+			if (canonical) aliases.add(canonical);
+			if (apiModel) aliases.add(apiModel);
+		}
+	}
+
+	return Array.from(aliases);
+}
+
+export async function getModelApps(
+	modelId: string,
+	_includeHidden: boolean,
+	limit = 24,
+): Promise<ModelAppUsage[]> {
+	const supabase = createAdminClient();
+	const safeLimit = Math.max(1, Math.min(100, Math.round(limit)));
+	const aliases = await getModelAliases(supabase, modelId);
+	const aggregate = new Map<
+		string,
+		{ requests: number; success: number; tokens: number }
+	>();
+
+	for (let page = 0, offset = 0; page < MAX_PAGES; page += 1, offset += PAGE_SIZE) {
+		const { data, error } = await supabase
+			.from("gateway_usage_rollup_daily_app_model")
+			.select("app_id, requests, success_requests, total_tokens")
+			.in("canonical_model_id", aliases)
+			.range(offset, offset + PAGE_SIZE - 1);
+
+		if (error) {
+			console.warn("[model-apps] failed to load model app rollups", {
+				modelId,
+				error,
+			});
+			return [];
+		}
+
+		if (!Array.isArray(data) || data.length === 0) break;
+
+		for (const row of data) {
+			const appId = String((row as any)?.app_id ?? "").trim();
+			if (!appId) continue;
+			const existing = aggregate.get(appId) ?? {
+				requests: 0,
+				success: 0,
+				tokens: 0,
+			};
+			existing.requests += toNumber((row as any)?.requests);
+			existing.success += toNumber((row as any)?.success_requests);
+			existing.tokens += toNumber((row as any)?.total_tokens);
+			aggregate.set(appId, existing);
+		}
+
+		if (data.length < PAGE_SIZE) break;
+	}
+
+	if (aggregate.size === 0) return [];
+
+	const appIds = Array.from(aggregate.keys());
+	const { data: appRows, error: appError } = await supabase
+		.from("api_apps")
+		.select("id, title, image_url, url, last_seen, is_public")
+		.in("id", appIds);
+
+	if (appError) {
+		console.warn("[model-apps] failed to resolve app metadata", {
+			modelId,
+			error: appError,
+		});
+	}
+
+	const appMetaById = new Map<
+		string,
+		{
+			title: string;
+			imageUrl: string | null;
+			url: string | null;
+			lastSeen: string | null;
+			isPublic: boolean;
+		}
+	>();
+	for (const row of appRows ?? []) {
+		const id = String((row as any)?.id ?? "").trim();
+		if (!id) continue;
+		const isPublic = Boolean((row as any)?.is_public);
+		appMetaById.set(id, {
+			title: String((row as any)?.title ?? id).trim() || id,
+			imageUrl:
+				typeof (row as any)?.image_url === "string" &&
+				(row as any).image_url.trim().length > 0
+					? (row as any).image_url.trim()
+					: null,
+			url:
+				typeof (row as any)?.url === "string" &&
+				(row as any).url.trim().length > 0
+					? (row as any).url.trim()
+					: null,
+			lastSeen:
+				typeof (row as any)?.last_seen === "string" &&
+				(row as any).last_seen.trim().length > 0
+					? (row as any).last_seen
+					: null,
+			isPublic,
+		});
+	}
+
+	return appIds
+		.map((appId) => {
+			const usage = aggregate.get(appId)!;
+			const meta = appMetaById.get(appId);
+			return {
+				appId,
+				title: meta?.title ?? appId,
+				imageUrl: meta?.imageUrl ?? null,
+				url: meta?.url ?? null,
+				lastSeen: meta?.lastSeen ?? null,
+				totalRequests: Math.max(0, Math.round(usage.requests)),
+				successfulRequests: Math.max(0, Math.round(usage.success)),
+				totalTokens: Math.max(0, Math.round(usage.tokens)),
+				isPublic: meta?.isPublic ?? false,
+			};
+		})
+		.filter((entry) => entry.isPublic)
+		.sort((a, b) => {
+			if (b.totalTokens !== a.totalTokens) return b.totalTokens - a.totalTokens;
+			if (b.totalRequests !== a.totalRequests) return b.totalRequests - a.totalRequests;
+			return a.appId.localeCompare(b.appId);
+		})
+		.slice(0, safeLimit)
+		.map((entry) => ({
+			appId: entry.appId,
+			title: entry.title,
+			imageUrl: entry.imageUrl,
+			url: entry.url,
+			lastSeen: entry.lastSeen,
+			totalRequests: entry.totalRequests,
+			successfulRequests: entry.successfulRequests,
+			totalTokens: entry.totalTokens,
+		}));
+}
+
+export async function getModelAppsCached(
+	modelId: string,
+	includeHidden: boolean,
+	limit = 24,
+): Promise<ModelAppUsage[]> {
+	"use cache";
+
+	cacheLife("days");
+	cacheTag("data:apps");
+	cacheTag("data:public_apps");
+	cacheTag(`data:model_apps:${modelId}`);
+	return getModelApps(modelId, includeHidden, limit);
+}

--- a/apps/web/src/lib/fetchers/models/getModelApps.ts
+++ b/apps/web/src/lib/fetchers/models/getModelApps.ts
@@ -14,6 +14,17 @@ export type ModelAppUsage = {
 	totalTokens: number;
 };
 
+type ModelAppsRollupRpcRow = {
+	app_id: string | null;
+	requests: number | string | null;
+	success_requests: number | string | null;
+	total_tokens: number | string | null;
+	title: string | null;
+	image_url: string | null;
+	url: string | null;
+	last_seen: string | null;
+};
+
 function toNumber(value: unknown): number {
 	const parsed = Number(value ?? 0);
 	return Number.isFinite(parsed) ? parsed : 0;
@@ -52,24 +63,85 @@ async function getModelAliases(client: ReturnType<typeof createAdminClient>, mod
 	return Array.from(aliases);
 }
 
-export async function getModelApps(
-	modelId: string,
-	_includeHidden: boolean,
-	limit = 24,
-): Promise<ModelAppUsage[]> {
-	const supabase = createAdminClient();
-	const safeLimit = Math.max(1, Math.min(100, Math.round(limit)));
-	const aliases = await getModelAliases(supabase, modelId);
+function mapRpcRowToModelAppUsage(row: ModelAppsRollupRpcRow): ModelAppUsage | null {
+	const appId = String(row?.app_id ?? "").trim();
+	if (!appId) return null;
+
+	const title = String(row?.title ?? appId).trim() || appId;
+	const imageUrl =
+		typeof row?.image_url === "string" && row.image_url.trim().length > 0
+			? row.image_url.trim()
+			: null;
+	const url =
+		typeof row?.url === "string" && row.url.trim().length > 0
+			? row.url.trim()
+			: null;
+	const lastSeen =
+		typeof row?.last_seen === "string" && row.last_seen.trim().length > 0
+			? row.last_seen
+			: null;
+
+	return {
+		appId,
+		title,
+		imageUrl,
+		url,
+		lastSeen,
+		totalRequests: Math.max(0, Math.round(toNumber(row?.requests))),
+		successfulRequests: Math.max(0, Math.round(toNumber(row?.success_requests))),
+		totalTokens: Math.max(0, Math.round(toNumber(row?.total_tokens))),
+	};
+}
+
+async function fetchModelAppsFromRollupRpc(args: {
+	client: ReturnType<typeof createAdminClient>;
+	modelId: string;
+	aliases: string[];
+	limit: number;
+}): Promise<ModelAppUsage[] | null> {
+	const { data, error } = await args.client.rpc("get_usage_model_apps", {
+		p_model_ids: args.aliases,
+		p_limit: args.limit,
+		p_since: null,
+	});
+
+	if (error) {
+		console.warn("[model-apps] rpc get_usage_model_apps failed; falling back to row pagination", {
+			modelId: args.modelId,
+			error,
+		});
+		return null;
+	}
+
+	const normalized = (data ?? [])
+		.map((row: unknown) => mapRpcRowToModelAppUsage(row as ModelAppsRollupRpcRow))
+		.filter((row: ModelAppUsage | null): row is ModelAppUsage => row !== null);
+
+	normalized.sort((a: ModelAppUsage, b: ModelAppUsage) => {
+		if (b.totalTokens !== a.totalTokens) return b.totalTokens - a.totalTokens;
+		if (b.totalRequests !== a.totalRequests) return b.totalRequests - a.totalRequests;
+		return a.appId.localeCompare(b.appId);
+	});
+
+	return normalized.slice(0, args.limit);
+}
+
+async function fetchModelAppsFromDailyRollupsFallback(args: {
+	client: ReturnType<typeof createAdminClient>;
+	modelId: string;
+	aliases: string[];
+	limit: number;
+}): Promise<ModelAppUsage[]> {
 	const aggregate = new Map<
 		string,
 		{ requests: number; success: number; tokens: number }
 	>();
 
 	for (let offset = 0; ; offset += PAGE_SIZE) {
-		const { data, error } = await supabase
+		const { data, error } = await args.client
 			.from("gateway_usage_rollup_daily_app_model")
 			.select("day_bucket, canonical_model_id, app_id, requests, success_requests, total_tokens")
-			.in("canonical_model_id", aliases)
+			.in("canonical_model_id", args.aliases)
 			.order("day_bucket", { ascending: true })
 			.order("app_id", { ascending: true })
 			.order("canonical_model_id", { ascending: true })
@@ -77,7 +149,7 @@ export async function getModelApps(
 
 		if (error) {
 			console.warn("[model-apps] failed to load model app rollups", {
-				modelId,
+				modelId: args.modelId,
 				error,
 			});
 			return [];
@@ -105,14 +177,14 @@ export async function getModelApps(
 	if (aggregate.size === 0) return [];
 
 	const appIds = Array.from(aggregate.keys());
-	const { data: appRows, error: appError } = await supabase
+	const { data: appRows, error: appError } = await args.client
 		.from("api_apps")
 		.select("id, title, image_url, url, last_seen, is_public")
 		.in("id", appIds);
 
 	if (appError) {
 		console.warn("[model-apps] failed to resolve app metadata", {
-			modelId,
+			modelId: args.modelId,
 			error: appError,
 		});
 	}
@@ -174,7 +246,7 @@ export async function getModelApps(
 			if (b.totalRequests !== a.totalRequests) return b.totalRequests - a.totalRequests;
 			return a.appId.localeCompare(b.appId);
 		})
-		.slice(0, safeLimit)
+		.slice(0, args.limit)
 		.map((entry) => ({
 			appId: entry.appId,
 			title: entry.title,
@@ -187,6 +259,31 @@ export async function getModelApps(
 		}));
 }
 
+export async function getModelApps(
+	modelId: string,
+	_includeHidden: boolean,
+	limit = 24,
+): Promise<ModelAppUsage[]> {
+	const supabase = createAdminClient();
+	const safeLimit = Math.max(1, Math.min(100, Math.round(limit)));
+	const aliases = await getModelAliases(supabase, modelId);
+
+	const rpcResult = await fetchModelAppsFromRollupRpc({
+		client: supabase,
+		modelId,
+		aliases,
+		limit: safeLimit,
+	});
+	if (rpcResult) return rpcResult;
+
+	return fetchModelAppsFromDailyRollupsFallback({
+		client: supabase,
+		modelId,
+		aliases,
+		limit: safeLimit,
+	});
+}
+
 export async function getModelAppsCached(
 	modelId: string,
 	includeHidden: boolean,
@@ -197,6 +294,7 @@ export async function getModelAppsCached(
 	cacheLife("days");
 	cacheTag("data:apps");
 	cacheTag("data:public_apps");
+	cacheTag("data:gateway_usage_rollups");
 	cacheTag(`data:model_apps:${modelId}`);
 	return getModelApps(modelId, includeHidden, limit);
 }

--- a/apps/web/src/lib/fetchers/models/getModelApps.ts
+++ b/apps/web/src/lib/fetchers/models/getModelApps.ts
@@ -25,9 +25,52 @@ type ModelAppsRollupRpcRow = {
 	last_seen: string | null;
 };
 
+type ModelAppsDailyRollupRow = {
+	app_id: string | null;
+	requests: number | string | bigint | null;
+	success_requests: number | string | bigint | null;
+	total_tokens: number | string | bigint | null;
+};
+
+type ModelAppMetadataRow = {
+	id: string | null;
+	title: string | null;
+	image_url: string | null;
+	url: string | null;
+	last_seen: string | null;
+	is_public: boolean | null;
+};
+
+const BIGINT_ZERO = BigInt(0);
+const BIGINT_MAX_SAFE = BigInt(Number.MAX_SAFE_INTEGER);
+
 function toNumber(value: unknown): number {
 	const parsed = Number(value ?? 0);
 	return Number.isFinite(parsed) ? parsed : 0;
+}
+
+function toBigInt(value: unknown): bigint {
+	if (typeof value === "bigint") return value;
+	if (typeof value === "number") {
+		if (!Number.isFinite(value)) return BIGINT_ZERO;
+		return BigInt(Math.trunc(value));
+	}
+	if (typeof value === "string") {
+		const trimmed = value.trim();
+		if (!trimmed) return BIGINT_ZERO;
+		try {
+			return BigInt(trimmed);
+		} catch {
+			return BIGINT_ZERO;
+		}
+	}
+	return BIGINT_ZERO;
+}
+
+function bigintToDisplayNumber(value: bigint): number {
+	if (value <= BIGINT_ZERO) return 0;
+	if (value > BIGINT_MAX_SAFE) return Number.MAX_SAFE_INTEGER;
+	return Number(value);
 }
 
 async function getModelAliases(client: ReturnType<typeof createAdminClient>, modelId: string): Promise<string[]> {
@@ -117,13 +160,8 @@ async function fetchModelAppsFromRollupRpc(args: {
 		.map((row: unknown) => mapRpcRowToModelAppUsage(row as ModelAppsRollupRpcRow))
 		.filter((row: ModelAppUsage | null): row is ModelAppUsage => row !== null);
 
-	normalized.sort((a: ModelAppUsage, b: ModelAppUsage) => {
-		if (b.totalTokens !== a.totalTokens) return b.totalTokens - a.totalTokens;
-		if (b.totalRequests !== a.totalRequests) return b.totalRequests - a.totalRequests;
-		return a.appId.localeCompare(b.appId);
-	});
-
-	return normalized.slice(0, args.limit);
+	// RPC already applies the deterministic ordering and limit.
+	return normalized;
 }
 
 async function fetchModelAppsFromDailyRollupsFallback(args: {
@@ -134,7 +172,7 @@ async function fetchModelAppsFromDailyRollupsFallback(args: {
 }): Promise<ModelAppUsage[]> {
 	const aggregate = new Map<
 		string,
-		{ requests: number; success: number; tokens: number }
+		{ requests: bigint; success: bigint; tokens: bigint }
 	>();
 
 	for (let offset = 0; ; offset += PAGE_SIZE) {
@@ -157,17 +195,17 @@ async function fetchModelAppsFromDailyRollupsFallback(args: {
 
 		if (!Array.isArray(data) || data.length === 0) break;
 
-		for (const row of data) {
-			const appId = String((row as any)?.app_id ?? "").trim();
+		for (const row of data as ModelAppsDailyRollupRow[]) {
+			const appId = String(row?.app_id ?? "").trim();
 			if (!appId) continue;
 			const existing = aggregate.get(appId) ?? {
-				requests: 0,
-				success: 0,
-				tokens: 0,
+				requests: BIGINT_ZERO,
+				success: BIGINT_ZERO,
+				tokens: BIGINT_ZERO,
 			};
-			existing.requests += toNumber((row as any)?.requests);
-			existing.success += toNumber((row as any)?.success_requests);
-			existing.tokens += toNumber((row as any)?.total_tokens);
+			existing.requests += toBigInt(row?.requests);
+			existing.success += toBigInt(row?.success_requests);
+			existing.tokens += toBigInt(row?.total_tokens);
 			aggregate.set(appId, existing);
 		}
 
@@ -177,16 +215,28 @@ async function fetchModelAppsFromDailyRollupsFallback(args: {
 	if (aggregate.size === 0) return [];
 
 	const appIds = Array.from(aggregate.keys());
-	const { data: appRows, error: appError } = await args.client
-		.from("api_apps")
-		.select("id, title, image_url, url, last_seen, is_public")
-		.in("id", appIds);
+	const appRows: ModelAppMetadataRow[] = [];
+	const APP_IDS_CHUNK_SIZE = 500;
 
-	if (appError) {
-		console.warn("[model-apps] failed to resolve app metadata", {
-			modelId: args.modelId,
-			error: appError,
-		});
+	for (let index = 0; index < appIds.length; index += APP_IDS_CHUNK_SIZE) {
+		const appIdChunk = appIds.slice(index, index + APP_IDS_CHUNK_SIZE);
+		const { data: chunkRows, error: chunkError } = await args.client
+			.from("api_apps")
+			.select("id, title, image_url, url, last_seen, is_public")
+			.in("id", appIdChunk);
+
+		if (chunkError) {
+			console.warn("[model-apps] failed to resolve app metadata", {
+				modelId: args.modelId,
+				error: chunkError,
+				chunkStart: index,
+			});
+			continue;
+		}
+
+		for (const row of chunkRows ?? []) {
+			appRows.push(row as ModelAppMetadataRow);
+		}
 	}
 
 	const appMetaById = new Map<
@@ -200,25 +250,25 @@ async function fetchModelAppsFromDailyRollupsFallback(args: {
 		}
 	>();
 	for (const row of appRows ?? []) {
-		const id = String((row as any)?.id ?? "").trim();
+		const id = String(row?.id ?? "").trim();
 		if (!id) continue;
-		const isPublic = Boolean((row as any)?.is_public);
+		const isPublic = Boolean(row?.is_public);
 		appMetaById.set(id, {
-			title: String((row as any)?.title ?? id).trim() || id,
+			title: String(row?.title ?? id).trim() || id,
 			imageUrl:
-				typeof (row as any)?.image_url === "string" &&
-				(row as any).image_url.trim().length > 0
-					? (row as any).image_url.trim()
+				typeof row?.image_url === "string" &&
+				row.image_url.trim().length > 0
+					? row.image_url.trim()
 					: null,
 			url:
-				typeof (row as any)?.url === "string" &&
-				(row as any).url.trim().length > 0
-					? (row as any).url.trim()
+				typeof row?.url === "string" &&
+				row.url.trim().length > 0
+					? row.url.trim()
 					: null,
 			lastSeen:
-				typeof (row as any)?.last_seen === "string" &&
-				(row as any).last_seen.trim().length > 0
-					? (row as any).last_seen
+				typeof row?.last_seen === "string" &&
+				row.last_seen.trim().length > 0
+					? row.last_seen
 					: null,
 			isPublic,
 		});
@@ -234,16 +284,18 @@ async function fetchModelAppsFromDailyRollupsFallback(args: {
 				imageUrl: meta?.imageUrl ?? null,
 				url: meta?.url ?? null,
 				lastSeen: meta?.lastSeen ?? null,
-				totalRequests: Math.max(0, Math.round(usage.requests)),
-				successfulRequests: Math.max(0, Math.round(usage.success)),
-				totalTokens: Math.max(0, Math.round(usage.tokens)),
+				totalRequests: bigintToDisplayNumber(usage.requests),
+				successfulRequests: bigintToDisplayNumber(usage.success),
+				totalTokens: bigintToDisplayNumber(usage.tokens),
 				isPublic: meta?.isPublic ?? false,
+				sortRequests: usage.requests,
+				sortTokens: usage.tokens,
 			};
 		})
 		.filter((entry) => entry.isPublic)
 		.sort((a, b) => {
-			if (b.totalTokens !== a.totalTokens) return b.totalTokens - a.totalTokens;
-			if (b.totalRequests !== a.totalRequests) return b.totalRequests - a.totalRequests;
+			if (a.sortTokens !== b.sortTokens) return b.sortTokens > a.sortTokens ? 1 : -1;
+			if (a.sortRequests !== b.sortRequests) return b.sortRequests > a.sortRequests ? 1 : -1;
 			return a.appId.localeCompare(b.appId);
 		})
 		.slice(0, args.limit)
@@ -265,7 +317,8 @@ export async function getModelApps(
 	limit = 24,
 ): Promise<ModelAppUsage[]> {
 	const supabase = createAdminClient();
-	const safeLimit = Math.max(1, Math.min(100, Math.round(limit)));
+	const normalizedLimit = Number.isFinite(limit) ? Math.round(limit) : 24;
+	const safeLimit = Math.max(1, Math.min(100, normalizedLimit));
 	const aliases = await getModelAliases(supabase, modelId);
 
 	const rpcResult = await fetchModelAppsFromRollupRpc({

--- a/apps/web/src/lib/fetchers/models/getModelApps.ts
+++ b/apps/web/src/lib/fetchers/models/getModelApps.ts
@@ -2,7 +2,6 @@ import { cacheLife, cacheTag } from "next/cache";
 import { createAdminClient } from "@/utils/supabase/admin";
 
 const PAGE_SIZE = 5000;
-const MAX_PAGES = 12;
 
 export type ModelAppUsage = {
 	appId: string;
@@ -66,11 +65,14 @@ export async function getModelApps(
 		{ requests: number; success: number; tokens: number }
 	>();
 
-	for (let page = 0, offset = 0; page < MAX_PAGES; page += 1, offset += PAGE_SIZE) {
+	for (let offset = 0; ; offset += PAGE_SIZE) {
 		const { data, error } = await supabase
 			.from("gateway_usage_rollup_daily_app_model")
-			.select("app_id, requests, success_requests, total_tokens")
+			.select("day_bucket, canonical_model_id, app_id, requests, success_requests, total_tokens")
 			.in("canonical_model_id", aliases)
+			.order("day_bucket", { ascending: true })
+			.order("app_id", { ascending: true })
+			.order("canonical_model_id", { ascending: true })
 			.range(offset, offset + PAGE_SIZE - 1);
 
 		if (error) {

--- a/packages/data/catalog/src/data/models/openai/gpt-5.4-cyber/model.json
+++ b/packages/data/catalog/src/data/models/openai/gpt-5.4-cyber/model.json
@@ -2,10 +2,10 @@
   "model_id": "openai/gpt-5.4-cyber",
   "organisation_id": "openai",
   "name": "GPT 5.4 Cyber",
-  "status": "Available",
+  "status": "Withheld",
   "previous_model_id": "openai/gpt-5.4",
   "announced_date": "2026-04-14T00:00:00",
-  "release_date": "2026-04-14T00:00:00",
+  "release_date": null,
   "deprecation_date": null,
   "retirement_date": null,
   "license": "Proprietary",
@@ -25,7 +25,7 @@
   "details": [
     {
       "name": "availability",
-      "value": "Available to highest Trusted Access for Cyber (TAC) tiers"
+      "value": "Not publicly accessible; announced for highest Trusted Access for Cyber (TAC) tiers"
     }
   ],
   "benchmarks": []

--- a/supabase/migrations/20260416143000_add_usage_model_apps_rpc.sql
+++ b/supabase/migrations/20260416143000_add_usage_model_apps_rpc.sql
@@ -1,0 +1,60 @@
+-- Aggregate top apps for one or more canonical model ids using daily app/model rollups.
+-- This avoids transferring large rollup row sets to the web tier for client-side aggregation.
+
+create or replace function public.get_usage_model_apps(
+  p_model_ids text[],
+  p_limit integer default 24,
+  p_since timestamptz default null
+)
+returns table (
+  app_id uuid,
+  requests bigint,
+  success_requests bigint,
+  total_tokens bigint,
+  title text,
+  image_url text,
+  url text,
+  last_seen timestamptz
+)
+language sql
+stable
+as $$
+  with normalized_limit as (
+    select greatest(1, least(coalesce(p_limit, 24), 100)) as value
+  ),
+  app_totals as (
+    select
+      d.app_id,
+      sum(d.requests)::bigint as requests,
+      sum(d.success_requests)::bigint as success_requests,
+      sum(d.total_tokens)::bigint as total_tokens
+    from public.gateway_usage_rollup_daily_app_model d
+    where array_length(p_model_ids, 1) is not null
+      and d.canonical_model_id = any(p_model_ids)
+      and (
+        p_since is null
+        or d.day_bucket >= (date_trunc('day', p_since at time zone 'utc') at time zone 'utc')
+      )
+    group by d.app_id
+  )
+  select
+    t.app_id,
+    t.requests,
+    t.success_requests,
+    t.total_tokens,
+    coalesce(a.title, t.app_id::text) as title,
+    nullif(trim(a.image_url), '') as image_url,
+    nullif(trim(a.url), '') as url,
+    a.last_seen
+  from app_totals t
+  join public.api_apps a
+    on a.id = t.app_id
+  where coalesce(a.is_public, false) = true
+  order by t.total_tokens desc, t.requests desc, t.app_id asc
+  limit (select value from normalized_limit);
+$$;
+
+comment on function public.get_usage_model_apps(text[], integer, timestamptz) is
+  'Aggregates app usage for model aliases from gateway_usage_rollup_daily_app_model and returns public app metadata.';
+
+grant execute on function public.get_usage_model_apps(text[], integer, timestamptz) to authenticated, service_role;


### PR DESCRIPTION
## Summary
- switch the model **Apps** section from subscription-plan data to gateway request usage data
- add a dedicated model app fetcher based on `gateway_usage_rollup_daily_app_model` + `api_apps` metadata
- update model Apps page metadata copy to reflect gateway app usage (not plans)
- refine model pricing card layout and token meter labeling across Text/Image/Audio/Video groups
- improve cache-write tier formatting with compact TTL labels (for example `5m`, `1h`) and clearer condition display
- update `openai/gpt-5.4-cyber` to `Withheld` with `release_date: null`

## Validation
- pnpm --filter @ai-stats/web typecheck
- pnpm validate:data


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Model pages now list public apps observed in gateway traffic, showing app usage metrics (requests, tokens) and direct app links.

* **Updates**
  * Reorganized pricing/token UI into grouped modality metrics, unified upcoming pricing, added capacity/performance blocks, and refined section headers/labels.
  * Improved SEO metadata for model pages to emphasize gateway app usage.
  * GPT-5.4-Cyber status changed to withheld (not publicly accessible).

* **Backend**
  * Added aggregated app-usage support to power model app listings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->