### PR TITLE
chore(data): add CrofAI provider and refresh DeepSeek/Venice pricing

### DIFF
--- a/packages/data/catalog/src/data/api_providers/crofai/api_provider.json
+++ b/packages/data/catalog/src/data/api_providers/crofai/api_provider.json
@@ -1,0 +1,9 @@
+{
+  "api_provider_id": "crofai",
+  "api_provider_name": "CrofAI",
+  "description": null,
+  "link": "https://crof.ai/docs",
+  "country_code": "US",
+  "status": "Beta",
+  "colour": "#16A34A"
+}

--- a/packages/data/catalog/src/data/api_providers/crofai/models.json
+++ b/packages/data/catalog/src/data/api_providers/crofai/models.json
@@ -1,0 +1,23 @@
+[
+  {
+    "api_model_id": "deepseek/deepseek-v4-pro",
+    "provider_api_model_id": "crofai:deepseek-v4-pro",
+    "provider_model_slug": "deepseek-v4-pro",
+    "internal_model_id": "deepseek/deepseek-v4-pro",
+    "is_active_gateway": true,
+    "quantization_scheme": "Q4_0",
+    "input_modalities": "text",
+    "output_modalities": "text",
+    "context_length": 1000000,
+    "max_output_tokens": 131072,
+    "effective_from": "2026-04-25T00:00:00",
+    "effective_to": null,
+    "capabilities": [
+      {
+        "capability_id": "text.generate",
+        "status": "active",
+        "params": []
+      }
+    ]
+  }
+]

