### PR TITLE
perf(web): reduce model page fetch fanout and split cache by volatility

### DIFF
--- a/apps/web/src/app/(dashboard)/models/[organisationId]/[modelId]/activity/page.tsx
+++ b/apps/web/src/app/(dashboard)/models/[organisationId]/[modelId]/activity/page.tsx
@@ -3,69 +3,37 @@ import { permanentRedirect } from "next/navigation";
 import { buildMetadata } from "@/lib/seo";
 import ModelDetailShell from "@/components/(data)/model/ModelDetailShell";
 import { ModelActivitySection } from "@/components/(data)/model/overview/ModelOverviewSections";
-import { getModelOverviewCached } from "@/lib/fetchers/models/getModel";
 import {
 	getModelPath,
+	getModelMetadataIdentity,
 	resolveModelRouteIds,
 	type ModelRouteParams,
 } from "@/components/(data)/model/model-route-helpers";
-
-async function fetchModel(modelId: string, includeHidden: boolean) {
-	try {
-		return await getModelOverviewCached(modelId, includeHidden);
-	} catch (error) {
-		console.warn("[seo] failed to load model overview for activity metadata", {
-			modelId,
-			error,
-		});
-		return null;
-	}
-}
 
 export async function generateMetadata(props: {
 	params: Promise<ModelRouteParams>;
 }): Promise<Metadata> {
 	const params = await props.params;
-	const includeHidden = false;
-	const { canonicalModelId: modelId } = await resolveModelRouteIds(
+	const { modelId, modelName, organisationName } = await getModelMetadataIdentity(
 		params,
-		includeHidden,
+		false,
 	);
-	const model = await fetchModel(modelId, includeHidden);
 	const path = getModelPath(modelId, "activity");
 	const imagePath = `/og/models/${modelId}`;
 
-	if (!model) {
-		return buildMetadata({
-			title: "Model Activity and Uptime",
-			description:
-				"Track recent usage and uptime signals for this AI model on AI Stats, including request volume, success rates, active providers, and token movement.",
-			path,
-			keywords: ["AI model activity", "AI uptime", "AI usage metrics", "AI Stats"],
-			imagePath,
-		});
-	}
-
-	const organisationName = model.organisation?.name ?? "AI provider";
-	const description = [
-		`${model.name} recent usage and uptime by ${organisationName} on AI Stats.`,
-		"See request volume, success rate, provider traffic, and cumulative token activity.",
-	]
-		.filter(Boolean)
-		.join(" ");
-
 	return buildMetadata({
-		title: `${model.name} Activity - Usage and Uptime`,
-		description,
+		title: `${modelName} Activity - Usage and Uptime`,
+		description:
+			`Track recent usage and uptime signals for ${modelName} on AI Stats, including request volume, success rates, active providers, and token movement.`,
 		path,
 		keywords: [
-			model.name,
-			`${model.name} uptime`,
-			`${model.name} usage`,
-			`${organisationName} AI`,
+			modelName,
+			`${modelName} uptime`,
+			`${modelName} usage`,
+			organisationName ? `${organisationName} AI` : null,
 			"AI reliability metrics",
 			"AI Stats",
-		],
+		].filter(Boolean) as string[],
 		imagePath,
 	});
 }

--- a/apps/web/src/app/(dashboard)/models/[organisationId]/[modelId]/apps/page.tsx
+++ b/apps/web/src/app/(dashboard)/models/[organisationId]/[modelId]/apps/page.tsx
@@ -3,69 +3,37 @@ import { permanentRedirect } from "next/navigation";
 import { buildMetadata } from "@/lib/seo";
 import ModelDetailShell from "@/components/(data)/model/ModelDetailShell";
 import { ModelAppsSection } from "@/components/(data)/model/overview/ModelOverviewSections";
-import { getModelOverviewCached } from "@/lib/fetchers/models/getModel";
 import {
 	getModelPath,
+	getModelMetadataIdentity,
 	resolveModelRouteIds,
 	type ModelRouteParams,
 } from "@/components/(data)/model/model-route-helpers";
-
-async function fetchModel(modelId: string, includeHidden: boolean) {
-	try {
-		return await getModelOverviewCached(modelId, includeHidden);
-	} catch (error) {
-		console.warn("[seo] failed to load model overview for apps metadata", {
-			modelId,
-			error,
-		});
-		return null;
-	}
-}
 
 export async function generateMetadata(props: {
 	params: Promise<ModelRouteParams>;
 }): Promise<Metadata> {
 	const params = await props.params;
-	const includeHidden = false;
-	const { canonicalModelId: modelId } = await resolveModelRouteIds(
+	const { modelId, modelName, organisationName } = await getModelMetadataIdentity(
 		params,
-		includeHidden,
+		false,
 	);
-	const model = await fetchModel(modelId, includeHidden);
 	const path = getModelPath(modelId, "apps");
 	const imagePath = `/og/models/${modelId}`;
 
-	if (!model) {
-		return buildMetadata({
-			title: "Model Apps and Distribution",
-			description:
-				"See which public apps are actively sending gateway requests to this model on AI Stats.",
-			path,
-			keywords: ["AI model apps", "gateway app usage", "AI distribution", "AI Stats"],
-			imagePath,
-		});
-	}
-
-	const organisationName = model.organisation?.name ?? "AI provider";
-	const description = [
-		`${model.name} app usage by ${organisationName} on AI Stats.`,
-		"Review which public apps are actively using this model through gateway requests.",
-	]
-		.filter(Boolean)
-		.join(" ");
-
 	return buildMetadata({
-		title: `${model.name} Apps - Product and Plan Availability`,
-		description,
+		title: `${modelName} Apps - Product and Plan Availability`,
+		description:
+			`See which public apps are actively sending gateway requests to ${modelName} on AI Stats.`,
 		path,
 		keywords: [
-			model.name,
-			`${model.name} apps`,
-			`${model.name} app usage`,
-			`${organisationName} AI`,
+			modelName,
+			`${modelName} apps`,
+			`${modelName} app usage`,
+			organisationName ? `${organisationName} AI` : null,
 			"gateway request usage",
 			"AI Stats",
-		],
+		].filter(Boolean) as string[],
 		imagePath,
 	});
 }

--- a/apps/web/src/app/(dashboard)/models/[organisationId]/[modelId]/benchmarks/page.tsx
+++ b/apps/web/src/app/(dashboard)/models/[organisationId]/[modelId]/benchmarks/page.tsx
@@ -1,72 +1,39 @@
 import { buildMetadata } from "@/lib/seo";
 import ModelDetailShell from "@/components/(data)/model/ModelDetailShell";
 import { ModelBenchmarksSection } from "@/components/(data)/model/overview/ModelOverviewSections";
-import { getModelOverviewCached } from "@/lib/fetchers/models/getModel";
 import type { Metadata } from "next";
 import {
 	getModelPath,
+	getModelMetadataIdentity,
 	resolveModelRouteIds,
 	type ModelRouteParams,
 } from "@/components/(data)/model/model-route-helpers";
 import { permanentRedirect } from "next/navigation";
 
-async function fetchModel(modelId: string, includeHidden: boolean) {
-	try {
-		return await getModelOverviewCached(modelId, includeHidden);
-	} catch (error) {
-		console.warn("[seo] failed to load model overview for metadata", {
-			modelId,
-			error,
-		});
-		return null;
-	}
-}
-
 export async function generateMetadata(props: {
 	params: Promise<ModelRouteParams>;
 }): Promise<Metadata> {
 	const params = await props.params;
-	const includeHidden = false;
-	const { canonicalModelId: modelId } = await resolveModelRouteIds(
+	const { modelId, modelName, organisationName } = await getModelMetadataIdentity(
 		params,
-		includeHidden,
+		false,
 	);
-	const model = await fetchModel(modelId, includeHidden);
 	const path = getModelPath(modelId, "benchmarks");
 	const imagePath = `/og/models/${modelId}`;
 
-	if (!model) {
-		return buildMetadata({
-			title: "Model Benchmarks Overview",
-			description:
-				"Explore detailed benchmark scores for AI models on AI Stats and compare performance across industry-standard evaluations, category breakdowns, and historical result updates.",
-			path,
-			keywords: ["AI model benchmarks", "AI performance", "AI Stats"],
-			imagePath,
-		});
-	}
-
-	const organisationName = model.organisation?.name ?? "AI provider";
-
-	const description = [
-		`${model.name} benchmarks by ${organisationName} on AI Stats.`,
-		"Review benchmark highlights and use Compare for side-by-side benchmark analysis.",
-	]
-		.filter(Boolean)
-		.join(" ");
-
 	return buildMetadata({
-		title: `${model.name} Benchmarks - Performance Highlights`,
-		description,
+		title: `${modelName} Benchmarks - Performance Highlights`,
+		description:
+			`Explore detailed benchmark scores for ${modelName} on AI Stats and compare performance across industry-standard evaluations, category breakdowns, and historical result updates.`,
 		path,
 		keywords: [
-			model.name,
-			`${model.name} benchmarks`,
-			`${organisationName} AI`,
+			modelName,
+			`${modelName} benchmarks`,
+			organisationName ? `${organisationName} AI` : null,
 			"AI model performance",
 			"AI model comparisons",
 			"AI Stats",
-		],
+		].filter(Boolean) as string[],
 		imagePath,
 	});
 }

--- a/apps/web/src/app/(dashboard)/models/[organisationId]/[modelId]/family/page.tsx
+++ b/apps/web/src/app/(dashboard)/models/[organisationId]/[modelId]/family/page.tsx
@@ -16,81 +16,42 @@ import { Badge } from "@/components/ui/badge";
 import { ArrowUpRight } from "lucide-react";
 import type { Metadata } from "next";
 import { buildMetadata } from "@/lib/seo";
-import { getModelOverviewCached } from "@/lib/fetchers/models/getModel";
 import { Logo } from "@/components/Logo";
 import { cn } from "@/lib/utils";
 import { formatDistanceToNow } from "date-fns";
 import type { CSSProperties } from "react";
 import {
 	getModelPath,
+	getModelMetadataIdentity,
 	resolveModelRouteIds,
 	type ModelRouteParams,
 } from "@/components/(data)/model/model-route-helpers";
 import { permanentRedirect } from "next/navigation";
 
