### PR TITLE
Add GPT Image 2 model mapping and pricing

### DIFF
--- a/apps/docs/v1/data-changelog.mdx
+++ b/apps/docs/v1/data-changelog.mdx
@@ -6,6 +6,12 @@ rss: true
 <Update label="21st April 2026">
 # Model Additions
 
+### OpenAI
+
+- [GPT Image 2](https://ai-stats.phaseo.app/models/openai/gpt-image-2)
+
+![GPT Image 2](../images/gpt-image-2.png)
+
 ### Qwen
 
 - [Qwen 3.6 Max Preview](https://ai-stats.phaseo.app/models/qwen/qwen3.6-max-preview)

--- a/packages/data/catalog/src/data/api_providers/openai/models.json
+++ b/packages/data/catalog/src/data/api_providers/openai/models.json
@@ -3661,7 +3661,7 @@
     "is_active_gateway": false,
     "quantization_scheme": null,
     "input_modalities": "text,image",
-    "output_modalities": "text,image",
+    "output_modalities": "image",
     "context_length": null,
     "max_output_tokens": null,
     "effective_from": "2026-04-21T00:00:00",

--- a/packages/data/catalog/src/data/api_providers/openai/models.json
+++ b/packages/data/catalog/src/data/api_providers/openai/models.json
@@ -3654,6 +3654,32 @@
     ]
   },
   {
+    "api_model_id": "openai/gpt-image-2",
+    "provider_api_model_id": "openai:openai/gpt-image-2",
+    "provider_model_slug": "gpt-image-2",
+    "internal_model_id": "openai/gpt-image-2",
+    "is_active_gateway": false,
+    "quantization_scheme": null,
+    "input_modalities": "text,image",
+    "output_modalities": "text,image",
+    "context_length": null,
+    "max_output_tokens": null,
+    "effective_from": "2026-04-21T00:00:00",
+    "effective_to": null,
+    "capabilities": [
+      {
+        "capability_id": "image.generate",
+        "status": "active",
+        "params": []
+      },
+      {
+        "capability_id": "image.edit",
+        "status": "active",
+        "params": []
+      }
+    ]
+  },
+  {
     "api_model_id": "openai/gpt-image-1-mini",
     "provider_api_model_id": "openai:openai/gpt-image-1-mini",
     "provider_model_slug": "gpt-image-1-mini",

--- a/packages/data/catalog/src/data/models/openai/gpt-image-2/model.json
+++ b/packages/data/catalog/src/data/models/openai/gpt-image-2/model.json
@@ -2,7 +2,7 @@
   "model_id": "openai/gpt-image-2",
   "organisation_id": "openai",
   "name": "GPT Image 2",
-  "status": "Rumoured",
+  "status": "Available",
   "previous_model_id": "openai/gpt-image-1.5",
   "announced_date": "2026-04-21T00:00:00",
   "release_date": "2026-04-21T00:00:00",
@@ -12,7 +12,12 @@
   "input_types": "text,image",
   "output_types": "image",
   "api_model_id": "openai/gpt-image-2",
-  "links": [],
+  "links": [
+    {
+      "platform": "pricing",
+      "url": "https://developers.openai.com/api/docs/pricing#image-generation"
+    }
+  ],
   "details": [],
   "benchmarks": []
 }

