### PR TITLE
Add GPT Image 2 base model entry

### DIFF
--- a/packages/data/catalog/src/data/models/openai/gpt-image-2/model.json
+++ b/packages/data/catalog/src/data/models/openai/gpt-image-2/model.json
@@ -1,0 +1,18 @@
+{
+  "model_id": "openai/gpt-image-2",
+  "organisation_id": "openai",
+  "name": "GPT Image 2",
+  "status": "Available",
+  "previous_model_id": "openai/gpt-image-1.5",
+  "announced_date": "2026-04-21T00:00:00",
+  "release_date": "2026-04-21T00:00:00",
+  "deprecation_date": null,
+  "retirement_date": null,
+  "license": "Proprietary",
+  "input_types": "text,image",
+  "output_types": "image",
+  "api_model_id": "openai/gpt-image-2",
+  "links": [],
+  "details": [],
+  "benchmarks": []
+}

--- a/packages/data/catalog/src/data/models/openai/gpt-image-2/model.json
+++ b/packages/data/catalog/src/data/models/openai/gpt-image-2/model.json
@@ -2,7 +2,7 @@
   "model_id": "openai/gpt-image-2",
   "organisation_id": "openai",
   "name": "GPT Image 2",
-  "status": "Available",
+  "status": "Rumoured",
   "previous_model_id": "openai/gpt-image-1.5",
   "announced_date": "2026-04-21T00:00:00",
   "release_date": "2026-04-21T00:00:00",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added GPT Image 2 model to the catalog. The model processes text and image inputs to generate images. Currently listed with "Rumoured" status and an expected release date of April 21, 2026.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->