### PR TITLE
Update AtlasCloud DeepSeek V4 Pro limits

### DIFF
--- a/packages/data/catalog/src/data/api_providers/atlascloud/models.json
+++ b/packages/data/catalog/src/data/api_providers/atlascloud/models.json
@@ -170,8 +170,8 @@
     "quantization_scheme": null,
     "input_modalities": "text",
     "output_modalities": "text",
-    "context_length": 65536,
-    "max_output_tokens": 16384,
+    "context_length": 262144,
+    "max_output_tokens": 65536,
     "effective_from": "2026-04-24T00:00:00",
     "effective_to": null,
     "capabilities": [


### PR DESCRIPTION
﻿## Summary
- update AtlasCloud `deepseek-v4-pro` provider limits to the newly published configuration
- keep pricing unchanged at $1.70 / $3.40 per 1M tokens

## Changes
- set `context_length` to `262144`
- set `max_output_tokens` to `65536`

## Validation
- `pnpm validate:data`
- `pnpm validate:gateway`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * AtlasCloud model now supports increased context length and output token capacity, enabling processing of larger documents and generating more extensive responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->