### PR TITLE
Update providers cards hover color and arrow styling

### DIFF
--- a/apps/web/src/components/(data)/api-providers/APIProviderCard.tsx
+++ b/apps/web/src/components/(data)/api-providers/APIProviderCard.tsx
@@ -9,9 +9,11 @@ import {
 	type LucideIcon,
 } from "lucide-react";
 import Link from "next/link";
+import { type CSSProperties } from "react";
 import { cn } from "@/lib/utils";
 import type { APIProviderCard as APIProviderCardType } from "@/lib/fetchers/api-providers/getAllAPIProviders";
 import { Logo } from "@/components/Logo";
+import { Button } from "@/components/ui/button";
 import {
 	Tooltip,
 	TooltipContent,
@@ -68,13 +70,19 @@ export default function APIProviderCard({ api_provider }: Props) {
 	const dailyTokens = Number(api_provider.total_daily_tokens ?? 0);
 	const monthlyTokens = Number(api_provider.total_monthly_tokens ?? 0);
 	const modalitySupport = api_provider.modality_support;
+	const rowStyle: CSSProperties & Record<string, string | undefined> = {
+		"--provider-accent": api_provider.colour ?? undefined,
+	};
 	const supportedModalities = MODALITIES.filter(({ key }) => {
 		const counts = modalitySupport[key];
 		return (counts?.input ?? 0) + (counts?.output ?? 0) > 0;
 	});
 
 	return (
-		<div className="group px-3 py-3 transition-colors hover:bg-muted/20 md:px-4 md:py-4">
+		<div
+			className="group px-3 py-3 transition-colors hover:bg-muted/20 md:px-4 md:py-4"
+			style={rowStyle}
+		>
 			<div className="space-y-3">
 				<div className="flex items-start justify-between gap-3">
 					<div className="min-w-0">
@@ -169,14 +177,28 @@ export default function APIProviderCard({ api_provider }: Props) {
 							</div>
 						</div>
 					</div>
-					<Link
-						href={`/api-providers/${id}`}
-						prefetch={false}
-						className="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-md border border-transparent text-muted-foreground transition-colors hover:border-border hover:bg-background hover:text-foreground"
-						aria-label={`Open ${name} provider page`}
+					<Button
+						asChild
+						size="icon"
+						variant="ghost"
+						className="h-8 w-8 shrink-0 focus-visible:ring-0 focus-visible:border-transparent"
 					>
-						<ArrowUpRight className="h-4 w-4" />
-					</Link>
+						<Link
+							href={`/api-providers/${id}`}
+							prefetch={false}
+							aria-label={`Open ${name} provider page`}
+							className="group/open"
+						>
+							<ArrowUpRight
+								className={cn(
+									"h-4 w-4 text-muted-foreground transition-colors",
+									api_provider.colour
+										? "group-hover:text-[var(--provider-accent)]"
+										: "group-hover:text-primary",
+								)}
+							/>
+						</Link>
+					</Button>
 				</div>
 			</div>
 		</div>

--- a/apps/web/src/components/(data)/api-providers/APIProviderCard.tsx
+++ b/apps/web/src/components/(data)/api-providers/APIProviderCard.tsx
@@ -181,7 +181,7 @@ export default function APIProviderCard({ api_provider }: Props) {
 						asChild
 						size="icon"
 						variant="ghost"
-						className="h-8 w-8 shrink-0 focus-visible:ring-0 focus-visible:border-transparent"
+						className="h-8 w-8 shrink-0 focus-visible:ring-2 focus-visible:ring-primary/40 focus-visible:border-primary"
 					>
 						<Link
 							href={`/api-providers/${id}`}

--- a/apps/web/src/lib/fetchers/api-providers/getAllAPIProviders.ts
+++ b/apps/web/src/lib/fetchers/api-providers/getAllAPIProviders.ts
@@ -22,6 +22,7 @@ export type ProviderModalitySupport = Record<
 export interface APIProviderCard {
     api_provider_id: string;
     api_provider_name: string;
+    colour?: string | null;
     country_code: string;
     total_models: number;
     active_models: number;
@@ -164,7 +165,7 @@ export async function getAllAPIProviders(): Promise<APIProviderCard[]> {
     const [providersRes, providerModelsRes, pricingRulesRes, dailyUsageRes, monthlyUsageRes] = await Promise.all([
         supabase
             .from("data_api_providers")
-            .select("api_provider_id, api_provider_name, country_code")
+            .select("api_provider_id, api_provider_name, colour, country_code")
             .order("api_provider_name", { ascending: true }),
         supabase
             .from("data_api_provider_models")
@@ -332,6 +333,7 @@ export async function getAllAPIProviders(): Promise<APIProviderCard[]> {
             .map((r: any) => ({
                 api_provider_id: r.api_provider_id,
                 api_provider_name: r.api_provider_name ?? r.name ?? "",
+                colour: r.colour ?? null,
                 country_code: r.country_code ?? "",
                 total_models:
                     totalModelsByProvider.get(r.api_provider_id)?.size ?? 0,

--- a/apps/web/src/lib/fetchers/api-providers/getAllAPIProviders.ts
+++ b/apps/web/src/lib/fetchers/api-providers/getAllAPIProviders.ts
@@ -333,7 +333,10 @@ export async function getAllAPIProviders(): Promise<APIProviderCard[]> {
             .map((r: any) => ({
                 api_provider_id: r.api_provider_id,
                 api_provider_name: r.api_provider_name ?? r.name ?? "",
-                colour: r.colour ?? null,
+                colour:
+                    typeof r.colour === "string" && r.colour.trim().length > 0
+                        ? r.colour.trim()
+                        : null,
                 country_code: r.country_code ?? "",
                 total_models:
                     totalModelsByProvider.get(r.api_provider_id)?.size ?? 0,


### PR DESCRIPTION
## Summary
- remove the provider-card arrow outline styling by switching the arrow action to the same ghost-button pattern used in model cards
- load `data_api_providers.colour` in provider list fetcher and expose it on card data
- apply provider colour on hover for the provider-card arrow icon (matching model-card behavior)

## Validation
- `pnpm --filter @ai-stats/web typecheck` ?
- `pnpm --filter @ai-stats/web lint -- "src/components/(data)/api-providers/APIProviderCard.tsx" "src/lib/fetchers/api-providers/getAllAPIProviders.ts"` ? (repo tooling issue: `react/display-name` rule crash in eslint-plugin-react)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * API provider cards now support branded color styling sourced from provider data and applied across the card UI.

* **UI Improvements**
  * The "open provider page" control has been redesigned as an icon button with color-aware hover states and improved focus visibility for better accessibility and interaction feedback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->