### PR TITLE
feat(data): enrich gpt-5.3-codex-spark benchmark metadata

### DIFF
--- a/packages/data/catalog/src/data/models/openai/gpt-5.3-codex-spark/model.json
+++ b/packages/data/catalog/src/data/models/openai/gpt-5.3-codex-spark/model.json
@@ -22,14 +22,6 @@
   "details": [],
   "benchmarks": [
     {
-      "benchmark_id": "swe-bench-pro",
-      "score": null,
-      "is_self_reported": true,
-      "other_info": null,
-      "source_link": "https://openai.com/index/introducing-gpt-5-3-codex-spark/",
-      "rank": null
-    },
-    {
       "benchmark_id": "terminal-bench-2.0",
       "score": 58.4,
       "is_self_reported": true,

--- a/packages/data/catalog/src/data/models/openai/gpt-5.3-codex-spark/model.json
+++ b/packages/data/catalog/src/data/models/openai/gpt-5.3-codex-spark/model.json
@@ -22,11 +22,19 @@
   "details": [],
   "benchmarks": [
     {
+      "benchmark_id": "swe-bench-pro",
+      "score": null,
+      "is_self_reported": true,
+      "other_info": null,
+      "source_link": "https://openai.com/index/introducing-gpt-5-3-codex-spark/",
+      "rank": null
+    },
+    {
       "benchmark_id": "terminal-bench-2.0",
       "score": 58.4,
       "is_self_reported": true,
       "other_info": null,
-      "source_link": null,
+      "source_link": "https://openai.com/index/introducing-gpt-5-3-codex-spark/",
       "rank": 12
     }
   ]


### PR DESCRIPTION
## Summary
- add missing benchmark metadata links for `openai/gpt-5.3-codex-spark`
- include self-reported `swe-bench-pro` benchmark metadata entry
- add official source link for existing `terminal-bench-2.0` entry

## Validation
- `pnpm validate:data`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added new performance benchmark entry for model evaluation
  * Updated benchmark source information and attribution links

<!-- end of auto-generated comment: release notes by coderabbit.ai -->