### PR TITLE
fix(data): disable CrofAI routing until adapter is available

### DIFF
--- a/packages/data/catalog/src/data/api_providers/crofai/models.json
+++ b/packages/data/catalog/src/data/api_providers/crofai/models.json
@@ -4,7 +4,7 @@
     "provider_api_model_id": "crofai:deepseek-v4-pro",
     "provider_model_slug": "deepseek-v4-pro",
     "internal_model_id": "deepseek/deepseek-v4-pro",
-    "is_active_gateway": true,
+    "is_active_gateway": false,
     "quantization_scheme": "Q4_0",
     "input_modalities": "text",
     "output_modalities": "text",
@@ -15,7 +15,7 @@
     "capabilities": [
       {
         "capability_id": "text.generate",
-        "status": "active",
+        "status": "coming_soon",
         "params": []
       }
     ]


### PR DESCRIPTION
## Summary
- disable CrofAI gateway routing for `deepseek/deepseek-v4-pro` until a CrofAI adapter exists
- keep provider + pricing data in place so enabling later is a minimal flip

## Changes
- set `is_active_gateway` from `true` -> `false`
- set capability status from `active` -> `coming_soon`

## Validation
- `pnpm validate:data`
- `pnpm validate:pricing`
- `pnpm validate:gateway`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated model availability status: The `deepseek/deepseek-v4-pro` model is no longer marked as an active gateway, and its text generation capability has been updated to "coming soon," reflecting a change in availability timeline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->