### PR TITLE
Polish announcements pages and site notice details link

### DIFF
--- a/apps/web/src/app/(dashboard)/announcements/[slug]/page.tsx
+++ b/apps/web/src/app/(dashboard)/announcements/[slug]/page.tsx
@@ -2,9 +2,11 @@ import type { Metadata } from "next";
 import Link from "next/link";
 import { notFound } from "next/navigation";
 import { compileMDX } from "next-mdx-remote/rsc";
+import { ArrowLeft } from "lucide-react";
 import remarkGfm from "remark-gfm";
 import { announcementMdxComponents } from "@/components/announcements/announcementMdxComponents";
 import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
 import {
 	formatAnnouncementDate,
 	getAnnouncementParams,
@@ -66,14 +68,14 @@ export default async function AnnouncementPostPage({
 	});
 
 	return (
-		<div className="container mx-auto mt-10 mb-20 max-w-6xl px-4 sm:px-6 lg:px-8">
-			<article className="mx-auto w-full max-w-4xl space-y-6">
-				<Link
-					href="/announcements"
-					className="inline-flex text-sm font-medium text-zinc-600 transition hover:text-zinc-900 dark:text-zinc-400 dark:hover:text-zinc-100"
-				>
-					{"<-"} Back to announcements
-				</Link>
+		<div className="container mx-auto mt-10 mb-20 max-w-7xl px-4 sm:px-6 lg:px-8">
+			<article className="mx-auto w-full max-w-5xl space-y-6">
+				<Button asChild variant="ghost" size="sm" className="-ml-2 w-fit">
+					<Link href="/announcements">
+						<ArrowLeft className="h-4 w-4" />
+						Back to announcements
+					</Link>
+				</Button>
 
 				<header className="space-y-4">
 					<div className="flex flex-wrap items-center gap-2">
@@ -103,9 +105,9 @@ export default async function AnnouncementPostPage({
 					/>
 				) : null}
 
-				<div className="rounded-2xl border border-zinc-200 bg-white px-6 py-6 shadow-sm dark:border-zinc-800 dark:bg-zinc-950 md:px-10 md:py-8">
-					{content}
-				</div>
+				<hr className="border-zinc-200 dark:border-zinc-800" />
+
+				<div>{content}</div>
 			</article>
 		</div>
 	);

--- a/apps/web/src/app/(dashboard)/announcements/page.tsx
+++ b/apps/web/src/app/(dashboard)/announcements/page.tsx
@@ -15,15 +15,15 @@ import {
 import { buildMetadata } from "@/lib/seo";
 
 export const metadata: Metadata = buildMetadata({
-	title: "Announcements - Local MDX Blog",
+	title: "Announcements",
 	description:
-		"Read AI Stats announcements published from local MDX files. Add new posts directly in the web app repository with support for images and JSX components.",
+		"Official AI Stats announcements, release notes, and security updates.",
 	path: "/announcements",
 	keywords: [
 		"AI Stats announcements",
-		"MDX blog",
 		"product announcements",
 		"release notes",
+		"security updates",
 	],
 });
 
@@ -31,14 +31,15 @@ export default async function AnnouncementsPage() {
 	const posts = await getAnnouncementPosts();
 
 	return (
-		<div className="container mx-auto mt-10 mb-20 max-w-6xl px-4 sm:px-6 lg:px-8">
+		<div className="container mx-auto mt-10 mb-20 max-w-7xl px-4 sm:px-6 lg:px-8">
 			<div className="space-y-6">
 				<div className="space-y-2">
 					<h1 className="text-3xl font-semibold tracking-tight text-zinc-950 dark:text-zinc-50 sm:text-4xl">
 						Announcements
 					</h1>
 					<p className="max-w-2xl text-sm leading-7 text-zinc-600 dark:text-zinc-300">
-						Local MDX announcement posts rendered directly inside the web app.
+						Official product announcements, release notes, and security updates
+						from AI Stats.
 					</p>
 				</div>
 
@@ -46,18 +47,11 @@ export default async function AnnouncementsPage() {
 					<Card className="border-dashed">
 						<CardContent className="space-y-3 py-8 text-sm text-zinc-600 dark:text-zinc-400">
 							<p>No announcements yet.</p>
-							<p>
-								Add your first post in{" "}
-								<code className="rounded bg-zinc-100 px-1 py-0.5 dark:bg-zinc-800">
-									apps/web/src/content/announcements
-								</code>{" "}
-								using a <code className="rounded bg-zinc-100 px-1 py-0.5 dark:bg-zinc-800">.mdx</code>{" "}
-								file.
-							</p>
+							<p>New updates will appear here as they are published.</p>
 						</CardContent>
 					</Card>
 				) : (
-					<div className="grid grid-cols-1 gap-4 xl:grid-cols-2">
+					<div className="grid grid-cols-1 gap-4">
 						{posts.map((post) => (
 							<Card
 								key={post.slug}

--- a/apps/web/src/lib/content/announcements.ts
+++ b/apps/web/src/lib/content/announcements.ts
@@ -13,6 +13,10 @@ const ANNOUNCEMENTS_CONTENT_ROOT = path.join(
 	"announcements"
 );
 const SUPPORTED_EXTENSIONS = [".mdx", ".md"] as const;
+const EXCLUDED_ANNOUNCEMENT_SLUGS = new Set([
+	"readme",
+	"welcome-to-announcements",
+]);
 
 type AnnouncementFrontmatterInput = {
 	title?: unknown;
@@ -174,6 +178,10 @@ const loadAnnouncements = cache(async (): Promise<AnnouncementPost[]> => {
 
 			const filePath = path.join(ANNOUNCEMENTS_CONTENT_ROOT, entry.name);
 			const slug = entry.name.slice(0, -extension.length);
+			if (EXCLUDED_ANNOUNCEMENT_SLUGS.has(slug.toLowerCase())) {
+				return null;
+			}
+
 			const raw = await fs.readFile(filePath, "utf8");
 			const { frontmatter, content } = parseDocument(raw);
 

--- a/apps/web/src/lib/siteNotice.ts
+++ b/apps/web/src/lib/siteNotice.ts
@@ -16,7 +16,7 @@ export type SiteNotice = {
 };
 
 export const VERCEL_SECURITY_NOTICE_HREF =
-	"https://vercel.com/kb/bulletin/vercel-april-2026-security-incident";
+	"/announcements/security-notice-key-rotation-vercel-2026-04-19";
 
 export const SITE_NOTICES: SiteNotice[] = [
 	{


### PR DESCRIPTION
## Summary
- make announcements list and detail pages more public-facing and professional
- widen announcements layouts and enforce single-row cards on the list view
- improve announcement detail UX with a ghost back button + Lucide icon, and add a simple section separator
- hide internal/non-public announcement entries (`README`, `welcome-to-announcements`)
- point the site notice `Details` CTA to the published security announcement page

## Testing
- not run in this step (changes are UI/content wiring)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  - Repositioned Announcements as "Official AI Stats" resource with updated messaging and SEO metadata
  - Enhanced announcement detail page navigation styling and layout adjustments
  - Refined announcement grid layout for improved readability
  - Updated security notice link to direct to internal announcement page

<!-- end of auto-generated comment: release notes by coderabbit.ai -->