### PR TITLE
feat(web): add resend onboarding automations flow

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -20,6 +20,7 @@
 		"db:reconcile-api-model-links": "tsx scripts/importer/reconcile-api-model-links.ts",
 		"db-progress": "cd ../../packages/data/catalog/src/data && python -X utf8 progressCalc.py",
 		"oauth:e2e:playwright": "tsx scripts/oauth-e2e-playwright.ts",
+		"resend:provision:onboarding": "tsx scripts/resend/provision-onboarding-automations.ts",
 		"test:live:playground-text": "tsx scripts/live-playground-text-smoke.ts",
 		"test": "jest --runInBand"
 	},

--- a/apps/web/scripts/resend/README.md
+++ b/apps/web/scripts/resend/README.md
@@ -1,0 +1,29 @@
+# Resend Onboarding Automations
+
+Provision 7-day onboarding and checkout-recovery automations:
+
+```bash
+pnpm --filter @ai-stats/web resend:provision:onboarding
+```
+
+## Required
+
+- `RESEND_API_KEY`
+
+## Optional
+
+- `RESEND_FROM_EMAIL` (default: `AI Stats <noreply@phaseo.app>`)
+- `RESEND_ONBOARDING_REPLY_TO_EMAIL` (default: `support@aistats.com`)
+- `RESEND_ONBOARDING_DASHBOARD_URL` (default: `NEXT_PUBLIC_WEBSITE_URL` then `https://www.aistats.com`)
+- `RESEND_ONBOARDING_PURCHASE_WINDOW` (default: `7 days`)
+- `RESEND_CHECKOUT_ABANDONED_TIMEOUT` (default: `24 hours`)
+- `RESEND_ONBOARDING_AUTOMATION_STATUS` (`enabled` or `disabled`, default: `enabled`)
+- `RESEND_CUSTOMERS_SEGMENT_ID` (optional; if set, purchased users are added to this segment)
+
+## Runtime Flag
+
+To send lifecycle events from the app at runtime, set:
+
+- `RESEND_ONBOARDING_AUTOMATIONS_ENABLED=true`
+
+When this flag is on, signup flow emits `user.created` and falls back to direct welcome email only if event delivery fails.

--- a/apps/web/scripts/resend/provision-onboarding-automations.ts
+++ b/apps/web/scripts/resend/provision-onboarding-automations.ts
@@ -84,14 +84,103 @@ async function callResend<T>(
 	throw new Error(`Unexpected retry exhaustion for ${label}`);
 }
 
