### PR TITLE
Model discovery: role routing + lifecycle watcher alerts

### DIFF
--- a/.github/workflows/check-new-models.yml
+++ b/.github/workflows/check-new-models.yml
@@ -14,6 +14,7 @@ env:
     DISCORD_WEBHOOK_NEW_MODELS_PUBLIC: ${{ secrets.DISCORD_WEBHOOK_NEW_MODELS_PUBLIC }}
     DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
     DISCORD_ROLE_ID_MODEL_UPDATES: "1377690778478055584"
+    DISCORD_ROLE_ID_DEV: ${{ vars.DISCORD_ROLE_ID_DEV }}
 
 permissions:
     contents: read
@@ -61,7 +62,6 @@ jobs:
                   DISCORD_WEBHOOK_NEW_MODELS_PUBLIC: ${{ github.ref == 'refs/heads/main' && secrets.DISCORD_WEBHOOK_NEW_MODELS_PUBLIC || '' }}
               run: |
                   pnpm exec tsx scripts/model-discovery/run-internal-public.ts \
-                    --discord-user-id "${{ secrets.DISCORD_USER_ID }}" \
                     --discord-role-id "${{ env.DISCORD_ROLE_ID_MODEL_UPDATES }}" \
                     --discord-avatar-url "https://ai-stats.phaseo.app/png_logo_light.png"
 
@@ -87,12 +87,10 @@ jobs:
               if: github.ref == 'refs/heads/main'
               env:
                   DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
-                  DISCORD_USER_ID: ${{ secrets.DISCORD_USER_ID }}
-                  DISCORD_ROLE_ID: ${{ env.DISCORD_ROLE_ID_MODEL_UPDATES }}
+                  DISCORD_ROLE_ID_DEV: ${{ env.DISCORD_ROLE_ID_DEV }}
               run: |
                   pnpm exec tsx scripts/model-discovery/run-hf-private.ts \
-                    --discord-user-id "${{ secrets.DISCORD_USER_ID }}" \
-                    --discord-role-id "${{ env.DISCORD_ROLE_ID_MODEL_UPDATES }}" \
+                    --discord-role-id "${{ env.DISCORD_ROLE_ID_DEV }}" \
                     --hf-orgs "${{ vars.HF_WATCH_ORGS }}" \
                     --hf-token "${{ secrets.HF_TOKEN }}"
 

--- a/apps/web/src/lib/model-discovery/internalModelDiscordNotifier.ts
+++ b/apps/web/src/lib/model-discovery/internalModelDiscordNotifier.ts
@@ -5,6 +5,7 @@ export type InternalModelNotificationModel = {
 	creatorId?: string;
 	creatorName?: string;
 	creatorColor?: string;
+	changeSummaryLines?: string[];
 };
 
 export type DiscordEmbed = {
@@ -86,6 +87,13 @@ function sanitizeModel(input: InternalModelNotificationModel): InternalModelNoti
 	const creatorId = trimOrNull(input.creatorId) ?? modelId.split("/")[0] ?? null;
 	const creatorName = trimOrNull(input.creatorName);
 	const creatorColor = trimOrNull(input.creatorColor);
+	const changeSummaryLines = Array.isArray(input.changeSummaryLines)
+		? input.changeSummaryLines
+				.filter((line): line is string => typeof line === "string")
+				.map((line) => line.trim())
+				.filter(Boolean)
+				.slice(0, 8)
+		: [];
 	return {
 		modelId,
 		modelName,
@@ -93,6 +101,7 @@ function sanitizeModel(input: InternalModelNotificationModel): InternalModelNoti
 		creatorId: creatorId ?? undefined,
 		creatorName: creatorName ?? undefined,
 		creatorColor: creatorColor ?? undefined,
+		changeSummaryLines: changeSummaryLines.length > 0 ? changeSummaryLines : undefined,
 	};
 }
 
@@ -184,10 +193,16 @@ export function formatSingleModelEmbed(
 		throw new Error("formatSingleModelEmbed requires modelId, modelName, and modelUrl.");
 	}
 
