### PR TITLE
Add provisional GPT-5.5 pricing structures

### DIFF
--- a/packages/data/catalog/src/data/api_providers/openai/models.json
+++ b/packages/data/catalog/src/data/api_providers/openai/models.json
@@ -2941,7 +2941,7 @@
       },
         {
           "capability_id": "batch",
-          "status": "coming_soon",
+          "status": "disabled",
           "params": []
         }
     ]
@@ -3194,7 +3194,7 @@
       },
         {
           "capability_id": "batch",
-          "status": "coming_soon",
+          "status": "disabled",
           "params": []
         }
     ]
@@ -3317,11 +3317,11 @@
           }
         ]
       },
-      {
-        "capability_id": "batch",
-        "status": "disabled",
-        "params": []
-      }
+        {
+          "capability_id": "batch",
+          "status": "coming_soon",
+          "params": []
+        }
     ]
   },
   {
@@ -3442,11 +3442,11 @@
           }
         ]
       },
-      {
-        "capability_id": "batch",
-        "status": "disabled",
-        "params": []
-      }
+        {
+          "capability_id": "batch",
+          "status": "coming_soon",
+          "params": []
+        }
     ]
   },
   {

--- a/packages/data/catalog/src/data/api_providers/openai/models.json
+++ b/packages/data/catalog/src/data/api_providers/openai/models.json
@@ -2939,11 +2939,11 @@
           }
         ]
       },
-      {
-        "capability_id": "batch",
-        "status": "disabled",
-        "params": []
-      }
+        {
+          "capability_id": "batch",
+          "status": "coming_soon",
+          "params": []
+        }
     ]
   },
   {
@@ -3192,11 +3192,11 @@
           }
         ]
       },
-      {
-        "capability_id": "batch",
-        "status": "disabled",
-        "params": []
-      }
+        {
+          "capability_id": "batch",
+          "status": "coming_soon",
+          "params": []
+        }
     ]
   },
   {

--- a/packages/data/catalog/src/data/pricing/google-ai-studio/google-gemini-embedding-2/text.embed/pricing.json
+++ b/packages/data/catalog/src/data/pricing/google-ai-studio/google-gemini-embedding-2/text.embed/pricing.json
@@ -52,54 +52,6 @@
       "match": [],
       "priority": 100,
       "effective_from": "2026-04-22T00:00:00"
-    },
-    {
-      "meter": "input_text_tokens",
-      "unit": "token",
-      "unit_size": 1000000,
-      "price_per_unit": 0.1,
-      "currency": "USD",
-      "pricing_plan": "batch",
-      "note": null,
-      "match": [],
-      "priority": 100,
-      "effective_from": "2026-04-22T00:00:00"
-    },
-    {
-      "meter": "input_image_tokens",
-      "unit": "token",
-      "unit_size": 1000000,
-      "price_per_unit": 0.225,
-      "currency": "USD",
-      "pricing_plan": "batch",
-      "note": null,
-      "match": [],
-      "priority": 100,
-      "effective_from": "2026-04-22T00:00:00"
-    },
-    {
-      "meter": "input_audio_tokens",
-      "unit": "token",
-      "unit_size": 1000000,
-      "price_per_unit": 3.25,
-      "currency": "USD",
-      "pricing_plan": "batch",
-      "note": null,
-      "match": [],
-      "priority": 100,
-      "effective_from": "2026-04-22T00:00:00"
-    },
-    {
-      "meter": "input_video_tokens",
-      "unit": "token",
-      "unit_size": 1000000,
-      "price_per_unit": 6,
-      "currency": "USD",
-      "pricing_plan": "batch",
-      "note": null,
-      "match": [],
-      "priority": 100,
-      "effective_from": "2026-04-22T00:00:00"
     }
   ]
 }

--- a/packages/data/catalog/src/data/pricing/google-vertex/google-gemini-embedding-2/text.embed/pricing.json
+++ b/packages/data/catalog/src/data/pricing/google-vertex/google-gemini-embedding-2/text.embed/pricing.json
@@ -52,54 +52,6 @@
       "match": [],
       "priority": 100,
       "effective_from": "2026-04-22T00:00:00"