-function markdownEmailWrapper(contentHtml: string): string {
-	return [
-		"<div style=\"background:#f6f8fc;padding:32px 12px;font-family:Inter,system-ui,-apple-system,Segoe UI,Roboto,sans-serif;color:#0f172a;\">",
-		"<div style=\"max-width:620px;margin:0 auto;background:#ffffff;border:1px solid #e2e8f0;border-radius:14px;padding:28px;\">",
-		contentHtml,
-		"</div>",
-		"</div>",
-	].join("");
+function renderEmailHtml(args: {
+	kicker: string;
+	title: string;
+	intro: string;
+	ctaLabel: string;
+	ctaHref: string;
+	steps: Array<{ title: string; body: string; hrefLabel?: string; href?: string }>;
+	replyNote: string;
+	includeUnsubscribe: boolean;
+}): string {
+	const stepsHtml = args.steps
+		.map((step, index) => {
+			const linkHtml =
+				step.href && step.hrefLabel
+					? `<p style="margin:8px 0 0;font-size:13px;line-height:1.5;"><a href="${step.href}" style="color:#1d4ed8;text-decoration:none;font-weight:700;">${step.hrefLabel}</a></p>`
+					: "";
+			return `
+				<tr>
+					<td style="padding:0 0 14px 0;">
+						<table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0">
+							<tr>
+								<td width="38" valign="top" style="padding:2px 10px 0 0;">
+									<div style="width:28px;height:28px;border-radius:999px;background:#dbeafe;color:#1e3a8a;font-size:13px;line-height:28px;text-align:center;font-weight:700;">${index + 1}</div>
+								</td>
+								<td valign="top" style="padding:0;">
+									<p style="margin:0;font-size:16px;line-height:1.35;color:#0f172a;font-weight:700;">${step.title}</p>
+									<p style="margin:5px 0 0;font-size:14px;line-height:1.6;color:#334155;">${step.body}</p>
+									${linkHtml}
+								</td>
+							</tr>
+						</table>
+					</td>
+				</tr>
+			`;
+		})
+		.join("");
+
+	const unsubscribeHtml = args.includeUnsubscribe
+		? `<p style="margin:16px 0 0;font-size:12px;line-height:1.6;color:#64748b;">Manage email preferences: <a href="{{{RESEND_UNSUBSCRIBE_URL}}}" style="color:#475569;">Unsubscribe</a></p>`
+		: "";
+
+	return `
+<!doctype html>
+<html lang="en">
+<head>
+	<meta charset="utf-8" />
+	<meta name="viewport" content="width=device-width,initial-scale=1" />
+	<link rel="preconnect" href="https://fonts.googleapis.com" />
+	<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+	<link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@500;600;700;800&display=swap" rel="stylesheet" />
+</head>
+<body style="margin:0;padding:0;background:#0a1021;">
+	<div style="display:none;max-height:0;overflow:hidden;opacity:0;">${args.title}</div>
+	<table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="background:#0a1021;background-image:radial-gradient(circle at 6% 15%, #1d4ed8 0, transparent 36%),radial-gradient(circle at 90% 6%, #22c55e 0, transparent 30%);">
+		<tr>
+			<td align="center" style="padding:26px 10px 34px;">
+				<table role="presentation" width="640" cellpadding="0" cellspacing="0" border="0" style="width:100%;max-width:640px;">
+					<tr>
+						<td style="padding:0;">
+							<table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="border-radius:24px 24px 0 0;overflow:hidden;">
+								<tr>
+									<td style="padding:34px 34px 30px;background:linear-gradient(132deg,#1d4ed8 0%,#0f172a 54%,#0ea5e9 100%);font-family:'Montserrat','Avenir Next','Segoe UI',Arial,sans-serif;color:#f8fafc;">
+										<p style="margin:0 0 10px;font-size:11px;line-height:1.2;letter-spacing:0.16em;text-transform:uppercase;opacity:0.95;font-weight:700;">${args.kicker}</p>
+										<h1 style="margin:0 0 12px;font-size:31px;line-height:1.15;font-weight:800;letter-spacing:-0.02em;">${args.title}</h1>
+										<p style="margin:0;font-size:15px;line-height:1.65;color:#dbeafe;font-weight:500;">${args.intro}</p>
+										<table role="presentation" cellpadding="0" cellspacing="0" border="0" style="margin-top:18px;">
+											<tr>
+												<td style="border-radius:999px;background:#ffffff;">
+													<a href="${args.ctaHref}" style="display:inline-block;padding:12px 18px;font-size:12px;line-height:1.2;text-decoration:none;letter-spacing:0.08em;text-transform:uppercase;font-family:'Montserrat','Avenir Next','Segoe UI',Arial,sans-serif;color:#0f172a;font-weight:800;">${args.ctaLabel}</a>
+												</td>
+											</tr>
+										</table>
+									</td>
+								</tr>
+							</table>
+							<table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="background:#f8fbff;border:1px solid #cbd5e1;border-top:none;border-radius:0 0 24px 24px;">
+								<tr>
+									<td style="padding:26px 30px 10px;font-family:'Montserrat','Avenir Next','Segoe UI',Arial,sans-serif;">
+										<table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0">
+											${stepsHtml}
+										</table>
+										<div style="margin:8px 0 0;padding:14px 16px;border-radius:12px;background:linear-gradient(90deg,#e0ecff 0%,#d9fbe8 100%);border:1px solid #bfdbfe;">
+											<p style="margin:0;font-size:13px;line-height:1.6;color:#0f172a;font-weight:600;">${args.replyNote}</p>
+										</div>
+										${unsubscribeHtml}
+									</td>
+								</tr>
+							</table>
+						</td>
+					</tr>
+				</table>
+			</td>
+		</tr>
+	</table>
+</body>
+</html>
+	`.trim();
 }
 
 function buildTemplates(args: {
@@ -108,37 +197,70 @@ function buildTemplates(args: {
 			alias: RESEND_ONBOARDING_TEMPLATE_ALIASES.WELCOME_INITIAL,
 			name: "Onboarding - Welcome",
 			subject: "Welcome to AI Stats",
-			html: markdownEmailWrapper(
-				[
-					"<h1 style=\"margin:0 0 14px;font-size:24px;line-height:1.2;\">Welcome to AI Stats</h1>",
-					"<p style=\"margin:0 0 14px;font-size:15px;line-height:1.6;\">You're in. Start routing traffic and monitoring usage in minutes.</p>",
-					"<ol style=\"margin:0 0 14px;padding-left:20px;font-size:15px;line-height:1.6;\">",
-					`<li>Add your first API key: <a href="${keysUrl}">${keysUrl}</a></li>`,
-					`<li>Review supported models: <a href="${modelsUrl}">${modelsUrl}</a></li>`,
-					`<li>Top up credits any time: <a href="${creditsUrl}">${creditsUrl}</a></li>`,
-					"</ol>",
-					"<p style=\"margin:0;font-size:14px;line-height:1.6;color:#334155;\">Reply if you want help getting your first request live.</p>",
-				].join(""),
-			),
+			html: renderEmailHtml({
+				kicker: "AI Stats onboarding",
+				title: "Welcome. Your control layer is ready.",
+				intro: "You now have one place to route requests, monitor usage, and move quickly across providers.",
+				ctaLabel: "Open dashboard",
+				ctaHref: dashboardUrl,
+				steps: [
+					{
+						title: "Create your first API key",
+						body: "Generate a key and keep your integration path simple from day one.",
+						hrefLabel: "Manage keys",
+						href: keysUrl,
+					},
+					{
+						title: "Choose models for your first route",
+						body: "Browse model IDs and pick a reliable baseline setup.",
+						hrefLabel: "View model catalog",
+						href: modelsUrl,
+					},
+					{
+						title: "Top up credits when ready",
+						body: "Enable uninterrupted testing and early production traffic.",
+						hrefLabel: "Open credits",
+						href: creditsUrl,
+					},
+				],
+				replyNote: "Reply directly if you want help shipping your first request this week.",
+				includeUnsubscribe: false,
+			}),
 			text: `Welcome to AI Stats.\n\n1) Add your first key: ${keysUrl}\n2) Explore models: ${modelsUrl}\n3) Top up credits: ${creditsUrl}\n\nReply if you want help with setup.`,
 		},
 		{
 			alias: RESEND_ONBOARDING_TEMPLATE_ALIASES.WELCOME_PURCHASED_7D,
 			name: "Onboarding - Purchased Within 7 Days",
 			subject: "You're ready to ship with AI Stats",
-			html: markdownEmailWrapper(
-				[
-					"<h1 style=\"margin:0 0 14px;font-size:24px;line-height:1.2;\">You're all set</h1>",
-					"<p style=\"margin:0 0 14px;font-size:15px;line-height:1.6;\">Thanks for purchasing credits. Here are the fastest next steps:</p>",
-					"<ul style=\"margin:0 0 14px;padding-left:20px;font-size:15px;line-height:1.6;\">",
-					`<li>Use one key to access multiple providers: <a href="${keysUrl}">${keysUrl}</a></li>`,
-					`<li>Find model IDs and pricing: <a href="${modelsUrl}">${modelsUrl}</a></li>`,
-					`<li>Track spend and usage in real time: <a href="${dashboardUrl}">${dashboardUrl}</a></li>`,
-					"</ul>",
-					"<p style=\"margin:0;font-size:14px;line-height:1.6;color:#334155;\">If you want implementation help, just reply and I'll assist directly.</p>",
-					"<p style=\"margin:16px 0 0;font-size:12px;line-height:1.6;color:#64748b;\">Manage email preferences: <a href=\"{{{RESEND_UNSUBSCRIBE_URL}}}\">Unsubscribe</a></p>",
-				].join(""),
-			),
+			html: renderEmailHtml({
+				kicker: "Momentum unlocked",
+				title: "Credits are live. Let's get you moving.",
+				intro: "Great call on purchasing credits early. Here is the fastest route to start seeing value immediately.",
+				ctaLabel: "Start building",
+				ctaHref: keysUrl,
+				steps: [
+					{
+						title: "Plug your key into your app",
+						body: "Use one key and keep your architecture clean while you test multiple providers.",
+						hrefLabel: "Open keys",
+						href: keysUrl,
+					},
+					{
+						title: "Lock in your default model set",
+						body: "Pick sensible defaults first, then tune for quality, speed, and spend.",
+						hrefLabel: "Explore models",
+						href: modelsUrl,
+					},
+					{
+						title: "Track usage and cost in real time",
+						body: "Watch calls, spend, and balance trends from one dashboard.",
+						hrefLabel: "Open usage dashboard",
+						href: dashboardUrl,
+					},
+				],
+				replyNote: "Reply if you want a quick architecture review before scaling up traffic.",
+				includeUnsubscribe: true,
+			}),
 			text: `Thanks for purchasing credits.\n\nNext: add an API key (${keysUrl}), review model IDs (${modelsUrl}), and monitor usage (${dashboardUrl}).\n\nReply for implementation help.\n\nUnsubscribe: {{{RESEND_UNSUBSCRIBE_URL}}}`,
 		},
 		{
@@ -146,15 +268,31 @@ function buildTemplates(args: {
 			name: "Onboarding - No Purchase In 7 Days",
 			subject: "Anything blocking you from getting started?",
 			replyTo: args.replyToEmail,
-			html: markdownEmailWrapper(
-				[
-					"<h1 style=\"margin:0 0 14px;font-size:24px;line-height:1.2;\">Quick check-in</h1>",
-					"<p style=\"margin:0 0 14px;font-size:15px;line-height:1.6;\">It looks like you haven't purchased credits yet. If something blocked you, reply and tell us what happened.</p>",
-					"<p style=\"margin:0 0 14px;font-size:15px;line-height:1.6;\">Common blockers we can help with: setup, pricing clarity, or model selection.</p>",
-					`<p style=\"margin:0;font-size:14px;line-height:1.6;color:#334155;\">You can also top up here any time: <a href="${creditsUrl}">${creditsUrl}</a></p>`,
-					"<p style=\"margin:16px 0 0;font-size:12px;line-height:1.6;color:#64748b;\">Manage email preferences: <a href=\"{{{RESEND_UNSUBSCRIBE_URL}}}\">Unsubscribe</a></p>",
-				].join(""),
-			),
+			html: renderEmailHtml({
+				kicker: "Quick pulse check",
+				title: "Anything blocking your first credit purchase?",
+				intro: "If you got stuck, reply and tell us what slowed you down. We will unblock you quickly.",
+				ctaLabel: "Resume checkout",
+				ctaHref: creditsUrl,
+				steps: [
+					{
+						title: "Technical setup issue?",
+						body: "We can help with key setup, API flow, or route configuration.",
+					},
+					{
+						title: "Pricing not clear enough?",
+						body: "Tell us your expected usage and we can suggest a practical starting plan.",
+					},
+					{
+						title: "Unsure which model to pick?",
+						body: "Share your use case and we can suggest a starting shortlist.",
+						hrefLabel: "See available models",
+						href: modelsUrl,
+					},
+				],
+				replyNote: `Replies go straight to ${args.replyToEmail}. A short note is enough.`,
+				includeUnsubscribe: true,
+			}),
 			text: `It looks like you haven't purchased credits yet.\n\nReply and tell us what blocked you (setup, pricing, model choice, or anything else) and we'll help.\n\nTop up any time: ${creditsUrl}\n\nUnsubscribe: {{{RESEND_UNSUBSCRIBE_URL}}}`,
 		},
 		{
@@ -162,15 +300,31 @@ function buildTemplates(args: {
 			name: "Onboarding - Checkout Started But Not Purchased",
 			subject: "Did anything go wrong at checkout?",
 			replyTo: args.replyToEmail,
-			html: markdownEmailWrapper(
-				[
-					"<h1 style=\"margin:0 0 14px;font-size:24px;line-height:1.2;\">Need help finishing checkout?</h1>",
-					"<p style=\"margin:0 0 14px;font-size:15px;line-height:1.6;\">We noticed checkout started but purchase didn't complete.</p>",
-					"<p style=\"margin:0 0 14px;font-size:15px;line-height:1.6;\">Reply with what stopped you and we'll fix it fast.</p>",
-					`<p style=\"margin:0;font-size:14px;line-height:1.6;color:#334155;\">Return to credits: <a href="${creditsUrl}">${creditsUrl}</a></p>`,
-					"<p style=\"margin:16px 0 0;font-size:12px;line-height:1.6;color:#64748b;\">Manage email preferences: <a href=\"{{{RESEND_UNSUBSCRIBE_URL}}}\">Unsubscribe</a></p>",
-				].join(""),
-			),
+			html: renderEmailHtml({
+				kicker: "Checkout support",
+				title: "Need help finishing your credit purchase?",
+				intro: "Looks like checkout started but did not complete. If anything failed, we can help fast.",
+				ctaLabel: "Return to checkout",
+				ctaHref: creditsUrl,
+				steps: [
+					{
+						title: "Payment friction",
+						body: "Card or wallet issue? Reply with what happened and we will investigate immediately.",
+					},
+					{
+						title: "Not ready to choose an amount",
+						body: "We can recommend a low-risk amount to start with for your usage pattern.",
+					},
+					{
+						title: "Need confidence before buying",
+						body: "We can help validate your integration plan first.",
+						hrefLabel: "Open credits settings",
+						href: creditsUrl,
+					},
+				],
+				replyNote: `Replies go straight to ${args.replyToEmail} so you can get direct help.`,
+				includeUnsubscribe: true,
+			}),
 			text: `We noticed checkout started but purchase didn't complete.\n\nReply with what went wrong and we'll help.\n\nReturn to credits: ${creditsUrl}\n\nUnsubscribe: {{{RESEND_UNSUBSCRIBE_URL}}}`,
 		},
 	];

--- a/apps/web/scripts/resend/provision-onboarding-automations.ts
+++ b/apps/web/scripts/resend/provision-onboarding-automations.ts
@@ -49,6 +49,41 @@ function unwrap<T>(result: { data: T | null; error: { message: string } | null }
 	return result.data;
 }
 
+function sleep(ms: number): Promise<void> {
+	return new Promise((resolve) => {
+		setTimeout(resolve, ms);
+	});
+}
+
+function isRateLimitError(error: unknown): boolean {
+	const message =
+		error instanceof Error ? error.message.toLowerCase() : String(error).toLowerCase();
+	return message.includes("too many requests") || message.includes("429");
+}
+
+async function callResend<T>(
+	label: string,
+	fn: () => PromiseLike<{ data: T | null; error: { message: string } | null }>,
+): Promise<T> {
+	let attempt = 0;
+	while (attempt < 6) {
+		attempt += 1;
+		try {
+			return unwrap(await fn());
+		} catch (error) {
+			if (!isRateLimitError(error) || attempt >= 6) {
+				throw error;
+			}
+			const waitMs = 400 * attempt;
+			console.warn(
+				`Rate limited on ${label}; retrying in ${waitMs}ms (attempt ${attempt}/6)`,
+			);
+			await sleep(waitMs);
+		}
+	}
+	throw new Error(`Unexpected retry exhaustion for ${label}`);
+}
+
 function markdownEmailWrapper(contentHtml: string): string {
 	return [
 		"<div style=\"background:#f6f8fc;padding:32px 12px;font-family:Inter,system-ui,-apple-system,Segoe UI,Roboto,sans-serif;color:#0f172a;\">",
@@ -148,8 +183,9 @@ async function listAllTemplates(resend: Resend): Promise<
 		name: string;
 	}>
 > {
-	const result = await resend.templates.list({ limit: 100 });
-	const data = unwrap(result);
+	const data = await callResend("templates.list", () =>
+		resend.templates.list({ limit: 100 }),
+	);
 	return data.data.map((template) => ({
 		id: template.id,
 		alias: template.alias,
@@ -176,16 +212,23 @@ async function upsertTemplate(
 
 	let templateId: string;
 	if (!existing) {
-		const created = unwrap(await resend.templates.create(payload));
+		const created = await callResend<{ id: string }>(
+			`templates.create:${template.alias}`,
+			() => resend.templates.create(payload),
+		);
 		templateId = created.id;
 		console.log(`Created template: ${template.alias}`);
 	} else {
-		unwrap(await resend.templates.update(existing.id, payload));
+		await callResend(`templates.update:${template.alias}`, () =>
+			resend.templates.update(existing.id, payload),
+		);
 		templateId = existing.id;
 		console.log(`Updated template: ${template.alias}`);
 	}
 
-	unwrap(await resend.templates.publish(templateId));
+	await callResend(`templates.publish:${template.alias}`, () =>
+		resend.templates.publish(templateId),
+	);
 	console.log(`Published template: ${template.alias}`);
 	return templateId;
 }
@@ -193,8 +236,9 @@ async function upsertTemplate(
 async function listAllContactProperties(resend: Resend): Promise<
 	Array<{ id: string; key: string; type: "string" | "number" }>
 > {
-	const result = await resend.contactProperties.list({ limit: 100 });
-	const data = unwrap(result);
+	const data = await callResend("contactProperties.list", () =>
+		resend.contactProperties.list({ limit: 100 }),
+	);
 	return data.data.map((item) => ({
 		id: item.id,
 		key: item.key,
@@ -218,7 +262,9 @@ async function ensureContactProperties(resend: Resend): Promise<void> {
 	for (const property of required) {
 		const current = existing.find((item) => item.key === property.key);
 		if (!current) {
-			unwrap(await resend.contactProperties.create(property));
+			await callResend(`contactProperties.create:${property.key}`, () =>
+				resend.contactProperties.create(property),
+			);
 			console.log(`Created contact property: ${property.key}`);
 			continue;
 		}
@@ -231,8 +277,7 @@ async function ensureContactProperties(resend: Resend): Promise<void> {
 }
 
 async function listAllEvents(resend: Resend): Promise<Array<{ id: string; name: string }>> {
-	const result = await resend.events.list({ limit: 100 });
-	const data = unwrap(result);
+	const data = await callResend("events.list", () => resend.events.list({ limit: 100 }));
 	return data.data.map((event) => ({
 		id: event.id,
 		name: event.name,
@@ -245,14 +290,17 @@ async function ensureEvents(resend: Resend): Promise<void> {
 
 	for (const eventName of required) {
 		if (current.some((event) => event.name === eventName)) continue;
-		unwrap(await resend.events.create({ name: eventName }));
+		await callResend(`events.create:${eventName}`, () =>
+			resend.events.create({ name: eventName }),
+		);
 		console.log(`Created event: ${eventName}`);
 	}
 }
 
 async function listAllAutomations(resend: Resend): Promise<Array<{ id: string; name: string }>> {
-	const result = await resend.automations.list({ limit: 100 });
-	const data = unwrap(result);
+	const data = await callResend("automations.list", () =>
+		resend.automations.list({ limit: 100 }),
+	);
 	return data.data.map((automation) => ({
 		id: automation.id,
 		name: automation.name,
@@ -414,8 +462,8 @@ async function upsertAutomation(
 ): Promise<void> {
 	const current = existing.find((automation) => automation.name === definition.name);
 	if (!current) {
-		unwrap(
-			await resend.automations.create({
+		await callResend(`automations.create:${definition.name}`, () =>
+			resend.automations.create({
 				name: definition.name,
 				status,
 				steps: definition.steps,
@@ -426,8 +474,8 @@ async function upsertAutomation(
 		return;
 	}
 
-	unwrap(
-		await resend.automations.update(current.id, {
+	await callResend(`automations.update:${definition.name}`, () =>
+		resend.automations.update(current.id, {
 			name: definition.name,
 			status,
 			steps: definition.steps,

--- a/apps/web/scripts/resend/provision-onboarding-automations.ts
+++ b/apps/web/scripts/resend/provision-onboarding-automations.ts
@@ -98,19 +98,19 @@ function renderEmailHtml(args: {
 		.map((step, index) => {
 			const linkHtml =
 				step.href && step.hrefLabel
-					? `<p style="margin:8px 0 0;font-size:13px;line-height:1.5;"><a href="${step.href}" style="color:#1d4ed8;text-decoration:none;font-weight:700;">${step.hrefLabel}</a></p>`
+					? `<p style="margin:8px 0 0;font-size:13px;line-height:1.5;"><a href="${step.href}" style="color:#18181b;text-decoration:underline;font-weight:600;">${step.hrefLabel}</a></p>`
 					: "";
 			return `
 				<tr>
-					<td style="padding:0 0 14px 0;">
+					<td style="padding:0 0 16px 0;">
 						<table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0">
 							<tr>
-								<td width="38" valign="top" style="padding:2px 10px 0 0;">
-									<div style="width:28px;height:28px;border-radius:999px;background:#dbeafe;color:#1e3a8a;font-size:13px;line-height:28px;text-align:center;font-weight:700;">${index + 1}</div>
+								<td width="30" valign="top" style="padding:0 10px 0 0;">
+									<p style="margin:0;font-size:12px;line-height:1.4;color:#71717a;font-weight:700;">0${index + 1}</p>
 								</td>
-								<td valign="top" style="padding:0;">
-									<p style="margin:0;font-size:16px;line-height:1.35;color:#0f172a;font-weight:700;">${step.title}</p>
-									<p style="margin:5px 0 0;font-size:14px;line-height:1.6;color:#334155;">${step.body}</p>
+								<td valign="top" style="padding:0 0 0 12px;border-left:1px solid #e4e4e7;">
+									<p style="margin:0;font-size:16px;line-height:1.35;color:#18181b;font-weight:700;">${step.title}</p>
+									<p style="margin:5px 0 0;font-size:14px;line-height:1.65;color:#3f3f46;">${step.body}</p>
 									${linkHtml}
 								</td>
 							</tr>
@@ -122,7 +122,7 @@ function renderEmailHtml(args: {
 		.join("");
 
 	const unsubscribeHtml = args.includeUnsubscribe
-		? `<p style="margin:16px 0 0;font-size:12px;line-height:1.6;color:#64748b;">Manage email preferences: <a href="{{{RESEND_UNSUBSCRIBE_URL}}}" style="color:#475569;">Unsubscribe</a></p>`
+		? `<p style="margin:16px 0 0;font-size:12px;line-height:1.6;color:#71717a;">Manage email preferences: <a href="{{{RESEND_UNSUBSCRIBE_URL}}}" style="color:#3f3f46;">Unsubscribe</a></p>`
 		: "";
 
 	return `
@@ -135,38 +135,33 @@ function renderEmailHtml(args: {
 	<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
 	<link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@500;600;700;800&display=swap" rel="stylesheet" />
 </head>
-<body style="margin:0;padding:0;background:#0a1021;">
+<body style="margin:0;padding:0;background:#f4f4f5;">
 	<div style="display:none;max-height:0;overflow:hidden;opacity:0;">${args.title}</div>
-	<table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="background:#0a1021;background-image:radial-gradient(circle at 6% 15%, #1d4ed8 0, transparent 36%),radial-gradient(circle at 90% 6%, #22c55e 0, transparent 30%);">
+	<table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="background:#f4f4f5;">
 		<tr>
 			<td align="center" style="padding:26px 10px 34px;">
 				<table role="presentation" width="640" cellpadding="0" cellspacing="0" border="0" style="width:100%;max-width:640px;">
 					<tr>
 						<td style="padding:0;">
-							<table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="border-radius:24px 24px 0 0;overflow:hidden;">
+							<table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="background:#ffffff;border:1px solid #e4e4e7;border-radius:20px;overflow:hidden;">
 								<tr>
-									<td style="padding:34px 34px 30px;background:linear-gradient(132deg,#1d4ed8 0%,#0f172a 54%,#0ea5e9 100%);font-family:'Montserrat','Avenir Next','Segoe UI',Arial,sans-serif;color:#f8fafc;">
-										<p style="margin:0 0 10px;font-size:11px;line-height:1.2;letter-spacing:0.16em;text-transform:uppercase;opacity:0.95;font-weight:700;">${args.kicker}</p>
-										<h1 style="margin:0 0 12px;font-size:31px;line-height:1.15;font-weight:800;letter-spacing:-0.02em;">${args.title}</h1>
-										<p style="margin:0;font-size:15px;line-height:1.65;color:#dbeafe;font-weight:500;">${args.intro}</p>
-										<table role="presentation" cellpadding="0" cellspacing="0" border="0" style="margin-top:18px;">
+									<td style="padding:30px 32px 12px;font-family:'Montserrat','Avenir Next','Segoe UI',Arial,sans-serif;">
+										<p style="margin:0 0 10px;font-size:11px;line-height:1.2;letter-spacing:0.14em;text-transform:uppercase;color:#71717a;font-weight:700;">${args.kicker}</p>
+										<h1 style="margin:0 0 12px;font-size:32px;line-height:1.12;font-weight:800;letter-spacing:-0.02em;color:#09090b;">${args.title}</h1>
+										<p style="margin:0 0 18px;font-size:15px;line-height:1.7;color:#3f3f46;font-weight:500;">${args.intro}</p>
+										<table role="presentation" cellpadding="0" cellspacing="0" border="0" style="margin:0 0 20px;">
 											<tr>
-												<td style="border-radius:999px;background:#ffffff;">
-													<a href="${args.ctaHref}" style="display:inline-block;padding:12px 18px;font-size:12px;line-height:1.2;text-decoration:none;letter-spacing:0.08em;text-transform:uppercase;font-family:'Montserrat','Avenir Next','Segoe UI',Arial,sans-serif;color:#0f172a;font-weight:800;">${args.ctaLabel}</a>
+												<td style="border-radius:999px;background:#18181b;">
+													<a href="${args.ctaHref}" style="display:inline-block;padding:12px 18px;font-size:12px;line-height:1.2;text-decoration:none;letter-spacing:0.08em;text-transform:uppercase;font-family:'Montserrat','Avenir Next','Segoe UI',Arial,sans-serif;color:#ffffff;font-weight:800;">${args.ctaLabel}</a>
 												</td>
 											</tr>
 										</table>
-									</td>
-								</tr>
-							</table>
-							<table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="background:#f8fbff;border:1px solid #cbd5e1;border-top:none;border-radius:0 0 24px 24px;">
-								<tr>
-									<td style="padding:26px 30px 10px;font-family:'Montserrat','Avenir Next','Segoe UI',Arial,sans-serif;">
+										<div style="height:1px;background:#e4e4e7;margin:0 0 18px;"></div>
 										<table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0">
 											${stepsHtml}
 										</table>
-										<div style="margin:8px 0 0;padding:14px 16px;border-radius:12px;background:linear-gradient(90deg,#e0ecff 0%,#d9fbe8 100%);border:1px solid #bfdbfe;">
-											<p style="margin:0;font-size:13px;line-height:1.6;color:#0f172a;font-weight:600;">${args.replyNote}</p>
+										<div style="margin:8px 0 0;padding:14px 16px;border-radius:10px;background:#fafafa;border:1px solid #e4e4e7;">
+											<p style="margin:0;font-size:13px;line-height:1.6;color:#27272a;font-weight:600;">${args.replyNote}</p>
 										</div>
 										${unsubscribeHtml}
 									</td>

--- a/apps/web/scripts/resend/provision-onboarding-automations.ts
+++ b/apps/web/scripts/resend/provision-onboarding-automations.ts
@@ -146,9 +146,10 @@ function renderEmailHtml(args: {
 							<table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="background:#ffffff;border:1px solid #e4e4e7;border-radius:20px;overflow:hidden;">
 								<tr>
 									<td style="padding:30px 32px 12px;font-family:'Montserrat','Avenir Next','Segoe UI',Arial,sans-serif;">
-										<p style="margin:0 0 10px;font-size:11px;line-height:1.2;letter-spacing:0.14em;text-transform:uppercase;color:#71717a;font-weight:700;">${args.kicker}</p>
-										<h1 style="margin:0 0 12px;font-size:32px;line-height:1.12;font-weight:800;letter-spacing:-0.02em;color:#09090b;">${args.title}</h1>
-										<p style="margin:0 0 18px;font-size:15px;line-height:1.7;color:#3f3f46;font-weight:500;">${args.intro}</p>
+											<p style="margin:0 0 10px;font-size:11px;line-height:1.2;letter-spacing:0.14em;text-transform:uppercase;color:#71717a;font-weight:700;">${args.kicker}</p>
+											<h1 style="margin:0 0 12px;font-size:32px;line-height:1.12;font-weight:800;letter-spacing:-0.02em;color:#09090b;">${args.title}</h1>
+											<p style="margin:0 0 8px;font-size:15px;line-height:1.7;color:#18181b;font-weight:600;">Hi {{{user_name}}},</p>
+											<p style="margin:0 0 18px;font-size:15px;line-height:1.7;color:#3f3f46;font-weight:500;">${args.intro}</p>
 										<table role="presentation" cellpadding="0" cellspacing="0" border="0" style="margin:0 0 20px;">
 											<tr>
 												<td style="border-radius:999px;background:#18181b;">
@@ -221,7 +222,7 @@ function buildTemplates(args: {
 				replyNote: "Reply directly if you want help shipping your first request this week.",
 				includeUnsubscribe: false,
 			}),
-			text: `Welcome to AI Stats.\n\n1) Add your first key: ${keysUrl}\n2) Explore models: ${modelsUrl}\n3) Top up credits: ${creditsUrl}\n\nReply if you want help with setup.`,
+			text: `Hi {{{user_name}}},\n\nWelcome to AI Stats.\n\n1) Add your first key: ${keysUrl}\n2) Explore models: ${modelsUrl}\n3) Top up credits: ${creditsUrl}\n\nReply if you want help with setup.`,
 		},
 		{
 			alias: RESEND_ONBOARDING_TEMPLATE_ALIASES.WELCOME_PURCHASED_7D,
@@ -256,7 +257,7 @@ function buildTemplates(args: {
 				replyNote: "Reply if you want a quick architecture review before scaling up traffic.",
 				includeUnsubscribe: true,
 			}),
-			text: `Thanks for purchasing credits.\n\nNext: add an API key (${keysUrl}), review model IDs (${modelsUrl}), and monitor usage (${dashboardUrl}).\n\nReply for implementation help.\n\nUnsubscribe: {{{RESEND_UNSUBSCRIBE_URL}}}`,
+			text: `Hi {{{user_name}}},\n\nThanks for purchasing credits.\n\nNext: add an API key (${keysUrl}), review model IDs (${modelsUrl}), and monitor usage (${dashboardUrl}).\n\nReply for implementation help.\n\nUnsubscribe: {{{RESEND_UNSUBSCRIBE_URL}}}`,
 		},
 		{
 			alias: RESEND_ONBOARDING_TEMPLATE_ALIASES.WELCOME_NOT_PURCHASED_7D,
@@ -288,7 +289,7 @@ function buildTemplates(args: {
 				replyNote: `Replies go straight to ${args.replyToEmail}. A short note is enough.`,
 				includeUnsubscribe: true,
 			}),
-			text: `It looks like you haven't purchased credits yet.\n\nReply and tell us what blocked you (setup, pricing, model choice, or anything else) and we'll help.\n\nTop up any time: ${creditsUrl}\n\nUnsubscribe: {{{RESEND_UNSUBSCRIBE_URL}}}`,
+			text: `Hi {{{user_name}}},\n\nIt looks like you haven't purchased credits yet.\n\nReply and tell us what blocked you (setup, pricing, model choice, or anything else) and we'll help.\n\nTop up any time: ${creditsUrl}\n\nUnsubscribe: {{{RESEND_UNSUBSCRIBE_URL}}}`,
 		},
 		{
 			alias: RESEND_ONBOARDING_TEMPLATE_ALIASES.CHECKOUT_ABANDONED,
@@ -320,7 +321,7 @@ function buildTemplates(args: {
 				replyNote: `Replies go straight to ${args.replyToEmail} so you can get direct help.`,
 				includeUnsubscribe: true,
 			}),
-			text: `We noticed checkout started but purchase didn't complete.\n\nReply with what went wrong and we'll help.\n\nReturn to credits: ${creditsUrl}\n\nUnsubscribe: {{{RESEND_UNSUBSCRIBE_URL}}}`,
+			text: `Hi {{{user_name}}},\n\nWe noticed checkout started but purchase didn't complete.\n\nReply with what went wrong and we'll help.\n\nReturn to credits: ${creditsUrl}\n\nUnsubscribe: {{{RESEND_UNSUBSCRIBE_URL}}}`,
 		},
 	];
 }
@@ -357,6 +358,13 @@ async function upsertTemplate(
 		replyTo: template.replyTo,
 		html: template.html,
 		text: template.text,
+		variables: [
+			{
+				key: "user_name",
+				type: "string",
+				fallbackValue: "there",
+			},
+		],
 	};
 
 	let templateId: string;
@@ -472,10 +480,22 @@ function buildAutomations(args: {
 				config: { eventName: RESEND_ONBOARDING_EVENT_NAMES.USER_CREATED },
 			},
 			{
+				key: "set_contact_name_from_signup",
+				type: "contact_update",
+				config: {
+					firstName: { var: "event.firstName" },
+				},
+			},
+			{
 				key: "send_welcome_initial",
 				type: "send_email",
 				config: {
-					template: { id: args.templateIds[RESEND_ONBOARDING_TEMPLATE_ALIASES.WELCOME_INITIAL] },
+					template: {
+						id: args.templateIds[RESEND_ONBOARDING_TEMPLATE_ALIASES.WELCOME_INITIAL],
+						variables: {
+							user_name: { var: "contact.first_name" },
+						},
+					},
 				},
 			},
 			{
@@ -492,6 +512,9 @@ function buildAutomations(args: {
 				config: {
 					template: {
 						id: args.templateIds[RESEND_ONBOARDING_TEMPLATE_ALIASES.WELCOME_PURCHASED_7D],
+						variables: {
+							user_name: { var: "contact.first_name" },
+						},
 					},
 				},
 			},
@@ -501,13 +524,17 @@ function buildAutomations(args: {
 				config: {
 					template: {
 						id: args.templateIds[RESEND_ONBOARDING_TEMPLATE_ALIASES.WELCOME_NOT_PURCHASED_7D],
+						variables: {
+							user_name: { var: "contact.first_name" },
+						},
 					},
 					replyTo: args.replyToEmail,
 				},
 			},
 		],
 		connections: [
-			{ from: "trigger_user_created", to: "send_welcome_initial" },
+			{ from: "trigger_user_created", to: "set_contact_name_from_signup" },
+			{ from: "set_contact_name_from_signup", to: "send_welcome_initial" },
 			{ from: "send_welcome_initial", to: "wait_for_purchase_7d" },
 			{
 				from: "wait_for_purchase_7d",
@@ -544,6 +571,9 @@ function buildAutomations(args: {
 				config: {
 					template: {
 						id: args.templateIds[RESEND_ONBOARDING_TEMPLATE_ALIASES.CHECKOUT_ABANDONED],
+						variables: {
+							user_name: { var: "event.firstName" },
+						},
 					},
 					replyTo: args.replyToEmail,
 				},
@@ -569,6 +599,7 @@ function buildAutomations(args: {
 			key: "contact_update_purchase_state",
 			type: "contact_update",
 			config: {
+				firstName: { var: "event.firstName" },
 				properties: {
 					has_bought_credits: "true",
 					last_credit_purchase_nanos: { var: "event.amountNanos" },

--- a/apps/web/scripts/resend/provision-onboarding-automations.ts
+++ b/apps/web/scripts/resend/provision-onboarding-automations.ts
@@ -1,0 +1,497 @@
+#!/usr/bin/env tsx
+
+import {
+	Resend,
+	type AutomationConnection,
+	type AutomationStep,
+	type CreateTemplateOptions,
+} from "resend";
+import {
+	RESEND_ONBOARDING_AUTOMATION_NAMES,
+	RESEND_ONBOARDING_EVENT_NAMES,
+	RESEND_ONBOARDING_TEMPLATE_ALIASES,
+} from "../../src/lib/automations/resend-onboarding.constants";
+
+type TemplateSpec = {
+	alias: string;
+	name: string;
+	subject: string;
+	replyTo?: string;
+	html: string;
+	text: string;
+};
+
+type AutomationDefinition = {
+	name: string;
+	steps: AutomationStep[];
+	connections: AutomationConnection[];
+};
+
+function env(name: string, fallback = ""): string {
+	return String(process.env[name] ?? fallback).trim();
+}
+
+function requiredEnv(name: string): string {
+	const value = env(name);
+	if (!value) {
+		throw new Error(`Missing required environment variable: ${name}`);
+	}
+	return value;
+}
+
+function unwrap<T>(result: { data: T | null; error: { message: string } | null }): T {
+	if (result.error) {
+		throw new Error(result.error.message);
+	}
+	if (!result.data) {
+		throw new Error("Resend API returned empty data");
+	}
+	return result.data;
+}
+
+function markdownEmailWrapper(contentHtml: string): string {
+	return [
+		"<div style=\"background:#f6f8fc;padding:32px 12px;font-family:Inter,system-ui,-apple-system,Segoe UI,Roboto,sans-serif;color:#0f172a;\">",
+		"<div style=\"max-width:620px;margin:0 auto;background:#ffffff;border:1px solid #e2e8f0;border-radius:14px;padding:28px;\">",
+		contentHtml,
+		"</div>",
+		"</div>",
+	].join("");
+}
+
+function buildTemplates(args: {
+	replyToEmail: string;
+	dashboardUrl: string;
+}): TemplateSpec[] {
+	const dashboardUrl = args.dashboardUrl.replace(/\/+$/, "");
+	const modelsUrl = `${dashboardUrl}/gateway`;
+	const creditsUrl = `${dashboardUrl}/settings/credits`;
+	const keysUrl = `${dashboardUrl}/settings/keys`;
+
+	return [
+		{
+			alias: RESEND_ONBOARDING_TEMPLATE_ALIASES.WELCOME_INITIAL,
+			name: "Onboarding - Welcome",
+			subject: "Welcome to AI Stats",
+			html: markdownEmailWrapper(
+				[
+					"<h1 style=\"margin:0 0 14px;font-size:24px;line-height:1.2;\">Welcome to AI Stats</h1>",
+					"<p style=\"margin:0 0 14px;font-size:15px;line-height:1.6;\">You're in. Start routing traffic and monitoring usage in minutes.</p>",
+					"<ol style=\"margin:0 0 14px;padding-left:20px;font-size:15px;line-height:1.6;\">",
+					`<li>Add your first API key: <a href="${keysUrl}">${keysUrl}</a></li>`,
+					`<li>Review supported models: <a href="${modelsUrl}">${modelsUrl}</a></li>`,
+					`<li>Top up credits any time: <a href="${creditsUrl}">${creditsUrl}</a></li>`,
+					"</ol>",
+					"<p style=\"margin:0;font-size:14px;line-height:1.6;color:#334155;\">Reply if you want help getting your first request live.</p>",
+				].join(""),
+			),
+			text: `Welcome to AI Stats.\n\n1) Add your first key: ${keysUrl}\n2) Explore models: ${modelsUrl}\n3) Top up credits: ${creditsUrl}\n\nReply if you want help with setup.`,
+		},
+		{
+			alias: RESEND_ONBOARDING_TEMPLATE_ALIASES.WELCOME_PURCHASED_7D,
+			name: "Onboarding - Purchased Within 7 Days",
+			subject: "You're ready to ship with AI Stats",
+			html: markdownEmailWrapper(
+				[
+					"<h1 style=\"margin:0 0 14px;font-size:24px;line-height:1.2;\">You're all set</h1>",
+					"<p style=\"margin:0 0 14px;font-size:15px;line-height:1.6;\">Thanks for purchasing credits. Here are the fastest next steps:</p>",
+					"<ul style=\"margin:0 0 14px;padding-left:20px;font-size:15px;line-height:1.6;\">",
+					`<li>Use one key to access multiple providers: <a href="${keysUrl}">${keysUrl}</a></li>`,
+					`<li>Find model IDs and pricing: <a href="${modelsUrl}">${modelsUrl}</a></li>`,
+					`<li>Track spend and usage in real time: <a href="${dashboardUrl}">${dashboardUrl}</a></li>`,
+					"</ul>",
+					"<p style=\"margin:0;font-size:14px;line-height:1.6;color:#334155;\">If you want implementation help, just reply and I'll assist directly.</p>",
+					"<p style=\"margin:16px 0 0;font-size:12px;line-height:1.6;color:#64748b;\">Manage email preferences: <a href=\"{{{RESEND_UNSUBSCRIBE_URL}}}\">Unsubscribe</a></p>",
+				].join(""),
+			),
+			text: `Thanks for purchasing credits.\n\nNext: add an API key (${keysUrl}), review model IDs (${modelsUrl}), and monitor usage (${dashboardUrl}).\n\nReply for implementation help.\n\nUnsubscribe: {{{RESEND_UNSUBSCRIBE_URL}}}`,
+		},
+		{
+			alias: RESEND_ONBOARDING_TEMPLATE_ALIASES.WELCOME_NOT_PURCHASED_7D,
+			name: "Onboarding - No Purchase In 7 Days",
+			subject: "Anything blocking you from getting started?",
+			replyTo: args.replyToEmail,
+			html: markdownEmailWrapper(
+				[
+					"<h1 style=\"margin:0 0 14px;font-size:24px;line-height:1.2;\">Quick check-in</h1>",
+					"<p style=\"margin:0 0 14px;font-size:15px;line-height:1.6;\">It looks like you haven't purchased credits yet. If something blocked you, reply and tell us what happened.</p>",
+					"<p style=\"margin:0 0 14px;font-size:15px;line-height:1.6;\">Common blockers we can help with: setup, pricing clarity, or model selection.</p>",
+					`<p style=\"margin:0;font-size:14px;line-height:1.6;color:#334155;\">You can also top up here any time: <a href="${creditsUrl}">${creditsUrl}</a></p>`,
+					"<p style=\"margin:16px 0 0;font-size:12px;line-height:1.6;color:#64748b;\">Manage email preferences: <a href=\"{{{RESEND_UNSUBSCRIBE_URL}}}\">Unsubscribe</a></p>",
+				].join(""),
+			),
+			text: `It looks like you haven't purchased credits yet.\n\nReply and tell us what blocked you (setup, pricing, model choice, or anything else) and we'll help.\n\nTop up any time: ${creditsUrl}\n\nUnsubscribe: {{{RESEND_UNSUBSCRIBE_URL}}}`,
+		},
+		{
+			alias: RESEND_ONBOARDING_TEMPLATE_ALIASES.CHECKOUT_ABANDONED,
+			name: "Onboarding - Checkout Started But Not Purchased",
+			subject: "Did anything go wrong at checkout?",
+			replyTo: args.replyToEmail,
+			html: markdownEmailWrapper(
+				[
+					"<h1 style=\"margin:0 0 14px;font-size:24px;line-height:1.2;\">Need help finishing checkout?</h1>",
+					"<p style=\"margin:0 0 14px;font-size:15px;line-height:1.6;\">We noticed checkout started but purchase didn't complete.</p>",
+					"<p style=\"margin:0 0 14px;font-size:15px;line-height:1.6;\">Reply with what stopped you and we'll fix it fast.</p>",
+					`<p style=\"margin:0;font-size:14px;line-height:1.6;color:#334155;\">Return to credits: <a href="${creditsUrl}">${creditsUrl}</a></p>`,
+					"<p style=\"margin:16px 0 0;font-size:12px;line-height:1.6;color:#64748b;\">Manage email preferences: <a href=\"{{{RESEND_UNSUBSCRIBE_URL}}}\">Unsubscribe</a></p>",
+				].join(""),
+			),
+			text: `We noticed checkout started but purchase didn't complete.\n\nReply with what went wrong and we'll help.\n\nReturn to credits: ${creditsUrl}\n\nUnsubscribe: {{{RESEND_UNSUBSCRIBE_URL}}}`,
+		},
+	];
+}
+
+async function listAllTemplates(resend: Resend): Promise<
+	Array<{
+		id: string;
+		alias: string | null;
+		name: string;
+	}>
+> {
+	const result = await resend.templates.list({ limit: 100 });
+	const data = unwrap(result);
+	return data.data.map((template) => ({
+		id: template.id,
+		alias: template.alias,
+		name: template.name,
+	}));
+}
+
+async function upsertTemplate(
+	resend: Resend,
+	existingTemplates: Array<{ id: string; alias: string | null; name: string }>,
+	template: TemplateSpec,
+	fromEmail: string,
+): Promise<string> {
+	const existing = existingTemplates.find((item) => item.alias === template.alias);
+	const payload: CreateTemplateOptions = {
+		name: template.name,
+		alias: template.alias,
+		subject: template.subject,
+		from: fromEmail,
+		replyTo: template.replyTo,
+		html: template.html,
+		text: template.text,
+	};
+
+	let templateId: string;
+	if (!existing) {
+		const created = unwrap(await resend.templates.create(payload));
+		templateId = created.id;
+		console.log(`Created template: ${template.alias}`);
+	} else {
+		unwrap(await resend.templates.update(existing.id, payload));
+		templateId = existing.id;
+		console.log(`Updated template: ${template.alias}`);
+	}
+
+	unwrap(await resend.templates.publish(templateId));
+	console.log(`Published template: ${template.alias}`);
+	return templateId;
+}
+
+async function listAllContactProperties(resend: Resend): Promise<
+	Array<{ id: string; key: string; type: "string" | "number" }>
+> {
+	const result = await resend.contactProperties.list({ limit: 100 });
+	const data = unwrap(result);
+	return data.data.map((item) => ({
+		id: item.id,
+		key: item.key,
+		type: item.type,
+	}));
+}
+
+async function ensureContactProperties(resend: Resend): Promise<void> {
+	const existing = await listAllContactProperties(resend);
+	const required = [
+		{ key: "has_bought_credits", type: "string" as const, fallbackValue: "false" },
+		{ key: "last_credit_purchase_nanos", type: "number" as const, fallbackValue: 0 },
+		{ key: "last_credit_purchase_at", type: "string" as const, fallbackValue: "" },
+		{
+			key: "last_credit_checkout_session_id",
+			type: "string" as const,
+			fallbackValue: "",
+		},
+	];
+
+	for (const property of required) {
+		const current = existing.find((item) => item.key === property.key);
+		if (!current) {
+			unwrap(await resend.contactProperties.create(property));
+			console.log(`Created contact property: ${property.key}`);
+			continue;
+		}
+		if (current.type !== property.type) {
+			throw new Error(
+				`Contact property type mismatch for "${property.key}". Expected ${property.type}, found ${current.type}.`,
+			);
+		}
+	}
+}
+
+async function listAllEvents(resend: Resend): Promise<Array<{ id: string; name: string }>> {
+	const result = await resend.events.list({ limit: 100 });
+	const data = unwrap(result);
+	return data.data.map((event) => ({
+		id: event.id,
+		name: event.name,
+	}));
+}
+
+async function ensureEvents(resend: Resend): Promise<void> {
+	const current = await listAllEvents(resend);
+	const required = Object.values(RESEND_ONBOARDING_EVENT_NAMES);
+
+	for (const eventName of required) {
+		if (current.some((event) => event.name === eventName)) continue;
+		unwrap(await resend.events.create({ name: eventName }));
+		console.log(`Created event: ${eventName}`);
+	}
+}
+
+async function listAllAutomations(resend: Resend): Promise<Array<{ id: string; name: string }>> {
+	const result = await resend.automations.list({ limit: 100 });
+	const data = unwrap(result);
+	return data.data.map((automation) => ({
+		id: automation.id,
+		name: automation.name,
+	}));
+}
+
+function buildAutomations(args: {
+	templateIds: Record<string, string>;
+	replyToEmail: string;
+	purchaseWindow: string;
+	checkoutTimeout: string;
+	customersSegmentId?: string;
+}): AutomationDefinition[] {
+	const welcome7Day: AutomationDefinition = {
+		name: RESEND_ONBOARDING_AUTOMATION_NAMES.WELCOME_7_DAY_BRANCH,
+		steps: [
+			{
+				key: "trigger_user_created",
+				type: "trigger",
+				config: { eventName: RESEND_ONBOARDING_EVENT_NAMES.USER_CREATED },
+			},
+			{
+				key: "send_welcome_initial",
+				type: "send_email",
+				config: {
+					template: { id: args.templateIds[RESEND_ONBOARDING_TEMPLATE_ALIASES.WELCOME_INITIAL] },
+				},
+			},
+			{
+				key: "wait_for_purchase_7d",
+				type: "wait_for_event",
+				config: {
+					eventName: RESEND_ONBOARDING_EVENT_NAMES.CREDITS_PURCHASED,
+					timeout: args.purchaseWindow,
+				},
+			},
+			{
+				key: "send_purchased_branch",
+				type: "send_email",
+				config: {
+					template: {
+						id: args.templateIds[RESEND_ONBOARDING_TEMPLATE_ALIASES.WELCOME_PURCHASED_7D],
+					},
+				},
+			},
+			{
+				key: "send_not_purchased_branch",
+				type: "send_email",
+				config: {
+					template: {
+						id: args.templateIds[RESEND_ONBOARDING_TEMPLATE_ALIASES.WELCOME_NOT_PURCHASED_7D],
+					},
+					replyTo: args.replyToEmail,
+				},
+			},
+		],
+		connections: [
+			{ from: "trigger_user_created", to: "send_welcome_initial" },
+			{ from: "send_welcome_initial", to: "wait_for_purchase_7d" },
+			{
+				from: "wait_for_purchase_7d",
+				to: "send_purchased_branch",
+				type: "event_received",
+			},
+			{
+				from: "wait_for_purchase_7d",
+				to: "send_not_purchased_branch",
+				type: "timeout",
+			},
+		],
+	};
+
+	const checkoutAbandoned: AutomationDefinition = {
+		name: RESEND_ONBOARDING_AUTOMATION_NAMES.CHECKOUT_ABANDONMENT,
+		steps: [
+			{
+				key: "trigger_checkout_started",
+				type: "trigger",
+				config: { eventName: RESEND_ONBOARDING_EVENT_NAMES.CHECKOUT_STARTED },
+			},
+			{
+				key: "wait_for_purchase",
+				type: "wait_for_event",
+				config: {
+					eventName: RESEND_ONBOARDING_EVENT_NAMES.CREDITS_PURCHASED,
+					timeout: args.checkoutTimeout,
+				},
+			},
+			{
+				key: "send_checkout_timeout",
+				type: "send_email",
+				config: {
+					template: {
+						id: args.templateIds[RESEND_ONBOARDING_TEMPLATE_ALIASES.CHECKOUT_ABANDONED],
+					},
+					replyTo: args.replyToEmail,
+				},
+			},
+		],
+		connections: [
+			{ from: "trigger_checkout_started", to: "wait_for_purchase" },
+			{
+				from: "wait_for_purchase",
+				to: "send_checkout_timeout",
+				type: "timeout",
+			},
+		],
+	};
+
+	const purchaseStateSteps: AutomationStep[] = [
+		{
+			key: "trigger_credits_purchased",
+			type: "trigger",
+			config: { eventName: RESEND_ONBOARDING_EVENT_NAMES.CREDITS_PURCHASED },
+		},
+		{
+			key: "contact_update_purchase_state",
+			type: "contact_update",
+			config: {
+				properties: {
+					has_bought_credits: "true",
+					last_credit_purchase_nanos: { var: "event.amountNanos" },
+					last_credit_purchase_at: { var: "event.creditedAtIso" },
+					last_credit_checkout_session_id: { var: "event.checkoutSessionId" },
+				},
+			},
+		},
+	];
+	const purchaseStateConnections: AutomationConnection[] = [
+		{ from: "trigger_credits_purchased", to: "contact_update_purchase_state" },
+	];
+
+	if (args.customersSegmentId) {
+		purchaseStateSteps.push({
+			key: "add_to_customers_segment",
+			type: "add_to_segment",
+			config: { segmentId: args.customersSegmentId },
+		});
+		purchaseStateConnections.push({
+			from: "contact_update_purchase_state",
+			to: "add_to_customers_segment",
+		});
+	}
+
+	const purchaseState: AutomationDefinition = {
+		name: RESEND_ONBOARDING_AUTOMATION_NAMES.PURCHASED_CONTACT_STATE,
+		steps: purchaseStateSteps,
+		connections: purchaseStateConnections,
+	};
+
+	return [welcome7Day, checkoutAbandoned, purchaseState];
+}
+
+async function upsertAutomation(
+	resend: Resend,
+	existing: Array<{ id: string; name: string }>,
+	definition: AutomationDefinition,
+	status: "enabled" | "disabled",
+): Promise<void> {
+	const current = existing.find((automation) => automation.name === definition.name);
+	if (!current) {
+		unwrap(
+			await resend.automations.create({
+				name: definition.name,
+				status,
+				steps: definition.steps,
+				connections: definition.connections,
+			}),
+		);
+		console.log(`Created automation: ${definition.name}`);
+		return;
+	}
+
+	unwrap(
+		await resend.automations.update(current.id, {
+			name: definition.name,
+			status,
+			steps: definition.steps,
+			connections: definition.connections,
+		}),
+	);
+	console.log(`Updated automation: ${definition.name}`);
+}
+
+async function main(): Promise<void> {
+	const apiKey = requiredEnv("RESEND_API_KEY");
+	const fromEmail = env("RESEND_FROM_EMAIL", "AI Stats <noreply@phaseo.app>");
+	const replyToEmail = env("RESEND_ONBOARDING_REPLY_TO_EMAIL", "support@aistats.com");
+	const dashboardUrl = env(
+		"RESEND_ONBOARDING_DASHBOARD_URL",
+		env("NEXT_PUBLIC_WEBSITE_URL", "https://www.aistats.com"),
+	);
+	const purchaseWindow = env("RESEND_ONBOARDING_PURCHASE_WINDOW", "7 days");
+	const checkoutTimeout = env("RESEND_CHECKOUT_ABANDONED_TIMEOUT", "24 hours");
+	const segmentId = env("RESEND_CUSTOMERS_SEGMENT_ID");
+	const automationStatusRaw = env("RESEND_ONBOARDING_AUTOMATION_STATUS", "enabled");
+	const automationStatus = automationStatusRaw === "disabled" ? "disabled" : "enabled";
+
+	const resend = new Resend(apiKey);
+
+	console.log("Ensuring custom events...");
+	await ensureEvents(resend);
+
+	console.log("Ensuring contact properties...");
+	await ensureContactProperties(resend);
+
+	console.log("Upserting templates...");
+	const existingTemplates = await listAllTemplates(resend);
+	const templateSpecs = buildTemplates({
+		replyToEmail,
+		dashboardUrl,
+	});
+	const templateIds: Record<string, string> = {};
+	for (const template of templateSpecs) {
+		templateIds[template.alias] = await upsertTemplate(
+			resend,
+			existingTemplates,
+			template,
+			fromEmail,
+		);
+	}
+
+	console.log("Upserting automations...");
+	const existingAutomations = await listAllAutomations(resend);
+	const automations = buildAutomations({
+		templateIds,
+		replyToEmail,
+		purchaseWindow,
+		checkoutTimeout,
+		customersSegmentId: segmentId || undefined,
+	});
+	for (const automation of automations) {
+		await upsertAutomation(resend, existingAutomations, automation, automationStatus);
+	}
+
+	console.log("Provisioning complete.");
+}
+
+main().catch((error) => {
+	console.error("Failed to provision onboarding automations:", error);
+	process.exitCode = 1;
+});

--- a/apps/web/src/app/api/checkout/create/route.ts
+++ b/apps/web/src/app/api/checkout/create/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
+import { sendCheckoutStartedEvent } from "@/lib/automations/resend-events";
 import { getStripe } from "@/lib/stripe";
 import { requireActiveWorkspaceStripeCustomer } from "@/lib/server/activeTeamStripe";
 
@@ -9,7 +10,7 @@ export async function POST(req: NextRequest) {
             typeof workspace_id === "string" && workspace_id.trim().length > 0
                 ? workspace_id.trim()
                 : undefined;
-        const { workspaceId, customerId } = await requireActiveWorkspaceStripeCustomer({
+        const { workspaceId, customerId, userId, userEmail } = await requireActiveWorkspaceStripeCustomer({
             createIfMissing: true,
         });
 
@@ -71,6 +72,29 @@ export async function POST(req: NextRequest) {
                     ...(workspaceId ? { workspace_id: workspaceId } : {}),
                 },
             });
+            if (userEmail) {
+                try {
+                    await sendCheckoutStartedEvent({
+                        email: userEmail,
+                        payload: {
+                            workspaceId,
+                            userId,
+                            checkoutSessionId: session.id,
+                            checkoutKind: "oneoff",
+                            currency,
+                            amountPence: Number(amount_pence),
+                            startedAtIso: new Date().toISOString(),
+                        },
+                    });
+                } catch (error) {
+                    console.error("Failed sending checkout.started event for oneoff checkout", {
+                        workspaceId,
+                        userId,
+                        checkoutSessionId: session.id,
+                        error: error instanceof Error ? error.message : String(error),
+                    });
+                }
+            }
 
             return NextResponse.json({ url: session.url });
         }
@@ -106,6 +130,29 @@ export async function POST(req: NextRequest) {
                 success_url: paymentSuccessUrl,
                 cancel_url: cancelUrl,
             });
+            if (userEmail) {
+                try {
+                    await sendCheckoutStartedEvent({
+                        email: userEmail,
+                        payload: {
+                            workspaceId,
+                            userId,
+                            checkoutSessionId: session.id,
+                            checkoutKind: "pay_and_save",
+                            currency,
+                            amountPence: Number(amount_pence),
+                            startedAtIso: new Date().toISOString(),
+                        },
+                    });
+                } catch (error) {
+                    console.error("Failed sending checkout.started event for pay_and_save checkout", {
+                        workspaceId,
+                        userId,
+                        checkoutSessionId: session.id,
+                        error: error instanceof Error ? error.message : String(error),
+                    });
+                }
+            }
 
             return NextResponse.json({ url: session.url });
         }

--- a/apps/web/src/app/api/checkout/create/route.ts
+++ b/apps/web/src/app/api/checkout/create/route.ts
@@ -1,5 +1,8 @@
 import { NextRequest, NextResponse } from "next/server";
-import { sendCheckoutStartedEvent } from "@/lib/automations/resend-events";
+import {
+	deriveFirstName,
+	sendCheckoutStartedEvent,
+} from "@/lib/automations/resend-events";
 import { getStripe } from "@/lib/stripe";
 import { requireActiveWorkspaceStripeCustomer } from "@/lib/server/activeTeamStripe";
 
@@ -10,9 +13,10 @@ export async function POST(req: NextRequest) {
             typeof workspace_id === "string" && workspace_id.trim().length > 0
                 ? workspace_id.trim()
                 : undefined;
-        const { workspaceId, customerId, userId, userEmail } = await requireActiveWorkspaceStripeCustomer({
+        const { workspaceId, customerId, userId, userEmail, userDisplayName } = await requireActiveWorkspaceStripeCustomer({
             createIfMissing: true,
         });
+        const firstName = deriveFirstName(userDisplayName);
 
         if (requestedTeamId && requestedTeamId !== workspaceId) {
             return NextResponse.json({ error: "Workspace mismatch" }, { status: 403 });
@@ -79,6 +83,7 @@ export async function POST(req: NextRequest) {
                         payload: {
                             workspaceId,
                             userId,
+                            firstName,
                             checkoutSessionId: session.id,
                             checkoutKind: "oneoff",
                             currency,
@@ -137,6 +142,7 @@ export async function POST(req: NextRequest) {
                         payload: {
                             workspaceId,
                             userId,
+                            firstName,
                             checkoutSessionId: session.id,
                             checkoutKind: "pay_and_save",
                             currency,

--- a/apps/web/src/app/api/checkout/route.ts
+++ b/apps/web/src/app/api/checkout/route.ts
@@ -1,5 +1,6 @@
 import { getStripe } from "@/lib/stripe";
 import { NextRequest, NextResponse } from "next/server";
+import { sendCheckoutStartedEvent } from "@/lib/automations/resend-events";
 import { requireActiveWorkspaceStripeCustomer } from "@/lib/server/activeTeamStripe";
 
 // Minimal Stripe integration. Requires STRIPE_SECRET_KEY in environment.
@@ -14,7 +15,7 @@ export async function POST(req: NextRequest) {
             typeof body?.workspace_id === "string" && body.workspace_id.trim().length > 0
                 ? body.workspace_id.trim()
                 : null;
-        const { workspaceId, customerId } = await requireActiveWorkspaceStripeCustomer({
+        const { workspaceId, customerId, userId: authenticatedUserId, userEmail } = await requireActiveWorkspaceStripeCustomer({
             createIfMissing: true,
         });
         if (requestedTeamId && requestedTeamId !== workspaceId) {
@@ -35,7 +36,7 @@ export async function POST(req: NextRequest) {
         const paymentAttempt = Date.now();
 
         // allow optional user_id to be passed from client so webhook can directly credit
-        const userId = body?.user_id;
+        const checkoutUserId = body?.user_id;
 
         const session = await stripe.checkout.sessions.create({
             mode: "payment",
@@ -51,7 +52,7 @@ export async function POST(req: NextRequest) {
                     quantity: 1,
                 },
             ],
-            metadata: userId ? { user_id: String(userId), purchase_amount_cents: String(purchaseAmount) } : { purchase_amount_cents: String(purchaseAmount) },
+            metadata: checkoutUserId ? { user_id: String(checkoutUserId), purchase_amount_cents: String(purchaseAmount) } : { purchase_amount_cents: String(purchaseAmount) },
             payment_intent_data: {
                 description: 'Credits purchase',
                 metadata: {
@@ -62,6 +63,29 @@ export async function POST(req: NextRequest) {
             success_url: `${origin}/settings/credits?checkout=success&payment_attempt=${paymentAttempt}`,
             cancel_url: `${origin}/settings/credits?checkout=cancelled`,
         });
+        if (userEmail) {
+            try {
+                await sendCheckoutStartedEvent({
+                    email: userEmail,
+                    payload: {
+                        workspaceId,
+                        userId: authenticatedUserId,
+                        checkoutSessionId: session.id,
+                        checkoutKind: "legacy_checkout",
+                        currency: "usd",
+                        amountPence: Number(totalAmount),
+                        startedAtIso: new Date().toISOString(),
+                    },
+                });
+            } catch (error) {
+                console.error("Failed sending checkout.started event for legacy checkout", {
+                    workspaceId,
+                    userId: authenticatedUserId,
+                    checkoutSessionId: session.id,
+                    error: error instanceof Error ? error.message : String(error),
+                });
+            }
+        }
 
         return NextResponse.json({ url: session.url });
     } catch (err: any) {

--- a/apps/web/src/app/api/checkout/route.ts
+++ b/apps/web/src/app/api/checkout/route.ts
@@ -1,6 +1,9 @@
 import { getStripe } from "@/lib/stripe";
 import { NextRequest, NextResponse } from "next/server";
-import { sendCheckoutStartedEvent } from "@/lib/automations/resend-events";
+import {
+	deriveFirstName,
+	sendCheckoutStartedEvent,
+} from "@/lib/automations/resend-events";
 import { requireActiveWorkspaceStripeCustomer } from "@/lib/server/activeTeamStripe";
 
 // Minimal Stripe integration. Requires STRIPE_SECRET_KEY in environment.
@@ -15,9 +18,16 @@ export async function POST(req: NextRequest) {
             typeof body?.workspace_id === "string" && body.workspace_id.trim().length > 0
                 ? body.workspace_id.trim()
                 : null;
-        const { workspaceId, customerId, userId: authenticatedUserId, userEmail } = await requireActiveWorkspaceStripeCustomer({
+        const {
+            workspaceId,
+            customerId,
+            userId: authenticatedUserId,
+            userEmail,
+            userDisplayName,
+        } = await requireActiveWorkspaceStripeCustomer({
             createIfMissing: true,
         });
+        const firstName = deriveFirstName(userDisplayName);
         if (requestedTeamId && requestedTeamId !== workspaceId) {
             return NextResponse.json({ error: "Workspace mismatch" }, { status: 403 });
         }
@@ -70,6 +80,7 @@ export async function POST(req: NextRequest) {
                     payload: {
                         workspaceId,
                         userId: authenticatedUserId,
+                        firstName,
                         checkoutSessionId: session.id,
                         checkoutKind: "legacy_checkout",
                         currency: "usd",

--- a/apps/web/src/app/api/webhooks/stripe-checkout/route.ts
+++ b/apps/web/src/app/api/webhooks/stripe-checkout/route.ts
@@ -1,7 +1,10 @@
 import { NextResponse } from "next/server";
 import Stripe from "stripe";
 import { createClient } from "@supabase/supabase-js";
-import { sendCreditsPurchasedEvent } from "@/lib/automations/resend-events";
+import {
+	deriveFirstName,
+	sendCreditsPurchasedEvent,
+} from "@/lib/automations/resend-events";
 import { getStripe } from "@/lib/stripe";
 
 const TOP_UP_PURPOSES = new Set(["top_up", "top_up_one_off", "auto_top_up", "credits_topup_offsession"]);
@@ -45,26 +48,31 @@ function readCustomerIdFromPaymentIntent(pi: Stripe.PaymentIntent): string | nul
     return null;
 }
 
-async function resolveCustomerEmail(
+async function resolveCustomerIdentity(
     stripe: Stripe,
     stripeCustomerId: string | null
-): Promise<string | null> {
-    if (!stripeCustomerId) return null;
+): Promise<{ email: string | null; firstName: string }> {
+    if (!stripeCustomerId) {
+        return { email: null, firstName: "" };
+    }
 
     try {
         const customer = await stripe.customers.retrieve(stripeCustomerId);
         if ("deleted" in customer && customer.deleted) {
-            return null;
+            return { email: null, firstName: "" };
         }
-        return typeof customer.email === "string" && customer.email.trim().length > 0
+        const email =
+            typeof customer.email === "string" && customer.email.trim().length > 0
             ? customer.email
             : null;
+        const firstName = deriveFirstName(customer.name ?? email);
+        return { email, firstName };
     } catch (error) {
         console.warn("[stripe-webhook] Failed to resolve customer email", {
             stripeCustomerId,
             error: error instanceof Error ? error.message : String(error),
         });
-        return null;
+        return { email: null, firstName: "" };
     }
 }
 
@@ -438,15 +446,16 @@ export async function POST(req: Request) {
                     `[stripe-webhook] Payment credited net=$${netUsd} fee=$${feeUsd} balance_before=$${beforeUsd} balance_after=$${afterUsd}`
                 );
 
-                const purchasedEmail = await resolveCustomerEmail(stripe, stripeCustomerId);
-                if (purchasedEmail) {
+                const customerIdentity = await resolveCustomerIdentity(stripe, stripeCustomerId);
+                if (customerIdentity.email) {
                     const checkoutSessionId = await resolveCheckoutSessionIdForPaymentIntent(stripe, pi.id);
                     try {
                         await sendCreditsPurchasedEvent({
-                            email: purchasedEmail,
+                            email: customerIdentity.email,
                             payload: {
                                 workspaceId: wallet.workspace_id,
                                 paymentIntentId: pi.id,
+                                firstName: customerIdentity.firstName,
                                 checkoutSessionId,
                                 currency: String(pi.currency ?? "usd").toLowerCase(),
                                 amountNanos: netNanos,

--- a/apps/web/src/app/api/webhooks/stripe-checkout/route.ts
+++ b/apps/web/src/app/api/webhooks/stripe-checkout/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import Stripe from "stripe";
 import { createClient } from "@supabase/supabase-js";
+import { sendCreditsPurchasedEvent } from "@/lib/automations/resend-events";
 import { getStripe } from "@/lib/stripe";
 
 const TOP_UP_PURPOSES = new Set(["top_up", "top_up_one_off", "auto_top_up", "credits_topup_offsession"]);
@@ -42,6 +43,50 @@ function readCustomerIdFromPaymentIntent(pi: Stripe.PaymentIntent): string | nul
         return typeof id === "string" && id.trim().length > 0 ? id : null;
     }
     return null;
+}
+
+async function resolveCustomerEmail(
+    stripe: Stripe,
+    stripeCustomerId: string | null
+): Promise<string | null> {
+    if (!stripeCustomerId) return null;
+
+    try {
+        const customer = await stripe.customers.retrieve(stripeCustomerId);
+        if ("deleted" in customer && customer.deleted) {
+            return null;
+        }
+        return typeof customer.email === "string" && customer.email.trim().length > 0
+            ? customer.email
+            : null;
+    } catch (error) {
+        console.warn("[stripe-webhook] Failed to resolve customer email", {
+            stripeCustomerId,
+            error: error instanceof Error ? error.message : String(error),
+        });
+        return null;
+    }
+}
+
+async function resolveCheckoutSessionIdForPaymentIntent(
+    stripe: Stripe,
+    paymentIntentId: string
+): Promise<string | undefined> {
+    try {
+        const sessions = await stripe.checkout.sessions.list({
+            payment_intent: paymentIntentId,
+            limit: 1,
+        });
+        const first = sessions.data[0];
+        if (!first?.id) return undefined;
+        return first.id;
+    } catch (error) {
+        console.warn("[stripe-webhook] Failed to resolve checkout session for payment_intent", {
+            paymentIntentId,
+            error: error instanceof Error ? error.message : String(error),
+        });
+        return undefined;
+    }
 }
 
 type WalletAttributionRow = {
@@ -392,6 +437,32 @@ export async function POST(req: Request) {
                 console.log(
                     `[stripe-webhook] Payment credited net=$${netUsd} fee=$${feeUsd} balance_before=$${beforeUsd} balance_after=$${afterUsd}`
                 );
+
+                const purchasedEmail = await resolveCustomerEmail(stripe, stripeCustomerId);
+                if (purchasedEmail) {
+                    const checkoutSessionId = await resolveCheckoutSessionIdForPaymentIntent(stripe, pi.id);
+                    try {
+                        await sendCreditsPurchasedEvent({
+                            email: purchasedEmail,
+                            payload: {
+                                workspaceId: wallet.workspace_id,
+                                paymentIntentId: pi.id,
+                                checkoutSessionId,
+                                currency: String(pi.currency ?? "usd").toLowerCase(),
+                                amountNanos: netNanos,
+                                kind,
+                                creditedAtIso: new Date().toISOString(),
+                            },
+                        });
+                    } catch (error) {
+                        console.error("[stripe-webhook] Failed sending credits.purchased event", {
+                            paymentIntentId: pi.id,
+                            workspaceId: wallet.workspace_id,
+                            checkoutSessionId: checkoutSessionId ?? null,
+                            error: error instanceof Error ? error.message : String(error),
+                        });
+                    }
+                }
 
                 break;
             }

--- a/apps/web/src/lib/auth/post-login.ts
+++ b/apps/web/src/lib/auth/post-login.ts
@@ -3,6 +3,10 @@ import { Resend } from "resend";
 import { createAdminClient } from "@/utils/supabase/admin";
 import { classifyAuthMethodFromSession } from "@/lib/auth/method";
 import { evaluateTeamSsoEnforcementNoop } from "@/lib/auth/ssoEnforcement";
+import {
+	isResendOnboardingAutomationsEnabled,
+	sendUserCreatedEvent,
+} from "@/lib/automations/resend-events";
 import { ensureWorkspaceStripeWallet } from "@/lib/server/activeTeamStripe";
 import type { createClient } from "@/utils/supabase/server";
 
@@ -107,6 +111,54 @@ async function sendSignupWelcomeEmail(args: {
 	if (error) {
 		throw new Error(`resend_error:${error.name}:${error.message}`);
 	}
+}
+
+async function sendSignupWelcomeNotification(args: {
+	email: string;
+	displayName: string;
+	userId: string;
+	workspaceId: string;
+	source: "auth_callback" | "server_action";
+	createdAtIso: string;
+}) {
+	if (!isResendOnboardingAutomationsEnabled()) {
+		await sendSignupWelcomeEmail({
+			email: args.email,
+			displayName: args.displayName,
+		});
+		return;
+	}
+
+	const firstName = deriveFirstName(args.displayName);
+
+	try {
+		await sendUserCreatedEvent({
+			email: args.email,
+			payload: {
+				userId: args.userId,
+				workspaceId: args.workspaceId,
+				displayName: args.displayName,
+				firstName,
+				source: args.source,
+				createdAtIso: args.createdAtIso,
+			},
+		});
+		return;
+	} catch (automationError) {
+		console.error("Failed sending onboarding automation signup event", {
+			userId: args.userId,
+			workspaceId: args.workspaceId,
+			error:
+				automationError instanceof Error
+					? automationError.message
+					: String(automationError),
+		});
+	}
+
+	await sendSignupWelcomeEmail({
+		email: args.email,
+		displayName: args.displayName,
+	});
 }
 
 async function sendSignupDiscordWebhook(args: {
@@ -433,11 +485,15 @@ export async function finalizePostLogin(
 
 		if (user.email) {
 			notificationTasks.push(
-				sendSignupWelcomeEmail({
+				sendSignupWelcomeNotification({
 					email: user.email,
 					displayName,
+					userId: user.id,
+					workspaceId,
+					source: input.source,
+					createdAtIso: String(user.created_at ?? new Date().toISOString()),
 				}).catch((error) => {
-					console.error("Failed sending direct signup welcome email", {
+					console.error("Failed sending signup onboarding notification", {
 						source: input.source,
 						userId: user.id,
 						workspaceId,

--- a/apps/web/src/lib/automations/resend-events.ts
+++ b/apps/web/src/lib/automations/resend-events.ts
@@ -1,0 +1,108 @@
+import { Resend } from "resend";
+import { RESEND_ONBOARDING_EVENT_NAMES } from "@/lib/automations/resend-onboarding.constants";
+
+export type ResendUserCreatedPayload = {
+	userId: string;
+	workspaceId: string;
+	displayName: string;
+	firstName: string;
+	source: "auth_callback" | "server_action";
+	createdAtIso: string;
+};
+
+export type ResendCheckoutStartedPayload = {
+	workspaceId: string;
+	userId: string;
+	checkoutSessionId: string;
+	checkoutKind: "oneoff" | "pay_and_save" | "legacy_checkout";
+	currency: string;
+	amountPence: number;
+	startedAtIso: string;
+};
+
+export type ResendCreditsPurchasedPayload = {
+	workspaceId: string;
+	paymentIntentId: string;
+	checkoutSessionId?: string;
+	currency: string;
+	amountNanos: number;
+	kind: "top_up" | "top_up_one_off" | "auto_top_up";
+	creditedAtIso: string;
+};
+
+function readBoolEnv(name: string): boolean | null {
+	const raw = String(process.env[name] ?? "").trim().toLowerCase();
+	if (!raw) return null;
+	if (raw === "1" || raw === "true" || raw === "yes" || raw === "on") return true;
+	if (raw === "0" || raw === "false" || raw === "no" || raw === "off") return false;
+	return null;
+}
+
+function isResendConfigured(): boolean {
+	return String(process.env.RESEND_API_KEY ?? "").trim().length > 0;
+}
+
+export function isResendOnboardingAutomationsEnabled(): boolean {
+	const explicit = readBoolEnv("RESEND_ONBOARDING_AUTOMATIONS_ENABLED");
+	if (explicit !== null) {
+		return explicit && isResendConfigured();
+	}
+	return isResendConfigured();
+}
+
+function createResendClient(): Resend {
+	const apiKey = String(process.env.RESEND_API_KEY ?? "").trim();
+	return new Resend(apiKey);
+}
+
+async function sendResendEvent(args: {
+	event: string;
+	email: string;
+	payload: Record<string, unknown>;
+}): Promise<void> {
+	if (!isResendOnboardingAutomationsEnabled()) return;
+	const email = args.email.trim();
+	if (!email) return;
+	const resend = createResendClient();
+	const { error } = await resend.events.send({
+		event: args.event,
+		email,
+		payload: args.payload,
+	});
+	if (error) {
+		throw new Error(`resend_event_error:${args.event}:${error.name}:${error.message}`);
+	}
+}
+
+export async function sendUserCreatedEvent(args: {
+	email: string;
+	payload: ResendUserCreatedPayload;
+}): Promise<void> {
+	await sendResendEvent({
+		event: RESEND_ONBOARDING_EVENT_NAMES.USER_CREATED,
+		email: args.email,
+		payload: args.payload,
+	});
+}
+
+export async function sendCheckoutStartedEvent(args: {
+	email: string;
+	payload: ResendCheckoutStartedPayload;
+}): Promise<void> {
+	await sendResendEvent({
+		event: RESEND_ONBOARDING_EVENT_NAMES.CHECKOUT_STARTED,
+		email: args.email,
+		payload: args.payload,
+	});
+}
+
+export async function sendCreditsPurchasedEvent(args: {
+	email: string;
+	payload: ResendCreditsPurchasedPayload;
+}): Promise<void> {
+	await sendResendEvent({
+		event: RESEND_ONBOARDING_EVENT_NAMES.CREDITS_PURCHASED,
+		email: args.email,
+		payload: args.payload,
+	});
+}

--- a/apps/web/src/lib/automations/resend-events.ts
+++ b/apps/web/src/lib/automations/resend-events.ts
@@ -13,6 +13,7 @@ export type ResendUserCreatedPayload = {
 export type ResendCheckoutStartedPayload = {
 	workspaceId: string;
 	userId: string;
+	firstName: string;
 	checkoutSessionId: string;
 	checkoutKind: "oneoff" | "pay_and_save" | "legacy_checkout";
 	currency: string;
@@ -23,12 +24,19 @@ export type ResendCheckoutStartedPayload = {
 export type ResendCreditsPurchasedPayload = {
 	workspaceId: string;
 	paymentIntentId: string;
+	firstName: string;
 	checkoutSessionId?: string;
 	currency: string;
 	amountNanos: number;
 	kind: "top_up" | "top_up_one_off" | "auto_top_up";
 	creditedAtIso: string;
 };
+
+export function deriveFirstName(value: string | null | undefined): string {
+	const normalized = String(value ?? "").trim();
+	if (!normalized) return "";
+	return normalized.split(/\s+/)[0] ?? "";
+}
 
 function readBoolEnv(name: string): boolean | null {
 	const raw = String(process.env[name] ?? "").trim().toLowerCase();

--- a/apps/web/src/lib/automations/resend-onboarding.constants.ts
+++ b/apps/web/src/lib/automations/resend-onboarding.constants.ts
@@ -1,0 +1,18 @@
+export const RESEND_ONBOARDING_EVENT_NAMES = {
+	USER_CREATED: "user.created",
+	CHECKOUT_STARTED: "checkout.started",
+	CREDITS_PURCHASED: "credits.purchased",
+} as const;
+
+export const RESEND_ONBOARDING_TEMPLATE_ALIASES = {
+	WELCOME_INITIAL: "onboarding-welcome-initial",
+	WELCOME_PURCHASED_7D: "onboarding-welcome-purchased-7d",
+	WELCOME_NOT_PURCHASED_7D: "onboarding-welcome-not-purchased-7d",
+	CHECKOUT_ABANDONED: "onboarding-checkout-abandoned",
+} as const;
+
+export const RESEND_ONBOARDING_AUTOMATION_NAMES = {
+	WELCOME_7_DAY_BRANCH: "Onboarding: Welcome + 7 day purchase branch",
+	CHECKOUT_ABANDONMENT: "Onboarding: Checkout started but no purchase",
+	PURCHASED_CONTACT_STATE: "Onboarding: Contact state from credits purchased",
+} as const;

--- a/apps/web/src/lib/server/activeTeamStripe.ts
+++ b/apps/web/src/lib/server/activeTeamStripe.ts
@@ -8,6 +8,8 @@ type ActiveWorkspaceStripeCustomer = {
     workspaceId: string;
     customerId: string;
     userId: string;
+    userEmail: string | null;
+    userDisplayName: string | null;
 };
 
 type RequireActiveWorkspaceStripeCustomerOptions = {
@@ -135,6 +137,8 @@ export async function requireActiveWorkspaceStripeCustomer(
             workspaceId,
             customerId,
             userId: user.id,
+            userEmail: user.email ?? null,
+            userDisplayName: deriveCustomerName(user) ?? null,
         };
     }
 
@@ -146,6 +150,8 @@ export async function requireActiveWorkspaceStripeCustomer(
         workspaceId: String(wallet.workspace_id),
         customerId: String(wallet.stripe_customer_id),
         userId: user.id,
+        userEmail: user.email ?? null,
+        userDisplayName: deriveCustomerName(user) ?? null,
     };
 }
 


### PR DESCRIPTION
## Summary
- Add a Resend onboarding automations module with canonical event/template/automation constants and typed event senders.
- Wire runtime lifecycle events:
  - `user.created` at post-login onboarding (with direct welcome-email fallback if event delivery fails)
  - `checkout.started` when Stripe checkout sessions are created
  - `credits.purchased` after Stripe webhook credit application succeeds
- Add `apps/web/scripts/resend/provision-onboarding-automations.ts` to upsert/publish onboarding templates, ensure contact properties/events, and upsert 3 automation graphs (7-day branch, checkout abandonment follow-up, purchased contact state).
- Add `pnpm --filter @ai-stats/web resend:provision:onboarding` and docs in `apps/web/scripts/resend/README.md`.

## Validation
- `pnpm --filter @ai-stats/web typecheck`

## Notes
- PR is intentionally **not merged** per request.
- Runtime event sending is gated by `RESEND_ONBOARDING_AUTOMATIONS_ENABLED` (and `RESEND_API_KEY`).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automated onboarding workflows: welcome series, abandoned-checkout recovery, and post-purchase updates triggered by signup, checkout start, and purchase events.
  * Signup now prefers event-driven welcome notifications with a fallback to sending direct welcome emails when needed.
  * Checkout and payment flows now emit richer events (including user email when available) to support automations.

* **Chores**
  * Added a provisioning script and README to configure and deploy the onboarding automations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->