### PR TITLE
fix(auth): remove signup enumeration hints

### DIFF
--- a/apps/web/src/app/(auth)/sign-in/page.tsx
+++ b/apps/web/src/app/(auth)/sign-in/page.tsx
@@ -21,7 +21,7 @@ export const metadata: Metadata = {
 export default async function Page({ searchParams }: SignInPageProps) {
 	const params = (await searchParams) ?? {};
 	const signup = Array.isArray(params.signup) ? params.signup[0] : params.signup;
-	const signupNotice = signup === "exists" || signup === "check-email" ? signup : null;
+	const signupNotice = signup === "exists" || signup === "check-email" ? "check-email" : null;
 	const authErrorParam = Array.isArray(params.error) ? params.error[0] : params.error;
 	const authError = authErrorParam === "auth-failed" ? "auth-failed" : null;
 	const returnUrlParam = Array.isArray(params.returnUrl)

--- a/apps/web/src/app/(auth)/sign-up/actions.ts
+++ b/apps/web/src/app/(auth)/sign-up/actions.ts
@@ -62,7 +62,8 @@ export async function handleEmailSignup(formData: FormData) {
 		})
 		const message = (error.message ?? '').toLowerCase()
 		if (message.includes('already registered') || message.includes('already exists')) {
-			redirect('/sign-in?signup=exists')
+			// Keep outward response identical to avoid account enumeration.
+			redirect('/sign-in?signup=check-email')
 		}
 		redirect(`/error?message=${encodeURIComponent(error.message || 'Authentication failed')}`)
 	}

--- a/apps/web/src/components/(gateway)/auth/Login.tsx
+++ b/apps/web/src/components/(gateway)/auth/Login.tsx
@@ -9,7 +9,7 @@ import { Building2, KeyRound } from "lucide-react";
 const OAUTH = ["google", "github", "gitlab"] as const;
 type OAuthProvider = (typeof OAUTH)[number];
 type Provider = OAuthProvider | "email";
-type SignupNotice = "exists" | "check-email" | null;
+type SignupNotice = "check-email" | null;
 
 export async function Login({
 	signupNotice = null,
@@ -36,11 +36,9 @@ export async function Login({
 		: null;
 
 	const signupNoticeText =
-		signupNotice === "exists"
-			? "That email is already registered. Sign in below or reset your password."
-			: signupNotice === "check-email"
-				? "Account created. Check your email to verify, then sign in."
-				: null;
+		signupNotice === "check-email"
+			? "If an account exists for that email, check your inbox for next steps."
+			: null;
 	const authErrorText = authError === "auth-failed" ? "Invalid email or password. Please try again." : null;
 
 	return (


### PR DESCRIPTION
## Summary
- remove explicit "email already registered" hints from signup flow
- normalize signup redirects to a single `signup=check-email` state
- update sign-in/login notice copy to a privacy-preserving message

## Scope
- `apps/web/src/app/(auth)/sign-up/actions.ts`
- `apps/web/src/app/(auth)/sign-in/page.tsx`
- `apps/web/src/components/(gateway)/auth/Login.tsx`

## Validation
- `pnpm --filter @ai-stats/web typecheck`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved signup flow consistency. When users attempt to register with an existing email address, they now receive a unified message prompting them to check their inbox for next steps, rather than receiving inconsistent notices about account status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->