### PR TITLE
Activate GPT-5.5 and GPT-5.5 Pro on OpenAI

### DIFF
--- a/packages/data/catalog/src/data/api_providers/openai/models.json
+++ b/packages/data/catalog/src/data/api_providers/openai/models.json
@@ -3204,18 +3204,18 @@
     "provider_api_model_id": "openai:openai/gpt-5.5",
     "provider_model_slug": "gpt-5.5",
     "internal_model_id": "openai/gpt-5.5",
-    "is_active_gateway": false,
+    "is_active_gateway": true,
     "quantization_scheme": null,
     "input_modalities": "text,image",
     "output_modalities": "text",
     "context_length": 1050000,
     "max_output_tokens": 128000,
-    "effective_from": "2026-04-23T00:00:00",
+    "effective_from": "2026-04-24T00:00:00",
     "effective_to": null,
     "capabilities": [
       {
         "capability_id": "text.generate",
-        "status": "coming_soon",
+        "status": "active",
         "params": [
           {
             "param_id": "seed",
@@ -3319,7 +3319,7 @@
       },
         {
           "capability_id": "batch",
-          "status": "coming_soon",
+          "status": "active",
           "params": []
         }
     ]
@@ -3329,18 +3329,18 @@
     "provider_api_model_id": "openai:openai/gpt-5.5-pro",
     "provider_model_slug": "gpt-5.5-pro",
     "internal_model_id": "openai/gpt-5.5-pro",
-    "is_active_gateway": false,
+    "is_active_gateway": true,
     "quantization_scheme": null,
     "input_modalities": "text,image",
     "output_modalities": "text",
     "context_length": 1050000,
     "max_output_tokens": 128000,
-    "effective_from": "2026-04-23T00:00:00",
+    "effective_from": "2026-04-24T00:00:00",
     "effective_to": null,
     "capabilities": [
       {
         "capability_id": "text.generate",
-        "status": "coming_soon",
+        "status": "active",
         "params": [
           {
             "param_id": "seed",
@@ -3444,7 +3444,7 @@
       },
         {
           "capability_id": "batch",
-          "status": "coming_soon",
+          "status": "active",
           "params": []
         }
     ]

--- a/packages/data/catalog/src/data/models/openai/gpt-5.5-pro/model.json
+++ b/packages/data/catalog/src/data/models/openai/gpt-5.5-pro/model.json
@@ -17,9 +17,26 @@
     {
       "platform": "announcement",
       "url": "https://openai.com/index/introducing-gpt-5-5/"
+    },
+    {
+      "platform": "api_reference",
+      "url": "https://developers.openai.com/api/docs/models/gpt-5.5-pro"
     }
   ],
-  "details": [],
+  "details": [
+    {
+      "name": "input_context_length",
+      "value": 1050000
+    },
+    {
+      "name": "output_context_length",
+      "value": 128000
+    },
+    {
+      "name": "knowledge_cutoff",
+      "value": "2025-12-01T00:00:00"
+    }
+  ],
   "benchmarks": [
     {
       "benchmark_id": "gdpval-aa",

--- a/packages/data/catalog/src/data/models/openai/gpt-5.5/model.json
+++ b/packages/data/catalog/src/data/models/openai/gpt-5.5/model.json
@@ -17,9 +17,26 @@
     {
       "platform": "announcement",
       "url": "https://openai.com/index/introducing-gpt-5-5/"
+    },
+    {
+      "platform": "api_reference",
+      "url": "https://developers.openai.com/api/docs/models/gpt-5.5"
     }
   ],
-  "details": [],
+  "details": [
+    {
+      "name": "input_context_length",
+      "value": 1050000
+    },
+    {
+      "name": "output_context_length",
+      "value": 128000
+    },
+    {
+      "name": "knowledge_cutoff",
+      "value": "2025-12-01T00:00:00"
+    }
+  ],
   "benchmarks": [
     {
       "benchmark_id": "swe-bench-pro",

--- a/packages/data/catalog/src/data/pricing/openai/openai-gpt-5.5-pro/batch/pricing.json
+++ b/packages/data/catalog/src/data/pricing/openai/openai-gpt-5.5-pro/batch/pricing.json
@@ -23,7 +23,7 @@
         }
       ],
       "priority": 100,
-      "effective_from": "2026-04-23T00:00:00"
+      "effective_from": "2026-04-24T00:00:00"
     },
     {
       "meter": "output_text_tokens",
@@ -43,7 +43,7 @@
         }
       ],
       "priority": 100,
-      "effective_from": "2026-04-23T00:00:00"
+      "effective_from": "2026-04-24T00:00:00"
     },
     {
       "meter": "input_text_tokens",
@@ -63,7 +63,7 @@
         }
       ],
       "priority": 100,
