### PR TITLE
Fix compare quick comparison duplicate keys

### DIFF
--- a/apps/web/src/components/(data)/compare/CompareDashboard.tsx
+++ b/apps/web/src/components/(data)/compare/CompareDashboard.tsx
@@ -20,6 +20,9 @@ type QuickComparison = {
 	logos: string[];
 };
 
+const buildQuickComparisonKey = (comparison: QuickComparison): string =>
+	`${comparison.title}:${comparison.modelIds.join("|")}`;
+
 const decodeModelIdFromUrl = (value: string): string => {
 	const trimmed = value?.trim();
 	if (!trimmed) return "";
@@ -269,14 +272,14 @@ export default function CompareDashboard({
 							{previewComparisons.length ? (
 								previewComparisons.map((comparison) => (
 									<Link
-										key={comparison.title}
+										key={buildQuickComparisonKey(comparison)}
 										href={buildQuickComparisonHref(comparison.modelIds)}
 										className="flex flex-col gap-3 rounded-xl border border-border/60 bg-background/50 p-4 transition hover:border-primary"
 									>
 										<div className="flex flex-wrap items-center gap-2">
-											{comparison.logos.map((logoId) => (
+											{comparison.logos.map((logoId, index) => (
 												<ProviderLogo
-													key={`${comparison.title}-${logoId}`}
+													key={`${comparison.modelIds[index] ?? index}-${logoId}`}
 													id={logoId}
 													alt={`${logoId} logo`}
 													size="sm"


### PR DESCRIPTION
## Summary
- fix duplicate React keys in compare quick-comparison preview cards
- key quick-comparison cards by their actual selected model IDs
- key provider logo chips by model ID plus provider slug so same-provider matchups do not collide

## Validation
- `pnpm --filter @ai-stats/web typecheck`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced stability of comparison cards in the dashboard to prevent potential rendering inconsistencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->