### PR TITLE
Fix provider list expansion reset and spacing jump

### DIFF
--- a/apps/web/src/components/(data)/model/pricing/ModelPricingClient.tsx
+++ b/apps/web/src/components/(data)/model/pricing/ModelPricingClient.tsx
@@ -597,7 +597,7 @@ export default function ModelPricingClient({
 
     useEffect(() => {
         setShowAllProviders(false);
-    }, [plan, quantizationFilter, sort, sortDirection]);
+    }, [plan, quantizationFilter]);
 
     useEffect(() => {
         try {
@@ -843,7 +843,7 @@ export default function ModelPricingClient({
                                         )}
                                     >
                                         <div className="overflow-hidden">
-                                            <div className="pt-3">
+                                            <div>
 												<div className="grid grid-cols-1 gap-3 md:grid-cols-2">
                                                     {extraProviders.map((prov) => (
                                                         <ProviderCard


### PR DESCRIPTION
## Summary
- keep the expanded provider list open when changing sort order or sort direction
- remove extra top padding before the expanded provider grid to eliminate the visible jump/gap

## Testing
- not run (repo eslint setup currently errors with eact/display-name / contextOrFilename.getFilename)