--- a/packages/data/catalog/src/data/api_providers/deepinfra/models.json
+++ b/packages/data/catalog/src/data/api_providers/deepinfra/models.json
@@ -162,6 +162,48 @@
     ]
   },
   {
+    "api_model_id": "deepseek/deepseek-v4-flash",
+    "provider_api_model_id": "deepinfra:deepseek/deepseek-v4-flash",
+    "provider_model_slug": "deepseek-ai/DeepSeek-V4-Flash",
+    "internal_model_id": "deepseek/deepseek-v4-flash",
+    "is_active_gateway": false,
+    "quantization_scheme": "FP4",
+    "input_modalities": "text",
+    "output_modalities": "text",
+    "context_length": 1000000,
+    "max_output_tokens": null,
+    "effective_from": "2026-04-26T00:00:00",
+    "effective_to": null,
+    "capabilities": [
+      {
+        "capability_id": "text.generate",
+        "status": "coming_soon",
+        "params": []
+      }
+    ]
+  },
+  {
+    "api_model_id": "deepseek/deepseek-v4-pro",
+    "provider_api_model_id": "deepinfra:deepseek/deepseek-v4-pro",
+    "provider_model_slug": "deepseek-ai/DeepSeek-V4-Pro",
+    "internal_model_id": "deepseek/deepseek-v4-pro",
+    "is_active_gateway": false,
+    "quantization_scheme": "FP4",
+    "input_modalities": "text",
+    "output_modalities": "text",
+    "context_length": 1000000,
+    "max_output_tokens": null,
+    "effective_from": "2026-04-26T00:00:00",
+    "effective_to": null,
+    "capabilities": [
+      {
+        "capability_id": "text.generate",
+        "status": "coming_soon",
+        "params": []
+      }
+    ]
+  },
+  {
     "api_model_id": "deepseek/deepseek-v3-0324",
     "provider_api_model_id": "deepinfra:deepseek/deepseek-v3-0324",
     "provider_model_slug": "deepseek-ai/DeepSeek-V3-0324",

--- a/packages/data/catalog/src/data/api_providers/venice-e2ee/models.json
+++ b/packages/data/catalog/src/data/api_providers/venice-e2ee/models.json
@@ -210,6 +210,27 @@
     ]
   },
   {
+    "api_model_id": "z-ai/glm-4.7-flash",
+    "provider_api_model_id": "venice/e2ee:z-ai/glm-4.7-flash",
+    "provider_model_slug": "e2ee-glm-4-7-flash-p",
+    "internal_model_id": "z-ai/glm-4.7-flash",
+    "is_active_gateway": true,
+    "quantization_scheme": null,
+    "input_modalities": null,
+    "output_modalities": null,
+    "context_length": null,
+    "max_output_tokens": null,
+    "effective_from": "2026-03-18T00:00:00",
+    "effective_to": null,
+    "capabilities": [
+      {
+        "capability_id": "text.generate",
+        "status": "active",
+        "params": []
+      }
+    ]
+  },
+  {
     "api_model_id": "z-ai/glm-5",
     "provider_api_model_id": "venice/e2ee:z-ai/glm-5",
     "provider_model_slug": "e2ee-glm-5",
@@ -221,6 +242,27 @@
     "context_length": null,
     "max_output_tokens": null,
     "effective_from": "2026-03-18T00:00:00",
+    "effective_to": null,
+    "capabilities": [
+      {
+        "capability_id": "text.generate",
+        "status": "active",
+        "params": []
+      }
+    ]
+  },
+  {
+    "api_model_id": "z-ai/glm-5.1",
+    "provider_api_model_id": "venice/e2ee:z-ai/glm-5.1",
+    "provider_model_slug": "e2ee-glm-5-1",
+    "internal_model_id": "z-ai/glm-5.1",
+    "is_active_gateway": true,
+    "quantization_scheme": null,
+    "input_modalities": null,
+    "output_modalities": null,
+    "context_length": null,
+    "max_output_tokens": null,
+    "effective_from": "2026-04-24T00:00:00",
     "effective_to": null,
     "capabilities": [
       {

--- a/packages/data/catalog/src/data/api_providers/venice/models.json
+++ b/packages/data/catalog/src/data/api_providers/venice/models.json
@@ -183,7 +183,7 @@
     "capabilities": [
       {
         "capability_id": "text.generate",
-        "status": "deranked_lvl1",
+        "status": "active",
         "params": []
       }
     ]
@@ -507,6 +507,27 @@
       {
         "capability_id": "text.generate",
         "status": "deranked_lvl1",
+        "params": []
+      }
+    ]
+  },
+  {
+    "api_model_id": "moonshotai/kimi-k2.6",
+    "provider_api_model_id": "venice:moonshotai/kimi-k2.6",
+    "provider_model_slug": "kimi-k2-6",
+    "internal_model_id": "moonshotai/kimi-k2.6",
+    "is_active_gateway": true,
+    "quantization_scheme": "int4",
+    "input_modalities": "text,image",
+    "output_modalities": "text",
+    "context_length": 256000,
+    "max_output_tokens": 65536,
+    "effective_from": "2026-04-20T00:00:00",
+    "effective_to": null,
+    "capabilities": [
+      {
+        "capability_id": "text.generate",
+        "status": "active",
         "params": []
       }
     ]
@@ -1137,6 +1158,27 @@
       {
         "capability_id": "text.generate",
         "status": "deranked_lvl1",
+        "params": []
+      }
+    ]
+  },
+  {
+    "api_model_id": "z-ai/glm-5.1",
+    "provider_api_model_id": "venice:z-ai/glm-5.1",
+    "provider_model_slug": "zai-org-glm-5-1",
+    "internal_model_id": "z-ai/glm-5.1",
+    "is_active_gateway": true,
+    "quantization_scheme": "fp8",
+    "input_modalities": "text",
+    "output_modalities": "text",
+    "context_length": 200000,
+    "max_output_tokens": 24000,
+    "effective_from": "2026-04-07T00:00:00",
+    "effective_to": null,
+    "capabilities": [
+      {
+        "capability_id": "text.generate",
+        "status": "active",
         "params": []
       }
     ]

--- a/packages/data/catalog/src/data/pricing/crofai/deepseek-deepseek-v4-pro/text.generate/pricing.json
+++ b/packages/data/catalog/src/data/pricing/crofai/deepseek-deepseek-v4-pro/text.generate/pricing.json
@@ -1,0 +1,84 @@
+{
+  "key": "crofai:deepseek/deepseek-v4-pro:text.generate",
+  "api_provider_id": "crofai",
+  "provider_slug": "crofai",
+  "api_model_id": "deepseek/deepseek-v4-pro",
+  "capability_id": "text.generate",
+  "rules": [
+    {
+      "meter": "input_text_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 0.2875,
+      "currency": "USD",
+      "pricing_plan": "standard",
+      "note": "Limited-time 75% discount",
+      "match": [],
+      "priority": 200,
+      "effective_from": "2026-04-26T00:00:00",
+      "effective_to": "2026-05-11T00:00:00"
+    },
+    {
+      "meter": "cached_read_text_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 0.0575,
+      "currency": "USD",
+      "pricing_plan": "standard",
+      "note": "Limited-time 75% discount",
+      "match": [],
+      "priority": 200,
+      "effective_from": "2026-04-26T00:00:00",
+      "effective_to": "2026-05-11T00:00:00"
+    },
+    {
+      "meter": "output_text_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 0.75,
+      "currency": "USD",
+      "pricing_plan": "standard",
+      "note": "Limited-time 75% discount",
+      "match": [],
+      "priority": 200,
+      "effective_from": "2026-04-26T00:00:00",
+      "effective_to": "2026-05-11T00:00:00"
+    },
+    {
+      "meter": "input_text_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 1.15,
+      "currency": "USD",
+      "pricing_plan": "standard",
+      "note": null,
+      "match": [],
+      "priority": 100,
+      "effective_from": "2026-04-25T00:00:00"
+    },
+    {
+      "meter": "cached_read_text_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 0.23,
+      "currency": "USD",
+      "pricing_plan": "standard",
+      "note": null,
+      "match": [],
+      "priority": 100,
+      "effective_from": "2026-04-25T00:00:00"
+    },
+    {
+      "meter": "output_text_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 3,
+      "currency": "USD",
+      "pricing_plan": "standard",
+      "note": null,
+      "match": [],
+      "priority": 100,
+      "effective_from": "2026-04-25T00:00:00"
+    }
+  ]
+}

--- a/packages/data/catalog/src/data/pricing/deepinfra/deepseek-deepseek-v4-flash/text.generate/pricing.json
+++ b/packages/data/catalog/src/data/pricing/deepinfra/deepseek-deepseek-v4-flash/text.generate/pricing.json
@@ -1,0 +1,42 @@
+{
+  "key": "deepinfra:deepseek/deepseek-v4-flash:text.generate",
+  "api_provider_id": "deepinfra",
+  "provider_slug": "deepinfra",
+  "api_model_id": "deepseek/deepseek-v4-flash",
+  "capability_id": "text.generate",
+  "rules": [
+    {
+      "meter": "input_text_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 0.14,
+      "currency": "USD",
+      "pricing_plan": "standard",
+      "note": null,
+      "match": [],
+      "priority": 100
+    },
+    {
+      "meter": "cached_read_text_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 0.028,
+      "currency": "USD",
+      "pricing_plan": "standard",
+      "note": null,
+      "match": [],
+      "priority": 100
+    },
+    {
+      "meter": "output_text_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 0.28,
+      "currency": "USD",
+      "pricing_plan": "standard",
+      "note": null,
+      "match": [],
+      "priority": 100
+    }
+  ]
+}

--- a/packages/data/catalog/src/data/pricing/deepinfra/deepseek-deepseek-v4-pro/text.generate/pricing.json
+++ b/packages/data/catalog/src/data/pricing/deepinfra/deepseek-deepseek-v4-pro/text.generate/pricing.json
@@ -1,0 +1,42 @@
+{
+  "key": "deepinfra:deepseek/deepseek-v4-pro:text.generate",
+  "api_provider_id": "deepinfra",
+  "provider_slug": "deepinfra",
+  "api_model_id": "deepseek/deepseek-v4-pro",
+  "capability_id": "text.generate",
+  "rules": [
+    {
+      "meter": "input_text_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 1.74,
+      "currency": "USD",
+      "pricing_plan": "standard",
+      "note": null,
+      "match": [],
+      "priority": 100
+    },
+    {
+      "meter": "cached_read_text_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 0.145,
+      "currency": "USD",
+      "pricing_plan": "standard",
+      "note": null,
+      "match": [],
+      "priority": 100
+    },
+    {
+      "meter": "output_text_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 3.48,
+      "currency": "USD",
+      "pricing_plan": "standard",
+      "note": null,
+      "match": [],
+      "priority": 100
+    }
+  ]
+}

--- a/packages/data/catalog/src/data/pricing/venice-e2ee/z-ai-glm-4.7-flash/text.generate/pricing.json
+++ b/packages/data/catalog/src/data/pricing/venice-e2ee/z-ai-glm-4.7-flash/text.generate/pricing.json
@@ -1,0 +1,31 @@
+{
+  "key": "venice-e2ee:z-ai/glm-4.7-flash:text.generate",
+  "api_provider_id": "venice-e2ee",
+  "provider_slug": "venice-e2ee",
+  "api_model_id": "z-ai/glm-4.7-flash",
+  "capability_id": "text.generate",
+  "rules": [
+    {
+      "meter": "input_text_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 0.13,
+      "currency": "USD",
+      "pricing_plan": "standard",
+      "note": null,
+      "match": [],
+      "priority": 100
+    },
+    {
+      "meter": "output_text_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 0.55,
+      "currency": "USD",
+      "pricing_plan": "standard",
+      "note": null,
+      "match": [],
+      "priority": 100
+    }
+  ]
+}

--- a/packages/data/catalog/src/data/pricing/venice-e2ee/z-ai-glm-5.1/text.generate/pricing.json
+++ b/packages/data/catalog/src/data/pricing/venice-e2ee/z-ai-glm-5.1/text.generate/pricing.json
@@ -1,0 +1,31 @@
+{
+  "key": "venice-e2ee:z-ai/glm-5.1:text.generate",
+  "api_provider_id": "venice-e2ee",
+  "provider_slug": "venice-e2ee",
+  "api_model_id": "z-ai/glm-5.1",
+  "capability_id": "text.generate",
+  "rules": [
+    {
+      "meter": "input_text_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 1.1,
+      "currency": "USD",
+      "pricing_plan": "standard",
+      "note": null,
+      "match": [],
+      "priority": 100
+    },
+    {
+      "meter": "output_text_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 4.15,
+      "currency": "USD",
+      "pricing_plan": "standard",
+      "note": null,
+      "match": [],
+      "priority": 100
+    }
+  ]
+}

--- a/packages/data/catalog/src/data/pricing/venice/moonshotai-kimi-k2.6/text.generate/pricing.json
+++ b/packages/data/catalog/src/data/pricing/venice/moonshotai-kimi-k2.6/text.generate/pricing.json
@@ -1,0 +1,42 @@
+{
+  "key": "venice:moonshotai/kimi-k2.6:text.generate",
+  "api_provider_id": "venice",
+  "provider_slug": "venice",
+  "api_model_id": "moonshotai/kimi-k2.6",
+  "capability_id": "text.generate",
+  "rules": [
+    {
+      "meter": "input_text_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 0.56,
+      "currency": "USD",
+      "pricing_plan": "standard",
+      "note": null,
+      "match": [],
+      "priority": 100
+    },
+    {
+      "meter": "cached_read_text_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 0.11,
+      "currency": "USD",
+      "pricing_plan": "standard",
+      "note": null,
+      "match": [],
+      "priority": 100
+    },
+    {
+      "meter": "output_text_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 3.5,
+      "currency": "USD",
+      "pricing_plan": "standard",
+      "note": null,
+      "match": [],
+      "priority": 100
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add `crofai` as a catalog API provider with `deepseek/deepseek-v4-pro`
- add CrofAI pricing for `deepseek-v4-pro` with base rates and higher-priority promo window
- add DeepInfra catalog entries/pricing for `deepseek-v4-flash` and `deepseek-v4-pro` as coming soon
- add Venice/Venice-E2EE pricing entries for recently added text models (`moonshotai/kimi-k2.6`, `z-ai/glm-4.7-flash`, `z-ai/glm-5.1`)
- keep DeepSeek official `deepseek-v4-pro` pricing aligned to the current discount-over-base pattern

## Validation
- `pnpm validate:data`
- `pnpm validate:pricing`
- `pnpm validate:gateway`

## Scope
This PR intentionally includes **data catalog changes only** under `packages/data/catalog/src/data`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added CrofAI as a new API provider with support for DeepSeek v4 Pro model
  * Expanded model catalog with DeepSeek v4 Flash and Pro variants via DeepInfra
  * Integrated GLM 4.7-Flash and GLM 5.1 models through Venice e2ee provider
  * Added Kimi K2.6 model support via Venice provider
  * Configured pricing structures for all newly added models

<!-- end of auto-generated comment: release notes by coderabbit.ai -->