### PR TITLE
Fix missing workspace list in settings

### DIFF
--- a/apps/web/src/app/(dashboard)/settings/teams/teamsData.ts
+++ b/apps/web/src/app/(dashboard)/settings/teams/teamsData.ts
@@ -65,9 +65,10 @@ export async function getTeamsSettingsData() {
 		}
 	}
 
-	const workspaceIds = uniqueStrings(
-		(membershipRows ?? []).map((row: any) => row?.workspace_id),
-	);
+	const workspaceIds = uniqueStrings([
+		...(membershipRows ?? []).map((row: any) => row?.workspace_id),
+		personalTeamId,
+	]);
 
 	let teams: Array<{ id: string; name: string }> = [];
 	if (workspaceIds.length) {
@@ -75,18 +76,13 @@ export async function getTeamsSettingsData() {
 			.from("workspaces")
 			.select("id, name")
 			.in("id", workspaceIds);
-		if (!error) teams = data ?? [];
-	}
-	if (!teams.length) {
-		const { data, error } = await readClient
-			.from("workspaces")
-			.select("id, name");
 		if (!error) {
 			teams = data ?? [];
 		} else {
 			const { data: legacyTeams } = await (readClient as any)
 				.from("teams")
-				.select("id, name");
+				.select("id, name")
+				.in("id", workspaceIds);
 			teams = legacyTeams ?? [];
 		}
 	}

--- a/apps/web/src/app/(dashboard)/settings/teams/teamsData.ts
+++ b/apps/web/src/app/(dashboard)/settings/teams/teamsData.ts
@@ -3,10 +3,21 @@ import { createAdminClient } from "@/utils/supabase/admin";
 import { getWorkspaceIdFromCookie } from "@/utils/workspaceCookie";
 import type { TeamSsoSettingsRow } from "@/lib/auth/teamSsoSettings";
 
+function uniqueStrings(values: Array<string | null | undefined>): string[] {
+	return Array.from(new Set(values.filter(Boolean) as string[]));
+}
+
 export async function getTeamsSettingsData() {
 	const supabase = await createClient();
+	let adminClient: ReturnType<typeof createAdminClient> | null = null;
+	try {
+		adminClient = createAdminClient();
+	} catch {
+		adminClient = null;
+	}
 
-	// current user
+	const readClient: any = adminClient ?? supabase;
+
 	const {
 		data: { user },
 	} = await supabase.auth.getUser();
@@ -15,54 +26,102 @@ export async function getTeamsSettingsData() {
 	let personalTeamId: string | null = null;
 
 	if (userId) {
-		const { data: userRow } = await supabase
+		const { data: userRow, error: userRowError } = await readClient
 			.from("users")
 			.select("default_workspace_id")
 			.eq("user_id", userId)
 			.maybeSingle();
 
-		personalTeamId = userRow?.default_workspace_id ?? null;
+		if (!userRowError) {
+			personalTeamId = userRow?.default_workspace_id ?? null;
+		} else {
+			const { data: legacyUserRow } = await (readClient as any)
+				.from("users")
+				.select("default_team_id")
+				.eq("user_id", userId)
+				.maybeSingle();
+			personalTeamId = legacyUserRow?.default_team_id ?? null;
+		}
 	}
 
-	// ── Fetch (unchanged queries; normalize later)
-	const { data: teams } = await supabase.from("workspaces").select("id, name");
+	let membershipRows: any[] = [];
+	if (userId) {
+		const { data, error } = await readClient
+			.from("workspace_members")
+			.select("workspace_id, user_id, role")
+			.eq("user_id", userId);
+		if (!error) {
+			membershipRows = data ?? [];
+		} else {
+			const { data: legacyMembershipRows } = await (readClient as any)
+				.from("team_members")
+				.select("team_id, user_id, role")
+				.eq("user_id", userId);
+			membershipRows = (legacyMembershipRows ?? []).map((row: any) => ({
+				workspace_id: row?.team_id,
+				user_id: row?.user_id,
+				role: row?.role,
+			}));
+		}
+	}
+
+	const workspaceIds = uniqueStrings(
+		(membershipRows ?? []).map((row: any) => row?.workspace_id),
+	);
+
+	let teams: Array<{ id: string; name: string }> = [];
+	if (workspaceIds.length) {
+		const { data, error } = await readClient
+			.from("workspaces")
+			.select("id, name")
+			.in("id", workspaceIds);
+		if (!error) teams = data ?? [];
+	}
+	if (!teams.length) {
+		const { data, error } = await readClient
+			.from("workspaces")
+			.select("id, name");
+		if (!error) {
+			teams = data ?? [];
+		} else {
+			const { data: legacyTeams } = await (readClient as any)
+				.from("teams")
+				.select("id, name");
+			teams = legacyTeams ?? [];
+		}
+	}
 
 	let teamMembers: any[] = [];
 	const usersById: Record<string, any> = {};
-	if (userId) {
-		const { data: membershipRows } = await supabase
+	if (workspaceIds.length) {
+		const { data, error } = await readClient
 			.from("workspace_members")
-			.select("workspace_id")
-			.eq("user_id", userId);
-		const workspaceIds = Array.from(
-			new Set(
-				(membershipRows ?? [])
-					.map((row: any) => row?.workspace_id)
-					.filter(Boolean),
-			),
-		) as string[];
+			.select("workspace_id, user_id, role")
+			.in("workspace_id", workspaceIds);
+		if (!error) {
+			teamMembers = data ?? [];
+		} else {
+			const { data: legacyMembers } = await (readClient as any)
+				.from("team_members")
+				.select("team_id, user_id, role")
+				.in("team_id", workspaceIds);
+			teamMembers = (legacyMembers ?? []).map((row: any) => ({
+				workspace_id: row?.team_id,
+				user_id: row?.user_id,
+				role: row?.role,
+			}));
+		}
 
-		if (workspaceIds.length) {
-			const admin = createAdminClient();
-			const { data: memberRows } = await admin
-				.from("workspace_members")
-				.select("workspace_id, user_id, role")
-				.in("workspace_id", workspaceIds);
-			teamMembers = memberRows ?? [];
-
-			const memberUserIds = Array.from(
-				new Set(
-					(teamMembers ?? []).map((m: any) => m?.user_id).filter(Boolean),
-				),
-			);
-			if (memberUserIds.length) {
-				const { data: users } = await admin
-					.from("users")
-					.select("user_id, display_name")
-					.in("user_id", memberUserIds as string[]);
-				for (const u of users ?? []) {
-					if (u?.user_id) usersById[u.user_id] = u;
-				}
+		const memberUserIds = uniqueStrings(
+			(teamMembers ?? []).map((member: any) => member?.user_id),
+		);
+		if (memberUserIds.length) {
+			const { data: users } = await readClient
+				.from("users")
+				.select("user_id, display_name")
+				.in("user_id", memberUserIds);
+			for (const u of users ?? []) {
+				if (u?.user_id) usersById[u.user_id] = u;
 			}
 		}
 	}
@@ -70,59 +129,124 @@ export async function getTeamsSettingsData() {
 	const sevenDaysAgoIso = new Date(
 		Date.now() - 7 * 24 * 60 * 60 * 1000,
 	).toISOString();
-	const { data: teamInvites } = await supabase
-		.from("workspace_invites")
-		.select("*, users(display_name)")
-		.or(`expires_at.is.null,expires_at.gte.${sevenDaysAgoIso}`);
 
-	const { data: teamJoinRequests } = await supabase
-		.from("workspace_join_requests")
-		.select(
-			`
-			id,
-			workspace_id,
-			requester_user_id,
-			status,
-			created_at,
-			decided_at,
-			teams:workspaces ( name ),
-			requester:users!workspace_join_requests_requester_user_id_fkey (
-				user_id,
-				display_name
-			),
-			decider:users!workspace_join_requests_decided_by_fkey (
-				user_id,
-				display_name
+	let teamInvites: any[] = [];
+	if (workspaceIds.length) {
+		const { data, error } = await readClient
+			.from("workspace_invites")
+			.select("*, users(display_name)")
+			.in("workspace_id", workspaceIds);
+		if (!error) {
+			teamInvites = data ?? [];
+		} else {
+			const { data: legacyInvites } = await (readClient as any)
+				.from("team_invites")
+				.select("*, users(display_name)")
+				.in("team_id", workspaceIds);
+			teamInvites = (legacyInvites ?? []).map((row: any) => ({
+				...row,
+				workspace_id: row?.team_id,
+			}));
+		}
+	}
+
+	let teamJoinRequests: any[] = [];
+	if (workspaceIds.length) {
+		const { data, error } = await readClient
+			.from("workspace_join_requests")
+			.select(
+				"id, workspace_id, requester_user_id, status, created_at, decided_at, decided_by, invite_id",
 			)
-		`,
-		)
-		.or(`decided_at.is.null,decided_at.gte.${sevenDaysAgoIso}`);
+			.in("workspace_id", workspaceIds);
+		if (!error) {
+			teamJoinRequests = data ?? [];
+		} else {
+			const { data: legacyRequests } = await (readClient as any)
+				.from("team_join_requests")
+				.select(
+					"id, team_id, requester_user_id, status, created_at, decided_at, decided_by, invite_id",
+				)
+				.in("team_id", workspaceIds);
+			teamJoinRequests = (legacyRequests ?? []).map((row: any) => ({
+				...row,
+				workspace_id: row?.team_id,
+			}));
+		}
+	}
 
-	// ── Normalize
 	const teamsArray = teams ?? [];
-	const membersArray = (teamMembers ?? []).map((m: any) => ({
-		...m,
-		display_name: usersById[m.user_id]?.display_name ?? null,
+	const membersArray = (teamMembers ?? []).map((member: any) => ({
+		...member,
+		display_name: usersById[member.user_id]?.display_name ?? null,
 	}));
-	const invitesArray = teamInvites ?? [];
-	const requestsArray = teamJoinRequests ?? [];
+	const invitesArray = (teamInvites ?? []).filter((invite: any) => {
+		if (!invite?.expires_at) return true;
+		return new Date(invite.expires_at).toISOString() >= sevenDaysAgoIso;
+	});
+
+	const requestUserIds = uniqueStrings(
+		(teamJoinRequests ?? []).flatMap((row: any) => [
+			row?.requester_user_id,
+			row?.decided_by,
+		]),
+	);
+
+	const missingRequestUserIds = requestUserIds.filter((id) => !usersById[id]);
+	if (missingRequestUserIds.length) {
+		const { data: requestUsers } = await readClient
+			.from("users")
+			.select("user_id, display_name")
+			.in("user_id", missingRequestUserIds);
+		for (const userRow of requestUsers ?? []) {
+			if (userRow?.user_id) usersById[userRow.user_id] = userRow;
+		}
+	}
+
+	const teamNameById = Object.fromEntries(
+		teamsArray.map((team) => [team.id, team.name]),
+	) as Record<string, string>;
+
+	const requestsArray = (teamJoinRequests ?? [])
+		.filter((request: any) => {
+			if (!request?.decided_at) return true;
+			return new Date(request.decided_at).toISOString() >= sevenDaysAgoIso;
+		})
+		.map((request: any) => ({
+			...request,
+			teams: {
+				name: teamNameById[request.workspace_id] ?? "Workspace",
+			},
+			requester: request.requester_user_id
+				? {
+						user_id: request.requester_user_id,
+						display_name:
+							usersById[request.requester_user_id]?.display_name ?? null,
+				  }
+				: null,
+			decider: request.decided_by
+				? {
+						user_id: request.decided_by,
+						display_name: usersById[request.decided_by]?.display_name ?? null,
+				  }
+				: null,
+		}));
 
 	const membersByTeam: Record<string, any[]> = {};
-	for (const m of membersArray) {
-		if (!m?.workspace_id) continue;
-		(membersByTeam[m.workspace_id] ||= []).push(m);
+	for (const member of membersArray) {
+		if (!member?.workspace_id) continue;
+		(membersByTeam[member.workspace_id] ||= []).push(member);
 	}
 
 	const invitesByTeam: Record<string, any[]> = {};
-	for (const i of invitesArray) {
-		if (!i?.workspace_id) continue;
-		(invitesByTeam[i.workspace_id] ||= []).push(i);
+	for (const invite of invitesArray) {
+		if (!invite?.workspace_id) continue;
+		(invitesByTeam[invite.workspace_id] ||= []).push(invite);
 	}
 
 	const requestsByTeam: Record<string, any[]> = {};
-	for (const r of requestsArray) {
-		if (!r?.workspace_id) continue;
-		(requestsByTeam[r.workspace_id] ||= []).push(r);
+	for (const request of requestsArray) {
+		if (!request?.workspace_id) continue;
+		(requestsByTeam[request.workspace_id] ||= []).push(request);
 	}
 
 	const initialTeamId = await getWorkspaceIdFromCookie();
@@ -146,7 +270,7 @@ export async function getTeamsSettingsData() {
 
 	const walletBalances: Record<string, number> = {};
 	if (teamsArray.length) {
-		const { data: wallets } = await supabase
+		const { data: wallets } = await readClient
 			.from("wallets")
 			.select("workspace_id,balance_nanos")
 			.in(
@@ -164,7 +288,7 @@ export async function getTeamsSettingsData() {
 
 	const teamSsoSettingsByTeam: Record<string, TeamSsoSettingsRow> = {};
 	if (teamsArray.length) {
-		const { data: settingsRows } = await supabase
+		const { data: settingsRows } = await readClient
 			.from("workspace_settings")
 			.select(
 				"workspace_id,sso_enabled,sso_enforced,sso_mode,sso_provider_identifier,sso_domains",
@@ -202,4 +326,3 @@ export async function getTeamsSettingsData() {
 		teamSsoSettingsByTeam,
 	};
 }
-

--- a/apps/web/src/components/header/AuthControls.tsx
+++ b/apps/web/src/components/header/AuthControls.tsx
@@ -1,6 +1,7 @@
 // components/header/AuthControls.tsx  (SERVER COMPONENT)
 import { cookies } from "next/headers";
 import { createClient } from "@/utils/supabase/server";
+import { createAdminClient } from "@/utils/supabase/admin";
 import HeaderClient from "./HeaderClient";
 
 export default async function AuthControls({
@@ -9,6 +10,13 @@ export default async function AuthControls({
 	variant?: "mobile" | "desktop";
 }) {
 	const supabase = await createClient();
+	let adminClient: ReturnType<typeof createAdminClient> | null = null;
+	try {
+		adminClient = createAdminClient();
+	} catch {
+		adminClient = null;
+	}
+	const readClient: any = adminClient ?? supabase;
 
 	// supabase.auth.getUser() returns { data: { user } }
 	const { data: getUserData } = await supabase.auth.getUser();
@@ -18,6 +26,8 @@ export default async function AuthControls({
 	let currentTeamId: string | undefined = undefined;
 	// fetch user role from users table (if available)
 	let userRole: string | undefined = undefined;
+	let defaultWorkspaceId: string | undefined = undefined;
+	let membershipWorkspaceIds: string[] = [];
 
 	try {
 		const cookieStore = await cookies();
@@ -29,19 +39,63 @@ export default async function AuthControls({
 		// Regardless of cookie, if we have a logged-in user try to fetch their role
 		if (user) {
 			try {
-				const u = await supabase
+				const u = await readClient
 					.from("users")
 					.select("default_workspace_id, role")
 					.eq("user_id", user.id)
 					.single();
 
 				if (!u.error && u.data) {
-					if (!currentTeamId && u.data.default_workspace_id) {
-						currentTeamId = String(u.data.default_workspace_id);
-					}
+					defaultWorkspaceId = String(
+						u.data.default_workspace_id ?? "",
+					).trim();
 					if (u.data.role) {
 						userRole = String(u.data.role);
 					}
+				} else {
+					const legacy = await (readClient as any)
+						.from("users")
+						.select("default_team_id, role")
+						.eq("user_id", user.id)
+						.single();
+					if (!legacy.error && legacy.data) {
+						defaultWorkspaceId = String(
+							legacy.data.default_team_id ?? "",
+						).trim();
+						if (legacy.data.role) {
+							userRole = String(legacy.data.role);
+						}
+					}
+				}
+
+				const memberships = await readClient
+					.from("workspace_members")
+					.select("workspace_id")
+					.eq("user_id", user.id);
+				if (!memberships.error) {
+					membershipWorkspaceIds = Array.from(
+						new Set(
+							(memberships.data ?? [])
+								.map((row: any) =>
+									String(row?.workspace_id ?? "").trim(),
+								)
+								.filter(Boolean),
+						),
+					);
+				} else {
+					const legacyMemberships = await (readClient as any)
+						.from("team_members")
+						.select("team_id")
+						.eq("user_id", user.id);
+					membershipWorkspaceIds = Array.from(
+						new Set(
+							(legacyMemberships.data ?? [])
+								.map((row: any) =>
+									String(row?.team_id ?? "").trim(),
+								)
+								.filter(Boolean),
+						),
+					);
 				}
 			} catch {
 				// ignore
@@ -67,17 +121,63 @@ export default async function AuthControls({
 	// Fetch teams for the team switcher. If the table doesn't exist, return empty array.
 	let teams: { id: string; name: string }[] = [];
 	try {
-		const res = await supabase.from("workspaces").select("id, name");
-		const data = res.data as any[] | null;
-		const error = res.error;
-		if (!error && Array.isArray(data)) {
-			teams = data.map((d) => ({
-				id: String(d.id),
-				name: String(d.name),
-			}));
+		if (membershipWorkspaceIds.length > 0) {
+			const scoped = await readClient
+				.from("workspaces")
+				.select("id, name")
+				.in("id", membershipWorkspaceIds);
+			if (!scoped.error && Array.isArray(scoped.data)) {
+				teams = scoped.data.map((row: any) => ({
+					id: String(row.id),
+					name: String(row.name),
+				}));
+			} else {
+				const legacyScoped = await (readClient as any)
+					.from("teams")
+					.select("id, name")
+					.in("id", membershipWorkspaceIds);
+				if (!legacyScoped.error && Array.isArray(legacyScoped.data)) {
+					teams = legacyScoped.data.map((row: any) => ({
+						id: String(row.id),
+						name: String(row.name),
+					}));
+				}
+			}
+		}
+
+		if (teams.length === 0) {
+			const res = await readClient.from("workspaces").select("id, name");
+			const data = res.data as any[] | null;
+			const error = res.error;
+			if (!error && Array.isArray(data)) {
+				teams = data.map((d) => ({
+					id: String(d.id),
+					name: String(d.name),
+				}));
+			} else {
+				const legacyRes = await (readClient as any)
+					.from("teams")
+					.select("id, name");
+				if (!legacyRes.error && Array.isArray(legacyRes.data)) {
+					teams = legacyRes.data.map((d: any) => ({
+						id: String(d.id),
+						name: String(d.name),
+					}));
+				}
+			}
 		}
 	} catch {
 		// ignore and keep teams empty
+	}
+
+	const teamIds = new Set(teams.map((team) => team.id));
+	const cookieTeamId = currentTeamId && teamIds.has(currentTeamId) ? currentTeamId : undefined;
+	if (cookieTeamId) {
+		currentTeamId = cookieTeamId;
+	} else if (defaultWorkspaceId && teamIds.has(defaultWorkspaceId)) {
+		currentTeamId = defaultWorkspaceId;
+	} else {
+		currentTeamId = teams[0]?.id;
 	}
 
 	// HeaderClient expects teams as array or undefined, not null


### PR DESCRIPTION
## Summary
- switch workspace settings data loader to membership-first fetch flow
- add robust fallback support between `workspace_*` and legacy `team_*` tables
- use admin client when available and gracefully degrade when service key is missing
- normalize requests/invites/member payloads without fragile embedded relationship lookups

## Validation
- `pnpm --filter @ai-stats/web typecheck`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved team/settings data loading with deduped workspace membership, batched reads, and normalized team/member/invite/request data for more reliable results.
* **Bug Fixes**
  * Added robust legacy fallbacks and safer read-client handling to avoid missing teams, users, or failures when admin access isn’t available.
* **UX**
  * More consistent current-team selection and expanded header auth metadata so workspace/team selection and invite/request displays are more accurate.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->