### PR TITLE
Fix unbilled usage when non-standard pricing tiers have rule gaps

### DIFF
--- a/apps/api/src/pipeline/pricing/engine.plan-fallback.test.ts
+++ b/apps/api/src/pipeline/pricing/engine.plan-fallback.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it } from "vitest";
+import { computeBillSummary } from "./engine";
+import type { PriceCard } from "./types";
+
+const makeCard = (rules: PriceCard["rules"]): PriceCard => ({
+	provider: "openai",
+	model: "openai/gpt-5.5",
+	endpoint: "text.generate",
+	effective_from: null,
+	effective_to: null,
+	currency: "USD",
+	version: null,
+	rules,
+});
+
+describe("pricing engine non-standard plan fallback", () => {
+	it("falls back to standard when requested plan is missing for a meter", () => {
+		const card = makeCard([
+			{
+				id: "standard-input",
+				pricing_plan: "standard",
+				meter: "input_text_tokens",
+				unit: "token",
+				unit_size: 1_000_000,
+				price_per_unit: "2",
+				currency: "USD",
+				match: [],
+				priority: 100,
+			},
+			{
+				id: "standard-output",
+				pricing_plan: "standard",
+				meter: "output_text_tokens",
+				unit: "token",
+				unit_size: 1_000_000,
+				price_per_unit: "10",
+				currency: "USD",
+				match: [],
+				priority: 100,
+			},
+		]);
+
+		const result = computeBillSummary(
+			{ input_text_tokens: 100_000, output_text_tokens: 10_000 },
+			card,
+			{},
+			"priority",
+		);
+
+		expect(result.lines).toHaveLength(2);
+		expect(result.cost_usd_str).toBe("0.300000000");
+		expect(result.lines.find((line) => line.dimension === "input_text_tokens")?.rule_id).toBe("standard-input");
+		expect(result.lines.find((line) => line.dimension === "output_text_tokens")?.rule_id).toBe("standard-output");
+	});
+
+	it("falls back to standard for long-context holes in non-standard plans", () => {
+		const card = makeCard([
+			{
+				id: "priority-input-lt-272k",
+				pricing_plan: "priority",
+				meter: "input_text_tokens",
+				unit: "token",
+				unit_size: 1_000_000,
+				price_per_unit: "12.5",
+				currency: "USD",
+				match: [{ path: "input_tokens", op: "lt", value: 272000, or_group: 1, and_index: 1 }],
+				priority: 100,
+			},
+			{
+				id: "priority-output-lt-272k",
+				pricing_plan: "priority",
+				meter: "output_text_tokens",
+				unit: "token",
+				unit_size: 1_000_000,
+				price_per_unit: "75",
+				currency: "USD",
+				match: [{ path: "input_tokens", op: "lt", value: 272000, or_group: 1, and_index: 1 }],
+				priority: 100,
+			},
+			{
+				id: "standard-input-gte-272k",
+				pricing_plan: "standard",
+				meter: "input_text_tokens",
+				unit: "token",
+				unit_size: 1_000_000,
+				price_per_unit: "15",
+				currency: "USD",
+				match: [{ path: "input_tokens", op: "gte", value: 272000, or_group: 1, and_index: 1 }],
+				priority: 100,
+			},
+			{
+				id: "standard-output-gte-272k",
+				pricing_plan: "standard",
+				meter: "output_text_tokens",
+				unit: "token",
+				unit_size: 1_000_000,
+				price_per_unit: "120",
+				currency: "USD",
+				match: [{ path: "input_tokens", op: "gte", value: 272000, or_group: 1, and_index: 1 }],
+				priority: 100,
+			},
+		]);
+
+		const result = computeBillSummary(
+			{
+				input_tokens: 300_000,
+				input_text_tokens: 300_000,
+				output_text_tokens: 45_000,
+			},
+			card,
+			{},
+			"priority",
+		);
+
+		expect(result.lines).toHaveLength(2);
+		expect(result.cost_usd_str).toBe("9.900000000");
+		expect(result.lines.find((line) => line.dimension === "input_text_tokens")?.rule_id).toBe("standard-input-gte-272k");
+		expect(result.lines.find((line) => line.dimension === "output_text_tokens")?.rule_id).toBe("standard-output-gte-272k");
+	});
+});
+