+	const descriptionLines = [
+		`Model ID: \`${safeModel.modelId}\``,
+		`[View Model](${safeModel.modelUrl})`,
+		...(safeModel.changeSummaryLines ? ["", ...safeModel.changeSummaryLines] : []),
+	];
+
 	return {
 		title: truncateText(buildDisplayTitle(safeModel), 180),
 		url: safeModel.modelUrl,
-		description: `Model ID: \`${safeModel.modelId}\`\n[View Model](${safeModel.modelUrl})`,
+		description: descriptionLines.join("\n"),
 		color: resolveEmbedColor(safeModel),
 		footer: { text: formatFooterText(nowIso) },
 	};
@@ -202,10 +217,16 @@ function formatPerModelDetailEmbed(
 		throw new Error("formatPerModelDetailEmbed requires modelId, modelName, and modelUrl.");
 	}
 
+	const descriptionLines = [
+		`Model ID: \`${safeModel.modelId}\``,
+		`[View Model](${safeModel.modelUrl})`,
+		...(safeModel.changeSummaryLines ? ["", ...safeModel.changeSummaryLines] : []),
+	];
+
 	return {
 		title: truncateText(buildDisplayTitle(safeModel), 180),
 		url: safeModel.modelUrl,
-		description: `Model ID: \`${safeModel.modelId}\`\n[View Model](${safeModel.modelUrl})`,
+		description: descriptionLines.join("\n"),
 		color: resolveEmbedColor(safeModel),
 		footer: { text: formatFooterText(nowIso) },
 	};

