### PR TITLE
data(catalog): enrich qwen3.6-35b-a3b metadata

### DIFF
--- a/packages/data/catalog/src/data/models/qwen/qwen3.6-35b-a3b/model.json
+++ b/packages/data/catalog/src/data/models/qwen/qwen3.6-35b-a3b/model.json
@@ -4,15 +4,33 @@
   "name": "Qwen 3.6 35B A3B",
   "status": "Available",
   "previous_model_id": null,
-  "announced_date": null,
-  "release_date": null,
+  "announced_date": "2026-04-17T00:00:00",
+  "release_date": "2026-04-17T00:00:00",
   "deprecation_date": null,
   "retirement_date": null,
-  "license": null,
+  "license": "Apache 2.0",
   "input_types": "text,image,video",
   "output_types": "text",
   "api_model_id": "qwen/qwen3.6-35b-a3b",
-  "links": [],
-  "details": [],
+  "links": [
+    {
+      "platform": "announcement",
+      "url": "https://qwen.ai/blog?id=qwen3.6-35b-a3b"
+    },
+    {
+      "platform": "weights",
+      "url": "https://huggingface.co/Qwen/Qwen3.6-35B-A3B"
+    }
+  ],
+  "details": [
+    {
+      "name": "input_context_length",
+      "value": 262144
+    },
+    {
+      "name": "parameter_count",
+      "value": 35000000000
+    }
+  ],
   "benchmarks": []
 }


### PR DESCRIPTION
## Summary
- enrich metadata for qwen/qwen3.6-35b-a3b in the data catalog
- add release/announcement date, license, and source links
- add core technical details used in model views (input_context_length, parameter_count)

## Validation
- pnpm validate:data


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Model metadata has been updated with complete information, including license details (Apache 2.0), publication and announcement dates, resource documentation links, and technical specifications (input context length and parameter counts).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->