-      "effective_from": "2026-04-23T00:00:00"
+      "effective_from": "2026-04-24T00:00:00"
     },
     {
       "meter": "output_text_tokens",
@@ -83,7 +83,7 @@
         }
       ],
       "priority": 100,
-      "effective_from": "2026-04-23T00:00:00"
+      "effective_from": "2026-04-24T00:00:00"
     }
   ]
 }

--- a/packages/data/catalog/src/data/pricing/openai/openai-gpt-5.5-pro/text.generate/pricing.json
+++ b/packages/data/catalog/src/data/pricing/openai/openai-gpt-5.5-pro/text.generate/pricing.json
@@ -23,7 +23,7 @@
         }
       ],
       "priority": 100,
-      "effective_from": "2026-04-23T00:00:00"
+      "effective_from": "2026-04-24T00:00:00"
     },
     {
       "meter": "output_text_tokens",
@@ -43,7 +43,7 @@
         }
       ],
       "priority": 100,
-      "effective_from": "2026-04-23T00:00:00"
+      "effective_from": "2026-04-24T00:00:00"
     },
     {
       "meter": "input_text_tokens",
@@ -63,7 +63,7 @@
         }
       ],
       "priority": 100,
-      "effective_from": "2026-04-23T00:00:00"
+      "effective_from": "2026-04-24T00:00:00"
     },
     {
       "meter": "output_text_tokens",
@@ -83,7 +83,7 @@
         }
       ],
       "priority": 100,
-      "effective_from": "2026-04-23T00:00:00"
+      "effective_from": "2026-04-24T00:00:00"
     },
     {
       "meter": "input_text_tokens",
@@ -103,7 +103,7 @@
         }
       ],
       "priority": 100,
-      "effective_from": "2026-04-23T00:00:00"
+      "effective_from": "2026-04-24T00:00:00"
     },
     {
       "meter": "output_text_tokens",
@@ -123,7 +123,7 @@
         }
       ],
       "priority": 100,
-      "effective_from": "2026-04-23T00:00:00"
+      "effective_from": "2026-04-24T00:00:00"
     },
     {
       "meter": "input_text_tokens",
@@ -143,7 +143,7 @@
         }
       ],
       "priority": 100,
-      "effective_from": "2026-04-23T00:00:00"
+      "effective_from": "2026-04-24T00:00:00"
     },
     {
       "meter": "output_text_tokens",
@@ -163,87 +163,7 @@
         }
       ],
       "priority": 100,
-      "effective_from": "2026-04-23T00:00:00"
-    },
-    {
-      "meter": "input_text_tokens",
-      "unit": "token",
-      "unit_size": 1000000,
-      "price_per_unit": 75,
-      "currency": "USD",
-      "pricing_plan": "priority",
-      "note": null,
-      "match": [
-        {
-          "path": "input_tokens",
-          "op": "lt",
-          "or_group": 1,
-          "and_index": 1,
-          "value": 272000
-        }
-      ],
-      "priority": 100,
-      "effective_from": "2026-04-23T00:00:00"
-    },
-    {
-      "meter": "output_text_tokens",
-      "unit": "token",
-      "unit_size": 1000000,
-      "price_per_unit": 450,
-      "currency": "USD",
-      "pricing_plan": "priority",
-      "note": null,
-      "match": [
-        {
-          "path": "input_tokens",
-          "op": "lt",
-          "or_group": 1,
-          "and_index": 1,
-          "value": 272000
-        }
-      ],
-      "priority": 100,
-      "effective_from": "2026-04-23T00:00:00"
-    },
-    {
-      "meter": "input_text_tokens",
-      "unit": "token",
-      "unit_size": 1000000,
-      "price_per_unit": 150,
-      "currency": "USD",
-      "pricing_plan": "priority",
-      "note": "High Context",
-      "match": [
-        {
-          "path": "input_tokens",
-          "op": "gte",
-          "or_group": 1,
-          "and_index": 1,
-          "value": 272000
-        }
-      ],
-      "priority": 100,
-      "effective_from": "2026-04-23T00:00:00"
-    },
-    {
-      "meter": "output_text_tokens",
-      "unit": "token",
-      "unit_size": 1000000,
-      "price_per_unit": 675,
-      "currency": "USD",
-      "pricing_plan": "priority",
-      "note": "High Context",
-      "match": [
-        {
-          "path": "input_tokens",
-          "op": "gte",
-          "or_group": 1,
-          "and_index": 1,
-          "value": 272000
-        }
-      ],
-      "priority": 100,
-      "effective_from": "2026-04-23T00:00:00"
+      "effective_from": "2026-04-24T00:00:00"
     }
   ]
 }