-    },
-    {
-      "meter": "input_text_tokens",
-      "unit": "token",
-      "unit_size": 1000000,
-      "price_per_unit": 0.1,
-      "currency": "USD",
-      "pricing_plan": "batch",
-      "note": null,
-      "match": [],
-      "priority": 100,
-      "effective_from": "2026-04-22T00:00:00"
-    },
-    {
-      "meter": "input_image_tokens",
-      "unit": "token",
-      "unit_size": 1000000,
-      "price_per_unit": 0.225,
-      "currency": "USD",
-      "pricing_plan": "batch",
-      "note": null,
-      "match": [],
-      "priority": 100,
-      "effective_from": "2026-04-22T00:00:00"
-    },
-    {
-      "meter": "input_audio_tokens",
-      "unit": "token",
-      "unit_size": 1000000,
-      "price_per_unit": 3.25,
-      "currency": "USD",
-      "pricing_plan": "batch",
-      "note": null,
-      "match": [],
-      "priority": 100,
-      "effective_from": "2026-04-22T00:00:00"
-    },
-    {
-      "meter": "input_video_tokens",
-      "unit": "token",
-      "unit_size": 1000000,
-      "price_per_unit": 6,
-      "currency": "USD",
-      "pricing_plan": "batch",
-      "note": null,
-      "match": [],
-      "priority": 100,
-      "effective_from": "2026-04-22T00:00:00"
     }
   ]
 }

--- a/packages/data/catalog/src/data/pricing/openai/openai-gpt-5.5-pro/batch/pricing.json
+++ b/packages/data/catalog/src/data/pricing/openai/openai-gpt-5.5-pro/batch/pricing.json
@@ -1,0 +1,89 @@
+{
+  "key": "openai:openai/gpt-5.5-pro:batch",
+  "api_provider_id": "openai",
+  "provider_slug": "openai",
+  "api_model_id": "openai/gpt-5.5-pro",
+  "capability_id": "batch",
+  "rules": [
+    {
+      "meter": "input_text_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 15,
+      "currency": "USD",
+      "pricing_plan": "batch",
+      "note": null,
+      "match": [
+        {
+          "path": "input_tokens",
+          "op": "lt",
+          "or_group": 1,
+          "and_index": 1,
+          "value": 272000
+        }
+      ],
+      "priority": 100,
+      "effective_from": "2026-04-23T00:00:00"
+    },
+    {
+      "meter": "output_text_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 90,
+      "currency": "USD",
+      "pricing_plan": "batch",
+      "note": null,
+      "match": [
+        {
+          "path": "input_tokens",
+          "op": "lt",
+          "or_group": 1,
+          "and_index": 1,
+          "value": 272000
+        }
+      ],
+      "priority": 100,
+      "effective_from": "2026-04-23T00:00:00"
+    },
+    {
+      "meter": "input_text_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 30,
+      "currency": "USD",
+      "pricing_plan": "batch",
+      "note": "High Context",
+      "match": [
+        {
+          "path": "input_tokens",
+          "op": "gte",
+          "or_group": 1,
+          "and_index": 1,
+          "value": 272000
+        }
+      ],
+      "priority": 100,
+      "effective_from": "2026-04-23T00:00:00"
+    },
+    {
+      "meter": "output_text_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 135,
+      "currency": "USD",
+      "pricing_plan": "batch",
+      "note": "High Context",
+      "match": [
+        {
+          "path": "input_tokens",
+          "op": "gte",
+          "or_group": 1,
+          "and_index": 1,
+          "value": 272000
+        }
+      ],
+      "priority": 100,
+      "effective_from": "2026-04-23T00:00:00"
+    }
+  ]
+}

--- a/packages/data/catalog/src/data/pricing/openai/openai-gpt-5.5-pro/text.generate/pricing.json
+++ b/packages/data/catalog/src/data/pricing/openai/openai-gpt-5.5-pro/text.generate/pricing.json
@@ -13,7 +13,15 @@
       "currency": "USD",
       "pricing_plan": "standard",
       "note": null,
