### PR TITLE
fix(web): harden cache tags + scoped revalidation for Supabase data

### DIFF
--- a/apps/web/eslint.config.mjs
+++ b/apps/web/eslint.config.mjs
@@ -51,6 +51,64 @@ export default [
 		},
 	},
 	{
+		files: [
+			"src/app/(dashboard)/models/**/*.{ts,tsx}",
+			"src/app/(dashboard)/families/**/*.{ts,tsx}",
+			"src/components/(data)/model/**/*.{ts,tsx}",
+		],
+		rules: {
+			"no-restricted-imports": [
+				"error",
+				{
+					paths: [
+						{
+							name: "@/lib/fetchers/models/getModel",
+							importNames: ["default", "getModelOverview"],
+							message:
+								"Use getModelCached/getModelOverviewCached in public model surfaces.",
+						},
+						{
+							name: "@/lib/fetchers/models/getFamilyModels",
+							importNames: ["default", "getFamilyModels"],
+							message:
+								"Use getFamilyModelsCached in public model surfaces.",
+						},
+						{
+							name: "@/lib/fetchers/models/getModelPricing",
+							importNames: ["default", "getModelPricing"],
+							message:
+								"Use getModelPricingCached in public model surfaces.",
+						},
+						{
+							name: "@/lib/fetchers/models/getModelGatewayMetadata",
+							importNames: ["default", "getModelGatewayMetadata"],
+							message:
+								"Use getModelGatewayMetadataCached in public model surfaces.",
+						},
+						{
+							name: "@/lib/fetchers/models/getModelSubscriptionPlans",
+							importNames: ["default", "getModelSubscriptionPlans"],
+							message:
+								"Use getModelSubscriptionPlansCached in public model surfaces.",
+						},
+						{
+							name: "@/lib/fetchers/models/getModelTimeline",
+							importNames: ["default", "getModelTimeline"],
+							message:
+								"Use getModelTimelineCached in public model surfaces.",
+						},
+						{
+							name: "@/lib/fetchers/models/getModelAvailability",
+							importNames: ["default", "getModelAvailability"],
+							message:
+								"Use getModelAvailabilityCached in public model surfaces.",
+						},
+					],
+				},
+			],
+		},
+	},
+	{
 		files: ["**/*.{js,jsx,mjs,cjs}"],
 		rules: {
 			"max-lines": [

--- a/apps/web/src/app/(dashboard)/apps/[appId]/page.tsx
+++ b/apps/web/src/app/(dashboard)/apps/[appId]/page.tsx
@@ -1,5 +1,6 @@
 import Link from "next/link";
 import type { Metadata } from "next";
+import { cacheLife, cacheTag } from "next/cache";
 import { Activity, BarChart3, ExternalLink } from "lucide-react";
 import AppUsageChart from "@/components/(data)/apps/AppUsageChart";
 import { ModelLeaderboard } from "@/components/(rankings)/ModelLeaderboard";
@@ -76,6 +77,39 @@ function getModelLookupVariants(modelId: string): string[] {
 	return Array.from(variants).filter(Boolean);
 }
 
+type ProviderModelMapping = {
+	provider_id: string | null;
+	api_model_id: string | null;
+	model_id: string | null;
+};
+
+async function getProviderModelMappingsCached(
+	apiLookupIds: string[],
+	providerIds: string[],
+): Promise<ProviderModelMapping[]> {
+	"use cache";
+
+	cacheLife("hours");
+	cacheTag("data:models");
+	cacheTag("data:data_api_provider_models");
+
+	if (apiLookupIds.length === 0) return [];
+
+	const supabase = createAdminClient();
+	let query = supabase
+		.from("data_api_provider_models")
+		.select("provider_id, api_model_id, model_id")
+		.in("api_model_id", apiLookupIds)
+		.not("model_id", "is", null);
+
+	if (providerIds.length > 0) {
+		query = query.in("provider_id", providerIds);
+	}
+
+	const { data } = await query;
+	return (data ?? []) as ProviderModelMapping[];
+}
+
 export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
 	const { appId } = await params;
 	const app = await getAppDetailsCached(appId);
@@ -145,24 +179,19 @@ export default async function Page({ params }: PageProps) {
 	);
 	const apiLookupIds = Array.from(
 		new Set(rawModelIds.flatMap((id) => getModelLookupVariants(id))),
+	).sort((a, b) => a.localeCompare(b));
+	const normalizedProviderIds = Array.from(new Set(providerIds)).sort((a, b) =>
+		a.localeCompare(b),
 	);
 
 	const providerToCanonicalByKey = new Map<string, string>();
 	const canonicalByApi = new Map<string, Set<string>>();
 
 	if (apiLookupIds.length > 0) {
-		const supabase = createAdminClient();
-		let providerModelsQuery = supabase
-			.from("data_api_provider_models")
-			.select("provider_id, api_model_id, model_id")
-			.in("api_model_id", apiLookupIds)
-			.not("model_id", "is", null);
-
-		if (providerIds.length > 0) {
-			providerModelsQuery = providerModelsQuery.in("provider_id", providerIds);
-		}
-
-		const { data: providerModels } = await providerModelsQuery;
+		const providerModels = await getProviderModelMappingsCached(
+			apiLookupIds,
+			normalizedProviderIds,
+		);
 		for (const row of providerModels ?? []) {
 			const providerId = row.provider_id?.trim();
 			const apiModelId = row.api_model_id?.trim();

--- a/apps/web/src/app/(dashboard)/apps/[appId]/page.tsx
+++ b/apps/web/src/app/(dashboard)/apps/[appId]/page.tsx
@@ -106,7 +106,12 @@ async function getProviderModelMappingsCached(
 		query = query.in("provider_id", providerIds);
 	}
 
-	const { data } = await query;
+	const { data, error } = await query;
+	if (error) {
+		throw new Error(
+			`Failed to load provider model mappings: ${error.message}`,
+		);
+	}
 	return (data ?? []) as ProviderModelMapping[];
 }
 

--- a/apps/web/src/app/(dashboard)/internal/audit/actions-advanced.ts
+++ b/apps/web/src/app/(dashboard)/internal/audit/actions-advanced.ts
@@ -1,7 +1,10 @@
 "use server";
 
 import { createClient } from "@/utils/supabase/server";
-import { revalidateModelDataTags } from "@/lib/cache/revalidateDataTags";
+import {
+	revalidateBenchmarkDataTags,
+	revalidateModelDataTags,
+} from "@/lib/cache/revalidateDataTags";
 
 async function checkAdminAuth() {
 	const supabase = await createClient();
@@ -350,7 +353,14 @@ export async function createBenchmarkResult(input: CreateBenchmarkResultInput) {
 		return { success: false, error: error.message };
 	}
 
-	revalidateModelDataTags({ modelId: input.modelId });
+	revalidateModelDataTags({
+		modelId: input.modelId,
+		benchmarkIds: [input.benchmarkId],
+	});
+	revalidateBenchmarkDataTags({
+		modelId: input.modelId,
+		benchmarkId: input.benchmarkId,
+	});
 
 	return { success: true };
 }
@@ -389,11 +399,18 @@ export async function updateBenchmarkResult(input: UpdateBenchmarkResultInput) {
 
 	const { data: benchmarkRow } = await supabase
 		.from("data_benchmark_results")
-		.select("model_id")
+		.select("model_id, benchmark_id")
 		.eq("id", input.resultId)
 		.maybeSingle();
 
-	revalidateModelDataTags({ modelId: benchmarkRow?.model_id ?? null });
+	revalidateModelDataTags({
+		modelId: benchmarkRow?.model_id ?? null,
+		benchmarkIds: [benchmarkRow?.benchmark_id ?? null],
+	});
+	revalidateBenchmarkDataTags({
+		modelId: benchmarkRow?.model_id ?? null,
+		benchmarkId: benchmarkRow?.benchmark_id ?? null,
+	});
 
 	return { success: true };
 }
@@ -406,7 +423,7 @@ export async function deleteBenchmarkResult(resultId: string) {
 
 	const { data: benchmarkRow } = await supabase
 		.from("data_benchmark_results")
-		.select("model_id")
+		.select("model_id, benchmark_id")
 		.eq("id", resultId)
 		.maybeSingle();
 
@@ -419,7 +436,14 @@ export async function deleteBenchmarkResult(resultId: string) {
 		return { success: false, error: error.message };
 	}
 
-	revalidateModelDataTags({ modelId: benchmarkRow?.model_id ?? null });
+	revalidateModelDataTags({
+		modelId: benchmarkRow?.model_id ?? null,
+		benchmarkIds: [benchmarkRow?.benchmark_id ?? null],
+	});
+	revalidateBenchmarkDataTags({
+		modelId: benchmarkRow?.model_id ?? null,
+		benchmarkId: benchmarkRow?.benchmark_id ?? null,
+	});
 
 	return { success: true };
 }

--- a/apps/web/src/app/(dashboard)/internal/cache/CacheOpsClient.tsx
+++ b/apps/web/src/app/(dashboard)/internal/cache/CacheOpsClient.tsx
@@ -8,11 +8,14 @@ import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
 import {
 	revalidateAppsDataAction,
+	revalidateBenchmarkScopeAction,
 	revalidateCustomScopeAction,
 	revalidateGlobalModelAndProviderAction,
 	revalidateLandingDataAction,
 	revalidateModelScopeAction,
 	revalidateModelsGlobalDataAction,
+	revalidateOrganisationScopeAction,
+	revalidateProviderScopeAction,
 	revalidateProvidersGlobalApiAction,
 	revalidateRankingsAction,
 	revalidateSearchDataAction,
@@ -28,6 +31,9 @@ export default function CacheOpsClient() {
 	const [isPending, startTransition] = useTransition();
 	const [status, setStatus] = useState<StatusState>(null);
 	const [modelId, setModelId] = useState("");
+	const [benchmarkId, setBenchmarkId] = useState("");
+	const [providerId, setProviderId] = useState("");
+	const [organisationId, setOrganisationId] = useState("");
 	const [appId, setAppId] = useState("");
 	const [customTagsText, setCustomTagsText] = useState("");
 	const [customPathsText, setCustomPathsText] = useState("");
@@ -188,6 +194,121 @@ export default function CacheOpsClient() {
 					>
 						Rankings
 					</Button>
+				</CardContent>
+			</Card>
+
+			<Card>
+				<CardHeader>
+					<CardTitle>Benchmarks</CardTitle>
+					<CardDescription>
+						Revalidate all benchmark caches, or one benchmark ID.
+					</CardDescription>
+				</CardHeader>
+				<CardContent className="space-y-3">
+					<Input
+						value={benchmarkId}
+						onChange={(event) => setBenchmarkId(event.target.value)}
+						placeholder="Optional benchmark id (e.g. mmlu-pro)"
+					/>
+					<div className="flex flex-wrap gap-2">
+						<Button
+							type="button"
+							variant="outline"
+							disabled={isPending}
+							onClick={() =>
+								runAction(() => revalidateBenchmarkScopeAction({}))
+							}
+						>
+							Revalidate Benchmarks (Global)
+						</Button>
+						<Button
+							type="button"
+							disabled={isPending || !benchmarkId.trim()}
+							onClick={() =>
+								runAction(() =>
+									revalidateBenchmarkScopeAction({ benchmarkId })
+								)
+							}
+						>
+							Revalidate This Benchmark
+						</Button>
+					</div>
+				</CardContent>
+			</Card>
+
+			<Card>
+				<CardHeader>
+					<CardTitle>Providers</CardTitle>
+					<CardDescription>
+						Revalidate all provider caches, or one provider ID.
+					</CardDescription>
+				</CardHeader>
+				<CardContent className="space-y-3">
+					<Input
+						value={providerId}
+						onChange={(event) => setProviderId(event.target.value)}
+						placeholder="Optional provider id (e.g. openai)"
+					/>
+					<div className="flex flex-wrap gap-2">
+						<Button
+							type="button"
+							variant="outline"
+							disabled={isPending}
+							onClick={() => runAction(() => revalidateProviderScopeAction({}))}
+						>
+							Revalidate Providers (Global)
+						</Button>
+						<Button
+							type="button"
+							disabled={isPending || !providerId.trim()}
+							onClick={() =>
+								runAction(() =>
+									revalidateProviderScopeAction({ providerId })
+								)
+							}
+						>
+							Revalidate This Provider
+						</Button>
+					</div>
+				</CardContent>
+			</Card>
+
+			<Card>
+				<CardHeader>
+					<CardTitle>Organisations</CardTitle>
+					<CardDescription>
+						Revalidate all organisation caches, or one organisation ID.
+					</CardDescription>
+				</CardHeader>
+				<CardContent className="space-y-3">
+					<Input
+						value={organisationId}
+						onChange={(event) => setOrganisationId(event.target.value)}
+						placeholder="Optional organisation id (e.g. anthropic)"
+					/>
+					<div className="flex flex-wrap gap-2">
+						<Button
+							type="button"
+							variant="outline"
+							disabled={isPending}
+							onClick={() =>
+								runAction(() => revalidateOrganisationScopeAction({}))
+							}
+						>
+							Revalidate Organisations (Global)
+						</Button>
+						<Button
+							type="button"
+							disabled={isPending || !organisationId.trim()}
+							onClick={() =>
+								runAction(() =>
+									revalidateOrganisationScopeAction({ organisationId })
+								)
+							}
+						>
+							Revalidate This Organisation
+						</Button>
+					</div>
 				</CardContent>
 			</Card>
 

--- a/apps/web/src/app/(dashboard)/internal/cache/actions.ts
+++ b/apps/web/src/app/(dashboard)/internal/cache/actions.ts
@@ -3,9 +3,12 @@
 import { revalidatePath, revalidateTag } from "next/cache";
 import {
 	revalidateAppDataTags,
+	revalidateBenchmarkDataTags,
 	revalidateModelApiInfoTags,
 	revalidateModelDataOnlyTags,
 	revalidateModelDataTags,
+	revalidateOrganisationDataTags,
+	revalidateProviderDataTags,
 } from "@/lib/cache/revalidateDataTags";
 import { createClient } from "@/utils/supabase/server";
 import {
@@ -113,12 +116,58 @@ export async function revalidateModelsGlobalDataAction(): Promise<CacheOpResult>
 
 export async function revalidateProvidersGlobalApiAction(): Promise<CacheOpResult> {
 	return runAdminAction("Providers (global API info)", async () => {
-		revalidateModelApiInfoTags();
+		revalidateProviderDataTags();
 		revalidateTag("collections", EXPIRE_NOW);
 		revalidatePath("/api-providers");
 		revalidatePath("/models");
 		revalidatePath("/models/collections");
 	});
+}
+
+export async function revalidateProviderScopeAction(input: {
+	providerId?: string;
+}): Promise<CacheOpResult> {
+	const providerId = input.providerId?.trim();
+	if (input.providerId !== undefined && !providerId) {
+		return { ok: false, message: "Provider ID is required." };
+	}
+
+	return runAdminAction(
+		providerId ? `Provider (${providerId})` : "Providers (global)",
+		async () => {
+			if (providerId) {
+				revalidateProviderDataTags({ providerId });
+				revalidatePath(`/api-providers/${providerId}`);
+				revalidatePath(`/api-providers/${providerId}/models`);
+			} else {
+				revalidateProviderDataTags();
+			}
+			revalidatePath("/api-providers");
+		}
+	);
+}
+
+export async function revalidateOrganisationScopeAction(input: {
+	organisationId?: string;
+}): Promise<CacheOpResult> {
+	const organisationId = input.organisationId?.trim();
+	if (input.organisationId !== undefined && !organisationId) {
+		return { ok: false, message: "Organisation ID is required." };
+	}
+
+	return runAdminAction(
+		organisationId ? `Organisation (${organisationId})` : "Organisations (global)",
+		async () => {
+			if (organisationId) {
+				revalidateOrganisationDataTags({ organisationId });
+				revalidatePath(`/organisations/${organisationId}`);
+				revalidatePath(`/organisations/${organisationId}/models`);
+			} else {
+				revalidateOrganisationDataTags();
+			}
+			revalidatePath("/organisations");
+		}
+	);
 }
 
 export async function revalidateGlobalModelAndProviderAction(): Promise<CacheOpResult> {
@@ -219,6 +268,28 @@ export async function revalidateModelScopeAction(input: {
 					: `Model (${modelId}) failed.`,
 		};
 	}
+}
+
+export async function revalidateBenchmarkScopeAction(input: {
+	benchmarkId?: string;
+}): Promise<CacheOpResult> {
+	const benchmarkId = input.benchmarkId?.trim();
+	if (input.benchmarkId !== undefined && !benchmarkId) {
+		return { ok: false, message: "Benchmark ID is required." };
+	}
+
+	return runAdminAction(
+		benchmarkId ? `Benchmark (${benchmarkId})` : "Benchmarks (global)",
+		async () => {
+			if (benchmarkId) {
+				revalidateBenchmarkDataTags({ benchmarkId });
+				revalidatePath(`/benchmarks/${benchmarkId}`);
+			} else {
+				revalidateBenchmarkDataTags();
+			}
+			revalidatePath("/benchmarks");
+		}
+	);
 }
 
 export async function revalidateCustomScopeAction(input: {

--- a/apps/web/src/app/(dashboard)/internal/data/actions.ts
+++ b/apps/web/src/app/(dashboard)/internal/data/actions.ts
@@ -3,6 +3,7 @@
 import { revalidatePath } from "next/cache";
 import { createClient } from "@/utils/supabase/server";
 import {
+	revalidateBenchmarkDataTags,
 	revalidateModelApiInfoTags,
 	revalidateModelDataOnlyTags,
 	revalidateModelDataTags,
@@ -462,7 +463,8 @@ export async function createBenchmarkAction(formData: FormData) {
 	});
 	if (error) throw new Error(error.message);
 
-	revalidateModelDataTags();
+	revalidateModelDataTags({ benchmarkIds: [id] });
+	revalidateBenchmarkDataTags({ benchmarkId: id });
 	revalidatePath("/internal/data/benchmarks");
 }
 
@@ -485,7 +487,8 @@ export async function updateBenchmarkAction(id: string, formData: FormData) {
 		.eq("id", id);
 	if (error) throw new Error(error.message);
 
-	revalidateModelDataTags();
+	revalidateModelDataTags({ benchmarkIds: [id] });
+	revalidateBenchmarkDataTags({ benchmarkId: id });
 	revalidatePath("/internal/data/benchmarks");
 }
 
@@ -494,7 +497,8 @@ export async function deleteBenchmarkAction(id: string) {
 	const { error } = await supabase.from("data_benchmarks").delete().eq("id", id);
 	if (error) throw new Error(error.message);
 
-	revalidateModelDataTags();
+	revalidateModelDataTags({ benchmarkIds: [id] });
+	revalidateBenchmarkDataTags({ benchmarkId: id });
 	revalidatePath("/internal/data/benchmarks");
 }
 

--- a/apps/web/src/app/(dashboard)/models/[organisationId]/[modelId]/benchmarks/page.tsx
+++ b/apps/web/src/app/(dashboard)/models/[organisationId]/[modelId]/benchmarks/page.tsx
@@ -1,7 +1,7 @@
 import { buildMetadata } from "@/lib/seo";
 import ModelDetailShell from "@/components/(data)/model/ModelDetailShell";
 import { ModelBenchmarksSection } from "@/components/(data)/model/overview/ModelOverviewSections";
-import { getModelOverview } from "@/lib/fetchers/models/getModel";
+import { getModelOverviewCached } from "@/lib/fetchers/models/getModel";
 import type { Metadata } from "next";
 import {
 	getModelPath,
@@ -12,7 +12,7 @@ import { permanentRedirect } from "next/navigation";
 
 async function fetchModel(modelId: string, includeHidden: boolean) {
 	try {
-		return await getModelOverview(modelId, includeHidden);
+		return await getModelOverviewCached(modelId, includeHidden);
 	} catch (error) {
 		console.warn("[seo] failed to load model overview for metadata", {
 			modelId,

--- a/apps/web/src/app/(dashboard)/models/[organisationId]/[modelId]/family/page.tsx
+++ b/apps/web/src/app/(dashboard)/models/[organisationId]/[modelId]/family/page.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link";
 import ModelDetailShell from "@/components/(data)/model/ModelDetailShell";
-import getFamilyModels, {
+import {
+	getFamilyModelsCached,
 	type FamilyModelItem,
 } from "@/lib/fetchers/models/getFamilyModels";
 import getModelOverviewHeader from "@/lib/fetchers/models/getModelOverviewHeader";
@@ -15,7 +16,7 @@ import { Badge } from "@/components/ui/badge";
 import { ArrowUpRight } from "lucide-react";
 import type { Metadata } from "next";
 import { buildMetadata } from "@/lib/seo";
-import { getModelOverview } from "@/lib/fetchers/models/getModel";
+import { getModelOverviewCached } from "@/lib/fetchers/models/getModel";
 import { Logo } from "@/components/Logo";
 import { cn } from "@/lib/utils";
 import { formatDistanceToNow } from "date-fns";
@@ -29,7 +30,7 @@ import { permanentRedirect } from "next/navigation";
 
 async function fetchModel(modelId: string, includeHidden: boolean) {
 	try {
-		return await getModelOverview(modelId, includeHidden);
+		return await getModelOverviewCached(modelId, includeHidden);
 	} catch (error) {
 		console.warn("[seo] failed to load model overview for metadata", {
 			modelId,
@@ -207,7 +208,9 @@ export default async function Page({
 		);
 	}
 	const familyId = header.family_id ?? null;
-	const family = familyId ? await getFamilyModels(familyId, includeHidden) : null;
+	const family = familyId
+		? await getFamilyModelsCached(familyId, includeHidden)
+		: null;
 
 	const members = family?.models ?? [];
 	const hasFamily = Boolean(family && members.length > 0);

--- a/apps/web/src/app/(dashboard)/models/[organisationId]/[modelId]/providers/page.tsx
+++ b/apps/web/src/app/(dashboard)/models/[organisationId]/[modelId]/providers/page.tsx
@@ -1,7 +1,7 @@
 import ModelDetailShell from "@/components/(data)/model/ModelDetailShell";
 import type { Metadata } from "next";
 import { buildMetadata } from "@/lib/seo";
-import { getModelOverview } from "@/lib/fetchers/models/getModel";
+import { getModelOverviewCached } from "@/lib/fetchers/models/getModel";
 import { ModelProvidersSection } from "@/components/(data)/model/overview/ModelOverviewSections";
 import {
 	getModelPath,
@@ -12,7 +12,7 @@ import { permanentRedirect } from "next/navigation";
 
 async function fetchModel(modelId: string, includeHidden: boolean) {
 	try {
-		return await getModelOverview(modelId, includeHidden);
+		return await getModelOverviewCached(modelId, includeHidden);
 	} catch (error) {
 		const message =
 			error instanceof Error ? error.message : typeof error === "string" ? error : "";

--- a/apps/web/src/app/(dashboard)/models/[organisationId]/[modelId]/quickstart/page.tsx
+++ b/apps/web/src/app/(dashboard)/models/[organisationId]/[modelId]/quickstart/page.tsx
@@ -2,7 +2,8 @@
 import { buildMetadata } from "@/lib/seo";
 import { ModelQuickstartSection } from "@/components/(data)/model/overview/ModelOverviewSections";
 import ModelDetailShell from "@/components/(data)/model/ModelDetailShell";
-import getModelGatewayMetadata, {
+import {
+	getModelGatewayMetadataCached,
 } from "@/lib/fetchers/models/getModelGatewayMetadata";
 import type { Metadata } from "next";
 import {
@@ -16,7 +17,7 @@ import { permanentRedirect } from "next/navigation";
 async function fetchModel(modelId: string, includeHidden: boolean) {
 	try {
 		const [metadata, header] = await Promise.all([
-			getModelGatewayMetadata(modelId, includeHidden),
+			getModelGatewayMetadataCached(modelId, includeHidden),
 			getModelOverviewHeader(modelId, includeHidden),
 		]);
 		if (!metadata) return null;

--- a/apps/web/src/app/(dashboard)/models/[organisationId]/[modelId]/timeline/page.tsx
+++ b/apps/web/src/app/(dashboard)/models/[organisationId]/[modelId]/timeline/page.tsx
@@ -1,5 +1,5 @@
 import { buildMetadata } from "@/lib/seo";
-import { getModelOverview } from "@/lib/fetchers/models/getModel";
+import { getModelOverviewCached } from "@/lib/fetchers/models/getModel";
 import ModelReleaseTimeline from "@/components/(data)/model/ModelReleaseTimeline";
 import ModelDetailShell from "@/components/(data)/model/ModelDetailShell";
 import type { Metadata } from "next";
@@ -12,7 +12,7 @@ import { permanentRedirect } from "next/navigation";
 
 async function fetchModel(modelId: string, includeHidden: boolean) {
 	try {
-		return await getModelOverview(modelId, includeHidden);
+		return await getModelOverviewCached(modelId, includeHidden);
 	} catch (error) {
 		console.warn("[seo] failed to load model overview for metadata", {
 			modelId,

--- a/apps/web/src/app/(dashboard)/models/actions.ts
+++ b/apps/web/src/app/(dashboard)/models/actions.ts
@@ -469,7 +469,26 @@ export async function updateModel(payload: ModelUpdatePayload) {
     }
   }
 
+  let previousBenchmarkIds: string[] = []
   if (benchmark_results !== undefined) {
+    const { data: existingBenchmarkRows, error: existingBenchmarksError } = await supabase
+      .from("data_benchmark_results")
+      .select("benchmark_id")
+      .eq("model_id", modelId)
+
+    if (existingBenchmarksError) {
+      console.error("[updateModel] Error loading existing benchmarks:", existingBenchmarksError)
+      throw new Error(existingBenchmarksError.message)
+    }
+
+    previousBenchmarkIds = Array.from(
+      new Set(
+        (existingBenchmarkRows ?? [])
+          .map((row) => row.benchmark_id?.trim() || "")
+          .filter(Boolean)
+      )
+    )
+
     const { error: deleteBenchmarksError } = await supabase
       .from("data_benchmark_results")
       .delete()
@@ -993,7 +1012,7 @@ export async function updateModel(payload: ModelUpdatePayload) {
     modelUpdate.organisation_id !== undefined
       ? (modelUpdate.organisation_id as string | null)
       : previousOrganisationId
-  const benchmarkIds =
+  const incomingBenchmarkIds =
     benchmark_results === undefined
       ? []
       : Array.from(
@@ -1003,6 +1022,9 @@ export async function updateModel(payload: ModelUpdatePayload) {
               .filter(Boolean)
           )
         )
+  const benchmarkIds = Array.from(
+    new Set([...previousBenchmarkIds, ...incomingBenchmarkIds])
+  )
   revalidateModelDataTags({
     modelId,
     organisationIds: [previousOrganisationId, nextOrganisationId],

--- a/apps/web/src/app/(dashboard)/models/actions.ts
+++ b/apps/web/src/app/(dashboard)/models/actions.ts
@@ -3,6 +3,7 @@
 import { createClient } from "@/utils/supabase/server"
 import { revalidatePath } from "next/cache"
 import {
+  revalidateBenchmarkDataTags,
   revalidateModelApiInfoTags,
   revalidateModelDataOnlyTags,
   revalidateModelDataTags,
@@ -992,10 +993,24 @@ export async function updateModel(payload: ModelUpdatePayload) {
     modelUpdate.organisation_id !== undefined
       ? (modelUpdate.organisation_id as string | null)
       : previousOrganisationId
+  const benchmarkIds =
+    benchmark_results === undefined
+      ? []
+      : Array.from(
+          new Set(
+            benchmark_results
+              .map((result) => result.benchmark_id?.trim() || "")
+              .filter(Boolean)
+          )
+        )
   revalidateModelDataTags({
     modelId,
     organisationIds: [previousOrganisationId, nextOrganisationId],
+    benchmarkIds,
   })
+  if (benchmarkIds.length > 0) {
+    revalidateBenchmarkDataTags({ modelId, benchmarkIds })
+  }
   revalidatePath(`/models/**`)
   revalidatePath("/models")
 
@@ -1024,7 +1039,7 @@ export async function deleteBenchmarkResult(id: string) {
 
   const { data: benchmarkRow } = await supabase
     .from("data_benchmark_results")
-    .select("model_id")
+    .select("model_id, benchmark_id")
     .eq("id", id)
     .maybeSingle()
 
@@ -1037,7 +1052,14 @@ export async function deleteBenchmarkResult(id: string) {
     throw new Error(error.message)
   }
 
-  revalidateModelDataOnlyTags({ modelId: benchmarkRow?.model_id ?? null })
+  revalidateModelDataOnlyTags({
+    modelId: benchmarkRow?.model_id ?? null,
+    benchmarkIds: [benchmarkRow?.benchmark_id ?? null],
+  })
+  revalidateBenchmarkDataTags({
+    modelId: benchmarkRow?.model_id ?? null,
+    benchmarkId: benchmarkRow?.benchmark_id ?? null,
+  })
   revalidatePath(`/models/**`)
   return { ok: true }
 }

--- a/apps/web/src/components/(data)/model/overview/ModelFamilyButtonServer.tsx
+++ b/apps/web/src/components/(data)/model/overview/ModelFamilyButtonServer.tsx
@@ -1,4 +1,4 @@
-import getFamilyModels from "@/lib/fetchers/models/getFamilyModels";
+import { getFamilyModelsCached } from "@/lib/fetchers/models/getFamilyModels";
 import ModelFamilyButtonClient from "./ModelFamilyButtonClient";
 import { resolveIncludeHidden } from "@/lib/fetchers/models/visibility";
 
@@ -11,7 +11,7 @@ export default async function ModelFamilyButtonServer({
 
 	try {
 		const includeHidden = await resolveIncludeHidden();
-		const family = await getFamilyModels(familyId, includeHidden);
+		const family = await getFamilyModelsCached(familyId, includeHidden);
 		if (!family) return null;
 		return <ModelFamilyButtonClient family={family} />;
 	} catch (err) {

--- a/apps/web/src/components/(data)/model/pricing/ModelPricing.tsx
+++ b/apps/web/src/components/(data)/model/pricing/ModelPricing.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { Card } from "@/components/ui/card";
 import { CircleAlert } from "lucide-react";
-import getModelPricing from "@/lib/fetchers/models/getModelPricing";
+import { getModelPricingCached } from "@/lib/fetchers/models/getModelPricing";
 import getModelOverviewHeader from "@/lib/fetchers/models/getModelOverviewHeader";
 import { getModelProviderRuntimeStatsCached } from "@/lib/fetchers/models/getModelProviderRuntimeStats";
 import { getModelSubscriptionPlansCached } from "@/lib/fetchers/models/getModelSubscriptionPlans";
@@ -26,7 +26,7 @@ export default async function ModelPricing({
 	showHeader?: boolean;
 }) {
 	const [providers, header, subscriptionPlans] = await Promise.all([
-		getModelPricing(modelId, includeHidden),
+		getModelPricingCached(modelId, includeHidden),
 		getModelOverviewHeader(modelId, includeHidden),
 		getModelSubscriptionPlansCached(modelId, includeHidden).catch((error) => {
 			console.warn("[pricing] failed to fetch subscription plans; continuing without plans", {

--- a/apps/web/src/lib/cache/revalidateDataTags.ts
+++ b/apps/web/src/lib/cache/revalidateDataTags.ts
@@ -46,6 +46,8 @@ const MODEL_API_GLOBAL_TAGS = [
 	"data:api_providers:list",
 	"data:model_aliases",
 	"data:data_api_provider_models",
+	"data:data_model_id_redirects",
+	"data:data_api_models",
 	"data:data_api_pricing_rules",
 	"data:gateway_requests",
 	"data:gateway_usage_rollups",

--- a/apps/web/src/lib/cache/revalidateDataTags.ts
+++ b/apps/web/src/lib/cache/revalidateDataTags.ts
@@ -1,9 +1,26 @@
 import { revalidateTag } from "next/cache";
 
-const EXPIRE_NOW = { expire: 0 } as const;
+const STALE_WHILE_REVALIDATE = "max" as const;
 
 type RevalidateModelDataTagOptions = {
 	modelId?: string | null;
+	organisationIds?: Array<string | null | undefined>;
+	benchmarkIds?: Array<string | null | undefined>;
+};
+
+type RevalidateBenchmarkTagOptions = {
+	benchmarkId?: string | null;
+	benchmarkIds?: Array<string | null | undefined>;
+	modelId?: string | null;
+};
+
+type RevalidateProviderTagOptions = {
+	providerId?: string | null;
+	providerIds?: Array<string | null | undefined>;
+};
+
+type RevalidateOrganisationTagOptions = {
+	organisationId?: string | null;
 	organisationIds?: Array<string | null | undefined>;
 };
 
@@ -13,8 +30,10 @@ const MODEL_DATA_GLOBAL_TAGS = [
 	"data:model-updates",
 	"data:models",
 	"data:organisations",
+	"data:organisations:list",
 	"data:families",
 	"data:benchmarks",
+	"data:benchmarks:list",
 	"data:sign-in:models",
 	"data:sign-in:supported-models-stats",
 	"landing:db-stats",
@@ -24,16 +43,22 @@ const MODEL_DATA_GLOBAL_TAGS = [
 
 const MODEL_API_GLOBAL_TAGS = [
 	"data:api_providers",
+	"data:api_providers:list",
 	"data:model_aliases",
 	"data:data_api_provider_models",
 	"data:data_api_pricing_rules",
+	"data:gateway_requests",
+	"data:gateway_usage_rollups",
+	"data:gateway_provider_health_states",
+	"data:top_apps",
+	"data:top_models",
 	"monitor-models",
 	"page:models",
 ] as const;
 
 function revalidateTagList(tags: readonly string[]) {
 	for (const tag of tags) {
-		revalidateTag(tag, EXPIRE_NOW);
+		revalidateTag(tag, STALE_WHILE_REVALIDATE);
 	}
 }
 
@@ -44,23 +69,47 @@ export function revalidateModelDataOnlyTags(
 
 	for (const organisationId of options.organisationIds ?? []) {
 		if (!organisationId) continue;
-		revalidateTag(`organisation:header:${organisationId}`, EXPIRE_NOW);
+		revalidateTag(
+			`organisation:header:${organisationId}`,
+			STALE_WHILE_REVALIDATE
+		);
+		revalidateTag(
+			`data:organisations:${organisationId}`,
+			STALE_WHILE_REVALIDATE
+		);
 	}
 
 	if (options.modelId) {
-		revalidateTag(`model:data:${options.modelId}`, EXPIRE_NOW);
-		revalidateTag(`model:header:${options.modelId}`, EXPIRE_NOW);
-		revalidateTag(`data:models:${options.modelId}`, EXPIRE_NOW);
-		revalidateTag(`data:benchmarks:model:${options.modelId}`, EXPIRE_NOW);
+		revalidateTag(`model:data:${options.modelId}`, STALE_WHILE_REVALIDATE);
+		revalidateTag(`model:header:${options.modelId}`, STALE_WHILE_REVALIDATE);
+		revalidateTag(`data:models:${options.modelId}`, STALE_WHILE_REVALIDATE);
+		revalidateTag(
+			`data:benchmarks:model:${options.modelId}`,
+			STALE_WHILE_REVALIDATE
+		);
 		revalidateTag(
 			`model:benchmarks:highlights:${options.modelId}`,
-			EXPIRE_NOW
+			STALE_WHILE_REVALIDATE
 		);
-		revalidateTag(`model:benchmarks:table:${options.modelId}`, EXPIRE_NOW);
+		revalidateTag(
+			`model:benchmarks:table:${options.modelId}`,
+			STALE_WHILE_REVALIDATE
+		);
 		revalidateTag(
 			`model:benchmarks:comparisons:${options.modelId}`,
-			EXPIRE_NOW
+			STALE_WHILE_REVALIDATE
 		);
+	}
+
+	for (const benchmarkId of options.benchmarkIds ?? []) {
+		if (!benchmarkId) continue;
+		revalidateTag(`data:benchmarks:${benchmarkId}`, STALE_WHILE_REVALIDATE);
+		if (options.modelId) {
+			revalidateTag(
+				`data:benchmarks:model:${options.modelId}:benchmark:${benchmarkId}`,
+				STALE_WHILE_REVALIDATE
+			);
+		}
 	}
 }
 
@@ -70,7 +119,15 @@ export function revalidateModelApiInfoTags(
 	revalidateTagList(MODEL_API_GLOBAL_TAGS);
 
 	if (options.modelId) {
-		revalidateTag(`model:api:${options.modelId}`, EXPIRE_NOW);
+		revalidateTag(`model:api:${options.modelId}`, STALE_WHILE_REVALIDATE);
+		revalidateTag(
+			`data:gateway_requests:model:${options.modelId}`,
+			STALE_WHILE_REVALIDATE
+		);
+		revalidateTag(
+			`data:gateway_usage_rollups:model:${options.modelId}`,
+			STALE_WHILE_REVALIDATE
+		);
 	}
 }
 
@@ -85,16 +142,96 @@ export function revalidateModelDataTags(
 	revalidateModelApiInfoTags(options);
 }
 
+export function revalidateBenchmarkDataTags(
+	options: RevalidateBenchmarkTagOptions = {}
+) {
+	revalidateTag("data:benchmarks", STALE_WHILE_REVALIDATE);
+	revalidateTag("data:benchmarks:list", STALE_WHILE_REVALIDATE);
+
+	const benchmarkIds = new Set<string>();
+	if (options.benchmarkId) benchmarkIds.add(options.benchmarkId);
+	for (const benchmarkId of options.benchmarkIds ?? []) {
+		if (!benchmarkId) continue;
+		benchmarkIds.add(benchmarkId);
+	}
+
+	for (const benchmarkId of benchmarkIds) {
+		revalidateTag(`data:benchmarks:${benchmarkId}`, STALE_WHILE_REVALIDATE);
+		if (options.modelId) {
+			revalidateTag(
+				`data:benchmarks:model:${options.modelId}:benchmark:${benchmarkId}`,
+				STALE_WHILE_REVALIDATE
+			);
+		}
+	}
+}
+
+export function revalidateProviderDataTags(
+	options: RevalidateProviderTagOptions = {}
+) {
+	revalidateTagList(MODEL_API_GLOBAL_TAGS);
+
+	const providerIds = new Set<string>();
+	if (options.providerId) providerIds.add(options.providerId);
+	for (const providerId of options.providerIds ?? []) {
+		if (!providerId) continue;
+		providerIds.add(providerId);
+	}
+
+	for (const providerId of providerIds) {
+		revalidateTag(`data:api_providers:${providerId}`, STALE_WHILE_REVALIDATE);
+		revalidateTag(`api_provider:header:${providerId}`, STALE_WHILE_REVALIDATE);
+		revalidateTag(
+			`data:gateway_usage_rollups:provider:${providerId}`,
+			STALE_WHILE_REVALIDATE
+		);
+		revalidateTag(
+			`data:gateway_provider_health_states:provider:${providerId}`,
+			STALE_WHILE_REVALIDATE
+		);
+		revalidateTag(`data:top_apps:provider:${providerId}`, STALE_WHILE_REVALIDATE);
+		revalidateTag(
+			`data:top_models:provider:${providerId}`,
+			STALE_WHILE_REVALIDATE
+		);
+	}
+}
+
+export function revalidateOrganisationDataTags(
+	options: RevalidateOrganisationTagOptions = {}
+) {
+	revalidateTag("data:organisations", STALE_WHILE_REVALIDATE);
+	revalidateTag("data:organisations:list", STALE_WHILE_REVALIDATE);
+
+	const organisationIds = new Set<string>();
+	if (options.organisationId) organisationIds.add(options.organisationId);
+	for (const organisationId of options.organisationIds ?? []) {
+		if (!organisationId) continue;
+		organisationIds.add(organisationId);
+	}
+
+	for (const organisationId of organisationIds) {
+		revalidateTag(
+			`organisation:header:${organisationId}`,
+			STALE_WHILE_REVALIDATE
+		);
+		revalidateTag(
+			`data:organisations:${organisationId}`,
+			STALE_WHILE_REVALIDATE
+		);
+	}
+}
+
 export function revalidateAppDataTags(appIds: string[] = []) {
-	revalidateTag("data:apps", EXPIRE_NOW);
-	revalidateTag("data:app_details", EXPIRE_NOW);
-	revalidateTag("data:app_usage", EXPIRE_NOW);
-	revalidateTag("data:top_apps", EXPIRE_NOW);
-	revalidateTag("public-top-apps", EXPIRE_NOW);
+	revalidateTag("data:apps", STALE_WHILE_REVALIDATE);
+	revalidateTag("data:app_details", STALE_WHILE_REVALIDATE);
+	revalidateTag("data:app_usage", STALE_WHILE_REVALIDATE);
+	revalidateTag("data:top_apps", STALE_WHILE_REVALIDATE);
+	revalidateTag("public-top-apps", STALE_WHILE_REVALIDATE);
 
 	for (const appId of appIds) {
 		if (!appId) continue;
-		revalidateTag(`data:app_details:${appId}`, EXPIRE_NOW);
-		revalidateTag(`data:app_usage:${appId}`, EXPIRE_NOW);
+		revalidateTag(`data:app_details:${appId}`, STALE_WHILE_REVALIDATE);
+		revalidateTag(`data:app_usage:${appId}`, STALE_WHILE_REVALIDATE);
 	}
 }

--- a/apps/web/src/lib/cache/revalidateDataTags.ts
+++ b/apps/web/src/lib/cache/revalidateDataTags.ts
@@ -60,6 +60,7 @@ const MODEL_API_GLOBAL_TAGS = [
 ] as const;
 
 const MODEL_CANONICAL_RESOLVER_TAGS = [
+	"data:models",
 	"data:model_aliases",
 	"data:data_api_provider_models",
 	"data:data_model_id_redirects",

--- a/apps/web/src/lib/cache/revalidateDataTags.ts
+++ b/apps/web/src/lib/cache/revalidateDataTags.ts
@@ -1,6 +1,7 @@
 import { revalidateTag } from "next/cache";
 
 const STALE_WHILE_REVALIDATE = "max" as const;
+const EXPIRE_IMMEDIATELY = { expire: 0 } as const;
 
 type RevalidateModelDataTagOptions = {
 	modelId?: string | null;
@@ -56,6 +57,13 @@ const MODEL_API_GLOBAL_TAGS = [
 	"data:top_models",
 	"monitor-models",
 	"page:models",
+] as const;
+
+const MODEL_CANONICAL_RESOLVER_TAGS = [
+	"data:model_aliases",
+	"data:data_api_provider_models",
+	"data:data_model_id_redirects",
+	"data:data_api_models",
 ] as const;
 
 function revalidateTagList(tags: readonly string[]) {
@@ -119,6 +127,9 @@ export function revalidateModelApiInfoTags(
 	options: RevalidateModelDataTagOptions = {}
 ) {
 	revalidateTagList(MODEL_API_GLOBAL_TAGS);
+	for (const tag of MODEL_CANONICAL_RESOLVER_TAGS) {
+		revalidateTag(tag, EXPIRE_IMMEDIATELY);
+	}
 
 	if (options.modelId) {
 		revalidateTag(`model:api:${options.modelId}`, STALE_WHILE_REVALIDATE);
@@ -149,6 +160,24 @@ export function revalidateBenchmarkDataTags(
 ) {
 	revalidateTag("data:benchmarks", STALE_WHILE_REVALIDATE);
 	revalidateTag("data:benchmarks:list", STALE_WHILE_REVALIDATE);
+	if (options.modelId) {
+		revalidateTag(
+			`data:benchmarks:model:${options.modelId}`,
+			STALE_WHILE_REVALIDATE
+		);
+		revalidateTag(
+			`model:benchmarks:highlights:${options.modelId}`,
+			STALE_WHILE_REVALIDATE
+		);
+		revalidateTag(
+			`model:benchmarks:table:${options.modelId}`,
+			STALE_WHILE_REVALIDATE
+		);
+		revalidateTag(
+			`model:benchmarks:comparisons:${options.modelId}`,
+			STALE_WHILE_REVALIDATE
+		);
+	}
 
 	const benchmarkIds = new Set<string>();
 	if (options.benchmarkId) benchmarkIds.add(options.benchmarkId);

--- a/apps/web/src/lib/fetchers/api-providers/api-provider/providerAppTokenTimeseries.ts
+++ b/apps/web/src/lib/fetchers/api-providers/api-provider/providerAppTokenTimeseries.ts
@@ -199,6 +199,7 @@ export async function getProviderAppTokenTimeseries(
 	cacheLife("minutes");
 	cacheTag("data:gateway_usage_rollups");
 	cacheTag(`data:gateway_usage_rollups:provider:${apiProviderId}`);
+	cacheTag(`data:api_providers:${apiProviderId}`);
 
 	if (!apiProviderId) return { apps: [], points: [] };
 

--- a/apps/web/src/lib/fetchers/api-providers/api-provider/providerTokenTimeseries.ts
+++ b/apps/web/src/lib/fetchers/api-providers/api-provider/providerTokenTimeseries.ts
@@ -195,6 +195,7 @@ export async function getProviderModelTokenTimeseries(
 	cacheLife("minutes");
 	cacheTag("data:gateway_usage_rollups");
 	cacheTag(`data:gateway_usage_rollups:provider:${apiProviderId}`);
+	cacheTag(`data:api_providers:${apiProviderId}`);
 
 	if (!apiProviderId) {
 		return { models: [], points: [] };

--- a/apps/web/src/lib/fetchers/api-providers/api-provider/top-apps.ts
+++ b/apps/web/src/lib/fetchers/api-providers/api-provider/top-apps.ts
@@ -106,6 +106,8 @@ export async function getTopAppsCached(
 
     cacheLife("days");
     cacheTag("data:top_apps");
+    cacheTag(`data:top_apps:provider:${apiProviderId}`);
+    cacheTag(`data:api_providers:${apiProviderId}`);
 
     console.log(`[fetch] HIT JSON for top apps - ${apiProviderId} - ${period}`);
     return getTopApps(apiProviderId, period, count);

--- a/apps/web/src/lib/fetchers/api-providers/api-provider/top-models.ts
+++ b/apps/web/src/lib/fetchers/api-providers/api-provider/top-models.ts
@@ -83,6 +83,8 @@ export async function getTopModelsCached(
 	cacheTag("data:gateway_usage_rollups");
 	cacheTag(`data:gateway_usage_rollups:provider:${apiProviderId}`);
 	cacheTag("data:top_models");
+	cacheTag(`data:top_models:provider:${apiProviderId}`);
+	cacheTag(`data:api_providers:${apiProviderId}`);
 
     console.log(`[fetch] HIT JSON for top models - ${apiProviderId}`);
     return getTopModels(apiProviderId, includeHidden, count);

--- a/apps/web/src/lib/fetchers/api-providers/getAPIProvider.ts
+++ b/apps/web/src/lib/fetchers/api-providers/getAPIProvider.ts
@@ -222,6 +222,7 @@ export async function getAPIProviderPricesCached(): Promise<APIProvider[]> {
 
 	cacheLife("days");
 	cacheTag("data:api_providers");
+	cacheTag("data:api_providers:list");
 
 	console.log("[fetch] HIT JSON for API providers");
 	return getAPIProvider();
@@ -417,6 +418,7 @@ export async function getAPIProviderModelsCached(
 
 	cacheLife("days");
 	cacheTag("data:api_providers");
+	cacheTag(`data:api_providers:${apiProviderId}`);
 
 	console.log(
 		`[fetch] HIT JSON for API providers - ${apiProviderId} / ${outputType}`,
@@ -440,6 +442,7 @@ export async function getAPIProviderTextModelsCached(
 
 	cacheLife("days");
 	cacheTag("data:api_providers");
+	cacheTag(`data:api_providers:${apiProviderId}`);
 
 	return getAPIProviderModels(apiProviderId, "text", includeHidden);
 }
@@ -459,6 +462,7 @@ export async function getAPIProviderImageModelsCached(
 
 	cacheLife("days");
 	cacheTag("data:api_providers");
+	cacheTag(`data:api_providers:${apiProviderId}`);
 
 	return getAPIProviderModels(apiProviderId, "image", includeHidden);
 }
@@ -781,6 +785,7 @@ export async function getAPIProviderModelsListByAddedCached(
 
 	cacheLife("days");
 	cacheTag("data:api_providers");
+	cacheTag(`data:api_providers:${apiProviderId}`);
 	cacheTag("data:data_api_provider_models");
 	cacheTag("data:data_api_pricing_rules");
 	cacheTag("data:models");

--- a/apps/web/src/lib/fetchers/api-providers/getAPIProvider.ts
+++ b/apps/web/src/lib/fetchers/api-providers/getAPIProvider.ts
@@ -417,8 +417,7 @@ export async function getAPIProviderModelsCached(
 	"use cache";
 
 	cacheLife("days");
-	cacheTag("data:api_providers");
-	cacheTag(`data:api_providers:${apiProviderId}`);
+	cacheAPIProviderTags(apiProviderId);
 
 	console.log(
 		`[fetch] HIT JSON for API providers - ${apiProviderId} / ${outputType}`,
@@ -441,8 +440,7 @@ export async function getAPIProviderTextModelsCached(
 	"use cache";
 
 	cacheLife("days");
-	cacheTag("data:api_providers");
-	cacheTag(`data:api_providers:${apiProviderId}`);
+	cacheAPIProviderTags(apiProviderId);
 
 	return getAPIProviderModels(apiProviderId, "text", includeHidden);
 }
@@ -461,8 +459,7 @@ export async function getAPIProviderImageModelsCached(
 	"use cache";
 
 	cacheLife("days");
-	cacheTag("data:api_providers");
-	cacheTag(`data:api_providers:${apiProviderId}`);
+	cacheAPIProviderTags(apiProviderId);
 
 	return getAPIProviderModels(apiProviderId, "image", includeHidden);
 }
@@ -784,11 +781,15 @@ export async function getAPIProviderModelsListByAddedCached(
 	"use cache";
 
 	cacheLife("days");
-	cacheTag("data:api_providers");
-	cacheTag(`data:api_providers:${apiProviderId}`);
+	cacheAPIProviderTags(apiProviderId);
 	cacheTag("data:data_api_provider_models");
 	cacheTag("data:data_api_pricing_rules");
 	cacheTag("data:models");
 
 	return getAPIProviderModelsListByAdded(apiProviderId, includeHidden);
+}
+
+function cacheAPIProviderTags(apiProviderId: string) {
+	cacheTag("data:api_providers");
+	cacheTag(`data:api_providers:${apiProviderId}`);
 }

--- a/apps/web/src/lib/fetchers/api-providers/getAPIProviderHeader.ts
+++ b/apps/web/src/lib/fetchers/api-providers/getAPIProviderHeader.ts
@@ -52,6 +52,7 @@ export default async function getAPIProviderHeader(
 
     cacheLife("days");
     cacheTag("data:api_providers");
+    cacheTag(`data:api_providers:${apiProviderId}`);
     cacheTag(`api_provider:header:${apiProviderId}`);
 
     console.log("[cache] COMPUTE getAPIProviderHeader", apiProviderId);

--- a/apps/web/src/lib/fetchers/api-providers/getAllAPIProviders.ts
+++ b/apps/web/src/lib/fetchers/api-providers/getAllAPIProviders.ts
@@ -358,6 +358,7 @@ export async function getAllAPIProvidersCached(): Promise<APIProviderCard[]> {
 
     cacheLife("days");
     cacheTag("data:api_providers");
+    cacheTag("data:api_providers:list");
 
     console.log("[fetch] HIT JSON for API providers");
     return getAllAPIProviders();

--- a/apps/web/src/lib/fetchers/api-providers/getProviderMetrics.ts
+++ b/apps/web/src/lib/fetchers/api-providers/getProviderMetrics.ts
@@ -353,6 +353,7 @@ export async function getProviderMetrics(
 	cacheLife("minutes");
 	cacheTag("data:gateway_usage_rollups");
 	cacheTag(`data:gateway_usage_rollups:provider:${providerId}`);
+	cacheTag(`data:api_providers:${providerId}`);
 
 	if (!providerId) {
 		return {

--- a/apps/web/src/lib/fetchers/api-providers/getProviderRoutingHealth.ts
+++ b/apps/web/src/lib/fetchers/api-providers/getProviderRoutingHealth.ts
@@ -48,6 +48,8 @@ export async function getProviderRoutingHealth(
 
 	cacheLife("minutes");
 	cacheTag("data:gateway_provider_health_states");
+	cacheTag(`data:gateway_provider_health_states:provider:${providerId}`);
+	cacheTag(`data:api_providers:${providerId}`);
 
 	if (!providerId) return null;
 	const windowHours = options?.windowHours ?? 24;

--- a/apps/web/src/lib/fetchers/benchmarks/getAllBenchmarks.ts
+++ b/apps/web/src/lib/fetchers/benchmarks/getAllBenchmarks.ts
@@ -50,6 +50,7 @@ export async function getAllBenchmarksCached(sorted = false): Promise<BenchmarkC
 
     cacheLife("days");
     cacheTag("data:benchmarks");
+    cacheTag("data:benchmarks:list");
 
     console.log("[fetch] HIT for benchmarks");
     return getAllBenchmarks(sorted);

--- a/apps/web/src/lib/fetchers/benchmarks/getBenchmark.ts
+++ b/apps/web/src/lib/fetchers/benchmarks/getBenchmark.ts
@@ -168,6 +168,7 @@ export async function getBenchmarkCached(
 
     cacheLife("days");
     cacheTag("data:benchmarks");
+    cacheTag(`data:benchmarks:${benchmark_id}`);
 
     console.log("[fetch] HIT DB for benchmark:", benchmark_id);
     return getBenchmark(benchmark_id, includeHidden);

--- a/apps/web/src/lib/fetchers/models/getModelBenchmarkData.ts
+++ b/apps/web/src/lib/fetchers/models/getModelBenchmarkData.ts
@@ -107,6 +107,10 @@ function modelBenchmarkPairTag(modelId: string, benchmarkId: string): string {
 	return `data:benchmarks:model:${modelId}:benchmark:${benchmarkId}`;
 }
 
+function benchmarkTag(benchmarkId: string): string {
+	return `data:benchmarks:${benchmarkId}`;
+}
+
 function normalizeMaybeArray<T>(value: T | T[] | null | undefined): T | null {
 	if (value == null) return null;
 	return Array.isArray(value) ? (value.length ? value[0] : null) : value;
@@ -642,6 +646,7 @@ export async function getModelBenchmarkHighlights(
 	"use cache";
 
 	cacheLife("hours");
+	cacheTag("data:benchmarks");
 	cacheTag(`model:data:${modelId}`);
 	cacheTag(modelBenchmarkTag(modelId));
 	cacheTag(`model:benchmarks:highlights:${modelId}`);
@@ -649,6 +654,7 @@ export async function getModelBenchmarkHighlights(
 	const { results } = await loadBenchmarkResults(modelId, includeHidden);
 	for (const result of results) {
 		if (!result.benchmark_id) continue;
+		cacheTag(benchmarkTag(result.benchmark_id));
 		cacheTag(modelBenchmarkPairTag(modelId, result.benchmark_id));
 	}
 	return selectHighlightResults(results);
@@ -661,6 +667,7 @@ export async function getModelBenchmarkTableData(
 	"use cache";
 
 	cacheLife("hours");
+	cacheTag("data:benchmarks");
 	cacheTag(`model:data:${modelId}`);
 	cacheTag(modelBenchmarkTag(modelId));
 	cacheTag(`model:benchmarks:table:${modelId}`);
@@ -668,6 +675,7 @@ export async function getModelBenchmarkTableData(
 	const { results } = await loadBenchmarkResults(modelId, includeHidden);
 	for (const result of results) {
 		if (!result.benchmark_id) continue;
+		cacheTag(benchmarkTag(result.benchmark_id));
 		cacheTag(modelBenchmarkPairTag(modelId, result.benchmark_id));
 	}
 	return groupResultsByBenchmarkName(results);
@@ -680,6 +688,7 @@ export async function getModelBenchmarkComparisonData(
 	"use cache";
 
 	cacheLife("hours");
+	cacheTag("data:benchmarks");
 	cacheTag(`model:data:${modelId}`);
 	cacheTag(modelBenchmarkTag(modelId));
 	cacheTag(`model:benchmarks:comparisons:${modelId}`);
@@ -687,6 +696,7 @@ export async function getModelBenchmarkComparisonData(
 	const charts = await fetchBenchmarkComparisonCharts(modelId, includeHidden);
 	for (const chart of charts) {
 		if (!chart.benchmarkId) continue;
+		cacheTag(benchmarkTag(chart.benchmarkId));
 		cacheTag(modelBenchmarkPairTag(modelId, chart.benchmarkId));
 	}
 	return charts;

--- a/apps/web/src/lib/fetchers/models/getModelProviderRoutingHealth.ts
+++ b/apps/web/src/lib/fetchers/models/getModelProviderRoutingHealth.ts
@@ -113,7 +113,7 @@ export async function getModelProviderRoutingHealthCached(args: {
 }): Promise<ProviderRoutingStatusMap> {
 	"use cache";
 
-	cacheLife("minutes");
+	cacheLife("hours");
 	cacheTag("data:gateway_provider_health_states");
 
 	return getModelProviderRoutingHealth(args);

--- a/apps/web/src/lib/fetchers/models/getModelProviderRuntimeStats.ts
+++ b/apps/web/src/lib/fetchers/models/getModelProviderRuntimeStats.ts
@@ -269,7 +269,7 @@ export async function getModelProviderRuntimeStatsCached(args: {
 }): Promise<ProviderRuntimeStatsMap> {
 	"use cache";
 
-	cacheLife("minutes");
+	cacheLife("hours");
 	cacheTag("data:gateway_usage_rollups");
 	cacheTag(`data:gateway_usage_rollups:model:${args.modelId}`);
 

--- a/apps/web/src/lib/fetchers/models/getModelRealtimeWindowStats.ts
+++ b/apps/web/src/lib/fetchers/models/getModelRealtimeWindowStats.ts
@@ -202,7 +202,7 @@ export async function getModelRealtimeWindowStatsCached(
 ): Promise<ModelRealtimeWindowStats> {
 	"use cache";
 
-	cacheLife("minutes");
+	cacheLife("hours");
 	cacheTag("data:gateway_requests");
 	cacheTag("data:gateway_usage_rollups");
 	cacheTag(`data:gateway_requests:model:${modelId}`);

--- a/apps/web/src/lib/fetchers/models/resolveCanonicalModelId.ts
+++ b/apps/web/src/lib/fetchers/models/resolveCanonicalModelId.ts
@@ -256,6 +256,8 @@ async function resolveCanonicalModelIdCached(
 	cacheTag("data:models");
 	cacheTag("data:model_aliases");
 	cacheTag("data:data_api_provider_models");
+	cacheTag("data:data_model_id_redirects");
+	cacheTag("data:data_api_models");
 
 	return resolveCanonicalModelIdUncached(requestedModelId, includeHidden);
 }

--- a/apps/web/src/lib/fetchers/models/resolveCanonicalModelId.ts
+++ b/apps/web/src/lib/fetchers/models/resolveCanonicalModelId.ts
@@ -1,5 +1,6 @@
 import { createClient } from "@/utils/supabase/client";
 import { applyHiddenFilter } from "@/lib/fetchers/models/visibility";
+import { cacheLife, cacheTag } from "next/cache";
 
 type ResolveModelIdSource =
 	| "direct"
@@ -130,7 +131,7 @@ async function resolveVisibleInternalModelIdForApiModel(
 	return null;
 }
 
-export async function resolveCanonicalModelId(
+async function resolveCanonicalModelIdUncached(
 	requestedModelId: string,
 	includeHidden: boolean,
 ): Promise<ResolveCanonicalModelIdResult> {
@@ -239,4 +240,29 @@ export async function resolveCanonicalModelId(
 		internalModelId: null,
 		source: "unresolved",
 	};
+}
+
+async function resolveCanonicalModelIdCached(
+	requestedModelId: string,
+	includeHidden: boolean,
+): Promise<ResolveCanonicalModelIdResult> {
+	"use cache";
+
+	cacheLife({
+		stale: 60 * 5,
+		revalidate: 60 * 60,
+		expire: 60 * 60 * 24,
+	});
+	cacheTag("data:models");
+	cacheTag("data:model_aliases");
+	cacheTag("data:data_api_provider_models");
+
+	return resolveCanonicalModelIdUncached(requestedModelId, includeHidden);
+}
+
+export async function resolveCanonicalModelId(
+	requestedModelId: string,
+	includeHidden: boolean,
+): Promise<ResolveCanonicalModelIdResult> {
+	return resolveCanonicalModelIdCached(requestedModelId, includeHidden);
 }

--- a/apps/web/src/lib/fetchers/organisations/getAllOrganisations.ts
+++ b/apps/web/src/lib/fetchers/organisations/getAllOrganisations.ts
@@ -40,6 +40,7 @@ export async function getAllOrganisationsCached(): Promise<OrganisationCard[]> {
 
     cacheLife("days");
     cacheTag("data:organisations");
+    cacheTag("data:organisations:list");
 
     console.log("[fetch] HIT DB for organisations");
     return getAllOrganisations();

--- a/apps/web/src/lib/fetchers/organisations/getOrganisation.ts
+++ b/apps/web/src/lib/fetchers/organisations/getOrganisation.ts
@@ -131,6 +131,8 @@ export async function getOrganisationDataCached(
 
     cacheLife("days");
     cacheTag("data:organisations");
+    cacheTag(`data:organisations:${organisationId}`);
+    cacheTag(`organisation:header:${organisationId}`);
 
     console.log(`[fetch] HIT JSON for organisation data ${organisationId}`);
     return getOrganisationData(organisationId, latestModelsLimit, includeHidden);
@@ -199,6 +201,8 @@ export async function getOrganisationModelsCached(
 
     cacheLife("days");
     cacheTag("data:organisations");
+    cacheTag(`data:organisations:${organisationId}`);
+    cacheTag(`organisation:header:${organisationId}`);
 
     console.log(`[fetch] HIT JSON for organisation models ${organisationId}`);
     return getOrganisationModels(organisationId, includeHidden);

--- a/apps/web/src/lib/fetchers/organisations/getOrganisationOverviewHeader.ts
+++ b/apps/web/src/lib/fetchers/organisations/getOrganisationOverviewHeader.ts
@@ -68,6 +68,8 @@ export default async function getOrganisationOverviewHeader(
 	"use cache";
 
 	cacheLife("days");
+	cacheTag("data:organisations");
+	cacheTag(`data:organisations:${organisationId}`);
 	cacheTag(`organisation:header:${organisationId}`);
 
 	console.log("[cache] COMPUTE getOrganisationOverviewHeader", organisationId);

--- a/supabase/migrations/20260416152000_optimize_model_route_resolver_indexes.sql
+++ b/supabase/migrations/20260416152000_optimize_model_route_resolver_indexes.sql
@@ -1,0 +1,10 @@
+-- Optimize resolver hot-path lookups used by public model routes.
+-- These indexes target repeated filters on api_model_id/model_id and provider_id.
+
+create index if not exists data_api_provider_models_api_provider_model_id_idx
+  on public.data_api_provider_models (api_model_id, provider_id, model_id)
+  where model_id is not null;
+
+create index if not exists data_api_provider_models_model_api_idx
+  on public.data_api_provider_models (model_id, api_model_id)
+  where api_model_id is not null;


### PR DESCRIPTION
## Summary
- harden cache invalidation semantics to stale-while-revalidate (`revalidateTag(..., "max")`) and expand global tag coverage for models, providers, organisations, and benchmarks
- add scoped revalidation helpers/actions/UI for benchmark, provider, and organisation (global and per-id)
- add missing per-id cache tags across provider/organisation/benchmark/model fetchers so targeted invalidation works reliably
- switch remaining public model surfaces to cached fetchers and add an ESLint guard that blocks uncached imports in public model/family routes
- add Supabase indexes for model route resolver hot-path lookups on `data_api_provider_models`
- cache provider-model mapping lookup on app detail page and move selected hot model stats cache lifetimes from minutes to hours

## Notes
- while rebasing onto `main`, `apps/web/src/app/(dashboard)/models/[organisationId]/[modelId]/pricing/page.tsx` no longer existed, so that one page-level cached import change was omitted in this PR

## Validation
- `pnpm --filter @ai-stats/web typecheck` (passed in the original working tree before branch isolation)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Admin cache controls: added scoped revalidation actions and UI controls for benchmarks, providers, and organisations.

* **Performance Improvements**
  * Switched many data fetches to cached variants, extended cache lifetimes, and added more granular cache tags and per-benchmark revalidation.
  * Added database indexes to speed up public model resolution.

* **Style**
  * Lint rule now enforces use of cached fetch helpers in dashboard code.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->