--- a/packages/data/catalog/src/data/pricing/openai/openai-gpt-5.5/batch/pricing.json
+++ b/packages/data/catalog/src/data/pricing/openai/openai-gpt-5.5/batch/pricing.json
@@ -23,7 +23,7 @@
         }
       ],
       "priority": 100,
-      "effective_from": "2026-04-23T00:00:00"
+      "effective_from": "2026-04-24T00:00:00"
     },
     {
       "meter": "cached_read_text_tokens",
@@ -43,7 +43,7 @@
         }
       ],
       "priority": 100,
-      "effective_from": "2026-04-23T00:00:00"
+      "effective_from": "2026-04-24T00:00:00"
     },
     {
       "meter": "output_text_tokens",
@@ -63,7 +63,7 @@
         }
       ],
       "priority": 100,
-      "effective_from": "2026-04-23T00:00:00"
+      "effective_from": "2026-04-24T00:00:00"
     },
     {
       "meter": "input_text_tokens",
@@ -83,7 +83,7 @@
         }
       ],
       "priority": 100,
-      "effective_from": "2026-04-23T00:00:00"
+      "effective_from": "2026-04-24T00:00:00"
     },
     {
       "meter": "cached_read_text_tokens",
@@ -103,7 +103,7 @@
         }
       ],
       "priority": 100,
-      "effective_from": "2026-04-23T00:00:00"
+      "effective_from": "2026-04-24T00:00:00"
     },
     {
       "meter": "output_text_tokens",
@@ -123,7 +123,7 @@
         }
       ],
       "priority": 100,
-      "effective_from": "2026-04-23T00:00:00"
+      "effective_from": "2026-04-24T00:00:00"
     }
   ]
 }

--- a/packages/data/catalog/src/data/pricing/openai/openai-gpt-5.5/text.generate/pricing.json
+++ b/packages/data/catalog/src/data/pricing/openai/openai-gpt-5.5/text.generate/pricing.json
@@ -23,7 +23,7 @@
         }
       ],
       "priority": 100,
-      "effective_from": "2026-04-23T00:00:00"
+      "effective_from": "2026-04-24T00:00:00"
     },
     {
       "meter": "cached_read_text_tokens",
@@ -43,7 +43,7 @@
         }
       ],
       "priority": 100,
-      "effective_from": "2026-04-23T00:00:00"
+      "effective_from": "2026-04-24T00:00:00"
     },
     {
       "meter": "output_text_tokens",
@@ -63,7 +63,7 @@
         }
       ],
       "priority": 100,
-      "effective_from": "2026-04-23T00:00:00"
+      "effective_from": "2026-04-24T00:00:00"
     },
     {
       "meter": "input_text_tokens",
@@ -83,7 +83,7 @@
         }
       ],
       "priority": 100,
-      "effective_from": "2026-04-23T00:00:00"
+      "effective_from": "2026-04-24T00:00:00"
     },
     {
       "meter": "cached_read_text_tokens",
@@ -103,7 +103,7 @@
         }
       ],
       "priority": 100,
-      "effective_from": "2026-04-23T00:00:00"
+      "effective_from": "2026-04-24T00:00:00"
     },
     {
       "meter": "output_text_tokens",
@@ -123,7 +123,7 @@
         }
       ],
       "priority": 100,
-      "effective_from": "2026-04-23T00:00:00"
+      "effective_from": "2026-04-24T00:00:00"
     },
     {
       "meter": "input_text_tokens",
@@ -143,7 +143,7 @@
         }
       ],
       "priority": 100,
-      "effective_from": "2026-04-23T00:00:00"
+      "effective_from": "2026-04-24T00:00:00"
     },
     {
       "meter": "cached_read_text_tokens",
@@ -163,7 +163,7 @@
         }
       ],
       "priority": 100,
