### PR TITLE
Adjust provider collapse threshold and add unreleased model banners

### DIFF
--- a/apps/web/src/components/(data)/model/overview/ModelOverviewSections.tsx
+++ b/apps/web/src/components/(data)/model/overview/ModelOverviewSections.tsx
@@ -33,6 +33,7 @@ import { getModelTokenTrajectoryCached } from "@/lib/fetchers/models/getModelTok
 import { getModelGatewayMetadataCached } from "@/lib/fetchers/models/getModelGatewayMetadata";
 import { getModelBenchmarkHighlights } from "@/lib/fetchers/models/getModelBenchmarkData";
 import { getModelPricingCached } from "@/lib/fetchers/models/getModelPricing";
+import { getModelPendingApiReleaseState } from "@/lib/fetchers/models/getModelPendingApiReleaseState";
 import { getModelAppsCached } from "@/lib/fetchers/models/getModelApps";
 import { getOrganisationModelsCached } from "@/lib/fetchers/organisations/getOrganisation";
 import { Badge } from "@/components/ui/badge";
@@ -52,6 +53,7 @@ import {
 	EmptyTitle,
 } from "@/components/ui/empty";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import ModelPendingApiReleaseBanner from "@/components/(data)/model/overview/ModelPendingApiReleaseBanner";
 
 type ModelOverviewSectionsProps = {
 	modelId: string;
@@ -217,12 +219,16 @@ export async function ModelPerformanceSection({
 	includeHidden,
 	surface = "page",
 }: ModelSectionSharedProps & { surface?: ModelSectionSurface }) {
-	const [performanceMetrics, tokenTrajectory] = await Promise.all([
+	const [performanceMetrics, tokenTrajectory, pendingApiRelease] =
+		await Promise.all([
 		getModelPerformanceMetricsCached(modelId, includeHidden, 24).catch(() => null),
 		surface === "page"
 			? getModelTokenTrajectoryCached(modelId, includeHidden).catch(() => null)
 			: Promise.resolve(null),
+		getModelPendingApiReleaseState(modelId, includeHidden).catch(() => null),
 	]);
+	const shouldShowPendingApiBanner =
+		!performanceMetrics && pendingApiRelease?.isPendingApiRelease;
 
 	return (
 		<Section id="performance">
@@ -241,17 +247,25 @@ export async function ModelPerformanceSection({
 					mode={surface}
 				/>
 			) : (
-				<Empty className="rounded-lg border p-8">
-					<EmptyHeader>
-						<EmptyMedia variant="icon">
-							<Activity className="size-5" />
-						</EmptyMedia>
-						<EmptyTitle>No performance telemetry yet</EmptyTitle>
-						<EmptyDescription>
-							Performance telemetry is not available yet.
-						</EmptyDescription>
-					</EmptyHeader>
-				</Empty>
+				<div className="space-y-3">
+					{shouldShowPendingApiBanner ? (
+						<ModelPendingApiReleaseBanner
+							modelName={pendingApiRelease?.modelName ?? "This model"}
+							surface="performance"
+						/>
+					) : null}
+					<Empty className="rounded-lg border p-8">
+						<EmptyHeader>
+							<EmptyMedia variant="icon">
+								<Activity className="size-5" />
+							</EmptyMedia>
+							<EmptyTitle>No performance telemetry yet</EmptyTitle>
+							<EmptyDescription>
+								Performance telemetry is not available yet.
+							</EmptyDescription>
+						</EmptyHeader>
+					</Empty>
+				</div>
 			)}
 		</Section>
 	);
@@ -453,13 +467,18 @@ export async function ModelBenchmarksSection({
 	includeHidden,
 	hideWhenEmpty = false,
 }: ModelSectionSharedProps & { hideWhenEmpty?: boolean }) {
-	const benchmarkHighlights = await getModelBenchmarkHighlights(
-		modelId,
-		includeHidden,
-	).catch(() => []);
+	const [benchmarkHighlights, pendingApiRelease] = await Promise.all([
+		getModelBenchmarkHighlights(
+			modelId,
+			includeHidden,
+		).catch(() => []),
+		getModelPendingApiReleaseState(modelId, includeHidden).catch(() => null),
+	]);
 	if (hideWhenEmpty && benchmarkHighlights.length === 0) {
 		return null;
 	}
+	const shouldShowPendingApiBanner =
+		benchmarkHighlights.length === 0 && pendingApiRelease?.isPendingApiRelease;
 
 	return (
 		<Section id="benchmarks">
@@ -476,14 +495,22 @@ export async function ModelBenchmarksSection({
 					mode="summary"
 				/>
 			) : (
-				<Empty className="rounded-lg border p-8">
-					<EmptyHeader>
-						<EmptyTitle>No benchmark data yet</EmptyTitle>
-						<EmptyDescription>
-							No benchmark data is available for this model yet.
-						</EmptyDescription>
-					</EmptyHeader>
-				</Empty>
+				<div className="space-y-3">
+					{shouldShowPendingApiBanner ? (
+						<ModelPendingApiReleaseBanner
+							modelName={pendingApiRelease?.modelName ?? "This model"}
+							surface="benchmarks"
+						/>
+					) : null}
+					<Empty className="rounded-lg border p-8">
+						<EmptyHeader>
+							<EmptyTitle>No benchmark data yet</EmptyTitle>
+							<EmptyDescription>
+								No benchmark data is available for this model yet.
+							</EmptyDescription>
+						</EmptyHeader>
+					</Empty>
+				</div>
 			)}
 		</Section>
 	);

--- a/apps/web/src/components/(data)/model/overview/ModelOverviewSections.tsx
+++ b/apps/web/src/components/(data)/model/overview/ModelOverviewSections.tsx
@@ -474,11 +474,11 @@ export async function ModelBenchmarksSection({
 		).catch(() => []),
 		getModelPendingApiReleaseState(modelId, includeHidden).catch(() => null),
 	]);
-	if (hideWhenEmpty && benchmarkHighlights.length === 0) {
-		return null;
-	}
 	const shouldShowPendingApiBanner =
 		benchmarkHighlights.length === 0 && pendingApiRelease?.isPendingApiRelease;
+	if (hideWhenEmpty && benchmarkHighlights.length === 0 && !shouldShowPendingApiBanner) {
+		return null;
+	}
 
 	return (
 		<Section id="benchmarks">
@@ -975,3 +975,4 @@ export default function ModelOverviewSections({
 		</div>
 	);
 }
+

--- a/apps/web/src/components/(data)/model/overview/ModelPendingApiReleaseBanner.tsx
+++ b/apps/web/src/components/(data)/model/overview/ModelPendingApiReleaseBanner.tsx
@@ -1,0 +1,50 @@
+import { AlertTriangle } from "lucide-react";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+
+type PendingBannerSurface = "benchmarks" | "performance" | "providers" | "pricing";
+
+const PENDING_COPY: Record<
+	PendingBannerSurface,
+	{ title: string; description: (modelName: string) => string }
+> = {
+	benchmarks: {
+		title: "Benchmark updates coming soon",
+		description: (modelName) =>
+			`${modelName} is not fully available on the API yet. Benchmark results will be published here as soon as rollout is complete. Please check back soon.`,
+	},
+	performance: {
+		title: "Performance data coming soon",
+		description: (modelName) =>
+			`${modelName} is not fully available on the API yet. Latency and throughput telemetry will appear here once live API traffic starts.`,
+	},
+	providers: {
+		title: "Provider rollout in progress",
+		description: (modelName) =>
+			`${modelName} is not fully available on the API yet. Provider availability and pricing will appear here as soon as rollout is complete.`,
+	},
+	pricing: {
+		title: "Pricing insights coming soon",
+		description: (modelName) =>
+			`${modelName} is not fully available on the API yet. Pricing insights and history will appear here once provider pricing is live.`,
+	},
+};
+
+export default function ModelPendingApiReleaseBanner({
+	modelName,
+	surface,
+}: {
+	modelName: string;
+	surface: PendingBannerSurface;
+}) {
+	const content = PENDING_COPY[surface];
+
+	return (
+		<Alert className="border-amber-200 bg-amber-50 text-amber-950 dark:border-amber-900/60 dark:bg-amber-900/20 dark:text-amber-50">
+			<AlertTriangle className="h-4 w-4 text-amber-700 dark:text-amber-300" />
+			<AlertTitle>{content.title}</AlertTitle>
+			<AlertDescription className="text-amber-900/90 dark:text-amber-100/90">
+				{content.description(modelName)}
+			</AlertDescription>
+		</Alert>
+	);
+}

--- a/apps/web/src/components/(data)/model/pricing/ModelPricing.tsx
+++ b/apps/web/src/components/(data)/model/pricing/ModelPricing.tsx
@@ -7,6 +7,7 @@ import { getModelProviderRuntimeStatsCached } from "@/lib/fetchers/models/getMod
 import { getModelSubscriptionPlansCached } from "@/lib/fetchers/models/getModelSubscriptionPlans";
 import { getModelProviderRoutingHealthCached } from "@/lib/fetchers/models/getModelProviderRoutingHealth";
 import ModelPricingClient from "@/components/(data)/model/pricing/ModelPricingClient";
+import ModelPendingApiReleaseBanner from "@/components/(data)/model/overview/ModelPendingApiReleaseBanner";
 import {
 	Empty,
 	EmptyContent,
@@ -48,6 +49,25 @@ export default async function ModelPricing({
 					providerModel.endpoint !== "unmapped"
 			)
 	);
+	const now = new Date();
+	const hasActiveApiProviders = providersForDisplay.some((provider) =>
+		provider.provider_models.some((providerModel) => {
+			if (!providerModel.is_active_gateway) return false;
+			if (providerModel.capability_status === "disabled") return false;
+			if (!providerModel.endpoint || providerModel.endpoint === "unmapped") return false;
+			const from = providerModel.effective_from
+				? new Date(providerModel.effective_from)
+				: null;
+			const to = providerModel.effective_to
+				? new Date(providerModel.effective_to)
+				: null;
+			if (from && Number.isFinite(from.getTime()) && now < from) return false;
+			if (to && Number.isFinite(to.getTime()) && now >= to) return false;
+			return true;
+		})
+	);
+	const showPendingApiBanner =
+		header?.status === "Available" && !hasActiveApiProviders;
 
 	const runtimeStats = await getModelProviderRuntimeStatsCached({
 		modelId,
@@ -77,6 +97,14 @@ export default async function ModelPricing({
 			<Card className="p-6">
 				{showHeader ? (
 					<h2 className="mb-2 text-xl font-semibold">Availability + Pricing</h2>
+				) : null}
+				{showPendingApiBanner ? (
+					<div className="mb-4">
+						<ModelPendingApiReleaseBanner
+							modelName={header?.name ?? "This model"}
+							surface="providers"
+						/>
+					</div>
 				) : null}
 				<Empty className="rounded-md border p-6">
 					<EmptyHeader>
@@ -110,13 +138,21 @@ export default async function ModelPricing({
 	}
 
 	return (
-		<ModelPricingClient
-			providers={providersForDisplay}
-			subscriptionPlans={subscriptionPlans}
-			creatorOrgId={header?.organisation_id ?? null}
-			runtimeStats={runtimeStats}
-			routingHealth={routingHealth}
-			showHeader={showHeader}
-		/>
+		<div className="space-y-4">
+			{showPendingApiBanner ? (
+				<ModelPendingApiReleaseBanner
+					modelName={header?.name ?? "This model"}
+					surface="providers"
+				/>
+			) : null}
+			<ModelPricingClient
+				providers={providersForDisplay}
+				subscriptionPlans={subscriptionPlans}
+				creatorOrgId={header?.organisation_id ?? null}
+				runtimeStats={runtimeStats}
+				routingHealth={routingHealth}
+				showHeader={showHeader}
+			/>
+		</div>
 	);
 }

--- a/apps/web/src/components/(data)/model/pricing/ModelPricing.tsx
+++ b/apps/web/src/components/(data)/model/pricing/ModelPricing.tsx
@@ -1,5 +1,4 @@
 import React from "react";
-import { Card } from "@/components/ui/card";
 import { CircleAlert } from "lucide-react";
 import { getModelPricingCached } from "@/lib/fetchers/models/getModelPricing";
 import getModelOverviewHeader from "@/lib/fetchers/models/getModelOverviewHeader";
@@ -94,19 +93,21 @@ export default async function ModelPricing({
 
 	if (!providersForDisplay.length && !subscriptionPlans.length) {
 		return (
-			<Card className="p-6">
+			<div className="space-y-4">
 				{showHeader ? (
-					<h2 className="mb-2 text-xl font-semibold">Availability + Pricing</h2>
+					<h2 className="text-2xl font-semibold tracking-tight text-foreground">
+						Availability + Pricing
+					</h2>
 				) : null}
 				{showPendingApiBanner ? (
-					<div className="mb-4">
+					<div>
 						<ModelPendingApiReleaseBanner
 							modelName={header?.name ?? "This model"}
 							surface="providers"
 						/>
 					</div>
 				) : null}
-				<Empty className="rounded-md border p-6">
+				<Empty className="rounded-lg border p-8">
 					<EmptyHeader>
 						<EmptyMedia variant="icon">
 							<CircleAlert className="size-4" />
@@ -133,7 +134,7 @@ export default async function ModelPricing({
 						</EmptyDescription>
 					</EmptyContent>
 				</Empty>
-			</Card>
+			</div>
 		);
 	}
 

--- a/apps/web/src/components/(data)/model/pricing/ModelPricingClient.tsx
+++ b/apps/web/src/components/(data)/model/pricing/ModelPricingClient.tsx
@@ -72,7 +72,7 @@ const PRICING_METER_PREFERENCE = [
     "input_audio_tokens",
     "output_audio_tokens",
 ] as const;
-const DEFAULT_VISIBLE_PROVIDER_COUNT = 4;
+const DEFAULT_VISIBLE_PROVIDER_COUNT = 6;
 const PLAN_FREQUENCY_ALIASES: Record<string, string> = {
     mo: "monthly",
     month: "monthly",

--- a/apps/web/src/components/(data)/model/pricing/ModelPricingInsightsSection.tsx
+++ b/apps/web/src/components/(data)/model/pricing/ModelPricingInsightsSection.tsx
@@ -14,6 +14,8 @@ import {
 	type ModelPricingHistoryProviderInput,
 } from "@/lib/fetchers/models/getModelPricingHistoryRules";
 import ModelPricingInsightsClient from "@/components/(data)/model/pricing/ModelPricingInsightsClient";
+import ModelPendingApiReleaseBanner from "@/components/(data)/model/overview/ModelPendingApiReleaseBanner";
+import { getModelPendingApiReleaseState } from "@/lib/fetchers/models/getModelPendingApiReleaseState";
 
 export default async function ModelPricingInsightsSection({
 	modelId,
@@ -25,6 +27,10 @@ export default async function ModelPricingInsightsSection({
 	showPageHeader?: boolean;
 }) {
 	const providers = await getModelPricingCached(modelId, includeHidden);
+	const pendingApiRelease = await getModelPendingApiReleaseState(
+		modelId,
+		includeHidden,
+	).catch(() => null);
 	const providersForDisplay = (providers || []).filter(
 		(provider) =>
 			Array.isArray(provider.provider_models) && provider.provider_models.length > 0,
@@ -86,23 +92,31 @@ export default async function ModelPricingInsightsSection({
 
 	if (!providersForDisplay.length) {
 		return (
-			<Empty className="rounded-md border p-6">
-				<EmptyHeader>
-					<EmptyMedia variant="icon">
-						<CircleAlert className="size-4" />
-					</EmptyMedia>
-					<EmptyTitle>No pricing data available yet</EmptyTitle>
-					<EmptyDescription>
-						No API pricing information is currently available for this model.
-					</EmptyDescription>
-				</EmptyHeader>
-				<EmptyContent>
-					<EmptyDescription>
-						If you know providers we should integrate, please tell us on Discord
-						or open an issue on GitHub so we can add pricing data.
-					</EmptyDescription>
-				</EmptyContent>
-			</Empty>
+			<div className="space-y-3">
+				{pendingApiRelease?.isPendingApiRelease ? (
+					<ModelPendingApiReleaseBanner
+						modelName={pendingApiRelease.modelName}
+						surface="pricing"
+					/>
+				) : null}
+				<Empty className="rounded-md border p-6">
+					<EmptyHeader>
+						<EmptyMedia variant="icon">
+							<CircleAlert className="size-4" />
+						</EmptyMedia>
+						<EmptyTitle>No pricing data available yet</EmptyTitle>
+						<EmptyDescription>
+							No API pricing information is currently available for this model.
+						</EmptyDescription>
+					</EmptyHeader>
+					<EmptyContent>
+						<EmptyDescription>
+							If you know providers we should integrate, please tell us on Discord
+							or open an issue on GitHub so we can add pricing data.
+						</EmptyDescription>
+					</EmptyContent>
+				</Empty>
+			</div>
 		);
 	}
 
@@ -126,11 +140,19 @@ export default async function ModelPricingInsightsSection({
 	]);
 
 	return (
-		<ModelPricingInsightsClient
-			providers={providersForDisplay}
-			runtimeStats={runtimeStats}
-			historyRules={pricingHistoryRules}
-			showPageHeader={showPageHeader}
-		/>
+		<div className="space-y-4">
+			{pendingApiRelease?.isPendingApiRelease ? (
+				<ModelPendingApiReleaseBanner
+					modelName={pendingApiRelease.modelName}
+					surface="pricing"
+				/>
+			) : null}
+			<ModelPricingInsightsClient
+				providers={providersForDisplay}
+				runtimeStats={runtimeStats}
+				historyRules={pricingHistoryRules}
+				showPageHeader={showPageHeader}
+			/>
+		</div>
 	);
 }

--- a/apps/web/src/lib/fetchers/models/getModelPendingApiReleaseState.ts
+++ b/apps/web/src/lib/fetchers/models/getModelPendingApiReleaseState.ts
@@ -1,0 +1,53 @@
+import { getModelOverviewCached } from "@/lib/fetchers/models/getModel";
+import { getModelPricingCached, type ProviderPricing } from "@/lib/fetchers/models/getModelPricing";
+
+function isProviderModelActiveNow(
+	providerModel: ProviderPricing["provider_models"][number],
+	now = new Date(),
+): boolean {
+	if (!providerModel.is_active_gateway) return false;
+	if (providerModel.capability_status === "disabled") return false;
+	if (!providerModel.endpoint || providerModel.endpoint === "unmapped") return false;
+
+	const from = providerModel.effective_from
+		? new Date(providerModel.effective_from)
+		: null;
+	const to = providerModel.effective_to
+		? new Date(providerModel.effective_to)
+		: null;
+
+	if (from && Number.isFinite(from.getTime()) && now < from) return false;
+	if (to && Number.isFinite(to.getTime()) && now >= to) return false;
+
+	return true;
+}
+
+function hasActiveApiProviders(providers: ProviderPricing[]): boolean {
+	return providers.some((provider) =>
+		provider.provider_models.some((providerModel) =>
+			isProviderModelActiveNow(providerModel),
+		),
+	);
+}
+
+export async function getModelPendingApiReleaseState(
+	modelId: string,
+	includeHidden: boolean,
+): Promise<{
+	isPendingApiRelease: boolean;
+	modelName: string;
+}> {
+	const [model, providers] = await Promise.all([
+		getModelOverviewCached(modelId, includeHidden).catch(() => null),
+		getModelPricingCached(modelId, includeHidden).catch(() => []),
+	]);
+
+	const isAvailableModel = model?.status === "Available";
+	const isPendingApiRelease =
+		isAvailableModel && !hasActiveApiProviders(providers);
+
+	return {
+		isPendingApiRelease,
+		modelName: model?.name ?? "This model",
+	};
+}

--- a/apps/web/src/lib/fetchers/models/getModelPendingApiReleaseState.ts
+++ b/apps/web/src/lib/fetchers/models/getModelPendingApiReleaseState.ts
@@ -39,15 +39,25 @@ export async function getModelPendingApiReleaseState(
 }> {
 	const [model, providers] = await Promise.all([
 		getModelOverviewCached(modelId, includeHidden).catch(() => null),
-		getModelPricingCached(modelId, includeHidden).catch(() => []),
+		getModelPricingCached(modelId, includeHidden).catch((error) => {
+			console.warn("[model] failed to fetch pricing while evaluating pending API rollout", {
+				modelId,
+				error,
+			});
+			return null;
+		}),
 	]);
 
 	const isAvailableModel = model?.status === "Available";
+	const hasProviderAvailability = providers
+		? hasActiveApiProviders(providers)
+		: true;
 	const isPendingApiRelease =
-		isAvailableModel && !hasActiveApiProviders(providers);
+		isAvailableModel && providers !== null && !hasProviderAvailability;
 
 	return {
 		isPendingApiRelease,
 		modelName: model?.name ?? "This model",
 	};
 }
+


### PR DESCRIPTION
## Summary
- increase the default visible providers on model provider cards from 4 to 6 before collapsing
- add a reusable pending API rollout banner for model tabs when a model is catalogued but has no active API provider availability yet
- show this banner on benchmarks, performance, providers, and pricing surfaces when data is not yet available

## Details
- added `getModelPendingApiReleaseState` helper to detect available-but-not-live API models using status + active provider capability windows
- wired banners into:
  - `ModelBenchmarksSection`
  - `ModelPerformanceSection`
  - `ModelPricing`
  - `ModelPricingInsightsSection`
- added reusable UI component `ModelPendingApiReleaseBanner`

## Validation
- `pnpm --filter @ai-stats/web typecheck`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
* Introduced pending API release status banners that appear across model pages (in benchmarks, performance, pricing, and provider sections) to inform users when a model is not yet available through pricing
* Enhanced provider listing on pricing pages to display 6 providers by default instead of 4, improving discoverability of available options
* Improved UI layout spacing to accommodate new banner components across affected pages

<!-- end of auto-generated comment: release notes by coderabbit.ai -->