-async function fetchModel(modelId: string, includeHidden: boolean) {
-	try {
-		return await getModelOverviewCached(modelId, includeHidden);
-	} catch (error) {
-		console.warn("[seo] failed to load model overview for metadata", {
-			modelId,
-			error,
-		});
-		return null;
-	}
-}
-
 export async function generateMetadata(props: {
 	params: Promise<ModelRouteParams>;
 }): Promise<Metadata> {
 	const params = await props.params;
-	const includeHidden = false;
-	const { canonicalModelId: modelId } = await resolveModelRouteIds(
+	const { modelId, modelName, organisationName } = await getModelMetadataIdentity(
 		params,
-		includeHidden,
+		false,
 	);
-	const model = await fetchModel(modelId, includeHidden);
 	const path = getModelPath(modelId, "family");
 	const imagePath = `/og/models/${modelId}`;
 
-	if (!model) {
-		return buildMetadata({
-			title: "Model Family Overview",
-			description:
-				"Explore this model's family on AI Stats, including related variants, benchmark context, provider coverage, pricing information, and release timeline connections.",
-			path,
-			keywords: [
-				"AI model family",
-				"related models",
-				"AI benchmarks",
-				"AI providers",
-				"AI Stats",
-			],
-			imagePath,
-		});
-	}
-
-	const organisationName = model.organisation?.name ?? "AI provider";
-
-	const description = [
-		`${model.name} family by ${organisationName} on AI Stats.`,
-		"Explore related models in this family, including variants, benchmarks, providers, and launch milestones.",
-	]
-		.filter(Boolean)
-		.join(" ");
-
 	return buildMetadata({
-		title: `${model.name} Family - Related Models & Variants`,
-		description,
+		title: `${modelName} Family - Related Models & Variants`,
+		description:
+			`Explore ${modelName}'s family on AI Stats, including related variants, benchmark context, provider coverage, pricing information, and release timeline connections.`,
 		path,
 		keywords: [
-			model.name,
-			`${model.name} family`,
-			`${model.name} related models`,
-			`${organisationName} AI`,
+			modelName,
+			`${modelName} family`,
+			`${modelName} related models`,
+			organisationName ? `${organisationName} AI` : null,
 			"AI Stats",
 			"AI model family",
-		],
+		].filter(Boolean) as string[],
 		imagePath,
 	});
 }