--- a/apps/api/src/pipeline/pricing/engine.ts
+++ b/apps/api/src/pipeline/pricing/engine.ts
@@ -254,22 +254,41 @@ export function computeBillSummary(
     const lines: PricingBreakdownLine[] = [];
     const matchContext = { ...ctx, ...meters };
 
+    const findCandidatesForPlanAndMeter = (plan: string, meter: PricingDimensionKey): PriceRule[] =>
+        card.rules
+            .filter((r) => r.pricing_plan === plan && r.meter === meter)
+            .filter((r) => matchesConditions(r.match, matchContext))
+            .sort((a, b) => (b.priority ?? 0) - (a.priority ?? 0));
+
     for (const dim of dims) {
         const qty = meters[dim];
         if (!qty || qty <= 0) continue;
 
         // choose the highest priority rule for this meter that matches plan + conditions
-        const candidates = card.rules
-            .filter((r) => r.pricing_plan === pricingPlan && r.meter === dim)
-            .filter((r) => matchesConditions(r.match, matchContext))
-            .sort((a, b) => (b.priority ?? 0) - (a.priority ?? 0));
+        let candidates = findCandidatesForPlanAndMeter(pricingPlan, dim);
+        let resolvedPlan = pricingPlan;
+        if (!candidates.length && pricingPlan !== "standard") {
+            const fallbackCandidates = findCandidatesForPlanAndMeter("standard", dim);
+            if (fallbackCandidates.length) {
+                candidates = fallbackCandidates;
+                resolvedPlan = "standard";
+                logPricingDebug("meter_plan_fallback", {
+                    meter: dim,
+                    quantity: qty,
+                    requestedPricingPlan: pricingPlan,
+                    fallbackPricingPlan: "standard",
+                    candidateRuleIds: candidates.map((r) => r.id),
+                });
+            }
+        }
 
         const selectionSummary = analyzeRuleSelection(candidates, matchContext);
 
         logPricingDebug("meter_candidates", {
             meter: dim,
             quantity: qty,
-            pricingPlan,
+            pricingPlan: resolvedPlan,
+            requestedPricingPlan: pricingPlan,
             candidateRuleIds: candidates.map((r) => r.id),
             candidateCount: candidates.length,
             candidates: candidates.slice(0, 10).map((r) => ({
@@ -286,7 +305,8 @@ export function computeBillSummary(
             logPricingDebug("meter_no_rule", {
                 meter: dim,
                 quantity: qty,
-                pricingPlan,
+                pricingPlan: resolvedPlan,
+                requestedPricingPlan: pricingPlan,
             });
             continue;
         }


### PR DESCRIPTION
## Summary
- fix billing fail-open behavior when non-standard pricing plans (for example `priority`) have no matching rules for a billed meter
- add engine fallback to use `standard` pricing rules per meter when requested non-standard plan has a gap
- add regression tests covering missing-plan and long-context priority-gap scenarios

## Why
A security finding showed that rule gaps in non-standard plans could result in zero billed lines (`meter_no_rule -> continue`), enabling unbilled usage for some combinations (notably GPT-5.5 priority high-context and GPT-5.5-pro priority).

## What changed
- `apps/api/src/pipeline/pricing/engine.ts`
  - factorized rule candidate lookup per plan+meter
  - when requested plan is non-standard and has no candidate for a meter, retry that meter with `standard`
  - improved debug payload to include requested vs resolved plan
- `apps/api/src/pipeline/pricing/engine.plan-fallback.test.ts`
  - adds tests validating fallback behavior for:
    - missing non-standard plan coverage
    - long-context hole in priority rules

## Validation
- `pnpm --filter @ai-stats/gateway-api exec vitest run src/pipeline/pricing/engine.plan-fallback.test.ts src/pipeline/pricing/engine.long-context.test.ts src/pipeline/after/pricing.test.ts` (run in the original workspace where dependencies are installed)

## Notes
- This is a fail-safe mitigation to stop uncapped billing gaps immediately.
- Follow-up can add explicit model/tier capability metadata and preflight rejection for unsupported `service_tier` combinations.