-      "match": [],
+      "match": [
+        {
+          "path": "input_tokens",
+          "op": "lt",
+          "or_group": 1,
+          "and_index": 1,
+          "value": 272000
+        }
+      ],
       "priority": 100,
       "effective_from": "2026-04-23T00:00:00"
     },
@@ -25,7 +33,215 @@
       "currency": "USD",
       "pricing_plan": "standard",
       "note": null,
-      "match": [],
+      "match": [
+        {
+          "path": "input_tokens",
+          "op": "lt",
+          "or_group": 1,
+          "and_index": 1,
+          "value": 272000
+        }
+      ],
+      "priority": 100,
+      "effective_from": "2026-04-23T00:00:00"
+    },
+    {
+      "meter": "input_text_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 60,
+      "currency": "USD",
+      "pricing_plan": "standard",
+      "note": "High Context",
+      "match": [
+        {
+          "path": "input_tokens",
+          "op": "gte",
+          "or_group": 1,
+          "and_index": 1,
+          "value": 272000
+        }
+      ],
+      "priority": 100,
+      "effective_from": "2026-04-23T00:00:00"
+    },
+    {
+      "meter": "output_text_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 270,
+      "currency": "USD",
+      "pricing_plan": "standard",
+      "note": "High Context",
+      "match": [
+        {
+          "path": "input_tokens",
+          "op": "gte",
+          "or_group": 1,
+          "and_index": 1,
+          "value": 272000
+        }
+      ],
+      "priority": 100,
+      "effective_from": "2026-04-23T00:00:00"
+    },
+    {
+      "meter": "input_text_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 15,
+      "currency": "USD",
+      "pricing_plan": "flex",
+      "note": null,
+      "match": [
+        {
+          "path": "input_tokens",
+          "op": "lt",
+          "or_group": 1,
+          "and_index": 1,
+          "value": 272000
+        }
+      ],
+      "priority": 100,
+      "effective_from": "2026-04-23T00:00:00"
+    },
+    {
+      "meter": "output_text_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 90,
+      "currency": "USD",
+      "pricing_plan": "flex",
+      "note": null,
+      "match": [
+        {
+          "path": "input_tokens",
+          "op": "lt",
+          "or_group": 1,
+          "and_index": 1,
+          "value": 272000
+        }
+      ],
+      "priority": 100,
+      "effective_from": "2026-04-23T00:00:00"
+    },
+    {
+      "meter": "input_text_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 30,
+      "currency": "USD",
+      "pricing_plan": "flex",
+      "note": "High Context",
+      "match": [
+        {
+          "path": "input_tokens",
+          "op": "gte",
+          "or_group": 1,
+          "and_index": 1,
+          "value": 272000
+        }
+      ],
+      "priority": 100,
+      "effective_from": "2026-04-23T00:00:00"
+    },
+    {
+      "meter": "output_text_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 135,
+      "currency": "USD",
+      "pricing_plan": "flex",
+      "note": "High Context",
+      "match": [
+        {
+          "path": "input_tokens",
+          "op": "gte",
+          "or_group": 1,
+          "and_index": 1,
+          "value": 272000
+        }
+      ],
+      "priority": 100,
+      "effective_from": "2026-04-23T00:00:00"
+    },
+    {
+      "meter": "input_text_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 75,
+      "currency": "USD",
+      "pricing_plan": "priority",
+      "note": null,
+      "match": [
+        {
+          "path": "input_tokens",
+          "op": "lt",
+          "or_group": 1,
+          "and_index": 1,
+          "value": 272000
+        }
+      ],
+      "priority": 100,
+      "effective_from": "2026-04-23T00:00:00"
+    },
+    {
+      "meter": "output_text_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 450,
+      "currency": "USD",
+      "pricing_plan": "priority",
+      "note": null,
+      "match": [
+        {
+          "path": "input_tokens",
+          "op": "lt",
+          "or_group": 1,
+          "and_index": 1,
+          "value": 272000
+        }
+      ],
+      "priority": 100,
+      "effective_from": "2026-04-23T00:00:00"
+    },
+    {
+      "meter": "input_text_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 150,
+      "currency": "USD",
+      "pricing_plan": "priority",
+      "note": "High Context",
+      "match": [
+        {
+          "path": "input_tokens",
+          "op": "gte",
+          "or_group": 1,
+          "and_index": 1,
+          "value": 272000
+        }
+      ],
+      "priority": 100,
+      "effective_from": "2026-04-23T00:00:00"
+    },
+    {
+      "meter": "output_text_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 675,
+      "currency": "USD",
+      "pricing_plan": "priority",
+      "note": "High Context",
+      "match": [
+        {
+          "path": "input_tokens",
+          "op": "gte",
+          "or_group": 1,
+          "and_index": 1,
+          "value": 272000
+        }
+      ],
       "priority": 100,
       "effective_from": "2026-04-23T00:00:00"
     }

