### PR TITLE
data: add Baseten DeepSeek V4 Pro

### DIFF
--- a/packages/data/catalog/src/data/api_providers/baseten/models.json
+++ b/packages/data/catalog/src/data/api_providers/baseten/models.json
@@ -42,6 +42,27 @@
     ]
   },
   {
+    "api_model_id": "deepseek/deepseek-v4-pro",
+    "provider_api_model_id": "baseten:deepseek/deepseek-v4-pro",
+    "provider_model_slug": "deepseek-ai/DeepSeek-V4-Pro",
+    "internal_model_id": "deepseek/deepseek-v4-pro",
+    "is_active_gateway": true,
+    "quantization_scheme": "FP8",
+    "input_modalities": "text",
+    "output_modalities": "text",
+    "context_length": 1048576,
+    "max_output_tokens": null,
+    "effective_from": "2026-04-27T00:00:00",
+    "effective_to": null,
+    "capabilities": [
+      {
+        "capability_id": "text.generate",
+        "status": "active",
+        "params": []
+      }
+    ]
+  },
+  {
     "api_model_id": "minimax/minimax-m2.5",
     "provider_api_model_id": "baseten:minimax/minimax-m2.5",
     "provider_model_slug": "MiniMaxAI/MiniMax-M2.5",

--- a/packages/data/catalog/src/data/pricing/baseten/deepseek-deepseek-v4-pro/text.generate/pricing.json
+++ b/packages/data/catalog/src/data/pricing/baseten/deepseek-deepseek-v4-pro/text.generate/pricing.json
@@ -1,0 +1,45 @@
+{
+  "key": "baseten:deepseek/deepseek-v4-pro:text.generate",
+  "api_provider_id": "baseten",
+  "provider_slug": "baseten",
+  "api_model_id": "deepseek/deepseek-v4-pro",
+  "capability_id": "text.generate",
+  "rules": [
+    {
+      "meter": "input_text_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 2.1,
+      "currency": "USD",
+      "pricing_plan": "standard",
+      "note": null,
+      "match": [],
+      "priority": 100,
+      "effective_from": "2026-04-27T00:00:00"
+    },
+    {
+      "meter": "cached_read_text_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 0.2,
+      "currency": "USD",
+      "pricing_plan": "standard",
+      "note": null,
+      "match": [],
+      "priority": 100,
+      "effective_from": "2026-04-27T00:00:00"
+    },
+    {
+      "meter": "output_text_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 4.4,
+      "currency": "USD",
+      "pricing_plan": "standard",
+      "note": null,
+      "match": [],
+      "priority": 100,
+      "effective_from": "2026-04-27T00:00:00"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add Baseten support for `deepseek/deepseek-v4-pro`
- add Baseten pricing for `text.generate`

## Validation
- `pnpm validate:data`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Deepseek v4 Pro model is now available with pricing configured at $2.1/M input tokens, $0.2/M cached read tokens, and $4.4/M output tokens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->