-      "effective_from": "2026-04-23T00:00:00"
+      "effective_from": "2026-04-24T00:00:00"
     },
     {
       "meter": "output_text_tokens",
@@ -183,7 +183,7 @@
         }
       ],
       "priority": 100,
-      "effective_from": "2026-04-23T00:00:00"
+      "effective_from": "2026-04-24T00:00:00"
     },
     {
       "meter": "input_text_tokens",
@@ -203,7 +203,7 @@
         }
       ],
       "priority": 100,
-      "effective_from": "2026-04-23T00:00:00"
+      "effective_from": "2026-04-24T00:00:00"
     },
     {
       "meter": "cached_read_text_tokens",
@@ -223,7 +223,7 @@
         }
       ],
       "priority": 100,
-      "effective_from": "2026-04-23T00:00:00"
+      "effective_from": "2026-04-24T00:00:00"
     },
     {
       "meter": "output_text_tokens",
@@ -243,7 +243,7 @@
         }
       ],
       "priority": 100,
-      "effective_from": "2026-04-23T00:00:00"
+      "effective_from": "2026-04-24T00:00:00"
     },
     {
       "meter": "input_text_tokens",
@@ -263,7 +263,7 @@
         }
       ],
       "priority": 100,
-      "effective_from": "2026-04-23T00:00:00"
+      "effective_from": "2026-04-24T00:00:00"
     },
     {
       "meter": "cached_read_text_tokens",
@@ -283,7 +283,7 @@
         }
       ],
       "priority": 100,
-      "effective_from": "2026-04-23T00:00:00"
+      "effective_from": "2026-04-24T00:00:00"
     },
     {
       "meter": "output_text_tokens",
@@ -303,67 +303,7 @@
         }
       ],
       "priority": 100,
-      "effective_from": "2026-04-23T00:00:00"
-    },
-    {
-      "meter": "input_text_tokens",
-      "unit": "token",
-      "unit_size": 1000000,
-      "price_per_unit": 25,
-      "currency": "USD",
-      "pricing_plan": "priority",
-      "note": "High Context",
-      "match": [
-        {
-          "path": "input_tokens",
-          "op": "gte",
-          "or_group": 1,
-          "and_index": 1,
-          "value": 272000
-        }
-      ],
-      "priority": 100,
-      "effective_from": "2026-04-23T00:00:00"
-    },
-    {
-      "meter": "cached_read_text_tokens",
-      "unit": "token",
-      "unit_size": 1000000,
-      "price_per_unit": 2.5,
-      "currency": "USD",
-      "pricing_plan": "priority",
-      "note": "High Context",
-      "match": [
-        {
-          "path": "input_tokens",
-          "op": "gte",
-          "or_group": 1,
-          "and_index": 1,
-          "value": 272000
-        }
-      ],
-      "priority": 100,
-      "effective_from": "2026-04-23T00:00:00"
-    },
-    {
-      "meter": "output_text_tokens",
-      "unit": "token",
-      "unit_size": 1000000,
-      "price_per_unit": 112.5,
-      "currency": "USD",
-      "pricing_plan": "priority",
-      "note": "High Context",
-      "match": [
-        {
-          "path": "input_tokens",
-          "op": "gte",
-          "or_group": 1,
-          "and_index": 1,
-          "value": 272000
-        }
-      ],
-      "priority": 100,
-      "effective_from": "2026-04-23T00:00:00"
+      "effective_from": "2026-04-24T00:00:00"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- activate `gpt-5.5` and `gpt-5.5-pro` on the OpenAI provider
- update GPT-5.5 / GPT-5.5 Pro pricing to match the current official OpenAI pricing tables
- add model metadata for API reference links, 1,050,000 context, 128,000 max output, and 2025-12-01 knowledge cutoff

## Validation
- `pnpm validate:data`
- `pnpm validate:pricing`
- `pnpm validate:gateway`

## Sources
- https://developers.openai.com/api/docs/pricing?latest-pricing=standard
- https://developers.openai.com/api/docs/models/gpt-5.5
- https://developers.openai.com/api/docs/models/gpt-5.5-pro


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Activated GPT-5.5 and GPT-5.5-pro models with text generation and batch capabilities.

* **Documentation**
  * Added detailed model specifications including input/output context lengths and knowledge cutoff dates.
  * Included API reference links for both models.
  * Updated pricing effective dates and plan availability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->