### PR TITLE
fix(api): report first-frame latency separately from generation timing

### DIFF
--- a/apps/api/src/pipeline/after/streaming.test.ts
+++ b/apps/api/src/pipeline/after/streaming.test.ts
@@ -451,12 +451,12 @@ describe("passthroughWithPricing", () => {
 		});
 	});
 
-	it("records stream latency from request start and generation from first frame to final frame", async () => {
+	it("records stream latency from upstream start and generation as total upstream duration", async () => {
 		const ctx = baseCtx({
 			endpoint: "chat.completions",
 			protocol: "openai.chat.completions",
 			meta: {
-				startedAtMs: Date.now() - 40,
+				upstreamStartMs: Date.now() - 40,
 			},
 		});
 		const upstream = makeDelayedSseResponse([
@@ -488,7 +488,7 @@ describe("passthroughWithPricing", () => {
 		expect(typeof ctx.meta.generation_ms).toBe("number");
 		expect((ctx.meta.latency_ms as number)!).toBeGreaterThan(0);
 		expect((ctx.meta.generation_ms as number)!).toBeGreaterThanOrEqual(0);
-		expect((ctx.meta.latency_ms as number)!).toBeGreaterThan((ctx.meta.generation_ms as number)!);
+		expect((ctx.meta.generation_ms as number)!).toBeGreaterThanOrEqual((ctx.meta.latency_ms as number)!);
 	});
 
 	it("overwrites adapter latency with first downstream frame timing for streamed responses", async () => {
@@ -496,7 +496,7 @@ describe("passthroughWithPricing", () => {
 			endpoint: "chat.completions",
 			protocol: "openai.chat.completions",
 			meta: {
-				startedAtMs: Date.now() - 50,
+				upstreamStartMs: Date.now() - 50,
 				latency_ms: 1,
 			},
 		});
@@ -526,6 +526,6 @@ describe("passthroughWithPricing", () => {
 
 		expect(typeof ctx.meta.latency_ms).toBe("number");
 		expect((ctx.meta.latency_ms as number)!).toBeGreaterThan(1);
-		expect((ctx.meta.latency_ms as number)!).toBeGreaterThan((ctx.meta.generation_ms as number)!);
+		expect((ctx.meta.generation_ms as number)!).toBeGreaterThanOrEqual((ctx.meta.latency_ms as number)!);
 	});
 });

--- a/apps/api/src/pipeline/after/streaming.ts
+++ b/apps/api/src/pipeline/after/streaming.ts
@@ -78,6 +78,12 @@ export async function passthroughWithPricing(opts: PassthroughWithPricingOpts): 
         downstreamClosed = true;
     });
 
+    const resolveRequestStartMs = () => {
+        if (typeof ctx.meta.upstreamStartMs === "number") return ctx.meta.upstreamStartMs;
+        if (typeof ctx.meta.startedAtMs === "number") return ctx.meta.startedAtMs;
+        return null;
+    };
+
     // Write one SSE JSON object as "event: X\ndata: {...}\n\n" (event optional)
     const writeJson = async (obj: unknown, eventName?: string | null) => {
         if (downstreamClosed) return;
@@ -106,8 +112,11 @@ export async function passthroughWithPricing(opts: PassthroughWithPricingOpts): 
             });
         }
 
-        if (firstFrameAt !== null && typeof ctx.meta.generation_ms !== "number") {
-            ctx.meta.generation_ms = Math.round(performance.now() - firstFrameAt);
+        if (typeof ctx.meta.generation_ms !== "number") {
+            const requestStartMs = resolveRequestStartMs();
+            ctx.meta.generation_ms = requestStartMs !== null
+                ? Math.max(0, Math.round(Date.now() - requestStartMs))
+                : Math.max(0, Math.round(performance.now() - tStart));
         }
         dispatchBackground(
             Promise.resolve(
@@ -184,18 +193,14 @@ export async function passthroughWithPricing(opts: PassthroughWithPricingOpts): 
                     if (firstFrameAt === null) {
                         firstFrameAt = performance.now();
                         firstFrameAtMs = Date.now();
-                        // For streamed responses, latency must mean request start -> first frame returned
-                        // by the gateway. Provider adapters may record first upstream bytes earlier than
-                        // the first downstream frame we actually emit, so overwrite here deliberately.
-                        if (typeof ctx.meta.startedAtMs === "number") {
+                        // For streamed responses, latency means upstream request start -> first frame
+                        // emitted back to the client. Provider adapters may record earlier upstream
+                        // timings, so overwrite here with the actual downstream first-frame timing.
+                        const requestStartMs = resolveRequestStartMs();
+                        if (requestStartMs !== null) {
                             ctx.meta.latency_ms = Math.max(
                                 0,
-                                Math.round(firstFrameAtMs - ctx.meta.startedAtMs),
-                            );
-                        } else if (typeof ctx.meta.upstreamStartMs === "number") {
-                            ctx.meta.latency_ms = Math.max(
-                                0,
-                                Math.round(firstFrameAtMs - ctx.meta.upstreamStartMs),
+                                Math.round(firstFrameAtMs - requestStartMs),
                             );
                         } else {
                             ctx.meta.latency_ms = Math.max(0, Math.round(firstFrameAt - tStart));
@@ -256,11 +261,11 @@ export async function passthroughWithPricing(opts: PassthroughWithPricingOpts): 
 
                     if (isFinalSnapshot) {
                         sawFinalUsage = true;
-                        if (typeof ctx.meta.generation_ms !== "number" && firstFrameAt !== null) {
-                            ctx.meta.generation_ms = Math.max(
-                                0,
-                                Math.round(performance.now() - firstFrameAt),
-                            );
+                        if (typeof ctx.meta.generation_ms !== "number") {
+                            const requestStartMs = resolveRequestStartMs();
+                            ctx.meta.generation_ms = requestStartMs !== null
+                                ? Math.max(0, Math.round(Date.now() - requestStartMs))
+                                : Math.max(0, Math.round(performance.now() - tStart));
                         }
                     }
 

--- a/apps/api/src/pipeline/execute/attempt.ts
+++ b/apps/api/src/pipeline/execute/attempt.ts
@@ -68,6 +68,10 @@ export async function attemptProvider(
         ...ctx.meta,
         stream: ctx.meta.stream,
     } as ProviderExecuteArgs["meta"];
+    delete (meta as Record<string, unknown>).latency_ms;
+    delete (meta as Record<string, unknown>).generation_ms;
+    delete (ctx.meta as Record<string, unknown>).latency_ms;
+    delete (ctx.meta as Record<string, unknown>).generation_ms;
 
     await onCallStart(ctx.endpoint, adapter.name, baseModel);
 
@@ -115,11 +119,7 @@ export async function attemptProvider(
             ctx.meta.generation_ms = meta.generation_ms;
         }
 
-        if (typeof latencyMs === "number") {
-            ctx.meta.latency_ms = latencyMs;
-        } else if (typeof ctx.meta.latency_ms !== "number") {
-            ctx.meta.latency_ms = generationMs;
-        }
+        ctx.meta.latency_ms = typeof latencyMs === "number" ? latencyMs : generationMs;
 
         // Record adapter roundtrip if not already recorded (first adapter)
         if (timing.timer.snapshot().adapter_roundtrip_ms === undefined) {
@@ -241,11 +241,7 @@ export async function attemptProvider(
         if (!ctx.stream) {
             ctx.meta.generation_ms = generationMs;
         }
-        if (typeof latencyMs === "number") {
-            ctx.meta.latency_ms = latencyMs;
-        } else if (typeof ctx.meta.latency_ms !== "number") {
-            ctx.meta.latency_ms = generationMs;
-        }
+        ctx.meta.latency_ms = typeof latencyMs === "number" ? latencyMs : generationMs;
 
         await onCallEnd(ctx.endpoint, {
             provider: adapter.name,

--- a/apps/api/src/pipeline/execute/attempt.ts
+++ b/apps/api/src/pipeline/execute/attempt.ts
@@ -104,12 +104,10 @@ export async function attemptProvider(
         }
 
         const duration = Math.round(performance.now() - t0);
-        const endToEndMs = Math.round(timing.timer.elapsed("request_start"));
-        const latencyMs = typeof meta.latency_ms === "number" ? meta.latency_ms : undefined;
-        const generationMs = typeof meta.generation_ms === "number"
-            ? meta.generation_ms
-            : (latencyMs !== undefined ? Math.max(duration - latencyMs, 0) : duration);
-        const fallbackLatencyMs = endToEndMs - duration;
+        const latencyMs = typeof meta.latency_ms === "number"
+            ? Math.max(0, Math.min(Math.round(meta.latency_ms), duration))
+            : undefined;
+        const generationMs = duration;
 
         if (!ctx.stream) {
             ctx.meta.generation_ms = generationMs;
@@ -117,10 +115,10 @@ export async function attemptProvider(
             ctx.meta.generation_ms = meta.generation_ms;
         }
 
-        if (typeof meta.latency_ms === "number") {
-            ctx.meta.latency_ms = meta.latency_ms;
+        if (typeof latencyMs === "number") {
+            ctx.meta.latency_ms = latencyMs;
         } else if (typeof ctx.meta.latency_ms !== "number") {
-            ctx.meta.latency_ms = fallbackLatencyMs;
+            ctx.meta.latency_ms = generationMs;
         }
 
         // Record adapter roundtrip if not already recorded (first adapter)
@@ -147,7 +145,7 @@ export async function attemptProvider(
                     ...r.normalized.meta,
                     throughput_tps: throughputTps,
                     generation_ms: generationMs,
-                    latency_ms: ctx.meta.latency_ms ?? fallbackLatencyMs,
+                    latency_ms: ctx.meta.latency_ms ?? generationMs,
                     finish_reason: r.bill?.finish_reason ?? null,
                 };
             }
@@ -160,7 +158,7 @@ export async function attemptProvider(
                     ...responseJson.meta,
                     throughput_tps: throughputTps,
                     generation_ms: generationMs,
-                    latency_ms: ctx.meta.latency_ms ?? fallbackLatencyMs,
+                    latency_ms: ctx.meta.latency_ms ?? generationMs,
                     finish_reason: r.bill?.finish_reason ?? null,
                 };
                 r.upstream = new Response(JSON.stringify(responseJson), {
@@ -177,8 +175,8 @@ export async function attemptProvider(
                 provider: adapter.name,
                 model: baseModel,
                 ok: true,
-                latency_ms: endToEndMs,      // End-to-end request time for health monitoring
-                generation_ms: generationMs, // Time from first token to final for non-stream
+                latency_ms: ctx.meta.latency_ms ?? generationMs,
+                generation_ms: generationMs,
                 tokens_in: tokensIn,
                 tokens_out: tokensOut,
             });
@@ -235,27 +233,25 @@ export async function attemptProvider(
         }
 
         // Calculate timings for error case
-        const endToEndMs = Math.round(timing.timer.elapsed("request_start"));
-        const latencyMs = typeof meta.latency_ms === "number" ? meta.latency_ms : undefined;
-        const generationMs = typeof meta.generation_ms === "number"
-            ? meta.generation_ms
-            : (latencyMs !== undefined ? Math.max(duration - latencyMs, 0) : duration);
-        const fallbackLatencyMs = endToEndMs - generationMs;
+        const latencyMs = typeof meta.latency_ms === "number"
+            ? Math.max(0, Math.min(Math.round(meta.latency_ms), duration))
+            : undefined;
+        const generationMs = duration;
 
         if (!ctx.stream) {
             ctx.meta.generation_ms = generationMs;
         }
-        if (typeof meta.latency_ms === "number") {
-            ctx.meta.latency_ms = meta.latency_ms;
+        if (typeof latencyMs === "number") {
+            ctx.meta.latency_ms = latencyMs;
         } else if (typeof ctx.meta.latency_ms !== "number") {
-            ctx.meta.latency_ms = fallbackLatencyMs;
+            ctx.meta.latency_ms = generationMs;
         }
 
         await onCallEnd(ctx.endpoint, {
             provider: adapter.name,
             model: baseModel,
             ok: false,
-            latency_ms: endToEndMs,
+            latency_ms: ctx.meta.latency_ms ?? generationMs,
             generation_ms: generationMs,
         });
 

--- a/apps/api/src/pipeline/execute/index.ts
+++ b/apps/api/src/pipeline/execute/index.ts
@@ -454,6 +454,8 @@ async function attemptProviderWithIR(
 		t0 = performance.now();
 
 		ctx.meta.upstreamStartMs = Date.now();
+		delete (ctx.meta as Record<string, unknown>).latency_ms;
+		delete (ctx.meta as Record<string, unknown>).generation_ms;
 		const executor = resolveProviderExecutor(candidate.providerId, ctx.capability);
 		if (!executor) {
 			attemptErrors.push({
@@ -694,12 +696,13 @@ async function attemptProviderWithIR(
 			message,
 		});
 		const endToEndMs = Math.round(timing.timer.elapsed("request_start"));
+		const failureLatencyMs = Math.round(performance.now() - t0);
 		await onCallEnd(ctx.endpoint, {
 			provider: candidate.providerId,
 			model: baseModel,
 			ok: false,
-			latency_ms: ctx.meta.latency_ms ?? Math.round(performance.now() - t0),
-			generation_ms: ctx.meta.generation_ms ?? Math.round(performance.now() - t0),
+			latency_ms: ctx.meta.latency_ms ?? failureLatencyMs,
+			generation_ms: ctx.meta.generation_ms ?? failureLatencyMs,
 		});
 		if (isProbe) {
 			await reportProbeResult(ctx.endpoint, candidate.providerId, baseModel, false);

--- a/apps/api/src/pipeline/execute/index.ts
+++ b/apps/api/src/pipeline/execute/index.ts
@@ -251,9 +251,18 @@ export type IRRequestResult = {
 	byokKeyId?: string | null;
 	mappedRequest?: string;
 	rawResponse?: any;
+	timing?: {
+		latencyMs?: number;
+		generationMs?: number;
+	};
 };
 
 export type RequestResult = IRRequestResult;
+
+function normalizeTimingValue(value: number | null | undefined): number | undefined {
+	if (typeof value !== "number" || !Number.isFinite(value)) return undefined;
+	return Math.max(0, Math.round(value));
+}
 
 /**
  * Execute request using IR pipeline
@@ -550,17 +559,16 @@ async function attemptProviderWithIR(
 		};
 
 		const executorResult = await executeWithRetry();
-
-		if (executorResult.timing) {
-			if (typeof executorResult.timing.latencyMs === "number") {
-				ctx.meta.latency_ms = executorResult.timing.latencyMs;
-			}
-			if (typeof executorResult.timing.generationMs === "number") {
-				ctx.meta.generation_ms = executorResult.timing.generationMs;
-			}
-		}
 		timing.timer.end("adapter_start");
 		const generationTimeMs = Math.round(performance.now() - t0);
+		const normalizedLatencyMs = normalizeTimingValue(executorResult.timing?.latencyMs);
+
+		if (typeof normalizedLatencyMs === "number") {
+			ctx.meta.latency_ms = Math.min(normalizedLatencyMs, generationTimeMs);
+		}
+		if (!ctx.stream) {
+			ctx.meta.generation_ms = generationTimeMs;
+		}
 
 		const endToEndMs = Math.round(timing.timer.elapsed("request_start"));
 		const usageForMetrics = executorResult.kind === "completed"
@@ -591,7 +599,7 @@ async function attemptProviderWithIR(
 				provider: candidate.providerId,
 				model: baseModel,
 				ok: executorResult.upstream.ok,
-				latency_ms: endToEndMs,
+				latency_ms: ctx.meta.latency_ms ?? generationTimeMs,
 				generation_ms: ctx.meta.generation_ms ?? generationTimeMs,
 				tokens_in: tokensIn,
 				tokens_out: tokensOut,
@@ -640,6 +648,7 @@ async function attemptProviderWithIR(
 			byokKeyId: executorResult.byokKeyId,
 			mappedRequest: executorResult.mappedRequest,
 			rawResponse: executorResult.rawResponse,
+			timing: executorResult.timing,
 		};
 		(result as any).healthContext = {
 			provider: candidate.providerId,
@@ -689,7 +698,7 @@ async function attemptProviderWithIR(
 			provider: candidate.providerId,
 			model: baseModel,
 			ok: false,
-			latency_ms: endToEndMs,
+			latency_ms: ctx.meta.latency_ms ?? Math.round(performance.now() - t0),
 			generation_ms: ctx.meta.generation_ms ?? Math.round(performance.now() - t0),
 		});
 		if (isProbe) {

--- a/apps/api/src/pipeline/surfaces/server-tools.stream.ts
+++ b/apps/api/src/pipeline/surfaces/server-tools.stream.ts
@@ -460,16 +460,21 @@ export async function consumeTextProtocolStreamToIR(args: {
 	requestId: string;
 	model: string;
 	provider: string;
+	startedAtMs?: number;
 }): Promise<{
 	ir: IRChatResponse;
 	rawResponse: any;
 	usageRaw: any;
 	frameCount: number;
 	sawDone: boolean;
+	firstFrameMs: number | null;
+	totalMs: number | null;
 }> {
 	const reader = args.stream.getReader();
 	const decoder = new TextDecoder();
 	let buffer = "";
+	const materializeStartMs = Date.now();
+	let firstFrameMs: number | null = null;
 	let frameCount = 0;
 	let sawDone = false;
 	let lastPayload: any = null;
@@ -503,6 +508,10 @@ export async function consumeTextProtocolStreamToIR(args: {
 			}
 
 			frameCount += 1;
+			if (firstFrameMs === null) {
+				const baseStartedAt = args.startedAtMs ?? materializeStartMs;
+				firstFrameMs = Math.max(0, Date.now() - baseStartedAt);
+			}
 			lastPayload = payload;
 			const normalizedPayloadForMeta = resolveRawPayloadForUsage(payload);
 			nativeId = nativeId ?? resolveNativeId(normalizedPayloadForMeta);
@@ -586,6 +595,10 @@ export async function consumeTextProtocolStreamToIR(args: {
 			try {
 				const payload = JSON.parse(data);
 				frameCount += 1;
+				if (firstFrameMs === null) {
+					const baseStartedAt = args.startedAtMs ?? materializeStartMs;
+					firstFrameMs = Math.max(0, Date.now() - baseStartedAt);
+				}
 				lastPayload = payload;
 				const events = extractUnifiedStreamEvents({
 					protocol: args.protocol,
@@ -633,5 +646,7 @@ export async function consumeTextProtocolStreamToIR(args: {
 		usageRaw: effectiveUsageRaw,
 		frameCount,
 		sawDone,
+		firstFrameMs,
+		totalMs: Math.max(0, Date.now() - (args.startedAtMs ?? materializeStartMs)),
 	};
 }

--- a/apps/api/src/pipeline/surfaces/text-generate.ts
+++ b/apps/api/src/pipeline/surfaces/text-generate.ts
@@ -79,6 +79,7 @@ async function materializeStreamResultToCompleted(args: {
 	requestId: string;
 	model: string;
 	result: any;
+	startedAtMs?: number;
 }): Promise<any> {
 	const stream = args.result.stream ?? args.result.upstream?.body ?? null;
 	if (!stream) {
@@ -90,6 +91,7 @@ async function materializeStreamResultToCompleted(args: {
 		requestId: args.requestId,
 		model: args.model,
 		provider: args.result.provider,
+		startedAtMs: args.startedAtMs,
 	});
 	return {
 		...args.result,
@@ -98,6 +100,20 @@ async function materializeStreamResultToCompleted(args: {
 		stream: null,
 		usageFinalizer: null,
 		rawResponse: consumed.rawResponse,
+		generationTimeMs:
+			typeof consumed.totalMs === "number"
+				? consumed.totalMs
+				: args.result.generationTimeMs,
+		timing: {
+			latencyMs:
+				typeof consumed.firstFrameMs === "number"
+					? consumed.firstFrameMs
+					: args.result?.timing?.latencyMs,
+			generationMs:
+				typeof consumed.totalMs === "number"
+					? consumed.totalMs
+					: args.result?.timing?.generationMs,
+		},
 		bill: {
 			...args.result.bill,
 			usage:
@@ -194,7 +210,14 @@ export async function runTextGeneratePipeline(args: PipelineRunnerArgs): Promise
 					requestId: pre.ctx.requestId,
 					model: pre.ctx.model,
 					result: exec.result,
+					startedAtMs: pre.ctx.meta.upstreamStartMs ?? pre.ctx.meta.startedAtMs,
 				});
+				if (typeof exec.result?.timing?.latencyMs === "number") {
+					pre.ctx.meta.latency_ms = exec.result.timing.latencyMs;
+				}
+				if (typeof exec.result?.timing?.generationMs === "number") {
+					pre.ctx.meta.generation_ms = exec.result.timing.generationMs;
+				}
 			} catch (error) {
 				const header = timing.timer.header();
 				pre.ctx.timing = timing.timer.snapshot();
@@ -285,7 +308,14 @@ export async function runTextGeneratePipeline(args: PipelineRunnerArgs): Promise
 							requestId: pre.ctx.requestId,
 							model: pre.ctx.model,
 							result: followUpResult,
+							startedAtMs: pre.ctx.meta.upstreamStartMs ?? pre.ctx.meta.startedAtMs,
 						});
+						if (typeof followUpResult?.timing?.latencyMs === "number") {
+							pre.ctx.meta.latency_ms = followUpResult.timing.latencyMs;
+						}
+						if (typeof followUpResult?.timing?.generationMs === "number") {
+							pre.ctx.meta.generation_ms = followUpResult.timing.generationMs;
+						}
 					} catch (error) {
 						const header = timing.timer.header();
 						pre.ctx.timing = timing.timer.snapshot();


### PR DESCRIPTION
## Summary
- separate `latency_ms` from `generation_ms` across streamed and materialized gateway paths
- preserve first-frame timing when non-stream chat completions are internally materialized from streamed upstream responses
- keep the existing timing normalization tests aligned with the new semantics

## Verification
- `pnpm --filter @ai-stats/gateway-api typecheck`
- `pnpm --filter @ai-stats/gateway-api exec vitest run src/pipeline/after/streaming.test.ts`
- local live request to `http://127.0.0.1:8788/v1/chat/completions` with `openai/gpt-5.4-nano` returned distinct timings: `latency_ms: 1246`, `generation_ms: 1412`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal timing and latency calculation logic for more accurate measurement of request and stream performance metrics across the pipeline.
  * Standardized timing reference points for consistent latency tracking throughout request lifecycle.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->