@@ -167,19 +128,6 @@ export default async function Page({
 		permanentRedirect(getModelPath(canonicalModelId, "family"));
 	}
 	const modelId = canonicalModelId;
-	const model = await fetchModel(modelId, includeHidden);
-
-	if (!model) {
-		return (
-			<ModelDetailShell
-				modelId={modelId}
-				tab="family"
-				includeHidden={includeHidden}
-			>
-				{null}
-			</ModelDetailShell>
-		);
-	}
 
 	let header: Awaited<ReturnType<typeof getModelOverviewHeader>> | null = null;
 	try {

--- a/apps/web/src/app/(dashboard)/models/[organisationId]/[modelId]/page.tsx
+++ b/apps/web/src/app/(dashboard)/models/[organisationId]/[modelId]/page.tsx
@@ -1,107 +1,42 @@
 import { getModelOverviewCached } from "@/lib/fetchers/models/getModel";
-import ModelOverviewSections from "@/components/(data)/model/overview/ModelOverviewSections";
+import ModelOverviewSections, {
+	ModelCreatorModelsSection,
+} from "@/components/(data)/model/overview/ModelOverviewSections";
 import ModelDetailShell from "@/components/(data)/model/ModelDetailShell";
 import type { Metadata } from "next";
 import { buildMetadata } from "@/lib/seo";
 import {
 	getModelPath,
+	getModelMetadataIdentity,
 	resolveModelRouteIds,
 	type ModelRouteParams,
 } from "@/components/(data)/model/model-route-helpers";
 import { permanentRedirect } from "next/navigation";
 
-async function fetchModelForMetadata(modelId: string, includeHidden: boolean) {
-	try {
-		return await getModelOverviewCached(modelId, includeHidden);
-	} catch (error) {
-		console.warn("[seo] failed to load model overview for metadata", {
-			modelId,
-			error,
-		});
-		return null;
-	}
-}
-
 export async function generateMetadata(props: {
 	params: Promise<ModelRouteParams>;
 }): Promise<Metadata> {
 	const params = await props.params;
-	const includeHidden = false;
-	const { canonicalModelId: modelId } = await resolveModelRouteIds(
+	const { modelId, modelName, organisationName } = await getModelMetadataIdentity(
 		params,
-		includeHidden,
+		false,
 	);
-	const model = await fetchModelForMetadata(modelId, includeHidden);
 	const path = getModelPath(modelId);
 	const imagePath = `/og/models/${modelId}`;
-	const fallbackModelLabel = decodeURIComponent(
-		modelId.split("/").filter(Boolean).pop() ?? modelId,
-	).trim();
-	const fallbackModelName = fallbackModelLabel || "AI model";
-
-	// Fallback if the model can't be loaded
-	if (!model) {
-		return buildMetadata({
-			title: `${fallbackModelName} - Benchmarks, Pricing & API Access`,
-			description:
-				`Browse benchmarks, providers, pricing, deployment options, and compatibility details for ${modelId} on AI Stats.`,
-			path,
-			keywords: [
-				fallbackModelName,
-				modelId,
-				"AI benchmarks",
-				"AI providers",
-				"AI Stats",
-				"model comparison",
-			],
-			imagePath,
-		});
-	}
-
-	const organisationName = model.organisation?.name ?? "AI provider";
-
-	const summaryParts: string[] = [];
-	const releaseYear = model.release_date
-		? new Date(model.release_date).getFullYear()
-		: null;
-
-	const modalities: string[] = [];
-	if (model.input_types) modalities.push(model.input_types);
-	if (model.output_types) modalities.push(model.output_types);
-
-	if (modalities.length) {
-		summaryParts.push(
-			`Modalities: ${modalities
-				.filter(Boolean)
-				.map((m) => m.toLowerCase())
-				.join(", ")}.`
-		);
-	}
-
-	if (releaseYear) {
-		summaryParts.push(`Released ${releaseYear}.`);
-	}
-
-	const description = [
-		`${model.name} is an AI model by ${organisationName}, tracked on AI Stats.`,
-		"View benchmarks, compatible providers, pricing models, and launch milestones in one place.",
-		summaryParts.join(" "),
-	]
-		.filter(Boolean)
-		.join(" ");
 
 	return buildMetadata({
-		title: `${model.name} - Benchmarks, Pricing & API Access`,
-		description,
+		title: `${modelName} - Benchmarks, Pricing & API Access`,
+		description:
+			`Browse benchmarks, providers, pricing, deployment options, and compatibility details for ${modelName} on AI Stats.`,
 		path,
 		keywords: [
-			model.name,
-			`${model.name} benchmarks`,
-			`${model.name} pricing`,
-			`${organisationName} AI`,
+			modelName,
+			`${modelName} benchmarks`,
+			`${modelName} pricing`,
+			organisationName ? `${organisationName} AI` : null,
 			"AI Stats",
 			"AI model comparison",
-		],
+		].filter(Boolean) as string[],
 		imagePath,
 	});
 }
@@ -131,6 +66,15 @@ export default async function Page({
 				model={model}
 				includeHidden={includeHidden}
 			/>
+			{model ? (
+				<div className="mt-10">
+					<ModelCreatorModelsSection
+						modelId={modelId}
+						includeHidden={includeHidden}
+						model={model}
+					/>
+				</div>
+			) : null}
 		</ModelDetailShell>
 	);
 }

--- a/apps/web/src/app/(dashboard)/models/[organisationId]/[modelId]/performance/page.tsx
+++ b/apps/web/src/app/(dashboard)/models/[organisationId]/[modelId]/performance/page.tsx
@@ -2,70 +2,38 @@ import ModelDetailShell from "@/components/(data)/model/ModelDetailShell";
 import { ModelPerformanceSection } from "@/components/(data)/model/overview/ModelOverviewSections";
 import type { Metadata } from "next";
 import { buildMetadata } from "@/lib/seo";
-import { getModelOverviewCached } from "@/lib/fetchers/models/getModel";
 import {
 	getModelPath,
+	getModelMetadataIdentity,
 	resolveModelRouteIds,
 	type ModelRouteParams,
 } from "@/components/(data)/model/model-route-helpers";
 import { permanentRedirect } from "next/navigation";
 
-async function fetchModelOverview(modelId: string, includeHidden: boolean) {
-	try {
-		return await getModelOverviewCached(modelId, includeHidden);
-	} catch (error) {
-		console.warn("[seo] failed to load model overview for metadata", {
-			modelId,
-			error,
-		});
-		return null;
-	}
-}
-
 export async function generateMetadata(props: {
 	params: Promise<ModelRouteParams>;
 }): Promise<Metadata> {
 	const params = await props.params;
-	const includeHidden = false;
-	const { canonicalModelId: modelId } = await resolveModelRouteIds(
+	const { modelId, modelName, organisationName } = await getModelMetadataIdentity(
 		params,
-		includeHidden,
+		false,
 	);
-	const model = await fetchModelOverview(modelId, includeHidden);
 	const path = getModelPath(modelId, "performance");
 	const imagePath = `/og/models/${modelId}`;
 
-	if (!model) {
-		return buildMetadata({
-			title: "Model Performance Overview",
-			description:
-				"Track AI model performance on AI Stats with latency trends, throughput signals, reliability movement, and historical usage metrics across recent gateway traffic.",
-			path,
-			keywords: ["AI model performance", "AI metrics", "AI Stats"],
-			imagePath,
-		});
-	}
-
-	const organisationName = model.organisation?.name ?? "AI provider";
-	const description = [
-		`${model.name} performance metrics by ${organisationName} on AI Stats.`,
-		"See latency, token trajectory, and other runtime signals over time.",
-	]
-		.filter(Boolean)
-		.join(" ");
-
 	return buildMetadata({
-		title: `${model.name} Performance - Latency & Token Trajectory`,
-		description,
+		title: `${modelName} Performance - Latency & Token Trajectory`,
+		description:
+			`Track ${modelName} performance on AI Stats with latency trends, throughput signals, reliability movement, and historical usage metrics across recent gateway traffic.`,
 		path,
 		keywords: [
-			model.name,
-			`${model.name} performance`,
-			`${organisationName} AI`,
+			modelName,
+			`${modelName} performance`,
+			organisationName ? `${organisationName} AI` : null,
 			"latency metrics",
 			"token usage",
 			"AI Stats",
-		],
+		].filter(Boolean) as string[],
 		imagePath,
 	});
 }

--- a/apps/web/src/app/(dashboard)/models/[organisationId]/[modelId]/playground/page.tsx
+++ b/apps/web/src/app/(dashboard)/models/[organisationId]/[modelId]/playground/page.tsx
@@ -3,6 +3,7 @@ import { permanentRedirect } from "next/navigation";
 import ModelDetailShell from "@/components/(data)/model/ModelDetailShell";
 import ModelPlayground from "@/components/(data)/model/playground/ModelPlayground";
 import { getModelGatewayMetadataCached } from "@/lib/fetchers/models/getModelGatewayMetadata";
+import getModelOverviewHeader from "@/lib/fetchers/models/getModelOverviewHeader";
 import { fetchFrontendGatewayModels } from "@/lib/fetchers/frontend/fetchFrontendGatewayModels";
 import type { GatewaySupportedModel } from "@/lib/fetchers/gateway/getGatewaySupportedModelIds";
 import { buildMetadata } from "@/lib/seo";
@@ -56,6 +57,12 @@ export default async function Page({
 		permanentRedirect(getModelPath(canonicalModelId, "playground"));
 	}
 	const modelId = canonicalModelId;
+	const modelDisplayName = await getModelOverviewHeader(
+		modelId,
+		includeHidden,
+	)
+		.then((header) => header.name?.trim() || modelId)
+		.catch(() => modelId);
 	let requestModelId = modelId;
 	const scopedModelIdentifiers = new Set<string>([modelId]);
 	try {
@@ -106,7 +113,7 @@ export default async function Page({
 			<ModelPlayground
 				modelId={modelId}
 				requestModelId={requestModelId}
-				modelName={modelId}
+				modelName={modelDisplayName}
 				gatewayModels={playgroundModels}
 			/>
 		</ModelDetailShell>

--- a/apps/web/src/app/(dashboard)/models/[organisationId]/[modelId]/playground/page.tsx
+++ b/apps/web/src/app/(dashboard)/models/[organisationId]/[modelId]/playground/page.tsx
@@ -2,78 +2,41 @@ import type { Metadata } from "next";
 import { permanentRedirect } from "next/navigation";
 import ModelDetailShell from "@/components/(data)/model/ModelDetailShell";
 import ModelPlayground from "@/components/(data)/model/playground/ModelPlayground";
-import { getModelOverviewCached } from "@/lib/fetchers/models/getModel";
 import { getModelGatewayMetadataCached } from "@/lib/fetchers/models/getModelGatewayMetadata";
 import { fetchFrontendGatewayModels } from "@/lib/fetchers/frontend/fetchFrontendGatewayModels";
 import type { GatewaySupportedModel } from "@/lib/fetchers/gateway/getGatewaySupportedModelIds";
 import { buildMetadata } from "@/lib/seo";
 import {
 	getModelPath,
+	getModelMetadataIdentity,
 	resolveModelRouteIds,
 	type ModelRouteParams,
 } from "@/components/(data)/model/model-route-helpers";
-
-async function fetchModel(modelId: string, includeHidden: boolean) {
-	try {
-		return await getModelOverviewCached(modelId, includeHidden);
-	} catch (error) {
-		console.warn("[seo] failed to load model overview for playground metadata", {
-			modelId,
-			error,
-		});
-		return null;
-	}
-}
 
 export async function generateMetadata(props: {
 	params: Promise<ModelRouteParams>;
 }): Promise<Metadata> {
 	const params = await props.params;
-	const includeHidden = false;
-	const { canonicalModelId: modelId } = await resolveModelRouteIds(
+	const { modelId, modelName, organisationName } = await getModelMetadataIdentity(
 		params,
-		includeHidden,
+		false,
 	);
-	const model = await fetchModel(modelId, includeHidden);
 	const path = getModelPath(modelId, "playground");
 	const imagePath = `/og/models/${modelId}`;
 
-	if (!model) {
-		return buildMetadata({
-			title: "Model Playground",
-			description:
-				"Run multimodal playground tests for this model on AI Stats, including text, image, video, audio, embeddings, and moderation workflows.",
-			path,
-			keywords: [
-				"AI model playground",
-				"single prompt test",
-				"AI billing",
-				"AI Stats",
-			],
-			imagePath,
-		});
-	}
-
-	const organisationName = model.organisation?.name ?? "AI provider";
-	const description = [
-		`Test ${model.name} from ${organisationName} in the AI Stats playground.`,
-		"Run multimodal workflows, inspect usage and billing, and iterate without leaving the model page.",
-	]
-		.filter(Boolean)
-		.join(" ");
-
 	return buildMetadata({
-		title: `${model.name} Playground - Single Prompt Test`,
-		description,
+		title: `${modelName} Playground - Single Prompt Test`,
+		description:
+			`Run multimodal playground tests for ${modelName} on AI Stats, including text, image, video, audio, embeddings, and moderation workflows.`,
 		path,
 		keywords: [
-			model.name,
-			`${model.name} playground`,
-			`${model.name} quick test`,
-			`${organisationName} AI`,
+			modelName,
+			`${modelName} playground`,
+			`${modelName} quick test`,
+			organisationName ? `${organisationName} AI` : null,
 			"AI model playground",
 			"AI Stats chat",
-		],
+		].filter(Boolean) as string[],
 		imagePath,
 	});
 }
@@ -93,7 +56,6 @@ export default async function Page({
 		permanentRedirect(getModelPath(canonicalModelId, "playground"));
 	}
 	const modelId = canonicalModelId;
-	const model = await fetchModel(modelId, includeHidden);
 	let requestModelId = modelId;
 	const scopedModelIdentifiers = new Set<string>([modelId]);
 	try {
@@ -144,7 +106,7 @@ export default async function Page({
 			<ModelPlayground
 				modelId={modelId}
 				requestModelId={requestModelId}
-				modelName={model?.name ?? modelId}
+				modelName={modelId}
 				gatewayModels={playgroundModels}
 			/>
 		</ModelDetailShell>

--- a/apps/web/src/app/(dashboard)/models/[organisationId]/[modelId]/pricing/page.tsx
+++ b/apps/web/src/app/(dashboard)/models/[organisationId]/[modelId]/pricing/page.tsx
@@ -4,78 +4,40 @@ import { Suspense } from "react";
 import ModelDetailShell from "@/components/(data)/model/ModelDetailShell";
 import ModelPricingInsightsSection from "@/components/(data)/model/pricing/ModelPricingInsightsSection";
 import { Skeleton } from "@/components/ui/skeleton";
-import { getModelOverviewCached } from "@/lib/fetchers/models/getModel";
 import { buildMetadata } from "@/lib/seo";
 import {
 	getModelPath,
+	getModelMetadataIdentity,
 	resolveModelRouteIds,
 	type ModelRouteParams,
 } from "@/components/(data)/model/model-route-helpers";
-
-async function fetchModel(modelId: string, includeHidden: boolean) {
-	try {
-		return await getModelOverviewCached(modelId, includeHidden);
-	} catch (error) {
-		const message =
-			error instanceof Error ? error.message : typeof error === "string" ? error : "";
-		const isAbort =
-			(error instanceof DOMException && error.name === "AbortError") ||
-			message.includes("AbortError");
-		if (!isAbort) {
-			console.warn("[seo] failed to load model overview for pricing metadata", {
-				modelId,
-				error,
-			});
-		}
-		return null;
-	}
-}
 
 export async function generateMetadata(props: {
 	params: Promise<ModelRouteParams>;
 }): Promise<Metadata> {
 	const params = await props.params;
-	const includeHidden = false;
-	const { canonicalModelId: modelId } = await resolveModelRouteIds(
+	const { modelId, modelName, organisationName } = await getModelMetadataIdentity(
 		params,
-		includeHidden,
+		false,
 	);
-	const model = await fetchModel(modelId, includeHidden);
 	const path = getModelPath(modelId, "pricing");
 	const imagePath = `/og/models/${modelId}`;
 
-	if (!model) {
-		return buildMetadata({
-			title: "Model Pricing Insights",
-			description:
-				"View effective pricing and 30-day pricing history for this model across providers.",
-			path,
-			keywords: [
-				"AI model pricing",
-				"effective pricing",
-				"pricing history",
-				"token pricing",
-				"AI Stats",
-			],
-			imagePath,
-		});
-	}
-
-	const organisationName = model.organisation?.name ?? "AI provider";
 	return buildMetadata({
-		title: `${model.name} Pricing - Effective Cost & History`,
-		description: `${model.name} pricing by ${organisationName} on AI Stats. Track weighted effective input/output pricing and 30-day pricing history by provider and meter.`,
+		title: `${modelName} Pricing - Effective Cost & History`,
+		description:
+			`${modelName} pricing on AI Stats. Track weighted effective input/output pricing and 30-day pricing history by provider and meter.`,
 		path,
 		keywords: [
-			model.name,
-			`${model.name} pricing`,
-			`${model.name} effective pricing`,
-			`${model.name} pricing history`,
-			`${organisationName} AI`,
+			modelName,
+			`${modelName} pricing`,
+			`${modelName} effective pricing`,
+			`${modelName} pricing history`,
+			organisationName ? `${organisationName} AI` : null,
 			"token pricing",
 			"AI billing",
 			"AI Stats",
-		],
+		].filter(Boolean) as string[],
 		imagePath,
 	});
 }

--- a/apps/web/src/app/(dashboard)/models/[organisationId]/[modelId]/providers/page.tsx
+++ b/apps/web/src/app/(dashboard)/models/[organisationId]/[modelId]/providers/page.tsx
@@ -1,87 +1,41 @@
 import ModelDetailShell from "@/components/(data)/model/ModelDetailShell";
 import type { Metadata } from "next";
 import { buildMetadata } from "@/lib/seo";
-import { getModelOverviewCached } from "@/lib/fetchers/models/getModel";
 import { ModelProvidersSection } from "@/components/(data)/model/overview/ModelOverviewSections";
 import {
 	getModelPath,
+	getModelMetadataIdentity,
 	resolveModelRouteIds,
 	type ModelRouteParams,
 } from "@/components/(data)/model/model-route-helpers";
 import { permanentRedirect } from "next/navigation";
 
-async function fetchModel(modelId: string, includeHidden: boolean) {
-	try {
-		return await getModelOverviewCached(modelId, includeHidden);
-	} catch (error) {
-		const message =
-			error instanceof Error ? error.message : typeof error === "string" ? error : "";
-		const isAbort =
-			(error instanceof DOMException && error.name === "AbortError") ||
-			message.includes("AbortError");
-		if (!isAbort) {
-			console.warn("[seo] failed to load model overview for metadata", {
-				modelId,
-				error,
-			});
-		}
-		return null;
-	}
-}
-
 export async function generateMetadata(props: {
 	params: Promise<ModelRouteParams>;
 }): Promise<Metadata> {
 	const params = await props.params;
-	const includeHidden = false;
-	const { canonicalModelId: modelId } = await resolveModelRouteIds(
+	const { modelId, modelName, organisationName } = await getModelMetadataIdentity(
 		params,
-		includeHidden,
+		false,
 	);
-	const model = await fetchModel(modelId, includeHidden);
 	const path = getModelPath(modelId, "providers");
 	const imagePath = `/og/models/${modelId}`;
 
-	if (!model) {
-		return buildMetadata({
-			title: "Model Providers Overview",
-			description:
-				"View providers for this model on AI Stats, including availability, subscription coverage, and pricing details across supported API endpoints.",
-			path,
-			keywords: [
-				"AI model providers",
-				"API providers",
-				"subscription plans",
-				"AI billing",
-				"AI Stats",
-			],
-			imagePath,
-		});
-	}
-
-	const organisationName = model.organisation?.name ?? "AI provider";
-
-	const description = [
-		`${model.name} providers and pricing by ${organisationName} on AI Stats.`,
-		"See availability, provider pricing, and subscription plan details for this model.",
-	]
-		.filter(Boolean)
-		.join(" ");
-
 	return buildMetadata({
-		title: `${model.name} Providers - Availability & Pricing Details`,
-		description,
+		title: `${modelName} Providers - Availability & Pricing Details`,
+		description:
+			`View providers for ${modelName} on AI Stats, including availability, subscription coverage, and pricing details across supported API endpoints.`,
 		path,
 		keywords: [
-			model.name,
-			`${model.name} providers`,
-			`${model.name} pricing`,
-			`${model.name} subscriptions`,
-			`${organisationName} AI`,
+			modelName,
+			`${modelName} providers`,
+			`${modelName} pricing`,
+			`${modelName} subscriptions`,
+			organisationName ? `${organisationName} AI` : null,
 			"token pricing",
 			"AI billing",
 			"AI Stats",
-		],
+		].filter(Boolean) as string[],
 		imagePath,
 	});
 }

--- a/apps/web/src/app/(dashboard)/models/[organisationId]/[modelId]/quickstart/page.tsx
+++ b/apps/web/src/app/(dashboard)/models/[organisationId]/[modelId]/quickstart/page.tsx
@@ -2,84 +2,40 @@
 import { buildMetadata } from "@/lib/seo";
 import { ModelQuickstartSection } from "@/components/(data)/model/overview/ModelOverviewSections";
 import ModelDetailShell from "@/components/(data)/model/ModelDetailShell";
-import {
-	getModelGatewayMetadataCached,
-} from "@/lib/fetchers/models/getModelGatewayMetadata";
 import type { Metadata } from "next";
 import {
 	getModelPath,
+	getModelMetadataIdentity,
 	resolveModelRouteIds,
 	type ModelRouteParams,
 } from "@/components/(data)/model/model-route-helpers";
-import getModelOverviewHeader from "@/lib/fetchers/models/getModelOverviewHeader";
 import { permanentRedirect } from "next/navigation";
-
-async function fetchModel(modelId: string, includeHidden: boolean) {
-	try {
-		const [metadata, header] = await Promise.all([
-			getModelGatewayMetadataCached(modelId, includeHidden),
-			getModelOverviewHeader(modelId, includeHidden),
-		]);
-		if (!metadata) return null;
-		return { metadata, header };
-	} catch (error) {
-		console.warn("[seo] failed to load model gateway metadata", {
-			modelId,
-			error,
-		});
-		return null;
-	}
-}
 
 export async function generateMetadata(props: {
 	params: Promise<ModelRouteParams>;
 }): Promise<Metadata> {
 	const params = await props.params;
-	const includeHidden = false;
-	const { canonicalModelId: modelId } = await resolveModelRouteIds(
+	const { modelId, modelName, organisationName } = await getModelMetadataIdentity(
 		params,
-		includeHidden,
+		false,
 	);
-	const result = await fetchModel(modelId, includeHidden);
 	const path = getModelPath(modelId, "quickstart");
 	const imagePath = `/og/models/${modelId}`;
 
-	if (!result) {
-		return buildMetadata({
-			title: "Gateway Integration for Model",
-			description:
-				"Explore gateway support for this AI model, including compatible providers, streaming behavior, request formats, and routing options available across AI Stats integrations.",
-			path,
-			keywords: [
-				"AI gateway",
-				"model routing",
-				"AI providers",
-				"AI Stats",
-			],
-			imagePath,
-		});
-	}
-
-	const { metadata, header } = result;
-	const displayName = header?.name ?? metadata.modelId;
-	const organisationName =
-		header?.organisation?.name ??
-		(metadata as any)?.providerName ??
-		"AI provider";
-	const description = `${displayName} Gateway support on AI Stats. View providers, streaming support, and routing options for this model.`;
+	const description = `${modelName} Gateway support on AI Stats. View providers, streaming support, and routing options for this model.`;
 
 	return buildMetadata({
-		title: `${displayName} Gateway - Providers & Routing Options`,
+		title: `${modelName} Gateway - Providers & Routing Options`,
 		description,
 		path,
 		imagePath,
 		keywords: [
-			displayName,
-			`${displayName} gateway`,
-			`${organisationName} provider`,
+			modelName,
+			`${modelName} gateway`,
+			organisationName ? `${organisationName} AI` : null,
 			"AI gateway",
 			"AI Stats",
-		],
+		].filter(Boolean) as string[],
 	});
 }
 

--- a/apps/web/src/app/(dashboard)/models/[organisationId]/[modelId]/timeline/page.tsx
+++ b/apps/web/src/app/(dashboard)/models/[organisationId]/[modelId]/timeline/page.tsx
@@ -1,77 +1,39 @@
 import { buildMetadata } from "@/lib/seo";
-import { getModelOverviewCached } from "@/lib/fetchers/models/getModel";
 import ModelReleaseTimeline from "@/components/(data)/model/ModelReleaseTimeline";
 import ModelDetailShell from "@/components/(data)/model/ModelDetailShell";
 import type { Metadata } from "next";
 import {
 	getModelPath,
+	getModelMetadataIdentity,
 	resolveModelRouteIds,
 	type ModelRouteParams,
 } from "@/components/(data)/model/model-route-helpers";
 import { permanentRedirect } from "next/navigation";
 
-async function fetchModel(modelId: string, includeHidden: boolean) {
-	try {
-		return await getModelOverviewCached(modelId, includeHidden);
-	} catch (error) {
-		console.warn("[seo] failed to load model overview for metadata", {
-			modelId,
-			error,
-		});
-		return null;
-	}
-}
-
 export async function generateMetadata(props: {
 	params: Promise<ModelRouteParams>;
 }): Promise<Metadata> {
 	const params = await props.params;
-	const includeHidden = false;
-	const { canonicalModelId: modelId } = await resolveModelRouteIds(
+	const { modelId, modelName, organisationName } = await getModelMetadataIdentity(
 		params,
-		includeHidden,
+		false,
 	);
-	const model = await fetchModel(modelId, includeHidden);
 	const path = getModelPath(modelId, "timeline");
 	const imagePath = `/og/models/${modelId}`;
 
-	if (!model) {
-		return buildMetadata({
-			title: "Model Timeline Overview",
-			description:
-				"Explore the release timeline for this AI model on AI Stats, including announcements, launches, version changes, deprecations, and retirement milestones over time.",
-			path,
-			keywords: [
-				"AI model timeline",
-				"AI releases",
-				"model history",
-				"AI Stats",
-			],
-			imagePath,
-		});
-	}
-
-	const organisationName = model.organisation?.name ?? "AI provider";
-
-	const description = [
-		`${model.name} release timeline by ${organisationName} on AI Stats.`,
-		"See announcements, releases, deprecations, and retirements in one view.",
-	]
-		.filter(Boolean)
-		.join(" ");
-
 	return buildMetadata({
-		title: `${model.name} Timeline - Announcements & Release History`,
-		description,
+		title: `${modelName} Timeline - Announcements & Release History`,
+		description:
+			`Explore the release timeline for ${modelName} on AI Stats, including announcements, launches, version changes, deprecations, and retirement milestones over time.`,
 		path,
 		imagePath,
 		keywords: [
-			model.name,
-			`${model.name} timeline`,
-			`${organisationName} AI`,
+			modelName,
+			`${modelName} timeline`,
+			organisationName ? `${organisationName} AI` : null,
 			"AI model releases",
 			"AI Stats",
-		],
+		].filter(Boolean) as string[],
 	});
 }
 
@@ -90,19 +52,6 @@ export default async function Page({
 		permanentRedirect(getModelPath(canonicalModelId, "timeline"));
 	}
 	const modelId = canonicalModelId;
-	const model = await fetchModel(modelId, includeHidden);
-
-	if (!model) {
-		return (
-			<ModelDetailShell
-				modelId={modelId}
-				tab="timeline"
-				includeHidden={includeHidden}
-			>
-				{null}
-			</ModelDetailShell>
-		);
-	}
 
 	return (
 		<ModelDetailShell modelId={modelId} tab="timeline" includeHidden={includeHidden}>

--- a/apps/web/src/components/(data)/model/ModelDetailShell.tsx
+++ b/apps/web/src/components/(data)/model/ModelDetailShell.tsx
@@ -8,10 +8,6 @@ import { Badge } from "@/components/ui/badge";
 import ModelNotFoundState from "@/components/(data)/model/ModelNotFoundState";
 import { Button } from "@/components/ui/button";
 import { MessageSquare, Scale } from "lucide-react";
-import { getModelOverviewCached } from "@/lib/fetchers/models/getModel";
-import { getModelBenchmarkHighlights } from "@/lib/fetchers/models/getModelBenchmarkData";
-import { ModelCreatorModelsSection } from "@/components/(data)/model/overview/ModelOverviewSections";
-import type { ModelOverviewPage } from "@/lib/fetchers/models/getModel";
 import { redirect } from "next/navigation";
 
 interface ModelDetailShellProps {
@@ -27,41 +23,20 @@ function isModelNotFoundError(error: unknown): boolean {
 	return false;
 }
 
-async function getVisibleTabKeys(
-	modelId: string,
-	includeHidden: boolean,
-	hasInternalModelData: boolean,
-	modelStatus: ModelOverviewPage["status"] | undefined,
-): Promise<string[]> {
-	const isLimitedAvailabilityModel =
-		modelStatus === "Announced" || modelStatus === "Withheld";
-	const baseTabs: string[] = isLimitedAvailabilityModel
-		? ["overview"]
-		: [
-			"overview",
-			"playground",
-			"providers",
-			"pricing",
-			"performance",
-			"apps",
-			"activity",
-			"quickstart",
-		];
-
-	const visibleTabs = [...baseTabs];
-
-	if (hasInternalModelData) {
-		visibleTabs.push("timeline");
-		const benchmarkHighlights = await getModelBenchmarkHighlights(
-			modelId,
-			includeHidden
-		).catch(() => []);
-		if (benchmarkHighlights.length > 0) {
-			visibleTabs.push("benchmarks");
-		}
-	}
-
-	return visibleTabs;
+function getVisibleTabKeys(): string[] {
+	return [
+		"overview",
+		"playground",
+		"providers",
+		"pricing",
+		"performance",
+		"apps",
+		"activity",
+		"quickstart",
+		"benchmarks",
+		"family",
+		"timeline",
+	];
 }
 
 export default async function ModelDetailShell({
@@ -81,17 +56,7 @@ export default async function ModelDetailShell({
 		return <ModelNotFoundState modelId={modelId} />;
 	}
 
-	const modelOverview: ModelOverviewPage | null = await getModelOverviewCached(
-		modelId,
-		includeHidden,
-	).catch(() => null);
-	const hasInternalModelData = Boolean(modelOverview);
-	const visibleTabKeys = await getVisibleTabKeys(
-		modelId,
-		includeHidden,
-		hasInternalModelData,
-		modelOverview?.status,
-	);
+	const visibleTabKeys = getVisibleTabKeys();
 	if (tab && !visibleTabKeys.includes(tab)) {
 		redirect(`/models/${modelId}`);
 	}
@@ -152,15 +117,6 @@ export default async function ModelDetailShell({
 				<TabBar modelId={modelId} visibleTabKeys={visibleTabKeys} />
 
 				<div className="mt-6 min-h-full">{children}</div>
-				{modelOverview ? (
-					<div className="mt-10">
-						<ModelCreatorModelsSection
-							modelId={modelId}
-							includeHidden={includeHidden}
-							model={modelOverview}
-						/>
-					</div>
-				) : null}
 			</div>
 		</main>
 	);

--- a/apps/web/src/components/(data)/model/ModelDetailShell.tsx
+++ b/apps/web/src/components/(data)/model/ModelDetailShell.tsx
@@ -23,7 +23,13 @@ function isModelNotFoundError(error: unknown): boolean {
 	return false;
 }
 
-function getVisibleTabKeys(): string[] {
+function getVisibleTabKeys(modelStatus?: string | null): string[] {
+	const isLimitedAvailabilityModel =
+		modelStatus === "Announced" || modelStatus === "Withheld";
+	if (isLimitedAvailabilityModel) {
+		return ["overview"];
+	}
+
 	return [
 		"overview",
 		"playground",
@@ -56,7 +62,7 @@ export default async function ModelDetailShell({
 		return <ModelNotFoundState modelId={modelId} />;
 	}
 
-	const visibleTabKeys = getVisibleTabKeys();
+	const visibleTabKeys = getVisibleTabKeys(header.status);
 	if (tab && !visibleTabKeys.includes(tab)) {
 		redirect(`/models/${modelId}`);
 	}

--- a/apps/web/src/components/(data)/model/ModelTabs.tsx
+++ b/apps/web/src/components/(data)/model/ModelTabs.tsx
@@ -30,7 +30,7 @@ const tabs: ModelTab[] = [
 	{ label: "Activity", key: "activity" },
 	{ label: "Quickstart", key: "quickstart" },
 	{ label: "Benchmarks", key: "benchmarks" },
-	{ label: "Family", key: "family", hidden: true },
+	{ label: "Family", key: "family" },
 	{ label: "Timeline", key: "timeline" },
 ];
 

--- a/apps/web/src/components/(data)/model/model-route-helpers.ts
+++ b/apps/web/src/components/(data)/model/model-route-helpers.ts
@@ -1,4 +1,5 @@
 import { resolveCanonicalModelId } from "@/lib/fetchers/models/resolveCanonicalModelId";
+import getModelOverviewHeader from "@/lib/fetchers/models/getModelOverviewHeader";
 
 export type ModelRouteParams = {
 	organisationId: string;
@@ -11,6 +12,53 @@ export function getModelIdFromParams(params: ModelRouteParams): string {
 
 export function getModelPath(modelId: string, tab?: string): string {
 	return tab ? `/models/${modelId}/${tab}` : `/models/${modelId}`;
+}
+
+export type ModelMetadataIdentity = {
+	modelId: string;
+	modelName: string;
+	organisationName: string | null;
+};
+
+export async function getModelMetadataIdentity(
+	params: ModelRouteParams,
+	includeHidden: boolean,
+): Promise<ModelMetadataIdentity> {
+	const requestedModelId = getModelIdFromParams(params);
+	const fallbackName = decodeURIComponent(params.modelId ?? "").trim() || "AI model";
+
+	try {
+		const header = await getModelOverviewHeader(requestedModelId, includeHidden);
+		return {
+			modelId: requestedModelId,
+			modelName: header.name?.trim() || fallbackName,
+			organisationName: header.organisation?.name ?? null,
+		};
+	} catch {
+		try {
+			const resolved = await resolveCanonicalModelId(requestedModelId, includeHidden);
+			const canonicalModelId = resolved.canonicalModelId ?? requestedModelId;
+			if (canonicalModelId !== requestedModelId) {
+				const canonicalHeader = await getModelOverviewHeader(
+					canonicalModelId,
+					includeHidden,
+				);
+				return {
+					modelId: canonicalModelId,
+					modelName: canonicalHeader.name?.trim() || fallbackName,
+					organisationName: canonicalHeader.organisation?.name ?? null,
+				};
+			}
+		} catch {
+			// Swallow and return metadata fallback below.
+		}
+
+		return {
+			modelId: requestedModelId,
+			modelName: fallbackName,
+			organisationName: null,
+		};
+	}
 }
 
 export async function resolveModelRouteIds(

--- a/apps/web/src/components/(data)/model/overview/ModelOverviewSections.tsx
+++ b/apps/web/src/components/(data)/model/overview/ModelOverviewSections.tsx
@@ -22,7 +22,10 @@ import ModelLinks, {
 	hasModelLinks,
 } from "@/components/(data)/model/overview/ModelLinks";
 import { getModelOverviewCached, type ModelOverviewPage } from "@/lib/fetchers/models/getModel";
-import { getModelPerformanceMetricsCached } from "@/lib/fetchers/models/getModelPerformance";
+import {
+	getModelPerformanceActivitySnapshotCached,
+	getModelPerformanceMetricsCached,
+} from "@/lib/fetchers/models/getModelPerformance";
 import { getModelTokenTrajectoryCached } from "@/lib/fetchers/models/getModelTokenTrajectory";
 import { getModelGatewayMetadataCached } from "@/lib/fetchers/models/getModelGatewayMetadata";
 import { getModelBenchmarkHighlights } from "@/lib/fetchers/models/getModelBenchmarkData";
@@ -291,18 +294,17 @@ export async function ModelActivitySection({
 	modelId,
 	includeHidden,
 }: ModelSectionSharedProps) {
-	const performanceMetrics = await getModelPerformanceMetricsCached(
+	const activitySnapshot = await getModelPerformanceActivitySnapshotCached(
 		modelId,
 		includeHidden,
-		24,
 	).catch(() => null);
 
-	const usageSummary = performanceMetrics?.summary ?? null;
+	const usageSummary = activitySnapshot?.summary ?? null;
 	const providerWithTelemetry =
-		performanceMetrics?.providerPerformance.filter(
+		activitySnapshot?.providerPerformance.filter(
 			(provider) => provider.requests > 0,
 		).length ?? 0;
-	const totalProviders = performanceMetrics?.providerPerformance.length ?? 0;
+	const totalProviders = activitySnapshot?.providerPerformance.length ?? 0;
 
 	return (
 		<Section id="activity">
@@ -345,8 +347,8 @@ export async function ModelActivitySection({
 							Tokens (Cumulative)
 						</p>
 						<p className="text-xl font-semibold">
-							{performanceMetrics?.cumulativeTokens != null
-								? performanceMetrics.cumulativeTokens.toLocaleString()
+							{activitySnapshot?.cumulativeTokens != null
+								? activitySnapshot.cumulativeTokens.toLocaleString()
 								: "N/A"}
 						</p>
 					</div>

--- a/apps/web/src/lib/cache/revalidateDataTags.ts
+++ b/apps/web/src/lib/cache/revalidateDataTags.ts
@@ -130,9 +130,9 @@ export function revalidateModelApiInfoTags(
 	const hasModelScope = Boolean(options.modelId);
 	if (!hasModelScope) {
 		revalidateTagList(MODEL_API_GLOBAL_TAGS);
-	}
-	for (const tag of MODEL_CANONICAL_RESOLVER_TAGS) {
-		revalidateTag(tag, EXPIRE_IMMEDIATELY);
+		for (const tag of MODEL_CANONICAL_RESOLVER_TAGS) {
+			revalidateTag(tag, EXPIRE_IMMEDIATELY);
+		}
 	}
 
 	if (options.modelId) {

--- a/apps/web/src/lib/cache/revalidateDataTags.ts
+++ b/apps/web/src/lib/cache/revalidateDataTags.ts
@@ -127,13 +127,21 @@ export function revalidateModelDataOnlyTags(
 export function revalidateModelApiInfoTags(
 	options: RevalidateModelDataTagOptions = {}
 ) {
-	revalidateTagList(MODEL_API_GLOBAL_TAGS);
+	const hasModelScope = Boolean(options.modelId);
+	if (!hasModelScope) {
+		revalidateTagList(MODEL_API_GLOBAL_TAGS);
+	}
 	for (const tag of MODEL_CANONICAL_RESOLVER_TAGS) {
 		revalidateTag(tag, EXPIRE_IMMEDIATELY);
 	}
 
 	if (options.modelId) {
+		revalidateTag(`model:canonical:${options.modelId}`, EXPIRE_IMMEDIATELY);
 		revalidateTag(`model:api:${options.modelId}`, STALE_WHILE_REVALIDATE);
+		revalidateTag(
+			`model:performance:${options.modelId}`,
+			STALE_WHILE_REVALIDATE
+		);
 		revalidateTag(
 			`data:gateway_requests:model:${options.modelId}`,
 			STALE_WHILE_REVALIDATE

--- a/apps/web/src/lib/cache/revalidateDataTags.ts
+++ b/apps/web/src/lib/cache/revalidateDataTags.ts
@@ -139,9 +139,14 @@ export function revalidateModelApiInfoTags(
 		revalidateTag(`model:canonical:${options.modelId}`, EXPIRE_IMMEDIATELY);
 		revalidateTag(`model:api:${options.modelId}`, STALE_WHILE_REVALIDATE);
 		revalidateTag(
+			`model:pricing-history:${options.modelId}`,
+			STALE_WHILE_REVALIDATE
+		);
+		revalidateTag(
 			`model:performance:${options.modelId}`,
 			STALE_WHILE_REVALIDATE
 		);
+		revalidateTag(`data:model_apps:${options.modelId}`, STALE_WHILE_REVALIDATE);
 		revalidateTag(
 			`data:gateway_requests:model:${options.modelId}`,
 			STALE_WHILE_REVALIDATE

--- a/apps/web/src/lib/fetchers/models/getModel.ts
+++ b/apps/web/src/lib/fetchers/models/getModel.ts
@@ -385,9 +385,9 @@ export async function getModelOverviewCached(
     "use cache";
 
     cacheLife({
-        stale: 60 * 60,
-        revalidate: 60 * 60 * 24,
-        expire: 60 * 60 * 24 * 7,
+        stale: 60 * 60 * 24,
+        revalidate: 60 * 60 * 24 * 7,
+        expire: 60 * 60 * 24 * 30,
     });
 
     cacheTag("data:models");

--- a/apps/web/src/lib/fetchers/models/getModelApps.ts
+++ b/apps/web/src/lib/fetchers/models/getModelApps.ts
@@ -348,6 +348,7 @@ export async function getModelAppsCached(
 	cacheTag("data:apps");
 	cacheTag("data:public_apps");
 	cacheTag("data:gateway_usage_rollups");
+	cacheTag(`model:api:${modelId}`);
 	cacheTag(`data:model_apps:${modelId}`);
 	return getModelApps(modelId, includeHidden, limit);
 }

--- a/apps/web/src/lib/fetchers/models/getModelApps.ts
+++ b/apps/web/src/lib/fetchers/models/getModelApps.ts
@@ -347,6 +347,7 @@ export async function getModelAppsCached(
 	cacheLife("days");
 	cacheTag("data:apps");
 	cacheTag("data:public_apps");
+	cacheTag("data:data_api_provider_models");
 	cacheTag("data:gateway_usage_rollups");
 	cacheTag(`model:api:${modelId}`);
 	cacheTag(`data:model_apps:${modelId}`);

--- a/apps/web/src/lib/fetchers/models/getModelOverviewHeader.ts
+++ b/apps/web/src/lib/fetchers/models/getModelOverviewHeader.ts
@@ -116,9 +116,9 @@ export async function fetchModelOverviewHeader(
 			normalizeId(providerByModelRes.data?.[0]?.api_model_id) ??
 			modelId;
 		const fallbackOrganisationId =
-			organisationFromModelId(providerByApiRes.data?.[0]?.model_id) ??
 			organisationFromModelId(modelId) ??
-			organisationFromModelId(resolvedApiModelId);
+			organisationFromModelId(resolvedApiModelId) ??
+			organisationFromModelId(providerByApiRes.data?.[0]?.model_id);
 		const resolvedOrganisationId =
 			normalizeId(apiModelRes.data?.organisation_id) ?? fallbackOrganisationId;
 		if (!resolvedApiModelId || !resolvedOrganisationId) {

--- a/apps/web/src/lib/fetchers/models/getModelOverviewHeader.ts
+++ b/apps/web/src/lib/fetchers/models/getModelOverviewHeader.ts
@@ -9,6 +9,7 @@ export interface ModelOverviewHeader {
 	organisation_id: string;
 	organisation: { name: string; country_code: string };
 	family_id?: string;
+	status?: string | null;
 	hidden?: boolean;
 }
 
@@ -45,6 +46,7 @@ export async function fetchModelOverviewHeader(
 			`
             model_id,
             name,
+            status,
             organisation_id,
             hidden,
             organisation:data_organisations!data_models_organisation_id_fkey ( name, country_code ),
@@ -143,6 +145,7 @@ export async function fetchModelOverviewHeader(
 				name: organisationName ?? "Unknown",
 				country_code: organisationCountryCode,
 			},
+			status: null,
 			hidden: false,
 		};
 	}
@@ -161,6 +164,7 @@ export async function fetchModelOverviewHeader(
 		organisation_id: data.organisation_id,
 		organisation: rawOrg as { name: string; country_code: string },
 		family_id: data.family_id || undefined,
+		status: (data as any).status ?? null,
 		hidden: Boolean((data as any).hidden),
 	};
 }

--- a/apps/web/src/lib/fetchers/models/getModelOverviewHeader.ts
+++ b/apps/web/src/lib/fetchers/models/getModelOverviewHeader.ts
@@ -7,8 +7,8 @@ export interface ModelOverviewHeader {
 	model_id: string;
 	name: string;
 	organisation_id: string;
-	organisation: { name: string; country_code: string }; // not nullable
-	family_id?: string; // optional, may be undefined
+	organisation: { name: string; country_code: string };
+	family_id?: string;
 	hidden?: boolean;
 }
 
@@ -20,6 +20,18 @@ function isMissingRelationError(error: unknown): boolean {
 		text.includes("relation") ||
 		text.includes("schema cache")
 	);
+}
+
+function normalizeId(value: unknown): string | null {
+	const normalized = String(value ?? "").trim();
+	return normalized.length > 0 ? normalized : null;
+}
+
+function organisationFromModelId(modelId: string | null | undefined): string | null {
+	const normalized = normalizeId(modelId);
+	if (!normalized || !normalized.includes("/")) return null;
+	const [organisationId] = normalized.split("/", 1);
+	return normalizeId(organisationId);
 }
 
 export async function fetchModelOverviewHeader(
@@ -43,51 +55,70 @@ export async function fetchModelOverviewHeader(
 	);
 	const { data, error } = await query.eq("model_id", modelId).maybeSingle();
 
-	console.log("[fetch] HIT DB for model header", modelId);
-
 	if (error) throw error;
 	if (!data) {
-		const { data: internalVisibility } = await supabase
-			.from("data_models")
-			.select("hidden")
-			.eq("model_id", modelId)
-			.maybeSingle();
-		if (!includeHidden && internalVisibility?.hidden) {
+		const [internalVisibilityRes, apiModelRes, providerByApiRes, providerByModelRes] =
+			await Promise.all([
+				supabase
+					.from("data_models")
+					.select("hidden")
+					.eq("model_id", modelId)
+					.maybeSingle(),
+				supabase
+					.from("data_api_models")
+					.select("api_model_id, display_name, organisation_id")
+					.eq("api_model_id", modelId)
+					.maybeSingle(),
+				supabase
+					.from("data_api_provider_models")
+					.select("model_id")
+					.eq("api_model_id", modelId)
+					.not("model_id", "is", null)
+					.limit(1),
+				supabase
+					.from("data_api_provider_models")
+					.select("api_model_id")
+					.eq("model_id", modelId)
+					.not("api_model_id", "is", null)
+					.limit(1),
+			]);
+
+		if (internalVisibilityRes.error) {
+			throw new Error(internalVisibilityRes.error.message ?? `Model not found: ${modelId}`);
+		}
+		if (!includeHidden && internalVisibilityRes.data?.hidden) {
 			throw new Error(`Model not found: ${modelId}`);
 		}
 
-		const { data: apiModelRow, error: apiModelError } = await supabase
-			.from("data_api_models")
-			.select("api_model_id, display_name, organisation_id")
-			.eq("api_model_id", modelId)
-			.maybeSingle();
-
-		const { count: providerMappingCount, error: providerMappingError } =
-			await supabase
-				.from("data_api_provider_models")
-				.select("provider_api_model_id", { count: "exact", head: true })
-				.eq("api_model_id", modelId);
-
-		if (providerMappingError) {
-			throw new Error(`Model not found: ${modelId}`);
+		if (providerByApiRes.error) {
+			throw new Error(providerByApiRes.error.message ?? `Model not found: ${modelId}`);
+		}
+		if (providerByModelRes.error) {
+			throw new Error(providerByModelRes.error.message ?? `Model not found: ${modelId}`);
 		}
 
-		if (apiModelError && !isMissingRelationError(apiModelError)) {
-			throw new Error(`Model not found: ${modelId}`);
+		if (apiModelRes.error && !isMissingRelationError(apiModelRes.error)) {
+			throw new Error(apiModelRes.error.message ?? `Model not found: ${modelId}`);
 		}
 
-		const hasApiModel = Boolean(apiModelRow?.api_model_id);
-		const hasProviderMapping = (providerMappingCount ?? 0) > 0;
+		const hasApiModel = Boolean(normalizeId(apiModelRes.data?.api_model_id));
+		const hasProviderMapping =
+			(providerByApiRes.data?.length ?? 0) > 0 ||
+			(providerByModelRes.data?.length ?? 0) > 0;
 		if (!hasApiModel && !hasProviderMapping) {
 			throw new Error(`Model not found: ${modelId}`);
 		}
 
-		const fallbackOrganisationId = modelId.includes("/")
-			? modelId.split("/")[0].trim()
-			: "";
-		const resolvedApiModelId = apiModelRow?.api_model_id ?? modelId;
+		const resolvedApiModelId =
+			normalizeId(apiModelRes.data?.api_model_id) ??
+			normalizeId(providerByModelRes.data?.[0]?.api_model_id) ??
+			modelId;
+		const fallbackOrganisationId =
+			organisationFromModelId(providerByApiRes.data?.[0]?.model_id) ??
+			organisationFromModelId(modelId) ??
+			organisationFromModelId(resolvedApiModelId);
 		const resolvedOrganisationId =
-			apiModelRow?.organisation_id ?? fallbackOrganisationId;
+			normalizeId(apiModelRes.data?.organisation_id) ?? fallbackOrganisationId;
 		if (!resolvedApiModelId || !resolvedOrganisationId) {
 			throw new Error(`Model not found: ${modelId}`);
 		}
@@ -100,14 +131,13 @@ export async function fetchModelOverviewHeader(
 				.select("name, country_code")
 				.eq("organisation_id", resolvedOrganisationId)
 				.maybeSingle();
-			organisationName =
-				organisationRow?.name ?? resolvedOrganisationId;
+			organisationName = organisationRow?.name ?? resolvedOrganisationId;
 			organisationCountryCode = organisationRow?.country_code ?? "";
 		}
 
 		return {
 			model_id: resolvedApiModelId,
-			name: apiModelRow?.display_name ?? resolvedApiModelId,
+			name: normalizeId(apiModelRes.data?.display_name) ?? resolvedApiModelId,
 			organisation_id: resolvedOrganisationId,
 			organisation: {
 				name: organisationName ?? "Unknown",
@@ -143,11 +173,16 @@ export default async function getModelOverviewHeader(
 ): Promise<ModelOverviewHeader> {
 	"use cache";
 
-	cacheLife("days");
+	cacheLife({
+		stale: 60 * 60 * 24,
+		revalidate: 60 * 60 * 24 * 7,
+		expire: 60 * 60 * 24 * 30,
+	});
 	cacheTag("data:models");
+	cacheTag("data:organisations");
+	cacheTag("data:data_api_models");
+	cacheTag("data:data_api_provider_models");
 	cacheTag(`model:data:${modelId}`);
 	cacheTag(`model:header:${modelId}`);
-
-	console.log("[cache] COMPUTE getModelOverviewHeader", modelId);
 	return fetchModelOverviewHeader(modelId, includeHidden);
 }

--- a/apps/web/src/lib/fetchers/models/getModelPerformance.ts
+++ b/apps/web/src/lib/fetchers/models/getModelPerformance.ts
@@ -97,6 +97,24 @@ export interface ModelPerformanceMetrics {
 	releaseDate?: string | null;
 }
 
+export interface ModelPerformanceActivitySnapshot {
+	summary: ModelPerformanceSummary;
+	providerPerformance: ModelProviderPerformance[];
+	cumulativeTokens?: number | null;
+}
+
+async function fetchPerformanceOverviewPayload(client: any, modelId: string) {
+	const { data, error } = await client.rpc("get_model_performance_overview", {
+		p_model_id: modelId,
+	});
+
+	if (error) {
+		throw new Error(error.message ?? "Failed to load model performance");
+	}
+
+	return (data?.[0] ?? {}) as RpcModelPerformanceResponse;
+}
+
 export async function getModelPerformanceMetrics(
 	modelId: string,
 	includeHidden: boolean,
@@ -108,18 +126,9 @@ export async function getModelPerformanceMetrics(
 
 	console.log(`[perf] querying model_id="${modelId}"`);
 
-	const { data, error } = await client.rpc("get_model_performance_overview", {
-		p_model_id: modelId,
-	});
-
+	const payload = await fetchPerformanceOverviewPayload(client, modelId);
 	const dur = Date.now() - t0;
-	console.log(`[perf] rpc dur=${dur}ms error=${!!error}`);
-
-	if (error) {
-		throw new Error(error.message ?? "Failed to load model performance");
-	}
-
-	const payload = (data?.[0] ?? {}) as RpcModelPerformanceResponse;
+	console.log(`[perf] rpc dur=${dur}ms error=false`);
 
 	const last24 = payload.last_24h;
 	const hourlyCnt = payload.hourly_24h?.length ?? 0;
@@ -152,6 +161,8 @@ export async function getModelPerformanceMetrics(
 
 	const mapDur = Date.now() - t0 - dur;
 	console.log(`[perf] mapped hourlyReqs=[${hourly.map(h => h.requests).join(",")}]`);
+	void hours;
+	void mapDur;
 
 	return {
 		summary,
@@ -167,6 +178,25 @@ export async function getModelPerformanceMetrics(
 	};
 }
 
+export async function getModelPerformanceActivitySnapshot(
+	modelId: string,
+	includeHidden: boolean,
+): Promise<ModelPerformanceActivitySnapshot> {
+	const client = createAdminClient();
+	void includeHidden;
+
+	const payload = await fetchPerformanceOverviewPayload(client, modelId);
+	const providerPerformance = (payload.provider_uptime_24h ?? []).map(
+		mapProviderPerformance,
+	);
+
+	return {
+		summary: mapSummary(payload.last_24h),
+		providerPerformance,
+		cumulativeTokens: toNumber(payload.cumulative_tokens?.total_tokens),
+	};
+}
+
 export async function getModelPerformanceMetricsCached(
 	modelId: string,
 	includeHidden: boolean,
@@ -174,11 +204,34 @@ export async function getModelPerformanceMetricsCached(
 ): Promise<ModelPerformanceMetrics> {
 	"use cache";
 
-	cacheLife("days");
+	cacheLife({
+		stale: 60 * 60,
+		revalidate: 60 * 60 * 6,
+		expire: 60 * 60 * 24,
+	});
 	cacheTag("data:gateway_usage_rollups");
 	cacheTag(`data:gateway_usage_rollups:model:${modelId}`);
+	cacheTag(`model:performance:${modelId}`);
 
 	return getModelPerformanceMetrics(modelId, includeHidden, hours);
+}
+
+export async function getModelPerformanceActivitySnapshotCached(
+	modelId: string,
+	includeHidden: boolean,
+): Promise<ModelPerformanceActivitySnapshot> {
+	"use cache";
+
+	cacheLife({
+		stale: 60 * 15,
+		revalidate: 60 * 60,
+		expire: 60 * 60 * 6,
+	});
+	cacheTag("data:gateway_usage_rollups");
+	cacheTag(`data:gateway_usage_rollups:model:${modelId}`);
+	cacheTag(`model:performance:${modelId}`);
+
+	return getModelPerformanceActivitySnapshot(modelId, includeHidden);
 }
 
 function toNumber(value: any): number | null {

--- a/apps/web/src/lib/fetchers/models/getModelPricingHistoryRules.ts
+++ b/apps/web/src/lib/fetchers/models/getModelPricingHistoryRules.ts
@@ -179,6 +179,8 @@ export async function getModelPricingHistoryRules(args: {
 	cacheTag("data:data_api_pricing_rules");
 	cacheTag("data:data_api_provider_models");
 	cacheTag(`data:models:${args.modelId}`);
+	cacheTag(`model:api:${args.modelId}`);
+	cacheTag(`model:pricing-history:${args.modelId}`);
 
 	const days = Number.isFinite(args.days) && (args.days ?? 0) > 0
 		? Math.round(args.days as number)

--- a/apps/web/src/lib/fetchers/models/resolveCanonicalModelId.ts
+++ b/apps/web/src/lib/fetchers/models/resolveCanonicalModelId.ts
@@ -18,6 +18,8 @@ export type ResolveCanonicalModelIdResult = {
 	source: ResolveModelIdSource;
 };
 
+type SupabaseClient = Awaited<ReturnType<typeof createClient>>;
+
 function isMissingRelationError(error: unknown): boolean {
 	const text = String((error as { message?: unknown })?.message ?? "").toLowerCase();
 	return (
@@ -27,108 +29,126 @@ function isMissingRelationError(error: unknown): boolean {
 	);
 }
 
-async function modelExistsVisible(
-	supabase: Awaited<ReturnType<typeof createClient>>,
-	modelId: string,
-	includeHidden: boolean,
-): Promise<boolean> {
-	if (!modelId) return false;
-	const { data, error } = await applyHiddenFilter(
-		supabase.from("data_models").select("model_id, hidden"),
-		includeHidden,
-	)
-		.eq("model_id", modelId)
-		.maybeSingle();
-
-	if (error) return false;
-	return Boolean(data?.model_id);
+function normalizeId(value: unknown): string | null {
+	const id = String(value ?? "").trim();
+	return id.length > 0 ? id : null;
 }
 
-async function apiModelExists(
-	supabase: Awaited<ReturnType<typeof createClient>>,
-	apiModelId: string,
-): Promise<boolean> {
-	if (!apiModelId) return false;
-	const { data, error } = await supabase
-		.from("data_api_models")
-		.select("api_model_id")
-		.eq("api_model_id", apiModelId)
-		.maybeSingle();
-	if (error) return false;
-	return Boolean(data?.api_model_id);
-}
-
-async function providerMappingExistsForApiModel(
-	supabase: Awaited<ReturnType<typeof createClient>>,
-	apiModelId: string,
-): Promise<boolean> {
-	if (!apiModelId) return false;
-	const { data, error } = await supabase
-		.from("data_api_provider_models")
-		.select("provider_api_model_id")
-		.eq("api_model_id", apiModelId)
-		.limit(1);
-	if (error) return false;
-	return Array.isArray(data) && data.length > 0;
-}
-
-async function resolveApiModelIdFromInternalModelId(
-	supabase: Awaited<ReturnType<typeof createClient>>,
-	internalModelId: string,
-): Promise<string | null> {
-	if (!internalModelId) return null;
-	const { data, error } = await supabase
-		.from("data_api_provider_models")
-		.select("api_model_id")
-		.eq("model_id", internalModelId)
-		.not("api_model_id", "is", null);
-	if (error) return null;
-	return (
-		Array.from(
-			new Set(
-				(data ?? [])
-					.map((row: any) => String(row?.api_model_id ?? "").trim())
-					.filter(Boolean),
-			),
-		)[0] ?? null
+function uniqueIds(ids: Array<string | null | undefined>): string[] {
+	return Array.from(
+		new Set(ids.map((id) => normalizeId(id)).filter((id): id is string => Boolean(id))),
 	);
 }
 
-async function resolveVisibleInternalModelIdForApiModel(
-	supabase: Awaited<ReturnType<typeof createClient>>,
-	apiModelId: string,
-	includeHidden: boolean,
-): Promise<string | null> {
-	if (!apiModelId) return null;
+function warnIfUnexpectedTableError(
+	context: string,
+	modelId: string,
+	error: unknown,
+): void {
+	if (isMissingRelationError(error)) return;
+	console.warn(`[resolveCanonicalModelId] ${context} failed`, { modelId, error });
+}
 
-	if (await modelExistsVisible(supabase, apiModelId, includeHidden)) {
-		return apiModelId;
-	}
+async function getVisibleModelIds(
+	supabase: SupabaseClient,
+	modelIds: Array<string | null | undefined>,
+	includeHidden: boolean,
+): Promise<Set<string>> {
+	const ids = uniqueIds(modelIds);
+	if (ids.length === 0) return new Set<string>();
+
+	const { data, error } = await applyHiddenFilter(
+		supabase.from("data_models").select("model_id"),
+		includeHidden,
+	)
+		.in("model_id", ids);
+
+	if (error) return new Set<string>();
+
+	return new Set(
+		(data ?? [])
+			.map((row: { model_id?: unknown }) => normalizeId(row?.model_id))
+			.filter((id: string | null): id is string => Boolean(id)),
+	);
+}
+
+async function apiModelExists(
+	supabase: SupabaseClient,
+	apiModelId: string,
+): Promise<boolean> {
+	const id = normalizeId(apiModelId);
+	if (!id) return false;
+	const { data, error } = await supabase
+		.from("data_api_models")
+		.select("api_model_id")
+		.eq("api_model_id", id)
+		.maybeSingle();
+	if (error) return false;
+	return normalizeId(data?.api_model_id) === id;
+}
+
+async function getMappedApiModelIdForInternalModel(
+	supabase: SupabaseClient,
+	internalModelId: string,
+): Promise<string | null> {
+	const id = normalizeId(internalModelId);
+	if (!id) return null;
+	const { data, error } = await supabase
+		.from("data_api_provider_models")
+		.select("api_model_id")
+		.eq("model_id", id)
+		.not("api_model_id", "is", null)
+		.limit(1);
+	if (error) return null;
+	return normalizeId(data?.[0]?.api_model_id);
+}
+
+async function getMappedInternalModelIdsForApiModel(
+	supabase: SupabaseClient,
+	apiModelId: string,
+): Promise<string[]> {
+	const id = normalizeId(apiModelId);
+	if (!id) return [];
 
 	const { data, error } = await supabase
 		.from("data_api_provider_models")
 		.select("model_id")
-		.eq("api_model_id", apiModelId)
+		.eq("api_model_id", id)
 		.not("model_id", "is", null);
+	if (error) return [];
+	return uniqueIds((data ?? []).map((row: { model_id?: unknown }) => normalizeId(row?.model_id)));
+}
 
-	if (error) return null;
+async function resolveVisibleInternalModelIdForCanonical(
+	supabase: SupabaseClient,
+	canonicalModelId: string,
+	includeHidden: boolean,
+): Promise<string | null> {
+	const canonical = normalizeId(canonicalModelId);
+	if (!canonical) return null;
 
-	const candidates = Array.from(
-		new Set(
-			(data ?? [])
-				.map((row: any) => String(row?.model_id ?? "").trim())
-				.filter(Boolean),
-		),
+	const directVisible = await getVisibleModelIds(
+		supabase,
+		[canonical],
+		includeHidden,
 	);
-
-	for (const candidate of candidates) {
-		if (includeHidden) return candidate;
-		if (await modelExistsVisible(supabase, candidate, includeHidden)) {
-			return candidate;
-		}
+	if (directVisible.has(canonical)) {
+		return canonical;
 	}
 
-	return null;
+	const candidates = await getMappedInternalModelIdsForApiModel(
+		supabase,
+		canonical,
+	);
+	if (candidates.length === 0) return null;
+	if (includeHidden) return candidates[0] ?? null;
+
+	const visibleCandidates = await getVisibleModelIds(
+		supabase,
+		candidates,
+		includeHidden,
+	);
+	return candidates.find((candidate) => visibleCandidates.has(candidate)) ?? null;
 }
 
 async function resolveCanonicalModelIdUncached(
@@ -149,12 +169,15 @@ async function resolveCanonicalModelIdUncached(
 	const buildResult = async (
 		canonicalModelId: string,
 		source: ResolveModelIdSource,
+		internalModelIdHint?: string | null,
 	): Promise<ResolveCanonicalModelIdResult> => {
-		const internalModelId = await resolveVisibleInternalModelIdForApiModel(
-			supabase,
-			canonicalModelId,
-			includeHidden,
-		);
+		const internalModelId =
+			normalizeId(internalModelIdHint) ??
+			(await resolveVisibleInternalModelIdForCanonical(
+				supabase,
+				canonicalModelId,
+				includeHidden,
+			));
 		return {
 			requestedModelId: modelId,
 			canonicalModelId,
@@ -163,72 +186,119 @@ async function resolveCanonicalModelIdUncached(
 		};
 	};
 
-	if (await modelExistsVisible(supabase, modelId, includeHidden)) {
-		return buildResult(modelId, "direct");
+	const directVisible = await getVisibleModelIds(supabase, [modelId], includeHidden);
+	if (directVisible.has(modelId)) {
+		return buildResult(modelId, "direct", modelId);
 	}
 
-	try {
-		const { data: redirectRow, error: redirectError } = await supabase
-			.from("data_model_id_redirects")
-			.select("model_id")
-			.eq("legacy_model_id", modelId)
-			.maybeSingle();
+	const [redirectRes, aliasRes, apiModelRes, providerByApiRes, providerByModelRes] =
+		await Promise.all([
+			supabase
+				.from("data_model_id_redirects")
+				.select("model_id")
+				.eq("legacy_model_id", modelId)
+				.maybeSingle(),
+			supabase
+				.from("data_api_model_aliases")
+				.select("api_model_id")
+				.eq("alias_slug", modelId)
+				.eq("is_enabled", true)
+				.maybeSingle(),
+			supabase
+				.from("data_api_models")
+				.select("api_model_id")
+				.eq("api_model_id", modelId)
+				.maybeSingle(),
+			supabase
+				.from("data_api_provider_models")
+				.select("model_id")
+				.eq("api_model_id", modelId)
+				.not("model_id", "is", null)
+				.limit(1),
+			supabase
+				.from("data_api_provider_models")
+				.select("api_model_id")
+				.eq("model_id", modelId)
+				.not("api_model_id", "is", null)
+				.limit(1),
+		]);
 
-		if (!redirectError && redirectRow?.model_id) {
-			const candidate = String(redirectRow.model_id).trim();
-			const mappedApiModelId = await resolveApiModelIdFromInternalModelId(
-				supabase,
-				candidate,
-			);
-			if (mappedApiModelId) {
-				return buildResult(mappedApiModelId, "redirect");
-			}
-			if (await apiModelExists(supabase, candidate)) {
-				return buildResult(candidate, "redirect");
-			}
-			if (await modelExistsVisible(supabase, candidate, includeHidden)) {
-				return buildResult(candidate, "redirect");
-			}
-		}
-	} catch (error) {
-		if (!isMissingRelationError(error)) {
-			console.warn("[resolveCanonicalModelId] redirect lookup failed", {
-				modelId,
-				error,
-			});
-		}
+	if (redirectRes.error) {
+		warnIfUnexpectedTableError("redirect lookup", modelId, redirectRes.error);
 	}
-
-	const { data: aliasRow, error: aliasError } = await supabase
-		.from("data_api_model_aliases")
-		.select("api_model_id")
-		.eq("alias_slug", modelId)
-		.eq("is_enabled", true)
-		.maybeSingle();
-
-	if (!aliasError && aliasRow?.api_model_id) {
-		const candidate = String(aliasRow.api_model_id).trim();
-		const internalModelId = await resolveVisibleInternalModelIdForApiModel(
-			supabase,
-			candidate,
-			includeHidden,
+	if (aliasRes.error) {
+		warnIfUnexpectedTableError("alias lookup", modelId, aliasRes.error);
+	}
+	if (apiModelRes.error) {
+		warnIfUnexpectedTableError("api model lookup", modelId, apiModelRes.error);
+	}
+	if (providerByApiRes.error) {
+		warnIfUnexpectedTableError(
+			"provider mapping (by api model) lookup",
+			modelId,
+			providerByApiRes.error,
 		);
-		if (internalModelId || (await apiModelExists(supabase, candidate))) {
-			return buildResult(candidate, "alias");
+	}
+	if (providerByModelRes.error) {
+		warnIfUnexpectedTableError(
+			"provider mapping (by internal model) lookup",
+			modelId,
+			providerByModelRes.error,
+		);
+	}
+
+	const redirectCandidate = normalizeId(redirectRes.data?.model_id);
+	if (redirectCandidate) {
+		const [
+			mappedApiModelId,
+			redirectCandidateVisible,
+			redirectCandidateIsApiModel,
+		] = await Promise.all([
+			getMappedApiModelIdForInternalModel(supabase, redirectCandidate),
+			getVisibleModelIds(supabase, [redirectCandidate], includeHidden),
+			redirectCandidate === modelId
+				? Promise.resolve(normalizeId(apiModelRes.data?.api_model_id) === modelId)
+				: apiModelExists(supabase, redirectCandidate),
+		]);
+
+		if (mappedApiModelId) {
+			return buildResult(mappedApiModelId, "redirect");
+		}
+		if (redirectCandidateIsApiModel) {
+			return buildResult(redirectCandidate, "redirect");
+		}
+		if (redirectCandidateVisible.has(redirectCandidate)) {
+			return buildResult(redirectCandidate, "redirect", redirectCandidate);
 		}
 	}
 
-	if (await apiModelExists(supabase, modelId)) {
+	const aliasCandidate = normalizeId(aliasRes.data?.api_model_id);
+	if (aliasCandidate) {
+		const [internalModelId, aliasApiExists] = await Promise.all([
+			resolveVisibleInternalModelIdForCanonical(
+				supabase,
+				aliasCandidate,
+				includeHidden,
+			),
+			aliasCandidate === modelId
+				? Promise.resolve(normalizeId(apiModelRes.data?.api_model_id) === modelId)
+				: apiModelExists(supabase, aliasCandidate),
+		]);
+		if (internalModelId || aliasApiExists) {
+			return buildResult(aliasCandidate, "alias", internalModelId);
+		}
+	}
+
+	if (normalizeId(apiModelRes.data?.api_model_id) === modelId) {
 		return buildResult(modelId, "api_model");
 	}
 
-	if (await providerMappingExistsForApiModel(supabase, modelId)) {
+	if ((providerByApiRes.data?.length ?? 0) > 0) {
 		return buildResult(modelId, "provider_mapping");
 	}
 
-	const mappedApiModelId = await resolveApiModelIdFromInternalModelId(
-		supabase,
-		modelId,
+	const mappedApiModelId = normalizeId(
+		providerByModelRes.data?.[0]?.api_model_id,
 	);
 	if (mappedApiModelId) {
 		return buildResult(mappedApiModelId, "legacy_internal_mapping");
@@ -249,15 +319,16 @@ async function resolveCanonicalModelIdCached(
 	"use cache";
 
 	cacheLife({
-		stale: 60 * 5,
-		revalidate: 60 * 60,
-		expire: 60 * 60 * 24,
+		stale: 60 * 60 * 24,
+		revalidate: 60 * 60 * 24 * 7,
+		expire: 60 * 60 * 24 * 30,
 	});
 	cacheTag("data:models");
 	cacheTag("data:model_aliases");
 	cacheTag("data:data_api_provider_models");
 	cacheTag("data:data_model_id_redirects");
 	cacheTag("data:data_api_models");
+	cacheTag(`model:canonical:${requestedModelId}`);
 
 	return resolveCanonicalModelIdUncached(requestedModelId, includeHidden);
 }


### PR DESCRIPTION
## Summary
- reduce model page fetch fanout by moving metadata identity lookups onto cached header/canonical helpers
- optimize canonical model resolution and model-header fallback chains to avoid redundant serial probes
- split model performance fetching by volatility:
  - full metrics fetcher for dashboard/performance views
  - lightweight activity snapshot fetcher for activity cards
- tune cache profiles by data volatility (heavier for stable model identity/details, shorter for gateway telemetry)
- narrow model-scoped API revalidation so single-model updates don't flush global API caches

## Scope
- model route metadata + shell fetch behavior
- model fetchers: canonical resolver, header, overview, performance
- cache revalidation tagging for model-scoped API updates

## Validation
- pnpm --filter @ai-stats/web typecheck

## Notes
- intentionally left unrelated local UI/logo changes out of this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * SEO metadata on model pages now consistently derives from model and organisation identity (removes prior fallback behavior).
  * Tab visibility logic simplified so tabs behave predictably across model states.
  * Model detail shell and page flows streamlined to rely on identity metadata.

* **New Features**
  * Activity section now shows an activity snapshot with provider uptime and cumulative tokens.
  * Playground and detail views use more stable model display names.

* **Chores**
  * Improved caching and cache-tagging for model-related data and revalidation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->