### PR TITLE
Move models monitor aggregation into SQL

### DIFF
--- a/apps/web/src/app/(dashboard)/models/page.tsx
+++ b/apps/web/src/app/(dashboard)/models/page.tsx
@@ -6,12 +6,6 @@ import {
 	type ModelCard,
 } from "@/lib/fetchers/models/getAllModels";
 import { getMonitorModels } from "@/lib/fetchers/models/table-view/getMonitorModels";
-import {
-	getModelRankingsRows,
-	getWeeklyModelProviderTokens,
-	type RankingModel,
-	type WeeklyModelProviderTokens,
-} from "@/lib/fetchers/rankings/getRankingsData";
 import type { Metadata } from "next";
 import { buildMetadata } from "@/lib/seo";
 import { featureOrder } from "@/lib/config/featureLabels";
@@ -584,95 +578,56 @@ type WeeklyRankingMetrics = {
 	latencyWeek: number | null;
 };
 
-type RankingAccumulator = {
-	tokensWeek: number;
-	throughputWeightedSum: number;
-	throughputWeight: number;
-	latencyWeightedSum: number;
-	latencyWeight: number;
-};
-
 function normalizeRankingModelKey(value: string): string {
 	return String(value ?? "").trim().toLowerCase();
 }
 
-function aggregateWeeklyRankingMetrics(
-	rankingRows: RankingModel[],
+function buildWeeklyMetricsByModel(
+	monitorRows: Awaited<ReturnType<typeof getMonitorModels>>["models"],
 ): Map<string, WeeklyRankingMetrics> {
-	const accumulators = new Map<string, RankingAccumulator>();
+	const metricsByKey = new Map<string, WeeklyRankingMetrics>();
 
-	for (const row of rankingRows) {
-		const key = normalizeRankingModelKey(row.model_id);
-		if (!key || key === "unknown" || key === "other") continue;
-
-		const acc = accumulators.get(key) ?? {
-			tokensWeek: 0,
-			throughputWeightedSum: 0,
-			throughputWeight: 0,
-			latencyWeightedSum: 0,
-			latencyWeight: 0,
+	for (const row of monitorRows) {
+		const metric: WeeklyRankingMetrics = {
+			tokensWeek: Number.isFinite(Number(row.weeklyTokensModel))
+				? Number(row.weeklyTokensModel)
+				: null,
+			throughputWeek: Number.isFinite(Number(row.weeklyThroughputModel))
+				? Number(row.weeklyThroughputModel)
+				: null,
+			latencyWeek: Number.isFinite(Number(row.weeklyLatencyModel))
+				? Number(row.weeklyLatencyModel)
+				: null,
 		};
-
-		const tokens = Number(row.total_tokens ?? 0);
-		if (Number.isFinite(tokens) && tokens > 0) {
-			acc.tokensWeek += tokens;
+		if (
+			metric.tokensWeek === null &&
+			metric.throughputWeek === null &&
+			metric.latencyWeek === null
+		) {
+			continue;
 		}
 
-		const requests = Number(row.requests ?? 0);
-		const weight = Number.isFinite(requests) && requests > 0 ? requests : 0;
-		const throughput = Number(row.median_throughput);
-		if (Number.isFinite(throughput) && throughput > 0 && weight > 0) {
-			acc.throughputWeightedSum += throughput * weight;
-			acc.throughputWeight += weight;
+		for (const candidate of [row.modelId, row.apiModelId]) {
+			const key = normalizeRankingModelKey(String(candidate ?? ""));
+			if (!key || key === "unknown" || key === "other") continue;
+			const existing = metricsByKey.get(key);
+			if (
+				!existing ||
+				(metric.tokensWeek ?? Number.NEGATIVE_INFINITY) >
+					(existing.tokensWeek ?? Number.NEGATIVE_INFINITY)
+			) {
+				metricsByKey.set(key, metric);
+			}
 		}
-		const latency = Number(row.median_latency_ms);
-		if (Number.isFinite(latency) && latency > 0 && weight > 0) {
-			acc.latencyWeightedSum += latency * weight;
-			acc.latencyWeight += weight;
-		}
-
-		accumulators.set(key, acc);
 	}
 
-	return new Map(
-		Array.from(accumulators.entries()).map(([key, acc]) => [
-			key,
-			{
-				tokensWeek: acc.tokensWeek > 0 ? acc.tokensWeek : null,
-				throughputWeek:
-					acc.throughputWeight > 0
-						? acc.throughputWeightedSum / acc.throughputWeight
-						: null,
-				latencyWeek:
-					acc.latencyWeight > 0 ? acc.latencyWeightedSum / acc.latencyWeight : null,
-			},
-		]),
-	);
-}
-
-function aggregateWeeklyTokenMetrics(
-	rows: WeeklyModelProviderTokens[],
-): Map<string, number> {
-	const tokensByModel = new Map<string, number>();
-
-	for (const row of rows) {
-		const key = normalizeRankingModelKey(row.model_id);
-		if (!key || key === "unknown" || key === "other") continue;
-
-		const tokens = Number(row.total_tokens ?? 0);
-		if (!Number.isFinite(tokens) || tokens <= 0) continue;
-
-		tokensByModel.set(key, (tokensByModel.get(key) ?? 0) + tokens);
-	}
-
-	return tokensByModel;
+	return metricsByKey;
 }
 
 function resolveModelWeeklyMetrics(
 	model: ModelCard,
 	signals: GatewaySignals | undefined,
 	metricsByKey: Map<string, WeeklyRankingMetrics>,
-	tokenTotalsByKey: Map<string, number>,
 ): WeeklyRankingMetrics {
 	const candidateKeys = [
 		model.model_id,
@@ -696,37 +651,21 @@ function resolveModelWeeklyMetrics(
 		}
 	}
 
-	let tokensWeek: number | null = null;
-	for (const key of candidateKeys) {
-		const tokens = tokenTotalsByKey.get(key);
-		if (!Number.isFinite(Number(tokens)) || Number(tokens) <= 0) continue;
-		tokensWeek =
-			tokensWeek === null ? Number(tokens) : Math.max(tokensWeek, Number(tokens));
-	}
-
-	if (selected) {
-		return {
-			...selected,
-			tokensWeek: tokensWeek ?? selected.tokensWeek ?? null,
-		};
-	}
-
-	return {
-		tokensWeek,
-		throughputWeek: null,
-		latencyWeek: null,
-	};
+	return (
+		selected ?? {
+			tokensWeek: null,
+			throughputWeek: null,
+			latencyWeek: null,
+		}
+	);
 }
 
 function withGatewayMetadata(
 	baseModels: ModelCard[],
 	monitorRows: Awaited<ReturnType<typeof getMonitorModels>>["models"],
-	rankingRows: RankingModel[],
-	weeklyTokenRows: WeeklyModelProviderTokens[],
 ): ModelsPageModel[] {
 	const signalsByModelId = aggregateGatewaySignals(monitorRows);
-	const weeklyMetricsByKey = aggregateWeeklyRankingMetrics(rankingRows);
-	const weeklyTokenTotalsByKey = aggregateWeeklyTokenMetrics(weeklyTokenRows);
+	const weeklyMetricsByKey = buildWeeklyMetricsByModel(monitorRows);
 	const baseModelById = new Map(
 		baseModels.map((model) => [String(model.model_id ?? "").trim(), model]),
 	);
@@ -739,7 +678,6 @@ function withGatewayMetadata(
 			model ?? ({ model_id: modelId, name: modelId, organisation_id: "" } as ModelCard),
 			signals,
 			weeklyMetricsByKey,
-			weeklyTokenTotalsByKey,
 		);
 		const providerCount = signals?.providerIds.size ?? 0;
 		const activeProviderCount = signals?.activeProviderIds.size ?? 0;
@@ -897,7 +835,6 @@ function withGatewayMetadata(
 				model,
 				undefined,
 				weeklyMetricsByKey,
-				weeklyTokenTotalsByKey,
 			);
 			const modelId = String(model.model_id ?? "").trim();
 
@@ -959,19 +896,11 @@ function withGatewayMetadata(
 
 async function ModelsPageDataSection() {
 	const includeHidden = false;
-	const [monitorResult, rankingsResult, weeklyUsageResult, allModels] =
-		await Promise.all([
-			getMonitorModels({}, includeHidden),
-			getModelRankingsRows("week", "tokens", 3000),
-			getWeeklyModelProviderTokens(),
-			getAllModelsCached(includeHidden),
-		]);
-	const models = withGatewayMetadata(
-		allModels,
-		monitorResult.models,
-		rankingsResult,
-		weeklyUsageResult.data ?? [],
-	);
+	const [monitorResult, allModels] = await Promise.all([
+		getMonitorModels({}, includeHidden),
+		getAllModelsCached(includeHidden),
+	]);
+	const models = withGatewayMetadata(allModels, monitorResult.models);
 	const facets = buildModelsFilterFacets(models);
 
 	return <ModelsDisplay models={models} facets={facets} />;

--- a/apps/web/src/app/(dashboard)/models/table/page.tsx
+++ b/apps/web/src/app/(dashboard)/models/table/page.tsx
@@ -2,10 +2,6 @@ import type { Metadata } from "next";
 import { headers } from "next/headers";
 import ModelsTableDisplay from "@/components/(data)/models/Models/ModelsTableDisplay";
 import { getMonitorModels } from "@/lib/fetchers/models/table-view/getMonitorModels";
-import {
-	getWeeklyModelProviderTokens,
-	type WeeklyModelProviderTokens,
-} from "@/lib/fetchers/rankings/getRankingsData";
 import { resolveIncludeHidden } from "@/lib/fetchers/models/visibility";
 
 export const metadata: Metadata = {
@@ -23,7 +19,7 @@ function normalizeRankingModelKey(value: string): string {
 }
 
 function buildWeeklyTokensMaps(
-	rows: WeeklyModelProviderTokens[],
+	rows: Awaited<ReturnType<typeof getMonitorModels>>["models"],
 ): {
 	weeklyTokensByModel: Record<string, number>;
 	weeklyTokensByModelProvider: Record<string, number>;
@@ -32,19 +28,20 @@ function buildWeeklyTokensMaps(
 	const tokensByModelProvider = new Map<string, number>();
 
 	for (const row of rows) {
-		const key = normalizeRankingModelKey(row.model_id);
+		const key = normalizeRankingModelKey(row.modelId);
 		if (!key || key === "unknown" || key === "other") continue;
-		const providerKey = normalizeRankingModelKey(row.provider);
-		const tokens = Number(row.total_tokens ?? 0);
-		if (!Number.isFinite(tokens) || tokens < 0) continue;
+		const providerKey = normalizeRankingModelKey(row.provider.id);
+		const modelTokens = Number(row.weeklyTokensModel ?? 0);
+		const providerTokens = Number(row.weeklyTokensModelProvider ?? 0);
+		if (Number.isFinite(modelTokens) && modelTokens >= 0) {
+			const existing = tokensByModel.get(key) ?? 0;
+			tokensByModel.set(key, Math.max(existing, modelTokens));
+		}
 
-		tokensByModel.set(key, (tokensByModel.get(key) ?? 0) + tokens);
-		if (providerKey) {
+		if (providerKey && Number.isFinite(providerTokens) && providerTokens >= 0) {
 			const providerCompositeKey = `${key}::${providerKey}`;
-			tokensByModelProvider.set(
-				providerCompositeKey,
-				(tokensByModelProvider.get(providerCompositeKey) ?? 0) + tokens,
-			);
+			const existing = tokensByModelProvider.get(providerCompositeKey) ?? 0;
+			tokensByModelProvider.set(providerCompositeKey, Math.max(existing, providerTokens));
 		}
 	}
 
@@ -58,10 +55,7 @@ export default async function ModelsTablePage() {
 	// Ensure request-scoped rendering before time-dependent calculations.
 	await headers();
 	const includeHidden = await resolveIncludeHidden();
-	const [monitorResult, weeklyUsageResult] = await Promise.all([
-		getMonitorModels({}, includeHidden),
-		getWeeklyModelProviderTokens(),
-	]);
+	const monitorResult = await getMonitorModels({}, includeHidden);
 	const {
 		models: modelData,
 		allTiers,
@@ -71,7 +65,7 @@ export default async function ModelsTablePage() {
 		allStatuses,
 	} = monitorResult;
 	const { weeklyTokensByModel, weeklyTokensByModelProvider } =
-		buildWeeklyTokensMaps(weeklyUsageResult.data ?? []);
+		buildWeeklyTokensMaps(modelData);
 
 	return (
 		<ModelsTableDisplay

--- a/apps/web/src/lib/cache/revalidateDataTags.ts
+++ b/apps/web/src/lib/cache/revalidateDataTags.ts
@@ -48,7 +48,6 @@ const MODEL_API_GLOBAL_TAGS = [
 	"data:api_providers:list",
 	"data:model_aliases",
 	"data:data_api_provider_models",
-	"data:data_model_id_redirects",
 	"data:data_api_models",
 	"data:data_api_pricing_rules",
 	"data:gateway_requests",
@@ -65,7 +64,6 @@ const MODEL_CANONICAL_RESOLVER_TAGS = [
 	"data:models",
 	"data:model_aliases",
 	"data:data_api_provider_models",
-	"data:data_model_id_redirects",
 	"data:data_api_models",
 ] as const;
 

--- a/apps/web/src/lib/fetchers/models/resolveCanonicalModelId.ts
+++ b/apps/web/src/lib/fetchers/models/resolveCanonicalModelId.ts
@@ -204,8 +204,14 @@ async function resolveCanonicalModelIdUncached(
 				.maybeSingle(),
 			supabase
 				.from("data_api_provider_models")
-				.select("model_id")
-				.eq("api_model_id", modelId)
+				.select("model_id, api_model_id, provider_api_model_id, provider_model_slug")
+				.or(
+					[
+						`api_model_id.eq.${modelId}`,
+						`provider_api_model_id.eq.${modelId}`,
+						`provider_model_slug.eq.${modelId}`,
+					].join(","),
+				)
 				.not("model_id", "is", null)
 				.limit(1),
 		]);
@@ -245,8 +251,9 @@ async function resolveCanonicalModelIdUncached(
 		return buildResult(modelId, "api_model");
 	}
 
-	if ((providerByApiRes.data?.length ?? 0) > 0) {
-		return buildResult(modelId, "provider_mapping");
+	const providerMappingCandidate = normalizeId(providerByApiRes.data?.[0]?.model_id);
+	if (providerMappingCandidate) {
+		return buildResult(providerMappingCandidate, "provider_mapping");
 	}
 
 	return {

--- a/apps/web/src/lib/fetchers/models/resolveCanonicalModelId.ts
+++ b/apps/web/src/lib/fetchers/models/resolveCanonicalModelId.ts
@@ -4,11 +4,9 @@ import { cacheLife, cacheTag } from "next/cache";
 
 type ResolveModelIdSource =
 	| "direct"
-	| "redirect"
 	| "alias"
 	| "api_model"
 	| "provider_mapping"
-	| "legacy_internal_mapping"
 	| "unresolved";
 
 export type ResolveCanonicalModelIdResult = {
@@ -191,13 +189,8 @@ async function resolveCanonicalModelIdUncached(
 		return buildResult(modelId, "direct", modelId);
 	}
 
-	const [redirectRes, aliasRes, apiModelRes, providerByApiRes, providerByModelRes] =
+	const [aliasRes, apiModelRes, providerByApiRes] =
 		await Promise.all([
-			supabase
-				.from("data_model_id_redirects")
-				.select("model_id")
-				.eq("legacy_model_id", modelId)
-				.maybeSingle(),
 			supabase
 				.from("data_api_model_aliases")
 				.select("api_model_id")
@@ -215,17 +208,8 @@ async function resolveCanonicalModelIdUncached(
 				.eq("api_model_id", modelId)
 				.not("model_id", "is", null)
 				.limit(1),
-			supabase
-				.from("data_api_provider_models")
-				.select("api_model_id")
-				.eq("model_id", modelId)
-				.not("api_model_id", "is", null)
-				.limit(1),
 		]);
 
-	if (redirectRes.error) {
-		warnIfUnexpectedTableError("redirect lookup", modelId, redirectRes.error);
-	}
 	if (aliasRes.error) {
 		warnIfUnexpectedTableError("alias lookup", modelId, aliasRes.error);
 	}
@@ -238,38 +222,6 @@ async function resolveCanonicalModelIdUncached(
 			modelId,
 			providerByApiRes.error,
 		);
-	}
-	if (providerByModelRes.error) {
-		warnIfUnexpectedTableError(
-			"provider mapping (by internal model) lookup",
-			modelId,
-			providerByModelRes.error,
-		);
-	}
-
-	const redirectCandidate = normalizeId(redirectRes.data?.model_id);
-	if (redirectCandidate) {
-		const [
-			mappedApiModelId,
-			redirectCandidateVisible,
-			redirectCandidateIsApiModel,
-		] = await Promise.all([
-			getMappedApiModelIdForInternalModel(supabase, redirectCandidate),
-			getVisibleModelIds(supabase, [redirectCandidate], includeHidden),
-			redirectCandidate === modelId
-				? Promise.resolve(normalizeId(apiModelRes.data?.api_model_id) === modelId)
-				: apiModelExists(supabase, redirectCandidate),
-		]);
-
-		if (mappedApiModelId) {
-			return buildResult(mappedApiModelId, "redirect");
-		}
-		if (redirectCandidateIsApiModel) {
-			return buildResult(redirectCandidate, "redirect");
-		}
-		if (redirectCandidateVisible.has(redirectCandidate)) {
-			return buildResult(redirectCandidate, "redirect", redirectCandidate);
-		}
 	}
 
 	const aliasCandidate = normalizeId(aliasRes.data?.api_model_id);
@@ -297,13 +249,6 @@ async function resolveCanonicalModelIdUncached(
 		return buildResult(modelId, "provider_mapping");
 	}
 
-	const mappedApiModelId = normalizeId(
-		providerByModelRes.data?.[0]?.api_model_id,
-	);
-	if (mappedApiModelId) {
-		return buildResult(mappedApiModelId, "legacy_internal_mapping");
-	}
-
 	return {
 		requestedModelId: modelId,
 		canonicalModelId: null,
@@ -326,7 +271,6 @@ async function resolveCanonicalModelIdCached(
 	cacheTag("data:models");
 	cacheTag("data:model_aliases");
 	cacheTag("data:data_api_provider_models");
-	cacheTag("data:data_model_id_redirects");
 	cacheTag("data:data_api_models");
 	cacheTag(`model:canonical:${requestedModelId}`);
 

--- a/apps/web/src/lib/fetchers/models/table-view/getMonitorModels.ts
+++ b/apps/web/src/lib/fetchers/models/table-view/getMonitorModels.ts
@@ -1,7 +1,7 @@
 import { createAdminClient } from "@/utils/supabase/admin";
 import { cacheLife, cacheTag } from "next/cache";
 import { featureOrder } from "@/lib/config/featureLabels";
-import type { MonitorModelData, MonitorModelFilters, GatewayProvider, GatewayModel } from "./types";
+import type { MonitorModelData, MonitorModelFilters, GatewayProvider } from "./types";
 import {
 	parseModalities,
 	extractFeatureKeys,
@@ -10,233 +10,57 @@ import {
 	normalizeCapabilityStatus,
 	normalizeEndpoint,
 	resolveGatewayStatus,
-	toUsdPerMillion,
 } from "./helpers";
 
 export type { MonitorModelData } from "./types";
 
-function normalizePricingDisplayUnit(
-	meterRaw: unknown,
-	unitRaw: unknown,
-): string | null {
-	const meter = String(meterRaw ?? "")
-		.trim()
-		.toLowerCase();
-	const unit = String(unitRaw ?? "")
-		.trim()
-		.toLowerCase();
-
-	if (
-		meter.includes("token") ||
-		unit === "token" ||
-		unit === "tokens"
-	) {
-		return "1M tokens";
-	}
-	if (["second", "seconds", "sec", "secs", "s"].includes(unit)) {
-		return "second";
-	}
-	if (["minute", "minutes", "min", "mins", "m"].includes(unit)) {
-		return "minute";
-	}
-	if (["hour", "hours", "hr", "hrs", "h"].includes(unit)) {
-		return "hour";
-	}
-	if (["image", "images"].includes(unit)) {
-		return "image";
-	}
-	if (["video", "videos"].includes(unit)) {
-		return "video";
-	}
-	if (["character", "characters", "char", "chars"].includes(unit)) {
-		return "character";
-	}
-
-	return unit || null;
-}
-
-function toDisplayPrice(
-	pricePerUnitRaw: unknown,
-	unitSizeRaw: unknown,
-	meterRaw: unknown,
-	unitRaw: unknown,
-): { value: number; unit: string } | null {
-	const pricePerUnit = Number(pricePerUnitRaw ?? Number.NaN);
-	const unitSize = Number(unitSizeRaw ?? Number.NaN);
-	if (!Number.isFinite(pricePerUnit) || pricePerUnit < 0) return null;
-	if (!Number.isFinite(unitSize) || unitSize <= 0) return null;
-
-	const normalizedUnit = normalizePricingDisplayUnit(meterRaw, unitRaw);
-	if (!normalizedUnit) return null;
-
-	if (normalizedUnit === "1M tokens") {
-		return {
-			value: toUsdPerMillion(pricePerUnit, unitSize),
-			unit: normalizedUnit,
-		};
-	}
-
-	// Normalize all time-based pricing to per-second so comparisons are valid.
-	if (normalizedUnit === "minute") {
-		return {
-			value: pricePerUnit / unitSize / 60,
-			unit: "second",
-		};
-	}
-	if (normalizedUnit === "hour") {
-		return {
-			value: pricePerUnit / unitSize / 3600,
-			unit: "second",
-		};
-	}
-
-	return {
-		value: pricePerUnit / unitSize,
-		unit: normalizedUnit,
-	};
-}
-
-function getStandardIoMeterMeta(
-	meterRaw: unknown,
-): { side: "input" | "output"; label: string; priority: number } | null {
-	const meter = String(meterRaw ?? "")
-		.trim()
-		.toLowerCase();
-
-	if (meter === "input_text_tokens" || meter === "input_tokens") {
-		return { side: "input", label: "Text Input", priority: 0 };
-	}
-	if (meter === "input_audio_tokens") {
-		return { side: "input", label: "Audio Input", priority: 1 };
-	}
-	if (meter === "input_image_tokens") {
-		return { side: "input", label: "Image Input", priority: 2 };
-	}
-	if (meter === "input_video_tokens") {
-		return { side: "input", label: "Video Input", priority: 3 };
-	}
-	if (meter === "output_text_tokens" || meter === "output_tokens") {
-		return { side: "output", label: "Text Output", priority: 0 };
-	}
-	if (meter === "output_audio_tokens") {
-		return { side: "output", label: "Audio Output", priority: 1 };
-	}
-	if (meter === "output_image_tokens") {
-		return { side: "output", label: "Image Output", priority: 2 };
-	}
-	if (meter === "output_video_tokens") {
-		return { side: "output", label: "Video Output", priority: 3 };
-	}
-	return null;
-}
-
-async function fetchProviderModelsPaginated({
-	supabase,
-	selectClause,
-	pageSize = 1000,
-}: {
-	supabase: ReturnType<typeof createAdminClient>;
-	selectClause: string;
-	pageSize?: number;
-}): Promise<{ data: any[] | null; error: any | null }> {
-	const rows: any[] = [];
-
-	for (let from = 0; ; from += pageSize) {
-		const to = from + pageSize - 1;
-		const { data, error } = await supabase
-			.from("data_api_provider_models")
-			.select(selectClause)
-			.not("api_model_id", "is", null)
-			.order("provider_api_model_id", { ascending: true })
-			.range(from, to);
-
-		if (error) {
-			return { data: null, error };
-		}
-		if (!Array.isArray(data) || data.length === 0) {
-			break;
-		}
-
-		rows.push(...data);
-		if (data.length < pageSize) {
-			break;
-		}
-	}
-
-	return { data: rows, error: null };
-}
-
-async function fetchPricingRulesByModelKeysInBatches({
-	supabase,
-	modelKeys,
-	batchSize = 120,
-}: {
-	supabase: ReturnType<typeof createAdminClient>;
-	modelKeys: string[];
-	batchSize?: number;
-}): Promise<
-	Array<{
-		model_key: string;
-		meter: string;
-		unit: string | null;
-		unit_size: number;
-		price_per_unit: number;
-		pricing_plan: string | null;
-		effective_from: string | null;
-		effective_to: string | null;
-	}>
-> {
-	const rows: Array<{
-		model_key: string;
-		meter: string;
-		unit: string | null;
-		unit_size: number;
-		price_per_unit: number;
-		pricing_plan: string | null;
-		effective_from: string | null;
-		effective_to: string | null;
-	}> = [];
-	const nowIso = new Date().toISOString();
-	const activePricingWindowClause = [
-		"and(effective_from.is.null,effective_to.is.null)",
-		`and(effective_from.is.null,effective_to.gt.${nowIso})`,
-		`and(effective_from.lte.${nowIso},effective_to.is.null)`,
-		`and(effective_from.lte.${nowIso},effective_to.gt.${nowIso})`,
-	].join(",");
-
-	for (let i = 0; i < modelKeys.length; i += batchSize) {
-		const batch = modelKeys.slice(i, i + batchSize);
-		if (!batch.length) continue;
-
-		const { data, error } = await supabase
-			.from("data_api_pricing_rules")
-			.select(`
-        model_key,
-        meter,
-        unit,
-        unit_size,
-        price_per_unit,
-        pricing_plan,
-        effective_from,
-        effective_to
-      `)
-			.in("model_key", batch)
-			.or(activePricingWindowClause)
-			.order("effective_from", { ascending: false });
-
-		if (error) {
-			throw new Error(
-				`Fetching pricing batch failed at index ${i}: ${error.message ?? String(error)}`,
-			);
-		}
-
-		if (Array.isArray(data) && data.length > 0) {
-			rows.push(...data);
-		}
-	}
-
-	return rows;
-}
+type MonitorModelRpcRow = {
+	model_id: string | null;
+	model_name: string | null;
+	model_release_date: string | null;
+	model_retirement_date: string | null;
+	model_status: string | null;
+	model_input_types: unknown;
+	model_output_types: unknown;
+	organisation_id: string | null;
+	organisation_name: string | null;
+	hidden: boolean | null;
+	provider_api_model_id: string | null;
+	provider_id: string | null;
+	api_model_id: string | null;
+	provider_model_slug: string | null;
+	is_active_gateway: boolean | null;
+	input_modalities: unknown;
+	output_modalities: unknown;
+	quantization_scheme: string | null;
+	context_length: number | null;
+	provider_max_output_tokens: number | null;
+	effective_from: string | null;
+	effective_to: string | null;
+	capability_id: string | null;
+	capability_params: unknown;
+	capability_status: string | null;
+	capability_max_input_tokens: number | null;
+	capability_max_output_tokens: number | null;
+	api_provider_name: string | null;
+	provider_link: string | null;
+	input_price: number | null;
+	output_price: number | null;
+	standard_input_price: number | null;
+	standard_output_price: number | null;
+	standard_input_price_label: string | null;
+	standard_input_price_unit: string | null;
+	standard_output_price_label: string | null;
+	standard_output_price_unit: string | null;
+	from_price: number | null;
+	from_price_unit: string | null;
+	pricing_tier: string | null;
+	is_free_variant: boolean | null;
+	weekly_tokens_model: number | null;
+	weekly_tokens_model_provider: number | null;
+	weekly_throughput_model: number | null;
+	weekly_latency_model: number | null;
+};
 
 export async function getMonitorModels(
 	filters: MonitorModelFilters = {},
@@ -260,411 +84,56 @@ export async function getMonitorModels(
 	cacheTag("data:api_providers");
 
 	const supabase = createAdminClient();
-	const baseSelect = `
-		provider_api_model_id,
-		provider_id,
-		model_id,
-		api_model_id,
-		provider_model_slug,
-		is_active_gateway,
-		input_modalities,
-		output_modalities,
-		quantization_scheme,
-		context_length,
-		max_output_tokens,
-		effective_from,
-		effective_to,
-		capabilities: data_api_provider_model_capabilities!inner(
-			capability_id,
-			params,
-			status,
-			max_input_tokens,
-			max_output_tokens
-		),
-		provider: data_api_providers(
-			api_provider_id,
-			api_provider_name,
-			link
-		)
-	`;
-	const legacySelect = `
-		provider_api_model_id,
-		provider_id,
-		api_model_id,
-		provider_model_slug,
-		is_active_gateway,
-		input_modalities,
-		output_modalities,
-		effective_from,
-		effective_to,
-		capabilities: data_api_provider_model_capabilities!inner(
-			capability_id,
-			params,
-			status,
-			max_input_tokens,
-			max_output_tokens
-		),
-		provider: data_api_providers(
-			api_provider_id,
-			api_provider_name,
-			link
-		)
-	`;
-
-	let providerModels: any[] | null = null;
-	let providerModelsError: any = null;
-	{
-		const res = await fetchProviderModelsPaginated({
-			supabase,
-			selectClause: baseSelect,
-			pageSize: 1000,
-		});
-		providerModels = res.data ?? null;
-		providerModelsError = res.error;
-	}
-
-	const providerModelLegacySchemaMissing =
-		/(model_id|context_length|max_output_tokens|quantization_scheme)/i.test(
-			String(providerModelsError?.message ?? ""),
-		);
-	if (providerModelsError && providerModelLegacySchemaMissing) {
-		const res = await fetchProviderModelsPaginated({
-			supabase,
-			selectClause: legacySelect,
-			pageSize: 1000,
-		});
-		providerModels = res.data ?? null;
-		providerModelsError = res.error;
-	}
-
-	if (providerModelsError) {
-		throw providerModelsError;
-	}
-
-	const modelIds = Array.from(
-		new Set(
-			(providerModels ?? [])
-				.map((pm: any) => {
-					const modelId = String(pm?.model_id ?? pm?.api_model_id ?? "").trim();
-					return modelId.length > 0 ? modelId : null;
-				})
-				.filter((modelId): modelId is string => Boolean(modelId)),
-		),
+	const { data: rpcRows, error: rpcError } = await supabase.rpc(
+		"get_monitor_model_rows",
+		{ p_include_hidden: includeHidden },
 	);
 
-	const { data: modelRows, error: modelRowsError } = modelIds.length
-		? await supabase
-				.from("data_models")
-				.select(
-					`
-					model_id,
-					name,
-					release_date,
-					retirement_date,
-					status,
-					input_types,
-					output_types,
-					hidden,
-					organisation: data_organisations!data_models_organisation_id_fkey(
-						organisation_id,
-						name
-					)
-					`,
-				)
-				.in("model_id", modelIds)
-		: { data: [] as any[], error: null as any };
-
-	if (modelRowsError) {
-		throw modelRowsError;
+	if (rpcError) {
+		throw rpcError;
 	}
 
-	const modelById = new Map<string, any>();
-	for (const row of modelRows ?? []) {
-		const modelId = String((row as any)?.model_id ?? "").trim();
-		if (!modelId) continue;
-		modelById.set(modelId, row);
-	}
-
-	const ctxByModelId = new Map<
-		string,
-		{ context: number; maxOutput: number; quantization?: string }
-	>();
-
-	const gatewayModelsData: GatewayModel[] = [];
-	const modelKeysSet = new Set<string>();
-	const providerModelByKey = new Map<string, any>();
-
-	for (const pm of providerModels ?? []) {
-		const modelId =
-			pm.model_id ??
-			pm.api_model_id ??
-			"";
-		const modelRow = modelById.get(modelId) ?? null;
-		if (!includeHidden && modelRow?.hidden) continue;
-		const capabilities: any[] = Array.isArray(pm.capabilities)
-			? pm.capabilities
-			: [];
-
-		if (modelId && !ctxByModelId.has(modelId)) {
-			const providerContext = Number(pm.context_length);
-			const providerMaxOutput = Number(pm.max_output_tokens);
-			const capMaxInput = capabilities.reduce((max: number, capability: any) => {
-				const value = Number((capability as any)?.max_input_tokens);
-				return Number.isFinite(value) && value > max ? value : max;
-			}, 0);
-			const capMaxOutput = capabilities.reduce((max: number, capability: any) => {
-				const value = Number((capability as any)?.max_output_tokens);
-				return Number.isFinite(value) && value > max ? value : max;
-			}, 0);
-			const context = Number.isFinite(providerContext) && providerContext > 0
-				? providerContext
-				: capMaxInput;
-			const maxOutput = Number.isFinite(providerMaxOutput) && providerMaxOutput > 0
-				? providerMaxOutput
-				: capMaxOutput;
-			const quantizationRaw = pm.quantization_scheme;
-			const quantization =
-				typeof quantizationRaw === "string" && quantizationRaw.trim()
-					? quantizationRaw
-					: undefined;
-			ctxByModelId.set(modelId, { context, maxOutput, quantization });
-		}
-
-		const providerRaw = Array.isArray(pm.provider)
-			? pm.provider[0]
-			: pm.provider;
-		const providerInfo: GatewayProvider = providerRaw
-			? {
-				api_provider_name: providerRaw.api_provider_name ?? null,
-				link: providerRaw.link ?? null,
-			}
-			: null;
-
-		const providerModelKey = `${pm.provider_id}:${pm.api_model_id}`;
-		if (pm.provider_id && pm.api_model_id) {
-			providerModelByKey.set(providerModelKey, pm);
-		}
-
-		for (const cap of capabilities) {
-			if (!cap?.capability_id) continue;
-			const key = `${pm.provider_id}:${pm.api_model_id}:${cap.capability_id}`;
-			modelKeysSet.add(key);
-
-			gatewayModelsData.push(
-				normalizeGatewayModel({
-					model_id: modelId,
-					api_model_id: pm.api_model_id,
-					api_provider_id: pm.provider_id,
-					key,
-					endpoint: cap.capability_id,
-					is_active_gateway: pm.is_active_gateway,
-					capability_status: cap.status ?? null,
-					input_modalities: pm.input_modalities,
-					output_modalities: pm.output_modalities,
-					params: cap.params ?? {},
-					provider: providerInfo,
-				})
-			);
-		}
-	}
-
-	const modelKeys = Array.from(modelKeysSet);
-
-	let pricingData:
-		| Array<{
-			model_key: string;
-			meter: string;
-			unit: string | null;
-			unit_size: number;
-			price_per_unit: number;
-			pricing_plan: string | null;
-			effective_from: string | null;
-			effective_to: string | null;
-		}>
-		| null = [];
-
-	if (modelKeys.length) {
-		pricingData = await fetchPricingRulesByModelKeysInBatches({
-			supabase,
-			modelKeys,
-			batchSize: 120,
-		});
-	}
-
-	const pricingByKey = new Map<
-		string,
-		{
-			inputPrice: number;
-			outputPrice: number;
-			standardInputPrice: number | null;
-			standardOutputPrice: number | null;
-			standardInputPriceLabel: string | null;
-			standardInputPriceUnit: string | null;
-			standardOutputPriceLabel: string | null;
-			standardOutputPriceUnit: string | null;
-			standardInputPriority: number;
-			standardOutputPriority: number;
-			tier: string;
-			fromPrice: number | null;
-			fromPriceUnit: string | null;
-		}
-	>();
-	const freeByKey = new Map<string, boolean>();
-	for (const p of pricingData ?? []) {
-		if (p.model_key) {
-			if (String(p.model_key).toLowerCase().includes(":free:")) {
-				freeByKey.set(p.model_key, true);
-			}
-		}
-		if (!pricingByKey.has(p.model_key)) {
-			pricingByKey.set(p.model_key, {
-				inputPrice: 0,
-				outputPrice: 0,
-				standardInputPrice: null,
-				standardOutputPrice: null,
-				standardInputPriceLabel: null,
-				standardInputPriceUnit: null,
-				standardOutputPriceLabel: null,
-				standardOutputPriceUnit: null,
-				standardInputPriority: Number.POSITIVE_INFINITY,
-				standardOutputPriority: Number.POSITIVE_INFINITY,
-				tier: "standard",
-				fromPrice: null,
-				fromPriceUnit: null,
-			});
-		}
-		const prices = pricingByKey.get(p.model_key)!;
-		const displayPrice = toDisplayPrice(
-			p.price_per_unit,
-			p.unit_size,
-			p.meter,
-			p.unit,
-		);
-		const normalizedPricingPlan = String(p.pricing_plan ?? "standard")
-			.trim()
-			.toLowerCase();
-		const isStandardPricingPlan =
-			normalizedPricingPlan === "" || normalizedPricingPlan === "standard";
-		if (
-			(p.meter === "input_text_tokens" || p.meter === "input_tokens") &&
-			prices.inputPrice === 0
-		) {
-			prices.inputPrice = toUsdPerMillion(p.price_per_unit, p.unit_size);
-			prices.tier = p.pricing_plan || "standard";
-		}
-		if (
-			isStandardPricingPlan &&
-			displayPrice
-		) {
-			const meterMeta = getStandardIoMeterMeta(p.meter);
-			if (meterMeta?.side === "input") {
-				const shouldReplaceInput =
-					prices.standardInputPrice === null ||
-					meterMeta.priority < prices.standardInputPriority ||
-					(meterMeta.priority === prices.standardInputPriority &&
-						displayPrice.value < prices.standardInputPrice);
-				if (shouldReplaceInput) {
-					prices.standardInputPrice = displayPrice.value;
-					prices.standardInputPriceLabel = meterMeta.label;
-					prices.standardInputPriceUnit = displayPrice.unit;
-					prices.standardInputPriority = meterMeta.priority;
-				}
-			}
-			if (meterMeta?.side === "output") {
-				const shouldReplaceOutput =
-					prices.standardOutputPrice === null ||
-					meterMeta.priority < prices.standardOutputPriority ||
-					(meterMeta.priority === prices.standardOutputPriority &&
-						displayPrice.value < prices.standardOutputPrice);
-				if (shouldReplaceOutput) {
-					prices.standardOutputPrice = displayPrice.value;
-					prices.standardOutputPriceLabel = meterMeta.label;
-					prices.standardOutputPriceUnit = displayPrice.unit;
-					prices.standardOutputPriority = meterMeta.priority;
-				}
-			}
-		}
-		if (
-			(p.meter === "output_text_tokens" || p.meter === "output_tokens") &&
-			prices.outputPrice === 0
-		) {
-			prices.outputPrice = toUsdPerMillion(p.price_per_unit, p.unit_size);
-			if (prices.tier === "standard") {
-				prices.tier = p.pricing_plan || "standard";
-			}
-		}
-		if (!displayPrice) continue;
-		if (prices.fromPrice === null || !prices.fromPriceUnit) {
-			prices.fromPrice = displayPrice.value;
-			prices.fromPriceUnit = displayPrice.unit;
-			continue;
-		}
-		// Only compare numeric values within the same display unit.
-		if (
-			prices.fromPriceUnit === displayPrice.unit &&
-			displayPrice.value < prices.fromPrice
-		) {
-			prices.fromPrice = displayPrice.value;
-			prices.fromPriceUnit = displayPrice.unit;
-		}
-	}
-
+	const featureOrderIndexForRow = new Map(
+		featureOrder.map((feature, index) => [feature, index]),
+	);
 	const allModels: MonitorModelData[] = [];
-	for (const gatewayModel of gatewayModelsData ?? []) {
-		const pm = providerModelByKey.get(
-			`${gatewayModel.api_provider_id}:${gatewayModel.api_model_id}`
-		);
-		const modelId =
-			pm?.model_id ??
-			pm?.api_model_id ??
-			gatewayModel.model_id ??
-			"";
-		const modelRow = modelById.get(modelId) ?? null;
 
-		const { context, maxOutput, quantization } =
-			ctxByModelId.get(modelId) ?? {
-				context: 0,
-				maxOutput: 0,
-				quantization: undefined,
-			};
+	for (const raw of (rpcRows ?? []) as MonitorModelRpcRow[]) {
+		const row = raw as MonitorModelRpcRow;
+		const modelId = String(row.model_id ?? row.api_model_id ?? "").trim();
+		if (!modelId) continue;
 
-		const baseInputModalities = parseModalities(modelRow?.input_types);
-		const baseOutputModalities = parseModalities(modelRow?.output_types);
-		const gatewayInputModalities = parseModalities(gatewayModel.input_modalities);
-		const gatewayOutputModalities = parseModalities(gatewayModel.output_modalities);
+		const providerInfo: GatewayProvider =
+			row.api_provider_name || row.provider_link
+				? {
+					api_provider_name: row.api_provider_name ?? null,
+					link: row.provider_link ?? null,
+				}
+				: null;
 
-		const prices =
-			(gatewayModel?.key
-				? pricingByKey.get(gatewayModel.key)
-				: undefined) ?? {
-				inputPrice: 0,
-				outputPrice: 0,
-				standardInputPrice: null,
-				standardOutputPrice: null,
-				standardInputPriceLabel: null,
-				standardInputPriceUnit: null,
-				standardOutputPriceLabel: null,
-				standardOutputPriceUnit: null,
-				standardInputPriority: Number.POSITIVE_INFINITY,
-				standardOutputPriority: Number.POSITIVE_INFINITY,
-				tier: "standard",
-				fromPrice: null,
-				fromPriceUnit: null,
-			};
+		const gatewayModel = normalizeGatewayModel({
+			model_id: modelId,
+			api_model_id: row.api_model_id,
+			api_provider_id: row.provider_id,
+			key: row.provider_id && row.api_model_id && row.capability_id
+				? `${row.provider_id}:${row.api_model_id}:${row.capability_id}`
+				: "",
+			endpoint: row.capability_id,
+			is_active_gateway: row.is_active_gateway,
+			capability_status: row.capability_status,
+			input_modalities: row.input_modalities,
+			output_modalities: row.output_modalities,
+			params: row.capability_params ?? {},
+			provider: providerInfo,
+		});
 
-		const extractedFeatures = extractFeatureKeys(gatewayModel?.params);
-		const supportedParameters = extractSupportedParameters(gatewayModel?.params);
-		const isFreeVariant =
-			(gatewayModel?.key ? freeByKey.get(gatewayModel.key) : false) ||
-			(Boolean(gatewayModel?.api_model_id) &&
-				String(gatewayModel?.api_model_id).includes(":free"));
+		const extractedFeatures = extractFeatureKeys(gatewayModel.params);
+		const supportedParameters = extractSupportedParameters(gatewayModel.params);
+		const isFreeVariant = Boolean(row.is_free_variant);
 		const normalizedFeatures = new Set<string>(
-			extractedFeatures.map((feature) => String(feature))
+			extractedFeatures.map((feature) => String(feature)),
 		);
 		if (isFreeVariant) normalizedFeatures.add("free");
-		const featureOrderIndexForRow = new Map(
-			featureOrder.map((feature, index) => [feature, index])
-		);
 		const sortedFeatures = Array.from(normalizedFeatures).sort((a, b) => {
 			const aIndex = featureOrderIndexForRow.get(a);
 			const bIndex = featureOrderIndexForRow.get(b);
@@ -677,58 +146,102 @@ export async function getMonitorModels(
 		});
 
 		const providerName =
-			gatewayModel.provider?.api_provider_name ||
-			gatewayModel.api_provider_id;
-		const organisationRecord = Array.isArray(modelRow?.organisation)
-			? (modelRow?.organisation[0] as any)
-			: (modelRow?.organisation as any);
+			gatewayModel.provider?.api_provider_name || gatewayModel.api_provider_id;
+		const providerContext = Number(row.context_length ?? Number.NaN);
+		const providerMaxOutput = Number(
+			row.provider_max_output_tokens ?? Number.NaN,
+		);
+		const capMaxInput = Number(row.capability_max_input_tokens ?? Number.NaN);
+		const capMaxOutput = Number(row.capability_max_output_tokens ?? Number.NaN);
+		const context =
+			Number.isFinite(providerContext) && providerContext > 0
+				? providerContext
+				: Number.isFinite(capMaxInput) && capMaxInput > 0
+					? capMaxInput
+					: 0;
+		const maxOutput =
+			Number.isFinite(providerMaxOutput) && providerMaxOutput > 0
+				? providerMaxOutput
+				: Number.isFinite(capMaxOutput) && capMaxOutput > 0
+					? capMaxOutput
+					: 0;
+		const quantization =
+			typeof row.quantization_scheme === "string" &&
+			row.quantization_scheme.trim()
+				? row.quantization_scheme
+				: undefined;
 
-		const rawEndpoint = gatewayModel?.endpoint || gatewayModel?.key || "";
 		const monitorModel: MonitorModelData = {
 			id: `${modelId}-${gatewayModel.api_provider_id}-${gatewayModel.key}`,
-			model: modelRow?.name || modelId || "",
+			model: String(row.model_name ?? modelId).trim() || modelId,
 			modelId,
-			apiModelId: pm?.api_model_id ?? gatewayModel.api_model_id ?? undefined,
-			organisationId: organisationRecord?.organisation_id || undefined,
-			organisationName: organisationRecord?.name || undefined,
+			apiModelId: row.api_model_id ?? undefined,
+			organisationId: row.organisation_id ?? undefined,
+			organisationName: row.organisation_name ?? undefined,
 			provider: {
 				name: providerName ?? gatewayModel.api_provider_id,
 				id: gatewayModel.api_provider_id,
-				inputPrice: prices.inputPrice,
-				outputPrice: prices.outputPrice,
-				standardInputPrice: prices.standardInputPrice,
-				standardOutputPrice: prices.standardOutputPrice,
-				standardInputPriceLabel: prices.standardInputPriceLabel,
-				standardInputPriceUnit: prices.standardInputPriceUnit,
-				standardOutputPriceLabel: prices.standardOutputPriceLabel,
-				standardOutputPriceUnit: prices.standardOutputPriceUnit,
-				fromPrice: prices.fromPrice,
-				fromPriceUnit: prices.fromPriceUnit,
+				inputPrice: Number(row.input_price ?? 0) || 0,
+				outputPrice: Number(row.output_price ?? 0) || 0,
+				standardInputPrice: Number.isFinite(Number(row.standard_input_price))
+					? Number(row.standard_input_price)
+					: null,
+				standardOutputPrice: Number.isFinite(Number(row.standard_output_price))
+					? Number(row.standard_output_price)
+					: null,
+				standardInputPriceLabel: row.standard_input_price_label ?? null,
+				standardInputPriceUnit: row.standard_input_price_unit ?? null,
+				standardOutputPriceLabel: row.standard_output_price_label ?? null,
+				standardOutputPriceUnit: row.standard_output_price_unit ?? null,
+				fromPrice: Number.isFinite(Number(row.from_price))
+					? Number(row.from_price)
+					: null,
+				fromPriceUnit: row.from_price_unit ?? null,
 				features: sortedFeatures,
 			},
-			endpoint: normalizeEndpoint(rawEndpoint),
+			endpoint: normalizeEndpoint(String(row.capability_id ?? "")),
 			gatewayStatus: resolveGatewayStatus(
-				gatewayModel?.is_active_gateway,
-				gatewayModel?.capability_status,
+				gatewayModel.is_active_gateway,
+				gatewayModel.capability_status,
 			),
-			inputModalities:
-				gatewayInputModalities.length > 0
-					? gatewayInputModalities
-					: baseInputModalities,
-			outputModalities:
-				gatewayOutputModalities.length > 0
-					? gatewayOutputModalities
-					: baseOutputModalities,
+			inputModalities: (() => {
+				const gatewayValues = parseModalities(gatewayModel.input_modalities);
+				return gatewayValues.length > 0
+					? gatewayValues
+					: parseModalities(row.model_input_types);
+			})(),
+			outputModalities: (() => {
+				const gatewayValues = parseModalities(gatewayModel.output_modalities);
+				return gatewayValues.length > 0
+					? gatewayValues
+					: parseModalities(row.model_output_types);
+			})(),
 			context,
 			maxOutput,
 			quantization,
 			supportedParameters,
-			effectiveFrom: pm?.effective_from ?? undefined,
-			tier: isFreeVariant ? "free" : prices.tier || "standard",
-			added: modelRow?.release_date || undefined,
-			retired: modelRow?.retirement_date
-				? new Date(modelRow.retirement_date).toISOString().split("T")[0]
+			effectiveFrom: row.effective_from ?? undefined,
+			tier: isFreeVariant ? "free" : String(row.pricing_tier ?? "standard"),
+			added: row.model_release_date ?? undefined,
+			retired: row.model_retirement_date
+				? new Date(row.model_retirement_date).toISOString().split("T")[0]
 				: undefined,
+			weeklyTokensModel: Number.isFinite(Number(row.weekly_tokens_model))
+				? Number(row.weekly_tokens_model)
+				: null,
+			weeklyTokensModelProvider: Number.isFinite(
+				Number(row.weekly_tokens_model_provider),
+			)
+				? Number(row.weekly_tokens_model_provider)
+				: null,
+			weeklyThroughputModel: Number.isFinite(
+				Number(row.weekly_throughput_model),
+			)
+				? Number(row.weekly_throughput_model)
+				: null,
+			weeklyLatencyModel: Number.isFinite(Number(row.weekly_latency_model))
+				? Number(row.weekly_latency_model)
+				: null,
 		};
 
 		allModels.push(monitorModel);

--- a/apps/web/src/lib/fetchers/models/table-view/getMonitorModels.ts
+++ b/apps/web/src/lib/fetchers/models/table-view/getMonitorModels.ts
@@ -18,6 +18,12 @@ import {
 
 export type { MonitorModelData } from "./types";
 
+function toNullableNumber(value: unknown): number | null {
+	if (value === null || value === undefined) return null;
+	const numericValue = Number(value);
+	return Number.isFinite(numericValue) ? numericValue : null;
+}
+
 type MonitorModelRpcRow = {
 	model_id: string | null;
 	model_name: string | null;
@@ -232,22 +238,12 @@ export async function getMonitorModels(
 			retired: row.model_retirement_date
 				? new Date(row.model_retirement_date).toISOString().split("T")[0]
 				: undefined,
-			weeklyTokensModel: Number.isFinite(Number(row.weekly_tokens_model))
-				? Number(row.weekly_tokens_model)
-				: null,
-			weeklyTokensModelProvider: Number.isFinite(
-				Number(row.weekly_tokens_model_provider),
-			)
-				? Number(row.weekly_tokens_model_provider)
-				: null,
-			weeklyThroughputModel: Number.isFinite(
-				Number(row.weekly_throughput_model),
-			)
-				? Number(row.weekly_throughput_model)
-				: null,
-			weeklyLatencyModel: Number.isFinite(Number(row.weekly_latency_model))
-				? Number(row.weekly_latency_model)
-				: null,
+			weeklyTokensModel: toNullableNumber(row.weekly_tokens_model),
+			weeklyTokensModelProvider: toNullableNumber(
+				row.weekly_tokens_model_provider,
+			),
+			weeklyThroughputModel: toNullableNumber(row.weekly_throughput_model),
+			weeklyLatencyModel: toNullableNumber(row.weekly_latency_model),
 		};
 
 		allModels.push(monitorModel);

--- a/apps/web/src/lib/fetchers/models/table-view/getMonitorModels.ts
+++ b/apps/web/src/lib/fetchers/models/table-view/getMonitorModels.ts
@@ -1,7 +1,11 @@
 import { createAdminClient } from "@/utils/supabase/admin";
 import { cacheLife, cacheTag } from "next/cache";
 import { featureOrder } from "@/lib/config/featureLabels";
-import type { MonitorModelData, MonitorModelFilters, GatewayProvider } from "./types";
+import type {
+	GatewayProvider,
+	MonitorModelData,
+	MonitorModelFilters,
+} from "@/lib/fetchers/models/table-view/types";
 import {
 	parseModalities,
 	extractFeatureKeys,
@@ -78,6 +82,8 @@ export async function getMonitorModels(
 	cacheLife("hours");
 	cacheTag("models:monitor");
 	cacheTag("monitor-models");
+	cacheTag("data:data_api_model_aliases");
+	cacheTag("data:data_api_provider_model_capabilities");
 	cacheTag("data:data_api_provider_models");
 	cacheTag("data:data_api_pricing_rules");
 	cacheTag("data:models");

--- a/apps/web/src/lib/fetchers/models/table-view/getMonitorModels.ts
+++ b/apps/web/src/lib/fetchers/models/table-view/getMonitorModels.ts
@@ -79,7 +79,7 @@ export async function getMonitorModels(
 }> {
 	"use cache";
 
-	cacheLife("hours");
+	cacheLife("minutes");
 	cacheTag("models:monitor");
 	cacheTag("monitor-models");
 	cacheTag("data:data_api_model_aliases");

--- a/apps/web/src/lib/fetchers/models/table-view/types.ts
+++ b/apps/web/src/lib/fetchers/models/table-view/types.ts
@@ -34,6 +34,10 @@ export interface MonitorModelData {
     tier?: string; // pricing tier
     added?: string;
     retired?: string; // When this model is retired
+    weeklyTokensModel?: number | null;
+    weeklyTokensModelProvider?: number | null;
+    weeklyThroughputModel?: number | null;
+    weeklyLatencyModel?: number | null;
 }
 
 export interface MonitorModelFilters {

--- a/packages/data/catalog/src/data/api_providers/openai/models.json
+++ b/packages/data/catalog/src/data/api_providers/openai/models.json
@@ -2941,7 +2941,7 @@
       },
         {
           "capability_id": "batch",
-          "status": "coming_soon",
+          "status": "disabled",
           "params": []
         }
     ]
@@ -3194,7 +3194,7 @@
       },
         {
           "capability_id": "batch",
-          "status": "coming_soon",
+          "status": "disabled",
           "params": []
         }
     ]
@@ -3317,11 +3317,11 @@
           }
         ]
       },
-      {
-        "capability_id": "batch",
-        "status": "disabled",
-        "params": []
-      }
+        {
+          "capability_id": "batch",
+          "status": "coming_soon",
+          "params": []
+        }
     ]
   },
   {
@@ -3442,11 +3442,11 @@
           }
         ]
       },
-      {
-        "capability_id": "batch",
-        "status": "disabled",
-        "params": []
-      }
+        {
+          "capability_id": "batch",
+          "status": "coming_soon",
+          "params": []
+        }
     ]
   },
   {

--- a/packages/data/catalog/src/data/api_providers/openai/models.json
+++ b/packages/data/catalog/src/data/api_providers/openai/models.json
@@ -2939,11 +2939,11 @@
           }
         ]
       },
-      {
-        "capability_id": "batch",
-        "status": "disabled",
-        "params": []
-      }
+        {
+          "capability_id": "batch",
+          "status": "coming_soon",
+          "params": []
+        }
     ]
   },
   {
@@ -3192,11 +3192,11 @@
           }
         ]
       },
-      {
-        "capability_id": "batch",
-        "status": "disabled",
-        "params": []
-      }
+        {
+          "capability_id": "batch",
+          "status": "coming_soon",
+          "params": []
+        }
     ]
   },
   {

--- a/packages/data/catalog/src/data/pricing/google-ai-studio/google-gemini-embedding-2/text.embed/pricing.json
+++ b/packages/data/catalog/src/data/pricing/google-ai-studio/google-gemini-embedding-2/text.embed/pricing.json
@@ -52,54 +52,6 @@
       "match": [],
       "priority": 100,
       "effective_from": "2026-04-22T00:00:00"
-    },
-    {
-      "meter": "input_text_tokens",
-      "unit": "token",
-      "unit_size": 1000000,
-      "price_per_unit": 0.1,
-      "currency": "USD",
-      "pricing_plan": "batch",
-      "note": null,
-      "match": [],
-      "priority": 100,
-      "effective_from": "2026-04-22T00:00:00"
-    },
-    {
-      "meter": "input_image_tokens",
-      "unit": "token",
-      "unit_size": 1000000,
-      "price_per_unit": 0.225,
-      "currency": "USD",
-      "pricing_plan": "batch",
-      "note": null,
-      "match": [],
-      "priority": 100,
-      "effective_from": "2026-04-22T00:00:00"
-    },
-    {
-      "meter": "input_audio_tokens",
-      "unit": "token",
-      "unit_size": 1000000,
-      "price_per_unit": 3.25,
-      "currency": "USD",
-      "pricing_plan": "batch",
-      "note": null,
-      "match": [],
-      "priority": 100,
-      "effective_from": "2026-04-22T00:00:00"
-    },
-    {
-      "meter": "input_video_tokens",
-      "unit": "token",
-      "unit_size": 1000000,
-      "price_per_unit": 6,
-      "currency": "USD",
-      "pricing_plan": "batch",
-      "note": null,
-      "match": [],
-      "priority": 100,
-      "effective_from": "2026-04-22T00:00:00"
     }
   ]
 }

--- a/packages/data/catalog/src/data/pricing/google-vertex/google-gemini-embedding-2/text.embed/pricing.json
+++ b/packages/data/catalog/src/data/pricing/google-vertex/google-gemini-embedding-2/text.embed/pricing.json
@@ -52,54 +52,6 @@
       "match": [],
       "priority": 100,
       "effective_from": "2026-04-22T00:00:00"
-    },
-    {
-      "meter": "input_text_tokens",
-      "unit": "token",
-      "unit_size": 1000000,
-      "price_per_unit": 0.1,
-      "currency": "USD",
-      "pricing_plan": "batch",
-      "note": null,
-      "match": [],
-      "priority": 100,
-      "effective_from": "2026-04-22T00:00:00"
-    },
-    {
-      "meter": "input_image_tokens",
-      "unit": "token",
-      "unit_size": 1000000,
-      "price_per_unit": 0.225,
-      "currency": "USD",
-      "pricing_plan": "batch",
-      "note": null,
-      "match": [],
-      "priority": 100,
-      "effective_from": "2026-04-22T00:00:00"
-    },
-    {
-      "meter": "input_audio_tokens",
-      "unit": "token",
-      "unit_size": 1000000,
-      "price_per_unit": 3.25,
-      "currency": "USD",
-      "pricing_plan": "batch",
-      "note": null,
-      "match": [],
-      "priority": 100,
-      "effective_from": "2026-04-22T00:00:00"
-    },
-    {
-      "meter": "input_video_tokens",
-      "unit": "token",
-      "unit_size": 1000000,
-      "price_per_unit": 6,
-      "currency": "USD",
-      "pricing_plan": "batch",
-      "note": null,
-      "match": [],
-      "priority": 100,
-      "effective_from": "2026-04-22T00:00:00"
     }
   ]
 }

--- a/packages/data/catalog/src/data/pricing/openai/openai-gpt-5.5-pro/batch/pricing.json
+++ b/packages/data/catalog/src/data/pricing/openai/openai-gpt-5.5-pro/batch/pricing.json
@@ -1,0 +1,89 @@
+{
+  "key": "openai:openai/gpt-5.5-pro:batch",
+  "api_provider_id": "openai",
+  "provider_slug": "openai",
+  "api_model_id": "openai/gpt-5.5-pro",
+  "capability_id": "batch",
+  "rules": [
+    {
+      "meter": "input_text_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 15,
+      "currency": "USD",
+      "pricing_plan": "batch",
+      "note": null,
+      "match": [
+        {
+          "path": "input_tokens",
+          "op": "lt",
+          "or_group": 1,
+          "and_index": 1,
+          "value": 272000
+        }
+      ],
+      "priority": 100,
+      "effective_from": "2026-04-23T00:00:00"
+    },
+    {
+      "meter": "output_text_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 90,
+      "currency": "USD",
+      "pricing_plan": "batch",
+      "note": null,
+      "match": [
+        {
+          "path": "input_tokens",
+          "op": "lt",
+          "or_group": 1,
+          "and_index": 1,
+          "value": 272000
+        }
+      ],
+      "priority": 100,
+      "effective_from": "2026-04-23T00:00:00"
+    },
+    {
+      "meter": "input_text_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 30,
+      "currency": "USD",
+      "pricing_plan": "batch",
+      "note": "High Context",
+      "match": [
+        {
+          "path": "input_tokens",
+          "op": "gte",
+          "or_group": 1,
+          "and_index": 1,
+          "value": 272000
+        }
+      ],
+      "priority": 100,
+      "effective_from": "2026-04-23T00:00:00"
+    },
+    {
+      "meter": "output_text_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 135,
+      "currency": "USD",
+      "pricing_plan": "batch",
+      "note": "High Context",
+      "match": [
+        {
+          "path": "input_tokens",
+          "op": "gte",
+          "or_group": 1,
+          "and_index": 1,
+          "value": 272000
+        }
+      ],
+      "priority": 100,
+      "effective_from": "2026-04-23T00:00:00"
+    }
+  ]
+}

--- a/packages/data/catalog/src/data/pricing/openai/openai-gpt-5.5-pro/text.generate/pricing.json
+++ b/packages/data/catalog/src/data/pricing/openai/openai-gpt-5.5-pro/text.generate/pricing.json
@@ -13,7 +13,15 @@
       "currency": "USD",
       "pricing_plan": "standard",
       "note": null,
-      "match": [],
+      "match": [
+        {
+          "path": "input_tokens",
+          "op": "lt",
+          "or_group": 1,
+          "and_index": 1,
+          "value": 272000
+        }
+      ],
       "priority": 100,
       "effective_from": "2026-04-23T00:00:00"
     },
@@ -25,7 +33,215 @@
       "currency": "USD",
       "pricing_plan": "standard",
       "note": null,
-      "match": [],
+      "match": [
+        {
+          "path": "input_tokens",
+          "op": "lt",
+          "or_group": 1,
+          "and_index": 1,
+          "value": 272000
+        }
+      ],
+      "priority": 100,
+      "effective_from": "2026-04-23T00:00:00"
+    },
+    {
+      "meter": "input_text_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 60,
+      "currency": "USD",
+      "pricing_plan": "standard",
+      "note": "High Context",
+      "match": [
+        {
+          "path": "input_tokens",
+          "op": "gte",
+          "or_group": 1,
+          "and_index": 1,
+          "value": 272000
+        }
+      ],
+      "priority": 100,
+      "effective_from": "2026-04-23T00:00:00"
+    },
+    {
+      "meter": "output_text_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 270,
+      "currency": "USD",
+      "pricing_plan": "standard",
+      "note": "High Context",
+      "match": [
+        {
+          "path": "input_tokens",
+          "op": "gte",
+          "or_group": 1,
+          "and_index": 1,
+          "value": 272000
+        }
+      ],
+      "priority": 100,
+      "effective_from": "2026-04-23T00:00:00"
+    },
+    {
+      "meter": "input_text_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 15,
+      "currency": "USD",
+      "pricing_plan": "flex",
+      "note": null,
+      "match": [
+        {
+          "path": "input_tokens",
+          "op": "lt",
+          "or_group": 1,
+          "and_index": 1,
+          "value": 272000
+        }
+      ],
+      "priority": 100,
+      "effective_from": "2026-04-23T00:00:00"
+    },
+    {
+      "meter": "output_text_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 90,
+      "currency": "USD",
+      "pricing_plan": "flex",
+      "note": null,
+      "match": [
+        {
+          "path": "input_tokens",
+          "op": "lt",
+          "or_group": 1,
+          "and_index": 1,
+          "value": 272000
+        }
+      ],
+      "priority": 100,
+      "effective_from": "2026-04-23T00:00:00"
+    },
+    {
+      "meter": "input_text_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 30,
+      "currency": "USD",
+      "pricing_plan": "flex",
+      "note": "High Context",
+      "match": [
+        {
+          "path": "input_tokens",
+          "op": "gte",
+          "or_group": 1,
+          "and_index": 1,
+          "value": 272000
+        }
+      ],
+      "priority": 100,
+      "effective_from": "2026-04-23T00:00:00"
+    },
+    {
+      "meter": "output_text_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 135,
+      "currency": "USD",
+      "pricing_plan": "flex",
+      "note": "High Context",
+      "match": [
+        {
+          "path": "input_tokens",
+          "op": "gte",
+          "or_group": 1,
+          "and_index": 1,
+          "value": 272000
+        }
+      ],
+      "priority": 100,
+      "effective_from": "2026-04-23T00:00:00"
+    },
+    {
+      "meter": "input_text_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 75,
+      "currency": "USD",
+      "pricing_plan": "priority",
+      "note": null,
+      "match": [
+        {
+          "path": "input_tokens",
+          "op": "lt",
+          "or_group": 1,
+          "and_index": 1,
+          "value": 272000
+        }
+      ],
+      "priority": 100,
+      "effective_from": "2026-04-23T00:00:00"
+    },
+    {
+      "meter": "output_text_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 450,
+      "currency": "USD",
+      "pricing_plan": "priority",
+      "note": null,
+      "match": [
+        {
+          "path": "input_tokens",
+          "op": "lt",
+          "or_group": 1,
+          "and_index": 1,
+          "value": 272000
+        }
+      ],
+      "priority": 100,
+      "effective_from": "2026-04-23T00:00:00"
+    },
+    {
+      "meter": "input_text_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 150,
+      "currency": "USD",
+      "pricing_plan": "priority",
+      "note": "High Context",
+      "match": [
+        {
+          "path": "input_tokens",
+          "op": "gte",
+          "or_group": 1,
+          "and_index": 1,
+          "value": 272000
+        }
+      ],
+      "priority": 100,
+      "effective_from": "2026-04-23T00:00:00"
+    },
+    {
+      "meter": "output_text_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 675,
+      "currency": "USD",
+      "pricing_plan": "priority",
+      "note": "High Context",
+      "match": [
+        {
+          "path": "input_tokens",
+          "op": "gte",
+          "or_group": 1,
+          "and_index": 1,
+          "value": 272000
+        }
+      ],
       "priority": 100,
       "effective_from": "2026-04-23T00:00:00"
     }

--- a/packages/data/catalog/src/data/pricing/openai/openai-gpt-5.5/batch/pricing.json
+++ b/packages/data/catalog/src/data/pricing/openai/openai-gpt-5.5/batch/pricing.json
@@ -1,0 +1,129 @@
+{
+  "key": "openai:openai/gpt-5.5:batch",
+  "api_provider_id": "openai",
+  "provider_slug": "openai",
+  "api_model_id": "openai/gpt-5.5",
+  "capability_id": "batch",
+  "rules": [
+    {
+      "meter": "input_text_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 2.5,
+      "currency": "USD",
+      "pricing_plan": "batch",
+      "note": null,
+      "match": [
+        {
+          "path": "input_tokens",
+          "op": "lt",
+          "or_group": 1,
+          "and_index": 1,
+          "value": 272000
+        }
+      ],
+      "priority": 100,
+      "effective_from": "2026-04-23T00:00:00"
+    },
+    {
+      "meter": "cached_read_text_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 0.25,
+      "currency": "USD",
+      "pricing_plan": "batch",
+      "note": null,
+      "match": [
+        {
+          "path": "input_tokens",
+          "op": "lt",
+          "or_group": 1,
+          "and_index": 1,
+          "value": 272000
+        }
+      ],
+      "priority": 100,
+      "effective_from": "2026-04-23T00:00:00"
+    },
+    {
+      "meter": "output_text_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 15,
+      "currency": "USD",
+      "pricing_plan": "batch",
+      "note": null,
+      "match": [
+        {
+          "path": "input_tokens",
+          "op": "lt",
+          "or_group": 1,
+          "and_index": 1,
+          "value": 272000
+        }
+      ],
+      "priority": 100,
+      "effective_from": "2026-04-23T00:00:00"
+    },
+    {
+      "meter": "input_text_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 5,
+      "currency": "USD",
+      "pricing_plan": "batch",
+      "note": "High Context",
+      "match": [
+        {
+          "path": "input_tokens",
+          "op": "gte",
+          "or_group": 1,
+          "and_index": 1,
+          "value": 272000
+        }
+      ],
+      "priority": 100,
+      "effective_from": "2026-04-23T00:00:00"
+    },
+    {
+      "meter": "cached_read_text_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 0.5,
+      "currency": "USD",
+      "pricing_plan": "batch",
+      "note": "High Context",
+      "match": [
+        {
+          "path": "input_tokens",
+          "op": "gte",
+          "or_group": 1,
+          "and_index": 1,
+          "value": 272000
+        }
+      ],
+      "priority": 100,
+      "effective_from": "2026-04-23T00:00:00"
+    },
+    {
+      "meter": "output_text_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 22.5,
+      "currency": "USD",
+      "pricing_plan": "batch",
+      "note": "High Context",
+      "match": [
+        {
+          "path": "input_tokens",
+          "op": "gte",
+          "or_group": 1,
+          "and_index": 1,
+          "value": 272000
+        }
+      ],
+      "priority": 100,
+      "effective_from": "2026-04-23T00:00:00"
+    }
+  ]
+}

--- a/packages/data/catalog/src/data/pricing/openai/openai-gpt-5.5/text.generate/pricing.json
+++ b/packages/data/catalog/src/data/pricing/openai/openai-gpt-5.5/text.generate/pricing.json
@@ -13,7 +13,35 @@
       "currency": "USD",
       "pricing_plan": "standard",
       "note": null,
-      "match": [],
+      "match": [
+        {
+          "path": "input_tokens",
+          "op": "lt",
+          "or_group": 1,
+          "and_index": 1,
+          "value": 272000
+        }
+      ],
+      "priority": 100,
+      "effective_from": "2026-04-23T00:00:00"
+    },
+    {
+      "meter": "cached_read_text_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 0.5,
+      "currency": "USD",
+      "pricing_plan": "standard",
+      "note": null,
+      "match": [
+        {
+          "path": "input_tokens",
+          "op": "lt",
+          "or_group": 1,
+          "and_index": 1,
+          "value": 272000
+        }
+      ],
       "priority": 100,
       "effective_from": "2026-04-23T00:00:00"
     },
@@ -25,7 +53,315 @@
       "currency": "USD",
       "pricing_plan": "standard",
       "note": null,
-      "match": [],
+      "match": [
+        {
+          "path": "input_tokens",
+          "op": "lt",
+          "or_group": 1,
+          "and_index": 1,
+          "value": 272000
+        }
+      ],
+      "priority": 100,
+      "effective_from": "2026-04-23T00:00:00"
+    },
+    {
+      "meter": "input_text_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 10,
+      "currency": "USD",
+      "pricing_plan": "standard",
+      "note": "High Context",
+      "match": [
+        {
+          "path": "input_tokens",
+          "op": "gte",
+          "or_group": 1,
+          "and_index": 1,
+          "value": 272000
+        }
+      ],
+      "priority": 100,
+      "effective_from": "2026-04-23T00:00:00"
+    },
+    {
+      "meter": "cached_read_text_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 1,
+      "currency": "USD",
+      "pricing_plan": "standard",
+      "note": "High Context",
+      "match": [
+        {
+          "path": "input_tokens",
+          "op": "gte",
+          "or_group": 1,
+          "and_index": 1,
+          "value": 272000
+        }
+      ],
+      "priority": 100,
+      "effective_from": "2026-04-23T00:00:00"
+    },
+    {
+      "meter": "output_text_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 45,
+      "currency": "USD",
+      "pricing_plan": "standard",
+      "note": "High Context",
+      "match": [
+        {
+          "path": "input_tokens",
+          "op": "gte",
+          "or_group": 1,
+          "and_index": 1,
+          "value": 272000
+        }
+      ],
+      "priority": 100,
+      "effective_from": "2026-04-23T00:00:00"
+    },
+    {
+      "meter": "input_text_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 2.5,
+      "currency": "USD",
+      "pricing_plan": "flex",
+      "note": null,
+      "match": [
+        {
+          "path": "input_tokens",
+          "op": "lt",
+          "or_group": 1,
+          "and_index": 1,
+          "value": 272000
+        }
+      ],
+      "priority": 100,
+      "effective_from": "2026-04-23T00:00:00"
+    },
+    {
+      "meter": "cached_read_text_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 0.25,
+      "currency": "USD",
+      "pricing_plan": "flex",
+      "note": null,
+      "match": [
+        {
+          "path": "input_tokens",
+          "op": "lt",
+          "or_group": 1,
+          "and_index": 1,
+          "value": 272000
+        }
+      ],
+      "priority": 100,
+      "effective_from": "2026-04-23T00:00:00"
+    },
+    {
+      "meter": "output_text_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 15,
+      "currency": "USD",
+      "pricing_plan": "flex",
+      "note": null,
+      "match": [
+        {
+          "path": "input_tokens",
+          "op": "lt",
+          "or_group": 1,
+          "and_index": 1,
+          "value": 272000
+        }
+      ],
+      "priority": 100,
+      "effective_from": "2026-04-23T00:00:00"
+    },
+    {
+      "meter": "input_text_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 5,
+      "currency": "USD",
+      "pricing_plan": "flex",
+      "note": "High Context",
+      "match": [
+        {
+          "path": "input_tokens",
+          "op": "gte",
+          "or_group": 1,
+          "and_index": 1,
+          "value": 272000
+        }
+      ],
+      "priority": 100,
+      "effective_from": "2026-04-23T00:00:00"
+    },
+    {
+      "meter": "cached_read_text_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 0.5,
+      "currency": "USD",
+      "pricing_plan": "flex",
+      "note": "High Context",
+      "match": [
+        {
+          "path": "input_tokens",
+          "op": "gte",
+          "or_group": 1,
+          "and_index": 1,
+          "value": 272000
+        }
+      ],
+      "priority": 100,
+      "effective_from": "2026-04-23T00:00:00"
+    },
+    {
+      "meter": "output_text_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 22.5,
+      "currency": "USD",
+      "pricing_plan": "flex",
+      "note": "High Context",
+      "match": [
+        {
+          "path": "input_tokens",
+          "op": "gte",
+          "or_group": 1,
+          "and_index": 1,
+          "value": 272000
+        }
+      ],
+      "priority": 100,
+      "effective_from": "2026-04-23T00:00:00"
+    },
+    {
+      "meter": "input_text_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 12.5,
+      "currency": "USD",
+      "pricing_plan": "priority",
+      "note": null,
+      "match": [
+        {
+          "path": "input_tokens",
+          "op": "lt",
+          "or_group": 1,
+          "and_index": 1,
+          "value": 272000
+        }
+      ],
+      "priority": 100,
+      "effective_from": "2026-04-23T00:00:00"
+    },
+    {
+      "meter": "cached_read_text_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 1.25,
+      "currency": "USD",
+      "pricing_plan": "priority",
+      "note": null,
+      "match": [
+        {
+          "path": "input_tokens",
+          "op": "lt",
+          "or_group": 1,
+          "and_index": 1,
+          "value": 272000
+        }
+      ],
+      "priority": 100,
+      "effective_from": "2026-04-23T00:00:00"
+    },
+    {
+      "meter": "output_text_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 75,
+      "currency": "USD",
+      "pricing_plan": "priority",
+      "note": null,
+      "match": [
+        {
+          "path": "input_tokens",
+          "op": "lt",
+          "or_group": 1,
+          "and_index": 1,
+          "value": 272000
+        }
+      ],
+      "priority": 100,
+      "effective_from": "2026-04-23T00:00:00"
+    },
+    {
+      "meter": "input_text_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 25,
+      "currency": "USD",
+      "pricing_plan": "priority",
+      "note": "High Context",
+      "match": [
+        {
+          "path": "input_tokens",
+          "op": "gte",
+          "or_group": 1,
+          "and_index": 1,
+          "value": 272000
+        }
+      ],
+      "priority": 100,
+      "effective_from": "2026-04-23T00:00:00"
+    },
+    {
+      "meter": "cached_read_text_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 2.5,
+      "currency": "USD",
+      "pricing_plan": "priority",
+      "note": "High Context",
+      "match": [
+        {
+          "path": "input_tokens",
+          "op": "gte",
+          "or_group": 1,
+          "and_index": 1,
+          "value": 272000
+        }
+      ],
+      "priority": 100,
+      "effective_from": "2026-04-23T00:00:00"
+    },
+    {
+      "meter": "output_text_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 112.5,
+      "currency": "USD",
+      "pricing_plan": "priority",
+      "note": "High Context",
+      "match": [
+        {
+          "path": "input_tokens",
+          "op": "gte",
+          "or_group": 1,
+          "and_index": 1,
+          "value": 272000
+        }
+      ],
       "priority": 100,
       "effective_from": "2026-04-23T00:00:00"
     }

--- a/supabase/migrations/20260424150000_add_monitor_models_rpc_and_raw_weekly_usage.sql
+++ b/supabase/migrations/20260424150000_add_monitor_models_rpc_and_raw_weekly_usage.sql
@@ -1,0 +1,409 @@
+create or replace function public.get_monitor_model_rows(
+  p_include_hidden boolean default false
+)
+returns table (
+  model_id text,
+  model_name text,
+  model_release_date date,
+  model_retirement_date date,
+  model_status text,
+  model_input_types text,
+  model_output_types text,
+  organisation_id text,
+  organisation_name text,
+  hidden boolean,
+  provider_api_model_id text,
+  provider_id text,
+  api_model_id text,
+  provider_model_slug text,
+  is_active_gateway boolean,
+  input_modalities text[],
+  output_modalities text[],
+  quantization_scheme text,
+  context_length integer,
+  provider_max_output_tokens integer,
+  effective_from timestamptz,
+  effective_to timestamptz,
+  capability_id text,
+  capability_params jsonb,
+  capability_status text,
+  capability_max_input_tokens integer,
+  capability_max_output_tokens integer,
+  api_provider_name text,
+  provider_link text,
+  input_price numeric,
+  output_price numeric,
+  standard_input_price numeric,
+  standard_output_price numeric,
+  standard_input_price_label text,
+  standard_input_price_unit text,
+  standard_output_price_label text,
+  standard_output_price_unit text,
+  from_price numeric,
+  from_price_unit text,
+  pricing_tier text,
+  is_free_variant boolean,
+  weekly_tokens_model bigint,
+  weekly_tokens_model_provider bigint,
+  weekly_throughput_model numeric,
+  weekly_latency_model numeric
+)
+language sql
+stable
+as $$
+  with normalized_weekly_requests as (
+    select
+      coalesce(
+        nullif(gr.canonical_model_id, ''),
+        public.resolve_public_model_id(gr.model_id, gr.provider),
+        nullif(gr.model_id, '')
+      ) as canonical_model_id,
+      coalesce(nullif(gr.provider, ''), 'unknown') as provider_id,
+      public.gateway_usage_total_tokens(gr.usage)::bigint as total_tokens,
+      gr.throughput::numeric as throughput,
+      gr.latency_ms::numeric as latency_ms
+    from public.gateway_requests gr
+    where gr.created_at >= now() - interval '7 days'
+  ),
+  weekly_model_usage as (
+    select
+      r.canonical_model_id as model_id,
+      sum(r.total_tokens)::bigint as weekly_tokens_model,
+      round(avg(r.throughput), 2) as weekly_throughput_model,
+      round(avg(r.latency_ms), 0) as weekly_latency_model
+    from normalized_weekly_requests r
+    where r.canonical_model_id is not null
+    group by r.canonical_model_id
+  ),
+  weekly_model_provider_usage as (
+    select
+      r.canonical_model_id as model_id,
+      r.provider_id,
+      sum(r.total_tokens)::bigint as weekly_tokens_model_provider
+    from normalized_weekly_requests r
+    where r.canonical_model_id is not null
+      and r.provider_id <> 'unknown'
+    group by r.canonical_model_id, r.provider_id
+  ),
+  active_pricing_rules as (
+    select
+      pr.model_key,
+      pr.meter,
+      pr.unit,
+      pr.unit_size,
+      pr.price_per_unit,
+      coalesce(nullif(lower(pr.pricing_plan), ''), 'standard') as pricing_plan,
+      case
+        when lower(coalesce(pr.meter, '')) like '%token%'
+          or lower(coalesce(pr.unit, '')) in ('token', 'tokens')
+          then pr.price_per_unit * (1000000 / nullif(pr.unit_size, 0))
+        when lower(coalesce(pr.unit, '')) in ('minute', 'minutes', 'min', 'mins', 'm')
+          then pr.price_per_unit / nullif(pr.unit_size, 0) / 60
+        when lower(coalesce(pr.unit, '')) in ('hour', 'hours', 'hr', 'hrs', 'h')
+          then pr.price_per_unit / nullif(pr.unit_size, 0) / 3600
+        else pr.price_per_unit / nullif(pr.unit_size, 0)
+      end as display_price,
+      case
+        when lower(coalesce(pr.meter, '')) like '%token%'
+          or lower(coalesce(pr.unit, '')) in ('token', 'tokens')
+          then '1M tokens'
+        when lower(coalesce(pr.unit, '')) in ('minute', 'minutes', 'min', 'mins', 'm')
+          then 'second'
+        when lower(coalesce(pr.unit, '')) in ('hour', 'hours', 'hr', 'hrs', 'h')
+          then 'second'
+        when lower(coalesce(pr.unit, '')) in ('second', 'seconds', 'sec', 'secs', 's')
+          then 'second'
+        when lower(coalesce(pr.unit, '')) in ('image', 'images')
+          then 'image'
+        when lower(coalesce(pr.unit, '')) in ('video', 'videos')
+          then 'video'
+        when lower(coalesce(pr.unit, '')) in ('character', 'characters', 'char', 'chars')
+          then 'character'
+        else nullif(lower(coalesce(pr.unit, '')), '')
+      end as display_unit,
+      case
+        when lower(coalesce(pr.meter, '')) in ('input_text_tokens', 'input_tokens')
+          then 'input'
+        when lower(coalesce(pr.meter, '')) = 'input_audio_tokens'
+          then 'input'
+        when lower(coalesce(pr.meter, '')) = 'input_image_tokens'
+          then 'input'
+        when lower(coalesce(pr.meter, '')) = 'input_video_tokens'
+          then 'input'
+        when lower(coalesce(pr.meter, '')) in ('output_text_tokens', 'output_tokens')
+          then 'output'
+        when lower(coalesce(pr.meter, '')) = 'output_audio_tokens'
+          then 'output'
+        when lower(coalesce(pr.meter, '')) = 'output_image_tokens'
+          then 'output'
+        when lower(coalesce(pr.meter, '')) = 'output_video_tokens'
+          then 'output'
+        else null
+      end as standard_side,
+      case
+        when lower(coalesce(pr.meter, '')) in ('input_text_tokens', 'input_tokens')
+          then 'Text Input'
+        when lower(coalesce(pr.meter, '')) = 'input_audio_tokens'
+          then 'Audio Input'
+        when lower(coalesce(pr.meter, '')) = 'input_image_tokens'
+          then 'Image Input'
+        when lower(coalesce(pr.meter, '')) = 'input_video_tokens'
+          then 'Video Input'
+        when lower(coalesce(pr.meter, '')) in ('output_text_tokens', 'output_tokens')
+          then 'Text Output'
+        when lower(coalesce(pr.meter, '')) = 'output_audio_tokens'
+          then 'Audio Output'
+        when lower(coalesce(pr.meter, '')) = 'output_image_tokens'
+          then 'Image Output'
+        when lower(coalesce(pr.meter, '')) = 'output_video_tokens'
+          then 'Video Output'
+        else null
+      end as standard_label,
+      case
+        when lower(coalesce(pr.meter, '')) in ('input_text_tokens', 'input_tokens', 'output_text_tokens', 'output_tokens')
+          then 0
+        when lower(coalesce(pr.meter, '')) in ('input_audio_tokens', 'output_audio_tokens')
+          then 1
+        when lower(coalesce(pr.meter, '')) in ('input_image_tokens', 'output_image_tokens')
+          then 2
+        when lower(coalesce(pr.meter, '')) in ('input_video_tokens', 'output_video_tokens')
+          then 3
+        else 99
+      end as standard_priority
+    from public.data_api_pricing_rules pr
+    where (pr.effective_from is null or pr.effective_from <= now())
+      and (pr.effective_to is null or now() < pr.effective_to)
+  ),
+  provider_rows as (
+    select
+      pm.*,
+      coalesce(
+        nullif(btrim(pm.model_id), ''),
+        public.resolve_public_model_id(nullif(btrim(pm.api_model_id), ''), pm.provider_id),
+        nullif(btrim(pm.api_model_id), '')
+      ) as canonical_model_id
+    from public.data_api_provider_models pm
+    where pm.api_model_id is not null
+      and btrim(pm.api_model_id) <> ''
+  ),
+  ranked_standard_rules as (
+    select
+      apr.model_key,
+      apr.standard_side,
+      apr.standard_label,
+      apr.display_unit,
+      apr.display_price,
+      row_number() over (
+        partition by apr.model_key, apr.standard_side
+        order by apr.standard_priority asc, apr.display_price asc nulls last, apr.standard_label asc
+      ) as row_num
+    from active_pricing_rules apr
+    where apr.pricing_plan = 'standard'
+      and apr.standard_side is not null
+      and apr.display_price is not null
+      and apr.display_unit is not null
+  ),
+  standard_price_choices as (
+    select
+      rsr.model_key,
+      max(case when rsr.standard_side = 'input' and rsr.row_num = 1 then rsr.display_price end) as standard_input_price,
+      max(case when rsr.standard_side = 'output' and rsr.row_num = 1 then rsr.display_price end) as standard_output_price,
+      max(case when rsr.standard_side = 'input' and rsr.row_num = 1 then rsr.standard_label end) as standard_input_price_label,
+      max(case when rsr.standard_side = 'input' and rsr.row_num = 1 then rsr.display_unit end) as standard_input_price_unit,
+      max(case when rsr.standard_side = 'output' and rsr.row_num = 1 then rsr.standard_label end) as standard_output_price_label,
+      max(case when rsr.standard_side = 'output' and rsr.row_num = 1 then rsr.display_unit end) as standard_output_price_unit
+    from ranked_standard_rules rsr
+    group by rsr.model_key
+  ),
+  pricing_summary as (
+    select
+      apr.model_key,
+      min(apr.price_per_unit * (1000000 / nullif(apr.unit_size, 0))) filter (
+        where apr.pricing_plan = 'standard'
+          and lower(coalesce(apr.meter, '')) in ('input_text_tokens', 'input_tokens')
+      ) as input_price,
+      min(apr.price_per_unit * (1000000 / nullif(apr.unit_size, 0))) filter (
+        where apr.pricing_plan = 'standard'
+          and lower(coalesce(apr.meter, '')) in ('output_text_tokens', 'output_tokens')
+      ) as output_price,
+      spc.standard_input_price,
+      spc.standard_output_price,
+      spc.standard_input_price_label,
+      spc.standard_input_price_unit,
+      spc.standard_output_price_label,
+      spc.standard_output_price_unit,
+      case
+        when count(distinct apr.display_unit) filter (
+          where apr.display_price is not null
+            and apr.display_unit is not null
+        ) = 1
+          then min(apr.display_price) filter (
+            where apr.display_price is not null
+              and apr.display_unit is not null
+          )
+        else null
+      end as from_price,
+      case
+        when count(distinct apr.display_unit) filter (
+          where apr.display_price is not null
+            and apr.display_unit is not null
+        ) = 1
+          then min(apr.display_unit) filter (
+            where apr.display_price is not null
+              and apr.display_unit is not null
+          )
+        else null
+      end as from_price_unit,
+      case
+        when apr.model_key like '%:free:%' then 'free'
+        when bool_or(apr.pricing_plan = 'standard') then 'standard'
+        else min(apr.pricing_plan)
+      end as pricing_tier
+    from active_pricing_rules apr
+    left join standard_price_choices spc
+      on spc.model_key = apr.model_key
+    group by
+      apr.model_key,
+      spc.standard_input_price,
+      spc.standard_output_price,
+      spc.standard_input_price_label,
+      spc.standard_input_price_unit,
+      spc.standard_output_price_label,
+      spc.standard_output_price_unit
+  )
+  select
+    pm.canonical_model_id as model_id,
+    dm.name as model_name,
+    dm.release_date as model_release_date,
+    dm.retirement_date as model_retirement_date,
+    dm.status as model_status,
+    dm.input_types as model_input_types,
+    dm.output_types as model_output_types,
+    dm.organisation_id,
+    org.name as organisation_name,
+    coalesce(dm.hidden, false) as hidden,
+    pm.provider_api_model_id,
+    pm.provider_id,
+    pm.api_model_id,
+    pm.provider_model_slug,
+    pm.is_active_gateway,
+    pm.input_modalities,
+    pm.output_modalities,
+    pm.quantization_scheme,
+    pm.context_length,
+    pm.max_output_tokens as provider_max_output_tokens,
+    pm.effective_from,
+    pm.effective_to,
+    cap.capability_id,
+    cap.params as capability_params,
+    cap.status as capability_status,
+    cap.max_input_tokens as capability_max_input_tokens,
+    cap.max_output_tokens as capability_max_output_tokens,
+    provider.api_provider_name,
+    provider.link as provider_link,
+    ps.input_price,
+    ps.output_price,
+    ps.standard_input_price,
+    ps.standard_output_price,
+    ps.standard_input_price_label,
+    ps.standard_input_price_unit,
+    ps.standard_output_price_label,
+    ps.standard_output_price_unit,
+    ps.from_price,
+    ps.from_price_unit,
+    coalesce(ps.pricing_tier, case when pm.api_model_id like '%:free%' then 'free' else 'standard' end) as pricing_tier,
+    (pm.api_model_id like '%:free%') as is_free_variant,
+    wmu.weekly_tokens_model,
+    wmpu.weekly_tokens_model_provider,
+    wmu.weekly_throughput_model,
+    wmu.weekly_latency_model
+  from provider_rows pm
+  join public.data_api_provider_model_capabilities cap
+    on cap.provider_api_model_id = pm.provider_api_model_id
+  left join public.data_models dm
+    on dm.model_id = pm.canonical_model_id
+  left join public.data_organisations org
+    on org.organisation_id = dm.organisation_id
+  left join public.data_api_providers provider
+    on provider.api_provider_id = pm.provider_id
+  left join pricing_summary ps
+    on ps.model_key = pm.provider_id || ':' || pm.api_model_id || ':' || cap.capability_id
+  left join weekly_model_usage wmu
+    on wmu.model_id = pm.canonical_model_id
+  left join weekly_model_provider_usage wmpu
+    on wmpu.model_id = pm.canonical_model_id
+   and wmpu.provider_id = pm.provider_id
+  where (p_include_hidden or coalesce(dm.hidden, false) = false)
+  order by pm.provider_api_model_id asc, cap.capability_id asc;
+$$;
+
+comment on function public.get_monitor_model_rows(boolean) is
+  'Returns provider-capability monitor rows with joined model/provider/pricing metadata and 7d raw gateway usage metrics.';
+
+create or replace function public.get_usage_tokens_weekly_model_provider(
+  p_since timestamptz default now() - interval '8 weeks'
+)
+returns table (
+  week_bucket timestamptz,
+  model_id text,
+  provider text,
+  requests bigint,
+  total_tokens bigint,
+  total_cost_usd numeric,
+  success_rate numeric
+)
+language sql
+stable
+as $$
+  with normalized_requests as (
+    select
+      date_trunc('week', gr.created_at) as week_bucket,
+      coalesce(
+        nullif(gr.canonical_model_id, ''),
+        public.resolve_public_model_id(gr.model_id, gr.provider),
+        nullif(gr.model_id, '')
+      ) as canonical_model_id,
+      coalesce(nullif(gr.provider, ''), 'unknown') as provider_id,
+      gr.success,
+      public.gateway_usage_total_tokens(gr.usage)::bigint as total_tokens,
+      coalesce(gr.cost_nanos, 0)::bigint as total_cost_nanos
+    from public.gateway_requests gr
+    where gr.created_at >= p_since
+  ),
+  grouped as (
+    select
+      nr.week_bucket,
+      nr.canonical_model_id as model_id,
+      nr.provider_id as provider,
+      count(*)::bigint as requests,
+      sum(nr.total_tokens)::bigint as total_tokens,
+      sum(nr.total_cost_nanos)::bigint as total_cost_nanos,
+      count(*) filter (where nr.success is true)::bigint as success_requests
+    from normalized_requests nr
+    where nr.canonical_model_id is not null
+      and nr.provider_id <> 'unknown'
+    group by nr.week_bucket, nr.canonical_model_id, nr.provider_id
+  )
+  select
+    g.week_bucket,
+    g.model_id,
+    g.provider,
+    g.requests,
+    g.total_tokens,
+    round(g.total_cost_nanos / 1000000000.0, 4) as total_cost_usd,
+    round(
+      case
+        when g.requests > 0 then g.success_requests::numeric / g.requests::numeric
+        else null
+      end,
+      4
+    ) as success_rate
+  from grouped g
+  order by g.week_bucket desc, g.total_tokens desc;
+$$;
+
+comment on function public.get_usage_tokens_weekly_model_provider(timestamptz) is
+  'Aggregates weekly model/provider usage directly from gateway_requests without relying on removed rollup tables.';
+
+grant execute on function public.get_monitor_model_rows(boolean) to authenticated, service_role;
+grant execute on function public.get_usage_tokens_weekly_model_provider(timestamptz) to authenticated, service_role;

--- a/supabase/migrations/20260424154500_fix_monitor_model_rows_signature.sql
+++ b/supabase/migrations/20260424154500_fix_monitor_model_rows_signature.sql
@@ -386,5 +386,7 @@ $$;
 comment on function public.get_usage_tokens_weekly_model_provider(timestamptz) is
   'Aggregates weekly model/provider usage directly from gateway_requests without relying on removed rollup tables.';
 
-grant execute on function public.get_monitor_model_rows(boolean) to authenticated, service_role;
-grant execute on function public.get_usage_tokens_weekly_model_provider(timestamptz) to authenticated, service_role;
+revoke execute on function public.get_monitor_model_rows(boolean) from authenticated;
+revoke execute on function public.get_usage_tokens_weekly_model_provider(timestamptz) from authenticated;
+grant execute on function public.get_monitor_model_rows(boolean) to service_role;
+grant execute on function public.get_usage_tokens_weekly_model_provider(timestamptz) to service_role;

--- a/supabase/migrations/20260424154500_fix_monitor_model_rows_signature.sql
+++ b/supabase/migrations/20260424154500_fix_monitor_model_rows_signature.sql
@@ -64,6 +64,7 @@ as $$
       gr.latency_ms::numeric as latency_ms
     from public.gateway_requests gr
     where gr.created_at >= now() - interval '7 days'
+      and gr.success is true
   ),
   weekly_model_usage as (
     select

--- a/supabase/migrations/20260424154500_fix_monitor_model_rows_signature.sql
+++ b/supabase/migrations/20260424154500_fix_monitor_model_rows_signature.sql
@@ -1,0 +1,389 @@
+create or replace function public.get_monitor_model_rows(
+  p_include_hidden boolean default false
+)
+returns table (
+  model_id text,
+  model_name text,
+  model_release_date date,
+  model_retirement_date date,
+  model_status text,
+  model_input_types text,
+  model_output_types text,
+  organisation_id text,
+  organisation_name text,
+  hidden boolean,
+  provider_api_model_id text,
+  provider_id text,
+  api_model_id text,
+  provider_model_slug text,
+  is_active_gateway boolean,
+  input_modalities text[],
+  output_modalities text[],
+  quantization_scheme text,
+  context_length integer,
+  provider_max_output_tokens integer,
+  effective_from timestamptz,
+  effective_to timestamptz,
+  capability_id text,
+  capability_params jsonb,
+  capability_status text,
+  capability_max_input_tokens integer,
+  capability_max_output_tokens integer,
+  api_provider_name text,
+  provider_link text,
+  input_price numeric,
+  output_price numeric,
+  standard_input_price numeric,
+  standard_output_price numeric,
+  standard_input_price_label text,
+  standard_input_price_unit text,
+  standard_output_price_label text,
+  standard_output_price_unit text,
+  from_price numeric,
+  from_price_unit text,
+  pricing_tier text,
+  is_free_variant boolean,
+  weekly_tokens_model bigint,
+  weekly_tokens_model_provider bigint,
+  weekly_throughput_model numeric,
+  weekly_latency_model numeric
+)
+language sql
+stable
+as $$
+  with normalized_weekly_requests as (
+    select
+      coalesce(
+        nullif(gr.canonical_model_id, ''),
+        public.resolve_public_model_id(gr.model_id, gr.provider),
+        nullif(gr.model_id, '')
+      ) as canonical_model_id,
+      coalesce(nullif(gr.provider, ''), 'unknown') as provider_id,
+      public.gateway_usage_total_tokens(gr.usage)::bigint as total_tokens,
+      gr.throughput::numeric as throughput,
+      gr.latency_ms::numeric as latency_ms
+    from public.gateway_requests gr
+    where gr.created_at >= now() - interval '7 days'
+  ),
+  weekly_model_usage as (
+    select
+      r.canonical_model_id as model_id,
+      sum(r.total_tokens)::bigint as weekly_tokens_model,
+      round(avg(r.throughput), 2) as weekly_throughput_model,
+      round(avg(r.latency_ms), 0) as weekly_latency_model
+    from normalized_weekly_requests r
+    where r.canonical_model_id is not null
+    group by r.canonical_model_id
+  ),
+  weekly_model_provider_usage as (
+    select
+      r.canonical_model_id as model_id,
+      r.provider_id,
+      sum(r.total_tokens)::bigint as weekly_tokens_model_provider
+    from normalized_weekly_requests r
+    where r.canonical_model_id is not null
+      and r.provider_id <> 'unknown'
+    group by r.canonical_model_id, r.provider_id
+  ),
+  active_pricing_rules as (
+    select
+      pr.model_key,
+      pr.meter,
+      pr.unit,
+      pr.unit_size,
+      pr.price_per_unit,
+      coalesce(nullif(lower(pr.pricing_plan), ''), 'standard') as pricing_plan,
+      case
+        when lower(coalesce(pr.meter, '')) like '%token%'
+          or lower(coalesce(pr.unit, '')) in ('token', 'tokens')
+          then pr.price_per_unit * (1000000 / nullif(pr.unit_size, 0))
+        when lower(coalesce(pr.unit, '')) in ('minute', 'minutes', 'min', 'mins', 'm')
+          then pr.price_per_unit / nullif(pr.unit_size, 0) / 60
+        when lower(coalesce(pr.unit, '')) in ('hour', 'hours', 'hr', 'hrs', 'h')
+          then pr.price_per_unit / nullif(pr.unit_size, 0) / 3600
+        else pr.price_per_unit / nullif(pr.unit_size, 0)
+      end as display_price,
+      case
+        when lower(coalesce(pr.meter, '')) like '%token%'
+          or lower(coalesce(pr.unit, '')) in ('token', 'tokens')
+          then '1M tokens'
+        when lower(coalesce(pr.unit, '')) in ('minute', 'minutes', 'min', 'mins', 'm')
+          then 'second'
+        when lower(coalesce(pr.unit, '')) in ('hour', 'hours', 'hr', 'hrs', 'h')
+          then 'second'
+        when lower(coalesce(pr.unit, '')) in ('second', 'seconds', 'sec', 'secs', 's')
+          then 'second'
+        when lower(coalesce(pr.unit, '')) in ('image', 'images')
+          then 'image'
+        when lower(coalesce(pr.unit, '')) in ('video', 'videos')
+          then 'video'
+        when lower(coalesce(pr.unit, '')) in ('character', 'characters', 'char', 'chars')
+          then 'character'
+        else nullif(lower(coalesce(pr.unit, '')), '')
+      end as display_unit,
+      case
+        when lower(coalesce(pr.meter, '')) in ('input_text_tokens', 'input_tokens') then 'input'
+        when lower(coalesce(pr.meter, '')) = 'input_audio_tokens' then 'input'
+        when lower(coalesce(pr.meter, '')) = 'input_image_tokens' then 'input'
+        when lower(coalesce(pr.meter, '')) = 'input_video_tokens' then 'input'
+        when lower(coalesce(pr.meter, '')) in ('output_text_tokens', 'output_tokens') then 'output'
+        when lower(coalesce(pr.meter, '')) = 'output_audio_tokens' then 'output'
+        when lower(coalesce(pr.meter, '')) = 'output_image_tokens' then 'output'
+        when lower(coalesce(pr.meter, '')) = 'output_video_tokens' then 'output'
+        else null
+      end as standard_side,
+      case
+        when lower(coalesce(pr.meter, '')) in ('input_text_tokens', 'input_tokens') then 'Text Input'
+        when lower(coalesce(pr.meter, '')) = 'input_audio_tokens' then 'Audio Input'
+        when lower(coalesce(pr.meter, '')) = 'input_image_tokens' then 'Image Input'
+        when lower(coalesce(pr.meter, '')) = 'input_video_tokens' then 'Video Input'
+        when lower(coalesce(pr.meter, '')) in ('output_text_tokens', 'output_tokens') then 'Text Output'
+        when lower(coalesce(pr.meter, '')) = 'output_audio_tokens' then 'Audio Output'
+        when lower(coalesce(pr.meter, '')) = 'output_image_tokens' then 'Image Output'
+        when lower(coalesce(pr.meter, '')) = 'output_video_tokens' then 'Video Output'
+        else null
+      end as standard_label,
+      case
+        when lower(coalesce(pr.meter, '')) in ('input_text_tokens', 'input_tokens', 'output_text_tokens', 'output_tokens') then 0
+        when lower(coalesce(pr.meter, '')) in ('input_audio_tokens', 'output_audio_tokens') then 1
+        when lower(coalesce(pr.meter, '')) in ('input_image_tokens', 'output_image_tokens') then 2
+        when lower(coalesce(pr.meter, '')) in ('input_video_tokens', 'output_video_tokens') then 3
+        else 99
+      end as standard_priority
+    from public.data_api_pricing_rules pr
+    where (pr.effective_from is null or pr.effective_from <= now())
+      and (pr.effective_to is null or now() < pr.effective_to)
+  ),
+  provider_rows as (
+    select
+      pm.*,
+      coalesce(
+        nullif(btrim(pm.model_id), ''),
+        public.resolve_public_model_id(nullif(btrim(pm.api_model_id), ''), pm.provider_id),
+        nullif(btrim(pm.api_model_id), '')
+      ) as canonical_model_id
+    from public.data_api_provider_models pm
+    where pm.api_model_id is not null
+      and btrim(pm.api_model_id) <> ''
+  ),
+  ranked_standard_rules as (
+    select
+      apr.model_key,
+      apr.standard_side,
+      apr.standard_label,
+      apr.display_unit,
+      apr.display_price,
+      row_number() over (
+        partition by apr.model_key, apr.standard_side
+        order by apr.standard_priority asc, apr.display_price asc nulls last, apr.standard_label asc
+      ) as row_num
+    from active_pricing_rules apr
+    where apr.pricing_plan = 'standard'
+      and apr.standard_side is not null
+      and apr.display_price is not null
+      and apr.display_unit is not null
+  ),
+  standard_price_choices as (
+    select
+      rsr.model_key,
+      max(case when rsr.standard_side = 'input' and rsr.row_num = 1 then rsr.display_price end) as standard_input_price,
+      max(case when rsr.standard_side = 'output' and rsr.row_num = 1 then rsr.display_price end) as standard_output_price,
+      max(case when rsr.standard_side = 'input' and rsr.row_num = 1 then rsr.standard_label end) as standard_input_price_label,
+      max(case when rsr.standard_side = 'input' and rsr.row_num = 1 then rsr.display_unit end) as standard_input_price_unit,
+      max(case when rsr.standard_side = 'output' and rsr.row_num = 1 then rsr.standard_label end) as standard_output_price_label,
+      max(case when rsr.standard_side = 'output' and rsr.row_num = 1 then rsr.display_unit end) as standard_output_price_unit
+    from ranked_standard_rules rsr
+    group by rsr.model_key
+  ),
+  pricing_summary as (
+    select
+      apr.model_key,
+      min(apr.price_per_unit * (1000000 / nullif(apr.unit_size, 0))) filter (
+        where apr.pricing_plan = 'standard'
+          and lower(coalesce(apr.meter, '')) in ('input_text_tokens', 'input_tokens')
+      ) as input_price,
+      min(apr.price_per_unit * (1000000 / nullif(apr.unit_size, 0))) filter (
+        where apr.pricing_plan = 'standard'
+          and lower(coalesce(apr.meter, '')) in ('output_text_tokens', 'output_tokens')
+      ) as output_price,
+      spc.standard_input_price,
+      spc.standard_output_price,
+      spc.standard_input_price_label,
+      spc.standard_input_price_unit,
+      spc.standard_output_price_label,
+      spc.standard_output_price_unit,
+      case
+        when count(distinct apr.display_unit) filter (
+          where apr.display_price is not null
+            and apr.display_unit is not null
+        ) = 1
+          then min(apr.display_price) filter (
+            where apr.display_price is not null
+              and apr.display_unit is not null
+          )
+        else null
+      end as from_price,
+      case
+        when count(distinct apr.display_unit) filter (
+          where apr.display_price is not null
+            and apr.display_unit is not null
+        ) = 1
+          then min(apr.display_unit) filter (
+            where apr.display_price is not null
+              and apr.display_unit is not null
+          )
+        else null
+      end as from_price_unit,
+      case
+        when apr.model_key like '%:free:%' then 'free'
+        when bool_or(apr.pricing_plan = 'standard') then 'standard'
+        else min(apr.pricing_plan)
+      end as pricing_tier
+    from active_pricing_rules apr
+    left join standard_price_choices spc
+      on spc.model_key = apr.model_key
+    group by
+      apr.model_key,
+      spc.standard_input_price,
+      spc.standard_output_price,
+      spc.standard_input_price_label,
+      spc.standard_input_price_unit,
+      spc.standard_output_price_label,
+      spc.standard_output_price_unit
+  )
+  select
+    pm.canonical_model_id as model_id,
+    dm.name as model_name,
+    dm.release_date as model_release_date,
+    dm.retirement_date as model_retirement_date,
+    dm.status as model_status,
+    dm.input_types as model_input_types,
+    dm.output_types as model_output_types,
+    dm.organisation_id,
+    org.name as organisation_name,
+    coalesce(dm.hidden, false) as hidden,
+    pm.provider_api_model_id,
+    pm.provider_id,
+    pm.api_model_id,
+    pm.provider_model_slug,
+    pm.is_active_gateway,
+    pm.input_modalities,
+    pm.output_modalities,
+    pm.quantization_scheme,
+    pm.context_length,
+    pm.max_output_tokens as provider_max_output_tokens,
+    pm.effective_from,
+    pm.effective_to,
+    cap.capability_id,
+    cap.params as capability_params,
+    cap.status as capability_status,
+    cap.max_input_tokens as capability_max_input_tokens,
+    cap.max_output_tokens as capability_max_output_tokens,
+    provider.api_provider_name,
+    provider.link as provider_link,
+    ps.input_price,
+    ps.output_price,
+    ps.standard_input_price,
+    ps.standard_output_price,
+    ps.standard_input_price_label,
+    ps.standard_input_price_unit,
+    ps.standard_output_price_label,
+    ps.standard_output_price_unit,
+    ps.from_price,
+    ps.from_price_unit,
+    coalesce(ps.pricing_tier, case when pm.api_model_id like '%:free%' then 'free' else 'standard' end) as pricing_tier,
+    (pm.api_model_id like '%:free%') as is_free_variant,
+    wmu.weekly_tokens_model,
+    wmpu.weekly_tokens_model_provider,
+    wmu.weekly_throughput_model,
+    wmu.weekly_latency_model
+  from provider_rows pm
+  join public.data_api_provider_model_capabilities cap
+    on cap.provider_api_model_id = pm.provider_api_model_id
+  left join public.data_models dm
+    on dm.model_id = pm.canonical_model_id
+  left join public.data_organisations org
+    on org.organisation_id = dm.organisation_id
+  left join public.data_api_providers provider
+    on provider.api_provider_id = pm.provider_id
+  left join pricing_summary ps
+    on ps.model_key = pm.provider_id || ':' || pm.api_model_id || ':' || cap.capability_id
+  left join weekly_model_usage wmu
+    on wmu.model_id = pm.canonical_model_id
+  left join weekly_model_provider_usage wmpu
+    on wmpu.model_id = pm.canonical_model_id
+   and wmpu.provider_id = pm.provider_id
+  where (p_include_hidden or coalesce(dm.hidden, false) = false)
+  order by pm.provider_api_model_id asc, cap.capability_id asc;
+$$;
+
+comment on function public.get_monitor_model_rows(boolean) is
+  'Returns provider-capability monitor rows with joined model/provider/pricing metadata and 7d raw gateway usage metrics.';
+
+create or replace function public.get_usage_tokens_weekly_model_provider(
+  p_since timestamptz default now() - interval '8 weeks'
+)
+returns table (
+  week_bucket timestamptz,
+  model_id text,
+  provider text,
+  requests bigint,
+  total_tokens bigint,
+  total_cost_usd numeric,
+  success_rate numeric
+)
+language sql
+stable
+as $$
+  with normalized_requests as (
+    select
+      date_trunc('week', gr.created_at) as week_bucket,
+      coalesce(
+        nullif(gr.canonical_model_id, ''),
+        public.resolve_public_model_id(gr.model_id, gr.provider),
+        nullif(gr.model_id, '')
+      ) as canonical_model_id,
+      coalesce(nullif(gr.provider, ''), 'unknown') as provider_id,
+      gr.success,
+      public.gateway_usage_total_tokens(gr.usage)::bigint as total_tokens,
+      coalesce(gr.cost_nanos, 0)::bigint as total_cost_nanos
+    from public.gateway_requests gr
+    where gr.created_at >= p_since
+  ),
+  grouped as (
+    select
+      nr.week_bucket,
+      nr.canonical_model_id as model_id,
+      nr.provider_id as provider,
+      count(*)::bigint as requests,
+      sum(nr.total_tokens)::bigint as total_tokens,
+      sum(nr.total_cost_nanos)::bigint as total_cost_nanos,
+      count(*) filter (where nr.success is true)::bigint as success_requests
+    from normalized_requests nr
+    where nr.canonical_model_id is not null
+      and nr.provider_id <> 'unknown'
+    group by nr.week_bucket, nr.canonical_model_id, nr.provider_id
+  )
+  select
+    g.week_bucket,
+    g.model_id,
+    g.provider,
+    g.requests,
+    g.total_tokens,
+    round(g.total_cost_nanos / 1000000000.0, 4) as total_cost_usd,
+    round(
+      case
+        when g.requests > 0 then g.success_requests::numeric / g.requests::numeric
+        else null
+      end,
+      4
+    ) as success_rate
+  from grouped g
+  order by g.week_bucket desc, g.total_tokens desc;
+$$;
+
+comment on function public.get_usage_tokens_weekly_model_provider(timestamptz) is
+  'Aggregates weekly model/provider usage directly from gateway_requests without relying on removed rollup tables.';
+
+grant execute on function public.get_monitor_model_rows(boolean) to authenticated, service_role;
+grant execute on function public.get_usage_tokens_weekly_model_provider(timestamptz) to authenticated, service_role;

--- a/supabase/migrations/20260424161500_remove_legacy_redirect_resolution.sql
+++ b/supabase/migrations/20260424161500_remove_legacy_redirect_resolution.sql
@@ -1,0 +1,54 @@
+create or replace function public.resolve_public_model_id(
+  p_model_id text,
+  p_provider text default null
+)
+returns text
+language sql
+stable
+as $$
+with direct_match as (
+  select dm.model_id as canonical_model_id
+  from public.data_models dm
+  where dm.model_id = p_model_id
+  limit 1
+),
+alias_match as (
+  select a.api_model_id as canonical_model_id
+  from public.data_api_model_aliases a
+  where a.alias_slug = p_model_id
+    and coalesce(a.is_enabled, true)
+  limit 1
+),
+provider_match as (
+  select coalesce(nullif(pm.model_id, ''), pm.api_model_id) as canonical_model_id,
+         pm.is_active_gateway,
+         pm.updated_at
+  from public.data_api_provider_models pm
+  where (p_provider is null or pm.provider_id = p_provider)
+    and (
+      pm.model_id = p_model_id
+      or pm.api_model_id = p_model_id
+      or pm.provider_api_model_id = p_model_id
+      or pm.provider_model_slug = p_model_id
+    )
+  order by pm.is_active_gateway desc, pm.updated_at desc nulls last
+  limit 1
+)
+select canonical_model_id
+from (
+  select 0 as ord, canonical_model_id from direct_match
+  union all
+  select 1 as ord, canonical_model_id from alias_match
+  union all
+  select 2 as ord, canonical_model_id from provider_match
+) candidates
+where canonical_model_id is not null
+  and btrim(canonical_model_id) <> ''
+order by ord
+limit 1;
+$$;
+
+comment on function public.resolve_public_model_id(text, text)
+  is 'Resolves canonical public model ids from canonical ids, aliases, and provider-facing model identifiers only.';
+
+drop table if exists public.data_model_id_redirects;


### PR DESCRIPTION
﻿## Summary
- move `/models` and `/models/table` monitor aggregation into a Supabase RPC instead of joining provider/model/pricing data in JS
- replace the broken weekly model/provider token source so it reads directly from `gateway_requests` instead of the dropped rollup table
- remove legacy redirect-table dependency from canonical model resolution so the app resolves only canonical ids, aliases, and provider-facing ids

## Changes
- add `get_monitor_model_rows(...)` and direct-from-raw `get_usage_tokens_weekly_model_provider(...)` migrations
- refactor `getMonitorModels` to consume the SQL RPC and carry weekly usage fields through to the UI
- simplify the models pages to use monitor-row weekly metrics directly
- remove `data_model_id_redirects` usage from app-side model resolution and cache revalidation tags

## Validation
- `pnpm --filter @ai-stats/web typecheck`
- applied linked Supabase migrations with `supabase db push --linked`
- browser validation against local web app for `/models` and `/models/table`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Pages and tables now surface weekly tokens, throughput, and latency directly from the consolidated monitoring feed; data fetch simplified.

* **Bug Fixes**
  * Canonical model resolution simplified by removing legacy redirect paths.
  * Cache revalidation behavior adjusted to stop using an obsolete model-redirect tag.

* **Chores**
  * Added unified DB functions for monitor/weekly usage.
  * Updated pricing: added GPT-5.5 / GPT-5.5-Pro high-context and batch pricing; removed some batch entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->