### PR TITLE
ci(web): deploy on Vercel to support sensitive env vars

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -452,8 +452,7 @@ jobs:
               if: ${{ env.VERCEL_PROJECT_ID != '' }}
               run: |
                   vercel pull --yes --environment=preview --git-branch="$GITHUB_HEAD_REF" --token=$VERCEL_TOKEN
-                  vercel build --token=$VERCEL_TOKEN
-                  vercel deploy --prebuilt --archive=tgz --token=$VERCEL_TOKEN
+                  vercel deploy --yes --archive=tgz --logs --token=$VERCEL_TOKEN
 
     deploy:
         runs-on: ubuntu-latest
@@ -507,8 +506,7 @@ jobs:
               if: ${{ matrix.target == 'web' && env.VERCEL_PROJECT_ID != '' }}
               run: |
                   vercel pull --yes --environment=production --token=$VERCEL_TOKEN
-                  vercel build --prod --token=$VERCEL_TOKEN
-                  vercel deploy --prebuilt --archive=tgz --prod --token=$VERCEL_TOKEN
+                  vercel deploy --yes --archive=tgz --prod --logs --token=$VERCEL_TOKEN
             # ---------- API (Cloudflare Workers) ----------
             # Install deps so wrangler can resolve imports
 


### PR DESCRIPTION
## Summary
- switch both web deploy jobs in CI from local prebuild (ercel build + ercel deploy --prebuilt) to Vercel-hosted builds (ercel deploy)
- keep ercel pull in place for project linking/context in both preview and production deploy paths
- enable --logs and --yes on deploy commands for CI-friendly output

## Why
- sensitive Vercel environment variables are non-readable when pulled locally, so local prebuilds in GitHub Actions were running without SUPABASE_SERVICE_ROLE_KEY
- building on Vercel allows sensitive vars to be available at build time, fixing the Missing SUPABASE_SERVICE_ROLE_KEY for admin Supabase client failure in Deploy Web

## Validation
- local verification of workflow diff only
- GitHub Actions should validate end-to-end on next CI run