--- a/packages/data/catalog/src/data/pricing/openai/openai-gpt-5.5/batch/pricing.json
+++ b/packages/data/catalog/src/data/pricing/openai/openai-gpt-5.5/batch/pricing.json
@@ -1,0 +1,129 @@
+{
+  "key": "openai:openai/gpt-5.5:batch",
+  "api_provider_id": "openai",
+  "provider_slug": "openai",
+  "api_model_id": "openai/gpt-5.5",
+  "capability_id": "batch",
+  "rules": [
+    {
+      "meter": "input_text_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 2.5,
+      "currency": "USD",
+      "pricing_plan": "batch",
+      "note": null,
+      "match": [
+        {
+          "path": "input_tokens",
+          "op": "lt",
+          "or_group": 1,
+          "and_index": 1,
+          "value": 272000
+        }
+      ],
+      "priority": 100,
+      "effective_from": "2026-04-23T00:00:00"
+    },
+    {
+      "meter": "cached_read_text_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 0.25,
+      "currency": "USD",
+      "pricing_plan": "batch",
+      "note": null,
+      "match": [
+        {
+          "path": "input_tokens",
+          "op": "lt",
+          "or_group": 1,
+          "and_index": 1,
+          "value": 272000
+        }
+      ],
+      "priority": 100,
+      "effective_from": "2026-04-23T00:00:00"
+    },
+    {
+      "meter": "output_text_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 15,
+      "currency": "USD",
+      "pricing_plan": "batch",
+      "note": null,
+      "match": [
+        {
+          "path": "input_tokens",
+          "op": "lt",
+          "or_group": 1,
+          "and_index": 1,
+          "value": 272000
+        }
+      ],
+      "priority": 100,
+      "effective_from": "2026-04-23T00:00:00"
+    },
+    {
+      "meter": "input_text_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 5,
+      "currency": "USD",
+      "pricing_plan": "batch",
+      "note": "High Context",
+      "match": [
+        {
+          "path": "input_tokens",
+          "op": "gte",
+          "or_group": 1,
+          "and_index": 1,
+          "value": 272000
+        }
+      ],
+      "priority": 100,
+      "effective_from": "2026-04-23T00:00:00"
+    },
+    {
+      "meter": "cached_read_text_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 0.5,
+      "currency": "USD",
+      "pricing_plan": "batch",
+      "note": "High Context",
+      "match": [
+        {
+          "path": "input_tokens",
+          "op": "gte",
+          "or_group": 1,
+          "and_index": 1,
+          "value": 272000
+        }
+      ],
+      "priority": 100,
+      "effective_from": "2026-04-23T00:00:00"
+    },
+    {
+      "meter": "output_text_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 22.5,
+      "currency": "USD",
+      "pricing_plan": "batch",
+      "note": "High Context",
+      "match": [
+        {
+          "path": "input_tokens",
+          "op": "gte",
+          "or_group": 1,
+          "and_index": 1,
+          "value": 272000
+        }
+      ],
+      "priority": 100,
+      "effective_from": "2026-04-23T00:00:00"
+    }
+  ]
+}

--- a/packages/data/catalog/src/data/pricing/openai/openai-gpt-5.5/text.generate/pricing.json
+++ b/packages/data/catalog/src/data/pricing/openai/openai-gpt-5.5/text.generate/pricing.json
@@ -13,7 +13,35 @@
       "currency": "USD",
       "pricing_plan": "standard",
       "note": null,
