### PR TITLE
feat(data): add Novita DeepSeek V4 Flash and Pro provider mappings

### DIFF
--- a/packages/data/catalog/src/data/api_providers/novita/models.json
+++ b/packages/data/catalog/src/data/api_providers/novita/models.json
@@ -1688,6 +1688,48 @@
     ]
   },
   {
+    "api_model_id": "deepseek/deepseek-v4-flash",
+    "provider_api_model_id": "novita:deepseek/deepseek-v4-flash",
+    "provider_model_slug": "deepseek/deepseek-v4-flash",
+    "internal_model_id": "deepseek/deepseek-v4-flash",
+    "is_active_gateway": true,
+    "quantization_scheme": null,
+    "input_modalities": "text",
+    "output_modalities": "text",
+    "context_length": 1048576,
+    "max_output_tokens": 393216,
+    "effective_from": "2026-04-24T00:00:00",
+    "effective_to": null,
+    "capabilities": [
+      {
+        "capability_id": "text.generate",
+        "status": "active",
+        "params": []
+      }
+    ]
+  },
+  {
+    "api_model_id": "deepseek/deepseek-v4-pro",
+    "provider_api_model_id": "novita:deepseek/deepseek-v4-pro",
+    "provider_model_slug": "deepseek/deepseek-v4-pro",
+    "internal_model_id": "deepseek/deepseek-v4-pro",
+    "is_active_gateway": true,
+    "quantization_scheme": null,
+    "input_modalities": "text",
+    "output_modalities": "text",
+    "context_length": 1048576,
+    "max_output_tokens": 393216,
+    "effective_from": "2026-04-24T00:00:00",
+    "effective_to": null,
+    "capabilities": [
+      {
+        "capability_id": "text.generate",
+        "status": "active",
+        "params": []
+      }
+    ]
+  },
+  {
     "api_model_id": "google/gemma-3-27b",
     "provider_api_model_id": "novita:google/gemma-3-27b",
     "provider_model_slug": "google/gemma-3-27b-it",

--- a/packages/data/catalog/src/data/pricing/novita/deepseek-deepseek-v4-flash/text.generate/pricing.json
+++ b/packages/data/catalog/src/data/pricing/novita/deepseek-deepseek-v4-flash/text.generate/pricing.json
@@ -1,0 +1,45 @@
+{
+  "key": "novita:deepseek/deepseek-v4-flash:text.generate",
+  "api_provider_id": "novita",
+  "provider_slug": "novita",
+  "api_model_id": "deepseek/deepseek-v4-flash",
+  "capability_id": "text.generate",
+  "rules": [
+    {
+      "meter": "input_text_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 0.14,
+      "currency": "USD",
+      "pricing_plan": "standard",
+      "note": null,
+      "match": [],
+      "priority": 100,
+      "effective_from": "2026-04-24T00:00:00"
+    },
+    {
+      "meter": "cached_read_text_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 0.028,
+      "currency": "USD",
+      "pricing_plan": "standard",
+      "note": null,
+      "match": [],
+      "priority": 100,
+      "effective_from": "2026-04-24T00:00:00"
+    },
+    {
+      "meter": "output_text_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 0.28,
+      "currency": "USD",
+      "pricing_plan": "standard",
+      "note": null,
+      "match": [],
+      "priority": 100,
+      "effective_from": "2026-04-24T00:00:00"
+    }
+  ]
+}

--- a/packages/data/catalog/src/data/pricing/novita/deepseek-deepseek-v4-pro/text.generate/pricing.json
+++ b/packages/data/catalog/src/data/pricing/novita/deepseek-deepseek-v4-pro/text.generate/pricing.json
@@ -1,0 +1,45 @@
+{
+  "key": "novita:deepseek/deepseek-v4-pro:text.generate",
+  "api_provider_id": "novita",
+  "provider_slug": "novita",
+  "api_model_id": "deepseek/deepseek-v4-pro",
+  "capability_id": "text.generate",
+  "rules": [
+    {
+      "meter": "input_text_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 1.74,
+      "currency": "USD",
+      "pricing_plan": "standard",
+      "note": null,
+      "match": [],
+      "priority": 100,
+      "effective_from": "2026-04-24T00:00:00"
+    },
+    {
+      "meter": "cached_read_text_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 0.145,
+      "currency": "USD",
+      "pricing_plan": "standard",
+      "note": null,
+      "match": [],
+      "priority": 100,
+      "effective_from": "2026-04-24T00:00:00"
+    },
+    {
+      "meter": "output_text_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 3.48,
+      "currency": "USD",
+      "pricing_plan": "standard",
+      "note": null,
+      "match": [],
+      "priority": 100,
+      "effective_from": "2026-04-24T00:00:00"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
Adds Novita as a provider option for the two newly supported DeepSeek V4 models in the catalog:
- `deepseek/deepseek-v4-flash`
- `deepseek/deepseek-v4-pro`

## Why
DeepSeek V4 Flash and Pro were present in the global model catalog and in other providers, but Novita-specific gateway mappings and pricing entries were missing.

## Root Cause
Novita provider data had not yet been updated with the DeepSeek V4 model records and corresponding `text.generate` pricing files.

## What Changed
- Added two Novita provider model entries in `api_providers/novita/models.json`.
- Added pricing records for both models under:
  - `pricing/novita/deepseek-deepseek-v4-flash/text.generate/pricing.json`
  - `pricing/novita/deepseek-deepseek-v4-pro/text.generate/pricing.json`

## Validation
- Ran `pnpm validate:gateway` successfully.

## User Impact
These models now resolve correctly through Novita in gateway/catalog data and include valid active pricing rules for usage metering.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* DeepSeek V4 Flash and V4 Pro models are now available through the Novita gateway for text generation
* Both models support exceptionally large context windows of 1M+ tokens, enabling extended conversations and comprehensive analysis of large documents
* Standard token-based pricing configured with separate rates for input tokens, cached input reads, and generation output
* General availability begins April 24, 2026

<!-- end of auto-generated comment: release notes by coderabbit.ai -->