### PR TITLE
Add Venice Opus 4.7 and GPT-Rosalind catalog entries

### DIFF
--- a/packages/data/catalog/src/data/api_providers/openai/models.json
+++ b/packages/data/catalog/src/data/api_providers/openai/models.json
@@ -3731,6 +3731,27 @@
     "capabilities": []
   },
   {
+    "api_model_id": "openai/gpt-rosalind",
+    "provider_api_model_id": "openai:openai/gpt-rosalind",
+    "provider_model_slug": "gpt-rosalind",
+    "internal_model_id": "openai/gpt-rosalind",
+    "is_active_gateway": false,
+    "quantization_scheme": null,
+    "input_modalities": "text",
+    "output_modalities": "text",
+    "context_length": null,
+    "max_output_tokens": null,
+    "effective_from": "2026-04-16T00:00:00",
+    "effective_to": null,
+    "capabilities": [
+      {
+        "capability_id": "text.generate",
+        "status": "inactive",
+        "params": []
+      }
+    ]
+  },
+  {
     "api_model_id": "openai/o1",
     "provider_api_model_id": "openai:openai/o1",
     "provider_model_slug": "o1-2024-12-17",

--- a/packages/data/catalog/src/data/api_providers/venice/models.json
+++ b/packages/data/catalog/src/data/api_providers/venice/models.json
@@ -63,6 +63,27 @@
     ]
   },
   {
+    "api_model_id": "anthropic/claude-opus-4.7",
+    "provider_api_model_id": "venice:anthropic/claude-opus-4.7",
+    "provider_model_slug": "claude-opus-4-7",
+    "internal_model_id": "anthropic/claude-opus-4.7",
+    "is_active_gateway": true,
+    "quantization_scheme": null,
+    "input_modalities": "text,image",
+    "output_modalities": "text",
+    "context_length": 1000000,
+    "max_output_tokens": 128000,
+    "effective_from": "2026-04-16T00:00:00",
+    "effective_to": null,
+    "capabilities": [
+      {
+        "capability_id": "text.generate",
+        "status": "deranked_lvl2",
+        "params": []
+      }
+    ]
+  },
+  {
     "api_model_id": "anthropic/claude-sonnet-4.5",
     "provider_api_model_id": "venice:anthropic/claude-sonnet-4.5",
     "provider_model_slug": "claude-sonnet-4-5",

--- a/packages/data/catalog/src/data/models/openai/gpt-rosalind/model.json
+++ b/packages/data/catalog/src/data/models/openai/gpt-rosalind/model.json
@@ -1,0 +1,32 @@
+{
+  "model_id": "openai/gpt-rosalind",
+  "organisation_id": "openai",
+  "name": "GPT Rosalind",
+  "status": "Withheld",
+  "previous_model_id": null,
+  "announced_date": "2026-04-16T00:00:00",
+  "release_date": null,
+  "deprecation_date": null,
+  "retirement_date": null,
+  "license": "Proprietary",
+  "input_types": "text",
+  "output_types": "text",
+  "api_model_id": "openai/gpt-rosalind",
+  "links": [
+    {
+      "platform": "announcement",
+      "url": "https://openai.com/index/introducing-gpt-rosalind/"
+    }
+  ],
+  "details": [
+    {
+      "name": "availability",
+      "value": "Research preview for qualified customers in ChatGPT, Codex, and the API through trusted access."
+    },
+    {
+      "name": "preview_billing",
+      "value": "During research preview, usage does not consume existing credits or tokens (subject to abuse guardrails)."
+    }
+  ],
+  "benchmarks": []
+}

--- a/packages/data/catalog/src/data/pricing/venice/anthropic-claude-opus-4.7/text.generate/pricing.json
+++ b/packages/data/catalog/src/data/pricing/venice/anthropic-claude-opus-4.7/text.generate/pricing.json
@@ -1,0 +1,42 @@
+{
+  "key": "venice:anthropic/claude-opus-4.7:text.generate",
+  "api_provider_id": "venice",
+  "provider_slug": "venice",
+  "api_model_id": "anthropic/claude-opus-4.7",
+  "capability_id": "text.generate",
+  "rules": [
+    {
+      "meter": "input_text_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 6,
+      "currency": "USD",
+      "pricing_plan": "standard",
+      "note": null,
+      "match": [],
+      "priority": 100
+    },
+    {
+      "meter": "cached_read_text_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 0.6,
+      "currency": "USD",
+      "pricing_plan": "standard",
+      "note": null,
+      "match": [],
+      "priority": 100
+    },
+    {
+      "meter": "output_text_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 30,
+      "currency": "USD",
+      "pricing_plan": "standard",
+      "note": null,
+      "match": [],
+      "priority": 100
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add Venice provider mapping for `anthropic/claude-opus-4.7` with `deranked_lvl2`, 1M context, and 128k max output
- add Venice pricing for `anthropic/claude-opus-4.7` (input 6, cached read 0.6, output 30 USD per 1M)
- add canonical model record for `openai/gpt-rosalind` (trusted-access research preview)
- add OpenAI provider mapping for `openai/gpt-rosalind` as inactive/not gateway-routable pending public API routing and pricing

## Validation
- `pnpm validate:data`
- `pnpm validate:pricing`
- `pnpm validate:gateway`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Claude Opus 4.7 model availability through Venice provider with text generation pricing (input, cached read, and output token rates).
  * Added OpenAI GPT-Rosalind model to the catalog (currently inactive).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->