--- a/packages/data/catalog/src/data/pricing/openai/openai-gpt-image-2/images.edits/pricing.json
+++ b/packages/data/catalog/src/data/pricing/openai/openai-gpt-image-2/images.edits/pricing.json
@@ -1,0 +1,324 @@
+{
+  "key": "openai:openai/gpt-image-2:images.edits",
+  "api_provider_id": "openai",
+  "provider_slug": "openai",
+  "api_model_id": "openai/gpt-image-2",
+  "capability_id": "images.edits",
+  "rules": [
+    {
+      "meter": "input_text_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 5,
+      "currency": "USD",
+      "pricing_plan": "standard",
+      "note": null,
+      "match": [],
+      "priority": 100,
+      "effective_from": "2026-04-21T00:00:00"
+    },
+    {
+      "meter": "cached_read_text_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 1.25,
+      "currency": "USD",
+      "pricing_plan": "standard",
+      "note": null,
+      "match": [],
+      "priority": 100,
+      "effective_from": "2026-04-21T00:00:00"
+    },
+    {
+      "meter": "output_text_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 10,
+      "currency": "USD",
+      "pricing_plan": "standard",
+      "note": null,
+      "match": [],
+      "priority": 100,
+      "effective_from": "2026-04-21T00:00:00"
+    },
+    {
+      "meter": "input_image_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 8,
+      "currency": "USD",
+      "pricing_plan": "standard",
+      "note": null,
+      "match": [],
+      "priority": 100,
+      "effective_from": "2026-04-21T00:00:00"
+    },
+    {
+      "meter": "cached_read_image_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 2,
+      "currency": "USD",
+      "pricing_plan": "standard",
+      "note": null,
+      "match": [],
+      "priority": 100,
+      "effective_from": "2026-04-21T00:00:00"
+    },
+    {
+      "meter": "output_image_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 32,
+      "currency": "USD",
+      "pricing_plan": "standard",
+      "note": null,
+      "match": [],
+      "priority": 100,
+      "effective_from": "2026-04-21T00:00:00"
+    },
+    {
+      "meter": "output_image",
+      "unit": "image",
+      "unit_size": 1,
+      "price_per_unit": 0.009,
+      "currency": "USD",
+      "pricing_plan": "standard",
+      "note": null,
+      "match": [
+        {
+          "path": "image_params.quality",
+          "op": "eq",
+          "or_group": 1,
+          "and_index": 1,
+          "value": "low"
+        },
+        {
+          "path": "image_params.resolution",
+          "op": "eq",
+          "or_group": 1,
+          "and_index": 2,
+          "value": "1024x1024"
+        }
+      ],
+      "priority": 100,
+      "effective_from": "2026-04-21T00:00:00"
+    },
+    {
+      "meter": "output_image",
+      "unit": "image",
+      "unit_size": 1,
+      "price_per_unit": 0.013,
+      "currency": "USD",
+      "pricing_plan": "standard",
+      "note": null,
+      "match": [
+        {
+          "path": "image_params.quality",
+          "op": "eq",
+          "or_group": 1,
+          "and_index": 1,
+          "value": "low"
+        },
+        {
+          "path": "image_params.resolution",
+          "op": "eq",
+          "or_group": 1,
+          "and_index": 2,
+          "value": "1024x1536"
+        }
+      ],
+      "priority": 100,
+      "effective_from": "2026-04-21T00:00:00"
+    },
+    {
+      "meter": "output_image",
+      "unit": "image",
+      "unit_size": 1,
+      "price_per_unit": 0.013,
+      "currency": "USD",
+      "pricing_plan": "standard",
+      "note": null,
+      "match": [
+        {
+          "path": "image_params.quality",
+          "op": "eq",
+          "or_group": 1,
+          "and_index": 1,
+          "value": "low"
+        },
+        {
+          "path": "image_params.resolution",
+          "op": "eq",
+          "or_group": 1,
+          "and_index": 2,
+          "value": "1536x1024"
+        }
+      ],
+      "priority": 100,
+      "effective_from": "2026-04-21T00:00:00"
+    },
+    {
+      "meter": "output_image",
+      "unit": "image",
+      "unit_size": 1,
+      "price_per_unit": 0.034,
+      "currency": "USD",
+      "pricing_plan": "standard",
+      "note": null,
+      "match": [
+        {
+          "path": "image_params.quality",
+          "op": "eq",
+          "or_group": 1,
+          "and_index": 1,
+          "value": "medium"
+        },
+        {
+          "path": "image_params.resolution",
+          "op": "eq",
+          "or_group": 1,
+          "and_index": 2,
+          "value": "1024x1024"
+        }
+      ],
+      "priority": 100,
+      "effective_from": "2026-04-21T00:00:00"
+    },
+    {
+      "meter": "output_image",
+      "unit": "image",
+      "unit_size": 1,
+      "price_per_unit": 0.05,
+      "currency": "USD",
+      "pricing_plan": "standard",
+      "note": null,
+      "match": [
+        {
+          "path": "image_params.quality",
+          "op": "eq",
+          "or_group": 1,
+          "and_index": 1,
+          "value": "medium"
+        },
+        {
+          "path": "image_params.resolution",
+          "op": "eq",
+          "or_group": 1,
+          "and_index": 2,
+          "value": "1024x1536"
+        }
+      ],
+      "priority": 100,
+      "effective_from": "2026-04-21T00:00:00"
+    },
+    {
+      "meter": "output_image",
+      "unit": "image",
+      "unit_size": 1,
+      "price_per_unit": 0.05,
+      "currency": "USD",
+      "pricing_plan": "standard",
+      "note": null,
+      "match": [
+        {
+          "path": "image_params.quality",
+          "op": "eq",
+          "or_group": 1,
+          "and_index": 1,
+          "value": "medium"
+        },
+        {
+          "path": "image_params.resolution",
+          "op": "eq",
+          "or_group": 1,
+          "and_index": 2,
+          "value": "1536x1024"
+        }
+      ],
+      "priority": 100,
+      "effective_from": "2026-04-21T00:00:00"
+    },
+    {
+      "meter": "output_image",
+      "unit": "image",
+      "unit_size": 1,
+      "price_per_unit": 0.133,
+      "currency": "USD",
+      "pricing_plan": "standard",
+      "note": null,
+      "match": [
+        {
+          "path": "image_params.quality",
+          "op": "eq",
+          "or_group": 1,
+          "and_index": 1,
+          "value": "high"
+        },
+        {
+          "path": "image_params.resolution",
+          "op": "eq",
+          "or_group": 1,
+          "and_index": 2,
+          "value": "1024x1024"
+        }
+      ],
+      "priority": 100,
+      "effective_from": "2026-04-21T00:00:00"
+    },
+    {
+      "meter": "output_image",
+      "unit": "image",
+      "unit_size": 1,
+      "price_per_unit": 0.2,
+      "currency": "USD",
+      "pricing_plan": "standard",
+      "note": null,
+      "match": [
+        {
+          "path": "image_params.quality",
+          "op": "eq",
+          "or_group": 1,
+          "and_index": 1,
+          "value": "high"
+        },
+        {
+          "path": "image_params.resolution",
+          "op": "eq",
+          "or_group": 1,
+          "and_index": 2,
+          "value": "1024x1536"
+        }
+      ],
+      "priority": 100,
+      "effective_from": "2026-04-21T00:00:00"
+    },
+    {
+      "meter": "output_image",
+      "unit": "image",
+      "unit_size": 1,
+      "price_per_unit": 0.2,
+      "currency": "USD",
+      "pricing_plan": "standard",
+      "note": null,
+      "match": [
+        {
+          "path": "image_params.quality",
+          "op": "eq",
+          "or_group": 1,
+          "and_index": 1,
+          "value": "high"
+        },
+        {
+          "path": "image_params.resolution",
+          "op": "eq",
+          "or_group": 1,
+          "and_index": 2,
+          "value": "1536x1024"
+        }
+      ],
+      "priority": 100,
+      "effective_from": "2026-04-21T00:00:00"
+    }
+  ]
+}