--- a/scripts/model-discovery/README.md
+++ b/scripts/model-discovery/README.md
@@ -21,7 +21,13 @@ Discord alerts are filtered to models from the database table `data_api_provider
 If any filtered diff exists, the runner sends a Discord webhook notification.
 
 Internal model file checks read from `packages/data/catalog/src/data/models`.
-Internal Discord alerts are sent as embed payloads when new internal models are added to the repository.
+Internal Discord alerts are sent as embed payloads when internal models are added or when lifecycle fields change:
+
+- status
+- announced date
+- release date
+- deprecation date
+- retirement date
 Already-announced model IDs are persisted to:
 
 - `scripts/model-discovery/state/internal-announced-models.json`
@@ -35,7 +41,7 @@ Providers not present in `discovery-policy.ts` are also treated as inactive by d
 ## Script entrypoints
 
 - `scripts/model-discovery/run-internal-public.ts`
-  - Public internal release notifications (website model additions only).
+  - Public internal model watcher notifications (new models + lifecycle updates).
 - `scripts/model-discovery/run.ts`
   - Private external provider tracking notifications.
 - `scripts/model-discovery/run-hf-private.ts`
@@ -56,6 +62,7 @@ pnpm run data:check-new-models:test
 - `DISCORD_WEBHOOK_NEW_MODELS_PUBLIC` (public webhook URL for internal website model additions)
 - `DISCORD_WEBHOOK_URL` (private/default webhook URL for provider and Hugging Face tracking alerts)
 - `DISCORD_ROLE_ID` (optional role mention)
+- `DISCORD_ROLE_ID_DEV` (optional dev role mention for Hugging Face private notifications)
 - `DISCORD_USER_ID` (optional mention)
 - `DISCORD_MODEL_DISCOVERY_AVATAR_URL` (optional manual override when calling internal runner scripts with `--discord-avatar-url`)
 - `NEXT_PUBLIC_SUPABASE_URL` (required for DB allowlist)

--- a/scripts/model-discovery/run-internal.ts
+++ b/scripts/model-discovery/run-internal.ts
@@ -26,6 +26,11 @@ type ModelFileSnapshot = {
     filePath: string;
     modelId: string | null;
     modelName: string | null;
+    status: string | null;
+    announcedDate: string | null;
+    releaseDate: string | null;
+    deprecationDate: string | null;
+    retirementDate: string | null;
 };
 
 type HuggingFaceOrgSnapshot = {
@@ -34,7 +39,7 @@ type HuggingFaceOrgSnapshot = {
 };
 
 type InternalModelsFileState = {
-    version: 2;
+    version: 3;
     generatedAt: string;
     files: Record<string, ModelFileSnapshot>;
     hfOrgs: Record<string, HuggingFaceOrgSnapshot>;
@@ -83,6 +88,17 @@ function migrateModelRootPrefix(filePath: string): string {
         return `${CANONICAL_MODELS_ROOT_PREFIX}${normalized.slice(LEGACY_MODELS_ROOT_PREFIX.length)}`;
     }
     return normalized;
+}
+
+function toNullableString(value: unknown): string | null {
+    if (typeof value !== "string") return null;
+    const trimmed = value.trim();
+    return trimmed || null;
+}
+
+function toNullableDateString(value: unknown): string | null {
+    if (value === null || value === undefined) return null;
+    return toNullableString(value);
 }
 
 function parseArgs(argv: string[]): CliOptions {
@@ -208,19 +224,23 @@ function readModelFileSnapshot(filePath: string, repoRoot: string): ModelFileSna
         const raw = fs.readFileSync(filePath, "utf-8");
         const parsed = JSON.parse(raw) as Record<string, unknown>;
 
-        const modelId =
-            typeof parsed.model_id === "string" && parsed.model_id.trim()
-                ? parsed.model_id.trim()
-                : null;
-        const modelName =
-            typeof parsed.name === "string" && parsed.name.trim()
-                ? parsed.name.trim()
-                : null;
+        const modelId = toNullableString(parsed.model_id);
+        const modelName = toNullableString(parsed.name);
+        const status = toNullableString(parsed.status);
+        const announcedDate = toNullableDateString(parsed.announced_date);
+        const releaseDate = toNullableDateString(parsed.release_date);
+        const deprecationDate = toNullableDateString(parsed.deprecation_date);
+        const retirementDate = toNullableDateString(parsed.retirement_date);
 
         return {
             filePath: migrateModelRootPrefix(path.relative(repoRoot, filePath)),
             modelId,
             modelName,
+            status,
+            announcedDate,
+            releaseDate,
+            deprecationDate,
+            retirementDate,
         };
     } catch (error) {
         const message = error instanceof Error ? error.message : String(error);
@@ -242,11 +262,24 @@ function normalizeStateFiles(files: Record<string, unknown>): Record<string, Mod
             typeof snapshot?.modelName === "string" && snapshot.modelName.trim()
                 ? snapshot.modelName.trim()
                 : null;
+        const status =
+            typeof snapshot?.status === "string" && snapshot.status.trim()
+                ? snapshot.status.trim()
+                : null;
+        const announcedDate = toNullableDateString(snapshot?.announcedDate);
+        const releaseDate = toNullableDateString(snapshot?.releaseDate);
+        const deprecationDate = toNullableDateString(snapshot?.deprecationDate);
+        const retirementDate = toNullableDateString(snapshot?.retirementDate);
 
         map.set(normalizedPath, {
             filePath: normalizedPath,
             modelId,
             modelName,
+            status,
+            announcedDate,
+            releaseDate,
+            deprecationDate,
+            retirementDate,
         });
     }
 
@@ -255,7 +288,7 @@ function normalizeStateFiles(files: Record<string, unknown>): Record<string, Mod
 
 function emptyState(): InternalModelsFileState {
     return {
-        version: 2,
+        version: 3,
         generatedAt: nowIso(),
         files: {},
         hfOrgs: {},
@@ -317,11 +350,11 @@ function readState(filePath: string): { state: InternalModelsFileState; hasHfSta
 
         const normalizedFiles = normalizeStateFiles(parsed.files as Record<string, unknown>);
 
-        if (parsed.version === 2) {
+        if (parsed.version === 3 || parsed.version === 2) {
             const hasHfState = parsed.hfOrgs !== undefined && typeof parsed.hfOrgs === "object";
             return {
                 state: {
-                    version: 2,
+                    version: 3,
                     generatedAt: typeof parsed.generatedAt === "string" ? parsed.generatedAt : nowIso(),
                     files: normalizedFiles,
                     hfOrgs: hasHfState ? (parsed.hfOrgs as Record<string, HuggingFaceOrgSnapshot>) : {},
@@ -333,7 +366,7 @@ function readState(filePath: string): { state: InternalModelsFileState; hasHfSta
         // Backward compatibility with v1 state (no hfOrgs key).
         return {
             state: {
-                version: 2,
+                version: 3,
                 generatedAt: typeof parsed.generatedAt === "string" ? parsed.generatedAt : nowIso(),
                 files: normalizedFiles,
                 hfOrgs: {},
@@ -356,7 +389,7 @@ function writeDiscoveryState(
     hfOrgs: Record<string, HuggingFaceOrgSnapshot>
 ): void {
     writeJson(statePath, {
-        version: 2,
+        version: 3,
         generatedAt: nowIso(),
         files,
         hfOrgs,
@@ -667,6 +700,55 @@ function toInternalNotificationModel(
     };
 }
 
+function formatStatusValue(status: string | null): string {
+    return status ?? "Not set";
+}
+
+function formatDateValue(value: string | null): string {
+    if (!value) return "Not set";
+    const parsed = new Date(value);
+    if (!Number.isFinite(parsed.getTime())) return value;
+    return parsed.toLocaleDateString("en-GB", {
+        year: "numeric",
+        month: "short",
+        day: "numeric",
+        timeZone: "UTC",
+    });
+}
+
+function buildAddedModelSummaryLines(snapshot: ModelFileSnapshot): string[] {
+    const lines = [`Event: Added`, `Status: ${formatStatusValue(snapshot.status)}`];
+    if (snapshot.announcedDate) lines.push(`Announced: ${formatDateValue(snapshot.announcedDate)}`);
+    if (snapshot.releaseDate) lines.push(`Release: ${formatDateValue(snapshot.releaseDate)}`);
+    if (snapshot.deprecationDate) lines.push(`Deprecation: ${formatDateValue(snapshot.deprecationDate)}`);
+    if (snapshot.retirementDate) lines.push(`Retirement: ${formatDateValue(snapshot.retirementDate)}`);
+    return lines;
+}
+
+function buildUpdatedModelSummaryLines(previous: ModelFileSnapshot, current: ModelFileSnapshot): string[] {
+    const lines: string[] = ["Event: Updated"];
+
+    if (previous.status !== current.status) {
+        lines.push(`Status: ${formatStatusValue(previous.status)} -> ${formatStatusValue(current.status)}`);
+    }
+    if (previous.announcedDate !== current.announcedDate) {
+        lines.push(`Announced: ${formatDateValue(previous.announcedDate)} -> ${formatDateValue(current.announcedDate)}`);
+    }
+    if (previous.releaseDate !== current.releaseDate) {
+        lines.push(`Release: ${formatDateValue(previous.releaseDate)} -> ${formatDateValue(current.releaseDate)}`);
+    }
+    if (previous.deprecationDate !== current.deprecationDate) {
+        lines.push(
+            `Deprecation: ${formatDateValue(previous.deprecationDate)} -> ${formatDateValue(current.deprecationDate)}`
+        );
+    }
+    if (previous.retirementDate !== current.retirementDate) {
+        lines.push(`Retirement: ${formatDateValue(previous.retirementDate)} -> ${formatDateValue(current.retirementDate)}`);
+    }
+
+    return lines.length > 1 ? lines : [];
+}
+
 function buildHfModelLine(modelId: string): string {
     const normalized = modelId.trim();
     if (!normalized) return "- Unknown HF model";
@@ -767,15 +849,46 @@ export async function runInternalModelDiscovery(argv: string[]): Promise<void> {
 
     const diff = diffStates(previousState, currentFiles);
     const announcedState = readAnnouncedState(announcedStatePath);
-    const detectedInternalModels = shouldCheckInternal
+    const detectedInternalAddedModels = shouldCheckInternal
         ? diff.added
             .map((filePath) => currentFiles[filePath])
             .filter((snapshot): snapshot is ModelFileSnapshot => Boolean(snapshot))
-            .map((snapshot) => toInternalNotificationModel(snapshot, organisationMetaMap))
+            .map((snapshot) => {
+                const model = toInternalNotificationModel(snapshot, organisationMetaMap);
+                if (!model) return null;
+                return {
+                    ...model,
+                    changeSummaryLines: buildAddedModelSummaryLines(snapshot),
+                } satisfies InternalModelNotificationModel;
+            })
             .filter((snapshot): snapshot is InternalModelNotificationModel => Boolean(snapshot))
         : [];
-    const newInternalModels = filterUnannouncedModels(detectedInternalModels, announcedState.announcedByModelId);
-    const skippedAlreadyAnnouncedInternal = Math.max(0, detectedInternalModels.length - newInternalModels.length);
+    const newInternalModels = filterUnannouncedModels(detectedInternalAddedModels, announcedState.announcedByModelId);
+    const skippedAlreadyAnnouncedInternal = Math.max(
+        0,
+        detectedInternalAddedModels.length - newInternalModels.length
+    );
+    const internalUpdatedModels = shouldCheckInternal
+        ? diff.changed
+            .map((filePath) => {
+                const previousSnapshot = previousState.files[filePath];
+                const currentSnapshot = currentFiles[filePath];
+                if (!previousSnapshot || !currentSnapshot) return null;
+                const changeSummaryLines = buildUpdatedModelSummaryLines(previousSnapshot, currentSnapshot);
+                if (changeSummaryLines.length === 0) return null;
+                const model = toInternalNotificationModel(currentSnapshot, organisationMetaMap);
+                if (!model) return null;
+                return {
+                    ...model,
+                    changeSummaryLines,
+                } satisfies InternalModelNotificationModel;
+            })
+            .filter((snapshot): snapshot is InternalModelNotificationModel => Boolean(snapshot))
+        : [];
+    const internalNotificationModels = [...newInternalModels, ...internalUpdatedModels];
+    const internalAdditionsCount = shouldCheckInternal ? newInternalModels.length : 0;
+    const internalUpdatesCount = shouldCheckInternal ? internalUpdatedModels.length : 0;
+    const internalNotificationCount = internalNotificationModels.length;
 
     const hfFirstBaseline = shouldCheckHf && !previous.hasHfState;
     const hfAdditionsByOrg = !shouldCheckHf || hfFirstBaseline
@@ -795,8 +908,10 @@ export async function runInternalModelDiscovery(argv: string[]): Promise<void> {
             baselineInitialized: hfFirstBaseline,
         },
         internalNotification: {
-            detectedAdded: detectedInternalModels.length,
-            newlyAnnounced: newInternalModels.length,
+            detectedAdded: detectedInternalAddedModels.length,
+            detectedUpdated: internalUpdatesCount,
+            newlyAnnouncedAdded: newInternalModels.length,
+            notifiedUpdates: internalUpdatesCount,
             skippedAlreadyAnnounced: skippedAlreadyAnnouncedInternal,
             announcedStatePath: path.relative(repoRoot, announcedStatePath),
         },
@@ -810,6 +925,9 @@ export async function runInternalModelDiscovery(argv: string[]): Promise<void> {
             console.log(
                 `[internal-model-check] Internal additions skipped as already announced: ${skippedAlreadyAnnouncedInternal}.`
             );
+        }
+        if (internalUpdatesCount > 0) {
+            console.log(`[internal-model-check] Internal model updates detected: ${internalUpdatesCount}.`);
         }
     } else {
         console.log("[internal-model-check] Internal model diff disabled (--skip-internal).");
@@ -832,16 +950,15 @@ export async function runInternalModelDiscovery(argv: string[]): Promise<void> {
         console.log("[internal-model-check] HF baseline initialized from existing state; skipping HF notifications this run.");
     }
 
-    const internalAdditionsCount = shouldCheckInternal ? newInternalModels.length : 0;
-    if (internalAdditionsCount === 0 && hfAdditionsTotal === 0) {
+    if (internalNotificationCount === 0 && hfAdditionsTotal === 0) {
         writeDiscoveryState(statePath, currentFiles, currentHf.snapshots);
-        console.log("[internal-model-check] No new internal or HF models detected.");
+        console.log("[internal-model-check] No internal model updates/additions or HF additions detected.");
         return;
     }
 
-    if (internalAdditionsCount > 0 && !internalWebhookUrl) {
+    if (internalNotificationCount > 0 && !internalWebhookUrl) {
         console.log(
-            `[internal-model-check] ${internalAdditionsCount} internal model addition(s) detected, but DISCORD_WEBHOOK_NEW_MODELS_PUBLIC is missing.`
+            `[internal-model-check] ${internalNotificationCount} internal model notification(s) detected, but DISCORD_WEBHOOK_NEW_MODELS_PUBLIC is missing.`
         );
     }
     if (hfAdditionsTotal > 0 && !hfWebhookUrl) {
@@ -850,9 +967,9 @@ export async function runInternalModelDiscovery(argv: string[]): Promise<void> {
         );
     }
 
-    const shouldSendInternal = shouldCheckInternal && internalAdditionsCount > 0 && Boolean(internalWebhookUrl);
+    const shouldSendInternal = shouldCheckInternal && internalNotificationCount > 0 && Boolean(internalWebhookUrl);
     const shouldSendHf = shouldCheckHf && hfAdditionsTotal > 0 && Boolean(hfWebhookUrl);
-    const holdInternalBaseline = shouldCheckInternal && internalAdditionsCount > 0 && !shouldSendInternal;
+    const holdInternalBaseline = shouldCheckInternal && internalNotificationCount > 0 && !shouldSendInternal;
     const holdHfBaseline = shouldCheckHf && hfAdditionsTotal > 0 && !shouldSendHf;
 
     if (!shouldSendInternal && !shouldSendHf) {
@@ -865,14 +982,14 @@ export async function runInternalModelDiscovery(argv: string[]): Promise<void> {
     }
 
     console.log(
-        `[internal-model-check] Changes detected (${internalAdditionsCount} internal new, ${diff.removed.length} internal removed, ${hfAdditionsTotal} HF new). Sending Discord notification${shouldSendInternal && shouldSendHf ? "s" : ""}.`
+        `[internal-model-check] Changes detected (${internalAdditionsCount} internal added, ${internalUpdatesCount} internal updated, ${diff.removed.length} internal removed, ${hfAdditionsTotal} HF new). Sending Discord notification${shouldSendInternal && shouldSendHf ? "s" : ""}.`
     );
 
     let mentionsSent = false;
 
     if (shouldSendInternal && internalWebhookUrl) {
         const avatarUrl = options.discordAvatarUrl ?? null;
-        const payload = buildWebhookPayload(newInternalModels, options.discordRoleId, {
+        const payload = buildWebhookPayload(internalNotificationModels, options.discordRoleId, {
             discordUserId: options.discordUserId,
             includeMentions: true,
             avatarUrl,

--- a/scripts/model-discovery/run-internal.ts
+++ b/scripts/model-discovery/run-internal.ts
@@ -97,8 +97,12 @@ function toNullableString(value: unknown): string | null {
 }
 
 function toNullableDateString(value: unknown): string | null {
-    if (value === null || value === undefined) return null;
-    return toNullableString(value);
+    const normalized = toNullableString(value);
+    if (!normalized) return null;
+    if (/^\d{4}-\d{2}-\d{2}$/.test(normalized)) return normalized;
+    const parsed = Date.parse(normalized);
+    if (!Number.isFinite(parsed)) return normalized;
+    return new Date(parsed).toISOString().slice(0, 10);
 }
 
 function parseArgs(argv: string[]): CliOptions {
@@ -334,9 +338,9 @@ function readAnnouncedState(filePath: string): AnnouncedInternalModelsState {
     }
 }
 
-function readState(filePath: string): { state: InternalModelsFileState; hasHfState: boolean } {
+function readState(filePath: string): { state: InternalModelsFileState; hasHfState: boolean; sourceVersion: number | null } {
     if (!fs.existsSync(filePath)) {
-        return { state: emptyState(), hasHfState: false };
+        return { state: emptyState(), hasHfState: false, sourceVersion: null };
     }
 
     try {
@@ -345,10 +349,14 @@ function readState(filePath: string): { state: InternalModelsFileState; hasHfSta
             | undefined;
 
         if (!parsed?.files || typeof parsed.files !== "object") {
-            return { state: emptyState(), hasHfState: false };
+            return { state: emptyState(), hasHfState: false, sourceVersion: null };
         }
 
         const normalizedFiles = normalizeStateFiles(parsed.files as Record<string, unknown>);
+        const sourceVersion =
+            typeof parsed.version === "number" && Number.isFinite(parsed.version)
+                ? parsed.version
+                : 1;
 
         if (parsed.version === 3 || parsed.version === 2) {
             const hasHfState = parsed.hfOrgs !== undefined && typeof parsed.hfOrgs === "object";
@@ -360,6 +368,7 @@ function readState(filePath: string): { state: InternalModelsFileState; hasHfSta
                     hfOrgs: hasHfState ? (parsed.hfOrgs as Record<string, HuggingFaceOrgSnapshot>) : {},
                 },
                 hasHfState,
+                sourceVersion,
             };
         }
 
@@ -372,9 +381,10 @@ function readState(filePath: string): { state: InternalModelsFileState; hasHfSta
                 hfOrgs: {},
             },
             hasHfState: false,
+            sourceVersion,
         };
     } catch {
-        return { state: emptyState(), hasHfState: false };
+        return { state: emptyState(), hasHfState: false, sourceVersion: null };
     }
 }
 
@@ -868,7 +878,7 @@ export async function runInternalModelDiscovery(argv: string[]): Promise<void> {
         0,
         detectedInternalAddedModels.length - newInternalModels.length
     );
-    const internalUpdatedModels = shouldCheckInternal
+    const detectedInternalUpdatedModels = shouldCheckInternal
         ? diff.changed
             .map((filePath) => {
                 const previousSnapshot = previousState.files[filePath];
@@ -885,6 +895,17 @@ export async function runInternalModelDiscovery(argv: string[]): Promise<void> {
             })
             .filter((snapshot): snapshot is InternalModelNotificationModel => Boolean(snapshot))
         : [];
+    const suppressLegacyLifecycleBackfillUpdates =
+        shouldCheckInternal &&
+        previous.sourceVersion !== null &&
+        previous.sourceVersion < 3 &&
+        detectedInternalUpdatedModels.length > 0;
+    const internalUpdatedModels = suppressLegacyLifecycleBackfillUpdates
+        ? []
+        : detectedInternalUpdatedModels;
+    const suppressedLegacyLifecycleUpdates = suppressLegacyLifecycleBackfillUpdates
+        ? detectedInternalUpdatedModels.length
+        : 0;
     const internalNotificationModels = [...newInternalModels, ...internalUpdatedModels];
     const internalAdditionsCount = shouldCheckInternal ? newInternalModels.length : 0;
     const internalUpdatesCount = shouldCheckInternal ? internalUpdatedModels.length : 0;
@@ -913,6 +934,7 @@ export async function runInternalModelDiscovery(argv: string[]): Promise<void> {
             newlyAnnouncedAdded: newInternalModels.length,
             notifiedUpdates: internalUpdatesCount,
             skippedAlreadyAnnounced: skippedAlreadyAnnouncedInternal,
+            suppressedLegacyLifecycleUpdates,
             announcedStatePath: path.relative(repoRoot, announcedStatePath),
         },
     });
@@ -928,6 +950,11 @@ export async function runInternalModelDiscovery(argv: string[]): Promise<void> {
         }
         if (internalUpdatesCount > 0) {
             console.log(`[internal-model-check] Internal model updates detected: ${internalUpdatesCount}.`);
+        }
+        if (suppressedLegacyLifecycleUpdates > 0) {
+            console.log(
+                `[internal-model-check] Suppressed ${suppressedLegacyLifecycleUpdates} lifecycle update notification(s) while upgrading legacy discovery state.`
+            );
         }
     } else {
         console.log("[internal-model-check] Internal model diff disabled (--skip-internal).");


### PR DESCRIPTION
## Summary
- route internal model discovery mentions to the New Model Releases role only (no user ping)
- route external Hugging Face discovery mentions to Dev role only
- upgrade internal discovery from "new models only" to watcher behavior by notifying on lifecycle field updates
- include lifecycle change details in Discord embeds (status, announced/release/deprecation/retirement dates)

## Validation
- pnpm --filter @ai-stats/web test -- internalModelDiscordNotifier.test.ts
- pnpm exec tsx scripts/model-discovery/run-internal.ts --skip-internal --skip-hf

## Notes
- Existing unrelated working tree changes were intentionally left out of this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Model discovery now tracks and notifies lifecycle changes (status, announced/release/deprecation/retirement dates) in addition to new models.
  * Discord notifications now include multi-line per-model change summaries and support a dedicated dev role mention.

* **Bug Fixes**
  * Discovery state schema upgraded with migration handling to preserve legacy data and avoid duplicate backfill notifications.

* **Documentation**
  * Model watcher docs updated to reflect expanded lifecycle tracking and new dev role variable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->