-      "match": [],
+      "match": [
+        {
+          "path": "input_tokens",
+          "op": "lt",
+          "or_group": 1,
+          "and_index": 1,
+          "value": 272000
+        }
+      ],
+      "priority": 100,
+      "effective_from": "2026-04-23T00:00:00"
+    },
+    {
+      "meter": "cached_read_text_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 0.5,
+      "currency": "USD",
+      "pricing_plan": "standard",
+      "note": null,
+      "match": [
+        {
+          "path": "input_tokens",
+          "op": "lt",
+          "or_group": 1,
+          "and_index": 1,
+          "value": 272000
+        }
+      ],
       "priority": 100,
       "effective_from": "2026-04-23T00:00:00"
     },
@@ -25,7 +53,315 @@
       "currency": "USD",
       "pricing_plan": "standard",
       "note": null,
-      "match": [],
+      "match": [
+        {
+          "path": "input_tokens",
+          "op": "lt",
+          "or_group": 1,
+          "and_index": 1,
+          "value": 272000
+        }
+      ],
+      "priority": 100,
+      "effective_from": "2026-04-23T00:00:00"
+    },
+    {
+      "meter": "input_text_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 10,
+      "currency": "USD",
+      "pricing_plan": "standard",
+      "note": "High Context",
+      "match": [
+        {
+          "path": "input_tokens",
+          "op": "gte",
+          "or_group": 1,
+          "and_index": 1,
+          "value": 272000
+        }
+      ],
+      "priority": 100,
+      "effective_from": "2026-04-23T00:00:00"
+    },
+    {
+      "meter": "cached_read_text_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 1,
+      "currency": "USD",
+      "pricing_plan": "standard",
+      "note": "High Context",
+      "match": [
+        {
+          "path": "input_tokens",
+          "op": "gte",
+          "or_group": 1,
+          "and_index": 1,
+          "value": 272000
+        }
+      ],
+      "priority": 100,
+      "effective_from": "2026-04-23T00:00:00"
+    },
+    {
+      "meter": "output_text_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 45,
+      "currency": "USD",
+      "pricing_plan": "standard",
+      "note": "High Context",
+      "match": [
+        {
+          "path": "input_tokens",
+          "op": "gte",
+          "or_group": 1,
+          "and_index": 1,
+          "value": 272000
+        }
+      ],
+      "priority": 100,
+      "effective_from": "2026-04-23T00:00:00"
+    },
+    {
+      "meter": "input_text_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 2.5,
+      "currency": "USD",
+      "pricing_plan": "flex",
+      "note": null,
+      "match": [
+        {
+          "path": "input_tokens",
+          "op": "lt",
+          "or_group": 1,
+          "and_index": 1,
+          "value": 272000
+        }
+      ],
+      "priority": 100,
+      "effective_from": "2026-04-23T00:00:00"
+    },
+    {
+      "meter": "cached_read_text_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 0.25,
+      "currency": "USD",
+      "pricing_plan": "flex",
+      "note": null,
+      "match": [
+        {
+          "path": "input_tokens",
+          "op": "lt",
+          "or_group": 1,
+          "and_index": 1,
+          "value": 272000
+        }
+      ],
+      "priority": 100,
+      "effective_from": "2026-04-23T00:00:00"
+    },
+    {
+      "meter": "output_text_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 15,
+      "currency": "USD",
+      "pricing_plan": "flex",
+      "note": null,
+      "match": [
+        {
+          "path": "input_tokens",
+          "op": "lt",
+          "or_group": 1,
+          "and_index": 1,
+          "value": 272000
+        }
+      ],
+      "priority": 100,
+      "effective_from": "2026-04-23T00:00:00"
+    },
+    {
+      "meter": "input_text_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 5,
+      "currency": "USD",
+      "pricing_plan": "flex",
+      "note": "High Context",
+      "match": [
+        {
+          "path": "input_tokens",
+          "op": "gte",
+          "or_group": 1,
+          "and_index": 1,
+          "value": 272000
+        }
+      ],
+      "priority": 100,
+      "effective_from": "2026-04-23T00:00:00"
+    },
+    {
+      "meter": "cached_read_text_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 0.5,
+      "currency": "USD",
+      "pricing_plan": "flex",
+      "note": "High Context",
+      "match": [
+        {
+          "path": "input_tokens",
+          "op": "gte",
+          "or_group": 1,
+          "and_index": 1,
+          "value": 272000
+        }
+      ],
+      "priority": 100,
+      "effective_from": "2026-04-23T00:00:00"
+    },
+    {
+      "meter": "output_text_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 22.5,
+      "currency": "USD",
+      "pricing_plan": "flex",
+      "note": "High Context",
+      "match": [
+        {
+          "path": "input_tokens",
+          "op": "gte",
+          "or_group": 1,
+          "and_index": 1,
+          "value": 272000
+        }
+      ],
+      "priority": 100,
+      "effective_from": "2026-04-23T00:00:00"
+    },
+    {
+      "meter": "input_text_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 12.5,
+      "currency": "USD",
+      "pricing_plan": "priority",
+      "note": null,
+      "match": [
+        {
+          "path": "input_tokens",
+          "op": "lt",
+          "or_group": 1,
+          "and_index": 1,
+          "value": 272000
+        }
+      ],
+      "priority": 100,
+      "effective_from": "2026-04-23T00:00:00"
+    },
+    {
+      "meter": "cached_read_text_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 1.25,
+      "currency": "USD",
+      "pricing_plan": "priority",
+      "note": null,
+      "match": [
+        {
+          "path": "input_tokens",
+          "op": "lt",
+          "or_group": 1,
+          "and_index": 1,
+          "value": 272000
+        }
+      ],
+      "priority": 100,
+      "effective_from": "2026-04-23T00:00:00"
+    },
+    {
+      "meter": "output_text_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 75,
+      "currency": "USD",
+      "pricing_plan": "priority",
+      "note": null,
+      "match": [
+        {
+          "path": "input_tokens",
+          "op": "lt",
+          "or_group": 1,
+          "and_index": 1,
+          "value": 272000
+        }
+      ],
+      "priority": 100,
+      "effective_from": "2026-04-23T00:00:00"
+    },
+    {
+      "meter": "input_text_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 25,
+      "currency": "USD",
+      "pricing_plan": "priority",
+      "note": "High Context",
+      "match": [
+        {
+          "path": "input_tokens",
+          "op": "gte",
+          "or_group": 1,
+          "and_index": 1,
+          "value": 272000
+        }
+      ],
+      "priority": 100,
+      "effective_from": "2026-04-23T00:00:00"
+    },
+    {
+      "meter": "cached_read_text_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 2.5,
+      "currency": "USD",
+      "pricing_plan": "priority",
+      "note": "High Context",
+      "match": [
+        {
+          "path": "input_tokens",
+          "op": "gte",
+          "or_group": 1,
+          "and_index": 1,
+          "value": 272000
+        }
+      ],
+      "priority": 100,
+      "effective_from": "2026-04-23T00:00:00"
+    },
+    {
+      "meter": "output_text_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 112.5,
+      "currency": "USD",
+      "pricing_plan": "priority",
+      "note": "High Context",
+      "match": [
+        {
+          "path": "input_tokens",
+          "op": "gte",
+          "or_group": 1,
+          "and_index": 1,
+          "value": 272000
+        }
+      ],
       "priority": 100,
       "effective_from": "2026-04-23T00:00:00"
     }


### PR DESCRIPTION
## Summary
- add provisional GPT-5.5 and GPT-5.5 Pro pricing structures for standard, flex, priority, and batch
- mark OpenAI batch support for GPT-5.5 models as coming soon to match the new pricing entries
- remove unsupported batch pricing from Gemini Embedding 2 on Google AI Studio and Vertex

## Validation
- pnpm validate:pricing
- pnpm validate:data
- pnpm validate:gateway


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added batch pricing support for GPT-5.5 and GPT-5.5‑pro models
  * Introduced high‑context pricing tiers for GPT models based on input token thresholds

* **Updates**
  * Updated text‑generation pricing to use token‑threshold pricing bands
  * Removed batch pricing entries for Google Gemini Embedding‑2
  * Batch capability status adjusted to "coming soon" for select OpenAI model entries
<!-- end of auto-generated comment: release notes by coderabbit.ai -->