--- a/packages/data/catalog/src/data/pricing/openai/openai-gpt-image-2/images.generations/pricing.json
+++ b/packages/data/catalog/src/data/pricing/openai/openai-gpt-image-2/images.generations/pricing.json
@@ -1,0 +1,324 @@
+{
+  "key": "openai:openai/gpt-image-2:images.generations",
+  "api_provider_id": "openai",
+  "provider_slug": "openai",
+  "api_model_id": "openai/gpt-image-2",
+  "capability_id": "images.generations",
+  "rules": [
+    {
+      "meter": "input_text_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 5,
+      "currency": "USD",
+      "pricing_plan": "standard",
+      "note": null,
+      "match": [],
+      "priority": 100,
+      "effective_from": "2026-04-21T00:00:00"
+    },
+    {
+      "meter": "cached_read_text_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 1.25,
+      "currency": "USD",
+      "pricing_plan": "standard",
+      "note": null,
+      "match": [],
+      "priority": 100,
+      "effective_from": "2026-04-21T00:00:00"
+    },
+    {
+      "meter": "output_text_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 10,
+      "currency": "USD",
+      "pricing_plan": "standard",
+      "note": null,
+      "match": [],
+      "priority": 100,
+      "effective_from": "2026-04-21T00:00:00"
+    },
+    {
+      "meter": "input_image_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 8,
+      "currency": "USD",
+      "pricing_plan": "standard",
+      "note": null,
+      "match": [],
+      "priority": 100,
+      "effective_from": "2026-04-21T00:00:00"
+    },
+    {
+      "meter": "cached_read_image_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 2,
+      "currency": "USD",
+      "pricing_plan": "standard",
+      "note": null,
+      "match": [],
+      "priority": 100,
+      "effective_from": "2026-04-21T00:00:00"
+    },
+    {
+      "meter": "output_image_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 32,
+      "currency": "USD",
+      "pricing_plan": "standard",
+      "note": null,
+      "match": [],
+      "priority": 100,
+      "effective_from": "2026-04-21T00:00:00"
+    },
+    {
+      "meter": "output_image",
+      "unit": "image",
+      "unit_size": 1,
+      "price_per_unit": 0.009,
+      "currency": "USD",
+      "pricing_plan": "standard",
+      "note": null,
+      "match": [
+        {
+          "path": "image_params.quality",
+          "op": "eq",
+          "or_group": 1,
+          "and_index": 1,
+          "value": "low"
+        },
+        {
+          "path": "image_params.resolution",
+          "op": "eq",
+          "or_group": 1,
+          "and_index": 2,
+          "value": "1024x1024"
+        }
+      ],
+      "priority": 100,
+      "effective_from": "2026-04-21T00:00:00"
+    },
+    {
+      "meter": "output_image",
+      "unit": "image",
+      "unit_size": 1,
+      "price_per_unit": 0.013,
+      "currency": "USD",
+      "pricing_plan": "standard",
+      "note": null,
+      "match": [
+        {
+          "path": "image_params.quality",
+          "op": "eq",
+          "or_group": 1,
+          "and_index": 1,
+          "value": "low"
+        },
+        {
+          "path": "image_params.resolution",
+          "op": "eq",
+          "or_group": 1,
+          "and_index": 2,
+          "value": "1024x1536"
+        }
+      ],
+      "priority": 100,
+      "effective_from": "2026-04-21T00:00:00"
+    },
+    {
+      "meter": "output_image",
+      "unit": "image",
+      "unit_size": 1,
+      "price_per_unit": 0.013,
+      "currency": "USD",
+      "pricing_plan": "standard",
+      "note": null,
+      "match": [
+        {
+          "path": "image_params.quality",
+          "op": "eq",
+          "or_group": 1,
+          "and_index": 1,
+          "value": "low"
+        },
+        {
+          "path": "image_params.resolution",
+          "op": "eq",
+          "or_group": 1,
+          "and_index": 2,
+          "value": "1536x1024"
+        }
+      ],
+      "priority": 100,
+      "effective_from": "2026-04-21T00:00:00"
+    },
+    {
+      "meter": "output_image",
+      "unit": "image",
+      "unit_size": 1,
+      "price_per_unit": 0.034,
+      "currency": "USD",
+      "pricing_plan": "standard",
+      "note": null,
+      "match": [
+        {
+          "path": "image_params.quality",
+          "op": "eq",
+          "or_group": 1,
+          "and_index": 1,
+          "value": "medium"
+        },
+        {
+          "path": "image_params.resolution",
+          "op": "eq",
+          "or_group": 1,
+          "and_index": 2,
+          "value": "1024x1024"
+        }
+      ],
+      "priority": 100,
+      "effective_from": "2026-04-21T00:00:00"
+    },
+    {
+      "meter": "output_image",
+      "unit": "image",
+      "unit_size": 1,
+      "price_per_unit": 0.05,
+      "currency": "USD",
+      "pricing_plan": "standard",
+      "note": null,
+      "match": [
+        {
+          "path": "image_params.quality",
+          "op": "eq",
+          "or_group": 1,
+          "and_index": 1,
+          "value": "medium"
+        },
+        {
+          "path": "image_params.resolution",
+          "op": "eq",
+          "or_group": 1,
+          "and_index": 2,
+          "value": "1024x1536"
+        }
+      ],
+      "priority": 100,
+      "effective_from": "2026-04-21T00:00:00"
+    },
+    {
+      "meter": "output_image",
+      "unit": "image",
+      "unit_size": 1,
+      "price_per_unit": 0.05,
+      "currency": "USD",
+      "pricing_plan": "standard",
+      "note": null,
+      "match": [
+        {
+          "path": "image_params.quality",
+          "op": "eq",
+          "or_group": 1,
+          "and_index": 1,
+          "value": "medium"
+        },
+        {
+          "path": "image_params.resolution",
+          "op": "eq",
+          "or_group": 1,
+          "and_index": 2,
+          "value": "1536x1024"
+        }
+      ],
+      "priority": 100,
+      "effective_from": "2026-04-21T00:00:00"
+    },
+    {
+      "meter": "output_image",
+      "unit": "image",
+      "unit_size": 1,
+      "price_per_unit": 0.133,
+      "currency": "USD",
+      "pricing_plan": "standard",
+      "note": null,
+      "match": [
+        {
+          "path": "image_params.quality",
+          "op": "eq",
+          "or_group": 1,
+          "and_index": 1,
+          "value": "high"
+        },
+        {
+          "path": "image_params.resolution",
+          "op": "eq",
+          "or_group": 1,
+          "and_index": 2,
+          "value": "1024x1024"
+        }
+      ],
+      "priority": 100,
+      "effective_from": "2026-04-21T00:00:00"
+    },
+    {
+      "meter": "output_image",
+      "unit": "image",
+      "unit_size": 1,
+      "price_per_unit": 0.2,
+      "currency": "USD",
+      "pricing_plan": "standard",
+      "note": null,
+      "match": [
+        {
+          "path": "image_params.quality",
+          "op": "eq",
+          "or_group": 1,
+          "and_index": 1,
+          "value": "high"
+        },
+        {
+          "path": "image_params.resolution",
+          "op": "eq",
+          "or_group": 1,
+          "and_index": 2,
+          "value": "1024x1536"
+        }
+      ],
+      "priority": 100,
+      "effective_from": "2026-04-21T00:00:00"
+    },
+    {
+      "meter": "output_image",
+      "unit": "image",
+      "unit_size": 1,
+      "price_per_unit": 0.2,
+      "currency": "USD",
+      "pricing_plan": "standard",
+      "note": null,
+      "match": [
+        {
+          "path": "image_params.quality",
+          "op": "eq",
+          "or_group": 1,
+          "and_index": 1,
+          "value": "high"
+        },
+        {
+          "path": "image_params.resolution",
+          "op": "eq",
+          "or_group": 1,
+          "and_index": 2,
+          "value": "1536x1024"
+        }
+      ],
+      "priority": 100,
+      "effective_from": "2026-04-21T00:00:00"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add OpenAI provider mapping for `openai/gpt-image-2`
- add `images.generations` pricing for GPT Image 2
- add `images.edits` pricing for GPT Image 2
- update GPT Image 2 model metadata linkage

## Validation
- `pnpm validate:data`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new OpenAI image-capable model that accepts text and image inputs and produces image outputs.
  * Enabled image generation and image editing capabilities; model status set to Available.
  * Configured tiered pricing for image generations and edits (quality/resolution-based), effective April 21, 2026.

* **Documentation**
  * Added a public changelog entry announcing the new model.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->