### PR TITLE
fix(web): correct homepage gateway fee copy

### DIFF
--- a/apps/api/src/pipeline/pricing/TIER-SYSTEM.md
+++ b/apps/api/src/pipeline/pricing/TIER-SYSTEM.md
@@ -1,399 +1,66 @@
-# Two-Tier Pricing System Documentation
+# Workspace Pricing System
 
 ## Overview
 
-The AI Gateway uses a simplified two-tier pricing system with **hybrid tier management**:
-
-- **Basic Tier**: 7% markup (default)
-- **Enterprise Tier**: 5% markup (high-volume teams)
-
-**How it works:**
-- **Active teams**: Tier calculated in real-time before every request (rolling 30-day spend)
-- **Dormant teams**: Cleaned up monthly via cron (prevents indefinite Enterprise status)
-
-## Tier Logic
-
-### Real-Time Calculation ⚡
-- Tier is calculated **before EVERY request** based on **rolling 30-day spend**
-- If last 30 days >= **$10,000** → Enterprise tier (5% fee)
-- If last 30 days < **$10,000** → Basic tier (7% fee)
-- The request that crosses the threshold uses the Basic rate, future requests use Enterprise rate
-
-### Grace Period for Downgrades 🛡️
-- Enterprise teams aren't immediately downgraded when spending dips below $10k
-- Grace period: **3 consecutive tier checks** (across multiple requests)
-- If 30-day spend stays below $10k for 3 checks → Downgrade to Basic
-- If 30-day spend goes back above $10k at any point → Counter resets to 0
-
-### Example Flow: Active Team
-```
-Request 1: 30-day spend = $9,000 → Basic (7%) → Counter: 0
-Request 2: 30-day spend = $12,000 → Enterprise (5%) → Counter: 0
-Request 3: 30-day spend = $11,500 → Enterprise (5%) → Counter: 0
-Request 4: 30-day spend = $9,500 → Enterprise (5%) → Counter: 1 (grace)
-Request 5: 30-day spend = $8,800 → Enterprise (5%) → Counter: 2 (grace)
-Request 6: 30-day spend = $8,200 → Enterprise (5%) → Counter: 3 (grace)
-Request 7: 30-day spend = $7,900 → Basic (7%) → Counter: 0 (downgraded)
-```
-
-### Example Flow: Dormant Team (Why Cron Is Needed)
-```
-Day 1: Team reaches Enterprise ($12k in 30 days)
-Day 2-180: Team makes ZERO requests (dormant for 6 months)
-
-Without monthly cron:
-  → Team stays Enterprise forever (no requests = no tier checks)
-  → Could abuse system by hitting threshold once, then going dormant
-
-With monthly cron (1st of each month):
-  → Month 1: Check 30-day spend = $0 → Counter: 1 → Keep Enterprise
-  → Month 2: Check 30-day spend = $0 → Counter: 2 → Keep Enterprise
-  → Month 3: Check 30-day spend = $0 → Counter: 3 → Keep Enterprise
-  → Month 4: Check 30-day spend = $0 → Downgrade to Basic ✅
-
-If team resumes activity:
-  → Their next request will use the updated tier (Basic)
-```
-
-## System Architecture
-
-### Database Schema
-
-```sql
--- teams table columns
-tier                              text        DEFAULT 'basic'
-tier_updated_at                   timestamptz DEFAULT now()
-consecutive_low_spend_months      int         DEFAULT 0
-
--- workspace_tier_history table (audit trail)
-id                                uuid
-workspace_id                           uuid
-old_tier                          text
-new_tier                          text
-reason                            text
-previous_month_spend_usd          numeric(12, 2)
-threshold_usd                     numeric(12, 2)
-consecutive_low_months            int
-changed_at                        timestamptz
-```
-
-### Key Functions
-
-1. **`calculate_tier_with_grace(workspace_id, spend_30d_nanos)`**
-   - Called automatically before EVERY request in `context.sql`
-   - Takes rolling 30-day spend as input
-   - Calculates tier with grace period logic
-   - Updates team tier in database if it changed
-   - Returns: Current effective tier ('basic' or 'enterprise')
-
-2. **`cleanup_dormant_enterprise_workspaces()`**
-   - Runs monthly via pg_cron (1st of each month)
-   - Checks only Enterprise teams
-   - Calculates rolling 30-day spend for each
-   - Applies grace period logic (same as per-request)
-   - Downgrades dormant teams after 3 consecutive checks below threshold
-   - Returns: `{total_teams_checked, teams_downgraded, downgraded_teams}`
-
-3. **`get_workspace_tier_info(workspace_id)`**
-   - UI helper function
-   - Returns comprehensive tier info for dashboard display
-   - Includes 30-day spend, thresholds, and grace period status
-
-## Implementation Details
-
-### Request Pipeline Integration
-
-**File**: `apps/api/src/pipeline/before/context.sql`
+The Gateway now runs on a **single-plan pricing model**:
 
-The tier is calculated **before** the request is processed:
+- **Standard plan**: 5% markup on credit purchases
+- **Model usage pricing**: billed at catalog rates
+- **No active enterprise/basic fee split** in the request path
 
-```sql
--- Calculate team 30-day spend from gateway_requests
-SELECT COALESCE(SUM(cost_nanos), 0) INTO team_spend_30d_nanos
-FROM gateway_requests
-WHERE workspace_id = gateway_fetch_request_context.workspace_id
-  AND success = true
-  AND created_at >= now() - interval '30 days';
+The repo still retains some compatibility surfaces named around "tiers" so older RPC calls and UI contracts do not break, but current pricing is flat.
 
--- Calculate tier with grace period (updates database if changed)
-team_tier := calculate_tier_with_grace(
-    gateway_fetch_request_context.workspace_id,
-    team_spend_30d_nanos
-);
+## Current Behavior
 
--- Return tier in context for use in pricing
-```
+### Request path
 
-The tier is then available in `ctx.teamEnrichment.tier` throughout the pipeline.
+- `calculate_tier_with_grace(...)` is still called by the request context RPC for compatibility.
+- In the current schema it resolves to the flat standard plan and returns the legacy `"basic"` value.
+- Pricing application ignores legacy tier differentiation and applies a flat 5% workspace markup.
 
-### Tier-Based Markup Application
+### Dashboard/UI
 
-**Files**: `apps/api/src/pipeline/after/*.ts`
+- `get_workspace_tier_info(...)` still exists for the dashboard.
+- It returns:
+  - `tier: "basic"` for compatibility
+  - `tier_display: "Standard"`
+  - `markup_percentage: 5.00`
+  - current and previous month spend
 
-All pricing calculations pull the tier from context:
-```typescript
-const tier = ctx.teamEnrichment?.tier ?? 'basic';
-const { pricedUsage, totalCents, totalNanos } = calculatePricing(
-    shapedUsage,
-    card,
-    ctx.body,
-    tier  // Applied to all pricing calculations
-);
-```
+### Billing and top-ups
 
-### Auto-Recharge Fee Handling
+- Credit purchases use a flat 5% top-up fee.
+- Stripe webhook handling reverse-calculates the fee from the gross payment amount using `5.0`.
+- Auto-recharge follows the same flat-fee behavior.
 
-**File**: `apps/web/src/app/api/webhooks/stripe-checkout/route.ts`
+## Source of Truth
 
-When auto-recharge triggers:
+The active database behavior is defined by the Supabase migrations:
 
-1. **Charge Creation** (`persist.ts`):
-   - Charges customer the raw `auto_top_up_amount` (e.g., $100)
+- [20260423120000_single_tier_workspace_pricing.sql](/E:/ai-stats-public/supabase/migrations/20260423120000_single_tier_workspace_pricing.sql)
+- [20260423170000_workspace_pricing_invoicing_cleanup.sql](/E:/ai-stats-public/supabase/migrations/20260423170000_workspace_pricing_invoicing_cleanup.sql)
 
-2. **Webhook Processing** (`stripe-checkout/route.ts`):
-   - Fetches team's **current tier** from database (includes instant upgrades)
-   - Applies reverse calculation: `net = gross / (1 + fee_rate)`
-   - **Example**:
-     - Basic (7%): Pay $100 → Receive $93.46 ($6.54 fee)
-     - Enterprise (5%): Pay $100 → Receive $95.24 ($4.76 fee)
-
-```typescript
-// Fetch current tier (includes instant upgrades)
-const { data: teamData } = await supabase
-    .from('workspaces')
-    .select('tier')
-    .eq('id', wallet.workspace_id)
-    .single();
-
-const tier = teamData?.tier ?? 'basic';
-const feePct = tier === 'enterprise' ? 5.0 : 7.0;
-
-// Reverse-engineer net amount from gross
-const { netNanos, feeNanos } = computeNetAndFeeFromGross(grossNanos, feePct);
-
-// Credit wallet with net amount (after fee)
-await supabase
-    .from('wallets')
-    .update({ balance_nanos: afterBalanceNanos })
-    .eq('workspace_id', wallet.workspace_id);
-```
+Those migrations:
 
-## Deployment Checklist
-
-### 1. Deploy SQL Migration ⚠️ REQUIRED
-
-Run `tier-migration.sql` in Supabase SQL Editor:
-
-```bash
-# Copy the entire contents of:
-apps/api/src/pipeline/pricing/tier-migration.sql
-
-# Paste and execute in Supabase Dashboard → SQL Editor
-```
-
-This creates:
-- ✅ Tier columns on teams table
-- ✅ Tier history audit table
-- ✅ Instant upgrade function
-- ✅ Monthly downgrade function
-- ✅ UI helper functions
-- ✅ Efficient indexes
-
-### 2. Enable Monthly Dormant Cleanup Cron ⚠️ REQUIRED
-
-**Why needed:** Active teams get real-time tier updates before each request. But dormant teams (no requests for months) need periodic cleanup to prevent staying on Enterprise tier indefinitely.
+- normalize workspaces to the flat standard tier
+- keep legacy function names stable
+- remove old enterprise/invoice tier bookkeeping
 
-In Supabase SQL Editor (as admin):
-
-```sql
--- Schedule monthly cleanup for dormant Enterprise teams
-SELECT cron.schedule(
-    'cleanup-dormant-enterprise-teams',
-    '0 0 1 * *',  -- Midnight UTC on 1st of each month
-    $$SELECT cleanup_dormant_enterprise_workspaces()$$
-);
-
--- Verify it's scheduled
-SELECT * FROM cron.job;
-```
-
-**What it does:**
-- Checks only Enterprise teams
-- Calculates their rolling 30-day spend
-- Applies grace period logic (same as per-request)
-- Downgrades dormant teams after 3 checks below threshold
-
-### 3. Deploy Code Changes ✅ COMPLETED
-
-The following files have been updated and are ready to deploy:
-
-**Backend (API)**:
-- ✅ `apps/api/src/pipeline/pricing/tier-markup.ts` (NEW)
-- ✅ `apps/api/src/pipeline/pricing/persist.ts` (instant upgrade check)
-- ✅ `apps/api/src/pipeline/after/pricing.ts` (tier parameter)
-- ✅ `apps/api/src/pipeline/after/index.ts` (tier from context)
-- ✅ `apps/api/src/pipeline/after/stream.ts` (tier from context, 3 locations)
-
-**Frontend (Web)**:
-- ✅ `apps/web/src/components/(gateway)/credits/tiers.ts` (two-tier definitions)
-- ✅ `apps/web/src/components/(gateway)/credits/TieringProgress.tsx` (new UI)
-- ✅ `apps/web/src/components/(gateway)/credits/TierBadge.tsx` (updated text)
-- ✅ `apps/web/src/app/api/webhooks/stripe-checkout/route.ts` (tier from DB)
-
-### 4. Initialize Existing Teams (Optional)
-
-After SQL migration, optionally set initial tiers for existing teams:
-
-```sql
--- Check which teams should be on Enterprise based on current month spend
-SELECT
-    t.id,
-    t.tier,
-    ROUND((SUM(gr.cost_nanos)::numeric / 1000000000.0)::numeric, 2) as current_month_spend
-FROM teams t
-LEFT JOIN gateway_requests gr ON gr.workspace_id = t.id
-    AND gr.success = true
-    AND gr.created_at >= date_trunc('month', now())
-GROUP BY t.id, t.tier
-HAVING ROUND((SUM(gr.cost_nanos)::numeric / 1000000000.0)::numeric, 2) >= 10000
-ORDER BY current_month_spend DESC;
-
--- Manually upgrade these teams if needed
-UPDATE teams SET tier = 'enterprise', tier_updated_at = now() WHERE id = '...';
-```
-
-## Testing
-
-### Test Instant Upgrades
-
-1. Create test team on Basic tier
-2. Make gateway requests totaling $10,000+
-3. Verify tier changes to Enterprise immediately
-4. Check `workspace_tier_history` for audit entry
-
-```sql
-SELECT * FROM workspace_tier_history WHERE workspace_id = '...' ORDER BY changed_at DESC;
-```
-
-### Test Monthly Downgrades
-
-1. Create test team on Enterprise tier
-2. Set `consecutive_low_spend_months = 2`
-3. Ensure current month spend < $10k
-4. Run: `SELECT update_all_team_tiers();`
-5. Verify tier downgrades to Basic
-6. Check audit history
-
-### Test Auto-Recharge Fees
-
-1. Enable auto-recharge for test team
-2. Set balance below threshold
-3. Make gateway request to trigger recharge
-4. Verify Stripe charge is created
-5. Check webhook applies correct tier fee
-6. Verify wallet credited with net amount (after fee)
-
-**Expected Results**:
-- Basic tier: Pay $100 → Receive ~$93.46
-- Enterprise tier: Pay $100 → Receive ~$95.24
-
-## Monitoring
-
-### Key Metrics to Track
-
-```sql
--- Current tier distribution
-SELECT tier, COUNT(*) as team_count
-FROM teams
-GROUP BY tier;
-
--- Teams at risk of downgrade (Enterprise with 2+ low months)
-SELECT id, tier, consecutive_low_spend_months
-FROM teams
-WHERE tier = 'enterprise' AND consecutive_low_spend_months >= 2;
-
--- Recent tier changes
-SELECT * FROM workspace_tier_history
-WHERE changed_at >= now() - interval '7 days'
-ORDER BY changed_at DESC;
-
--- Monthly tier change summary
-SELECT
-    DATE_TRUNC('month', changed_at) as month,
-    old_tier,
-    new_tier,
-    COUNT(*) as changes
-FROM workspace_tier_history
-GROUP BY month, old_tier, new_tier
-ORDER BY month DESC;
-```
-
-## Troubleshooting
-
-### Team not upgrading to Enterprise
-
-**Check**:
-1. Current month spend: `SELECT get_workspace_tier_info('workspace_id');`
-2. Tier upgrade log: `SELECT * FROM workspace_tier_history WHERE workspace_id = '...' ORDER BY changed_at DESC;`
-3. Gateway request records: Ensure `success = true` and `cost_nanos > 0`
-
-**Fix**: Manually upgrade if needed:
-```sql
-UPDATE teams SET tier = 'enterprise', consecutive_low_spend_months = 0 WHERE id = '...';
-```
-
-### Auto-recharge applying wrong fee
-
-**Check**:
-1. Team tier at time of webhook: Query `teams` table
-2. Webhook logs: Check `[stripe-webhook]` console output
-3. Ledger entry: `SELECT * FROM credit_ledger WHERE ref_id = 'pi_xxx';`
-
-**Fix**: Ensure webhook fetches tier from database (not recalculating)
-
-### pg_cron not running
-
-**Check**:
-```sql
--- View scheduled jobs
-SELECT * FROM cron.job;
-
--- View job run history
-SELECT * FROM cron.job_run_details ORDER BY start_time DESC LIMIT 10;
-```
-
-**Fix**: Re-schedule if missing:
-```sql
-SELECT cron.schedule('monthly-tier-downgrade-check', '0 0 1 * *', $$SELECT update_all_team_tiers()$$);
-```
-
-## Future Enhancements
-
-### Potential Improvements
-
-1. **Configurable Thresholds**
-   - Make $10k threshold adjustable per team
-   - Allow custom tier definitions
-
-2. **Grace Period Notifications**
-   - Email alerts when Enterprise team has 2 consecutive low months
-   - Warning in dashboard UI
-
-3. **Tier Forecasting**
-   - Predict next month's tier based on current spend trajectory
-   - Show "days until Enterprise" for Basic teams
-
-4. **Custom Tier Discounts**
-   - Allow manual tier overrides for special partnerships
-   - Custom markup percentages per team
-
-5. **API Endpoints**
-   - `GET /v1/team/tier` - Get current tier info
-   - `POST /v1/team/tier` - Manually set tier (admin only)
-
-## Support
-
-For questions or issues:
-- Check tier history: `SELECT * FROM workspace_tier_history WHERE workspace_id = '...';`
-- Review logs: Look for `[tier-upgrade]` and `[stripe-webhook]` prefixes
-- Manual override: Contact admin to adjust tier manually if needed
+## Compatibility Notes
+
+Some files and fields still use tier-oriented names because they are part of older public or internal contracts:
+
+- workspace `tier` column
+- `calculate_tier_with_grace(...)`
+- `cleanup_dormant_enterprise_workspaces()`
+- `get_workspace_tier_info(...)`
+
+These should be treated as compatibility shims, not as evidence of an active multi-tier pricing model.
+
+## Operational Summary
+
+If you need to reason about pricing today:
+
+1. Credit purchases incur a **5%** top-up fee.
+2. Usage consumes credits at catalog pricing.
+3. There is a single live top-up fee path in the current standard Gateway billing model: **5%**.

--- a/apps/api/src/pipeline/pricing/TIER-SYSTEM.md
+++ b/apps/api/src/pipeline/pricing/TIER-SYSTEM.md
@@ -37,8 +37,8 @@ The repo still retains some compatibility surfaces named around "tiers" so older
 
 The active database behavior is defined by the Supabase migrations:
 
-- [20260423120000_single_tier_workspace_pricing.sql](/E:/ai-stats-public/supabase/migrations/20260423120000_single_tier_workspace_pricing.sql)
-- [20260423170000_workspace_pricing_invoicing_cleanup.sql](/E:/ai-stats-public/supabase/migrations/20260423170000_workspace_pricing_invoicing_cleanup.sql)
+- `supabase/migrations/20260423120000_single_tier_workspace_pricing.sql`
+- `supabase/migrations/20260423170000_workspace_pricing_invoicing_cleanup.sql`
 
 Those migrations:
 

--- a/apps/api/src/pipeline/pricing/persist.ts
+++ b/apps/api/src/pipeline/pricing/persist.ts
@@ -166,9 +166,9 @@ export async function recordUsageAndCharge(args: {
             // Trigger auto-recharge
             // NOTE: The amount charged is the raw auto_top_up_amount
             // The Stripe webhook will:
-            // 1. Fetch the team's current tier from database (uses rolling 30-day calculation)
-            // 2. Apply reverse calculation: net = gross / (1 + tier_fee_rate)
-            // 3. Credit wallet with net amount (after tier-based fee deduction)
+            // 1. Apply reverse calculation: net = gross / (1 + fee_rate)
+            // 2. Use the flat 5% top-up fee
+            // 3. Credit wallet with net amount after the fee deduction
             const stripe = getStripe();
             const minTopUpNanos = 1 * 1_000_000_000;
             if (chargeResult.auto_top_up_amount_nanos < minTopUpNanos) {

--- a/apps/api/src/pipeline/pricing/tier-cron.ts
+++ b/apps/api/src/pipeline/pricing/tier-cron.ts
@@ -1,11 +1,11 @@
 /**
- * Monthly Dormant Team Cleanup Cron Job
- * Purpose: Clean up dormant Enterprise teams that stopped making requests
+ * Legacy workspace pricing cleanup cron
+ * Purpose: Retained as a compatibility shim after the flat 5% pricing rollout
  * Schedule: Runs at 00:00 UTC on the 1st of each month
  *
  * HOW IT WORKS:
- * - Active teams: Tier calculated in real-time before each request (context.sql)
- * - Dormant teams: Cleaned up monthly via this cron (prevents indefinite Enterprise status)
+ * - Current pricing is single-tier and this job is effectively a no-op
+ * - The RPC remains in place so older operational hooks do not break
  *
  * Setup Instructions (Option 1 - Preferred):
  * Use Supabase's built-in pg_cron extension:
@@ -20,7 +20,7 @@
  * 2. Export the handleScheduledEvent function
  * 3. Ensure SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY are set
  *
- * See TIER-SYSTEM.md for full documentation.
+ * See TIER-SYSTEM.md for the current pricing model summary.
  */
 
 import { getSupabaseAdmin } from "@/runtime/env";
@@ -40,23 +40,21 @@ export interface TierCleanupResult {
 }
 
 /**
- * Execute monthly cleanup for dormant Enterprise teams
- * Calls the Supabase RPC function cleanup_dormant_enterprise_workspaces()
+ * Execute the legacy pricing cleanup RPC.
+ * Calls the Supabase RPC function cleanup_dormant_enterprise_workspaces().
  *
- * Active teams are handled by per-request tier calculation in context.sql
- * This cron handles teams that stopped making requests while on Enterprise tier
+ * In single-tier mode this returns an empty/no-op result.
  */
 export async function executeDormantTeamCleanup(): Promise<TierCleanupResult> {
     try {
         const supabase = getSupabaseAdmin();
 
-        console.log("[tier-cron] Starting dormant Enterprise team cleanup...");
+        console.log("[tier-cron] Running legacy workspace pricing cleanup...");
 
-        // Call the RPC function to cleanup dormant teams
         const { data, error } = await supabase.rpc("cleanup_dormant_enterprise_workspaces");
 
         if (error) {
-            console.error("[tier-cron] Error cleaning up dormant teams:", error);
+            console.error("[tier-cron] Error running compatibility cleanup:", error);
             return {
                 success: false,
                 total_teams_checked: 0,
@@ -67,7 +65,7 @@ export async function executeDormantTeamCleanup(): Promise<TierCleanupResult> {
             };
         }
 
-        console.log("[tier-cron] Cleanup completed successfully:", {
+        console.log("[tier-cron] Compatibility cleanup completed:", {
             checked: data.total_teams_checked,
             downgraded: data.teams_downgraded,
         });
@@ -105,9 +103,11 @@ export async function handleScheduledEvent(event: ScheduledEvent): Promise<void>
     const result = await executeDormantTeamCleanup();
 
     if (result.success) {
-        console.log(`[tier-cron] ✅ Checked ${result.total_teams_checked} Enterprise teams, downgraded ${result.teams_downgraded}`);
+        console.log(
+            `[tier-cron] Completed compatibility cleanup: checked ${result.total_teams_checked}, downgraded ${result.teams_downgraded}`
+        );
     } else {
-        console.error(`[tier-cron] ❌ Failed: ${result.error}`);
+        console.error(`[tier-cron] Failed: ${result.error}`);
     }
 }
 
@@ -116,7 +116,6 @@ export async function handleScheduledEvent(event: ScheduledEvent): Promise<void>
  * Can be called via: POST /api/admin/cleanup-dormant-teams
  */
 export async function handleManualTrigger(request: Request): Promise<Response> {
-    // Verify authorization (you should add proper auth here)
     const authHeader = request.headers.get("Authorization");
     if (!authHeader || !authHeader.startsWith("Bearer ")) {
         return new Response(JSON.stringify({ error: "Unauthorized" }), {
@@ -124,8 +123,6 @@ export async function handleManualTrigger(request: Request): Promise<Response> {
             headers: { "Content-Type": "application/json" },
         });
     }
-
-    // TODO: Verify the bearer token against your admin secret
 
     console.log("[tier-cron] Manual cleanup trigger requested");
 

--- a/apps/api/src/pipeline/pricing/tier-migration.sql
+++ b/apps/api/src/pipeline/pricing/tier-migration.sql
@@ -59,7 +59,14 @@ begin
     consecutive_low_spend_months = 0,
     enterprise_lock_through_month = null,
     tier_low_streak_evaluated_month = null
-  where id = p_workspace_id;
+  where id = p_workspace_id
+    and (
+      tier is distinct from 'basic'
+      or tier_updated_at is null
+      or consecutive_low_spend_months is distinct from 0
+      or enterprise_lock_through_month is not null
+      or tier_low_streak_evaluated_month is not null
+    );
 
   perform p_spend_30d_nanos;
   return 'basic';

--- a/apps/api/src/pipeline/pricing/tier-migration.sql
+++ b/apps/api/src/pipeline/pricing/tier-migration.sql
@@ -1,419 +1,164 @@
 -- ============================================================================
--- TWO-TIER PRICING SYSTEM WITH ROLLING 30-DAY CALCULATION
--- Purpose: Simplified pricing with real-time tier management
--- Basic: 7% markup | Enterprise: 5% markup
---
--- HOW IT WORKS:
--- - Tier is calculated BEFORE each request based on rolling 30-day spend
--- - If last 30 days >= $10k → Enterprise (5% fee)
--- - If last 30 days < $10k → Basic (7% fee)
--- - Grace Period: Enterprise teams get 3 consecutive checks before downgrade
--- - No monthly cron needed - tier updates happen on every request
+-- SINGLE-TIER WORKSPACE PRICING COMPATIBILITY SCRIPT
+-- Purpose: Keep legacy tier-shaped RPCs stable while enforcing the flat 5% plan
+-- Current behavior:
+-- - All workspaces resolve to the standard plan
+-- - Legacy tier value remains "basic" for compatibility
+-- - UI/display markup percentage is always 5.00
 -- ============================================================================
 
--- 1. Add tier tracking columns to teams table (if not exists)
-DO $$
-BEGIN
-    -- Add tier column (basic or enterprise)
-    IF NOT EXISTS (SELECT 1 FROM information_schema.columns
-                   WHERE table_name = 'teams' AND column_name = 'tier') THEN
-        ALTER TABLE public.workspaces ADD COLUMN tier text DEFAULT 'basic';
-    END IF;
+alter table public.workspaces
+  add column if not exists tier text default 'basic';
 
-    -- Add tier updated timestamp
-    IF NOT EXISTS (SELECT 1 FROM information_schema.columns
-                   WHERE table_name = 'teams' AND column_name = 'tier_updated_at') THEN
-        ALTER TABLE public.workspaces ADD COLUMN tier_updated_at timestamptz DEFAULT now();
-    END IF;
+alter table public.workspaces
+  add column if not exists tier_updated_at timestamptz default now();
 
-    -- Add consecutive low-spend months counter
-    IF NOT EXISTS (SELECT 1 FROM information_schema.columns
-                   WHERE table_name = 'teams' AND column_name = 'consecutive_low_spend_months') THEN
-        ALTER TABLE public.workspaces ADD COLUMN consecutive_low_spend_months int DEFAULT 0;
-    END IF;
-END $$;
+alter table public.workspaces
+  add column if not exists consecutive_low_spend_months integer default 0;
 
--- 2. Create tier history table for audit trail
-CREATE TABLE IF NOT EXISTS public.workspace_tier_history (
-    id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
-    workspace_id uuid NOT NULL REFERENCES public.workspaces(id) ON DELETE CASCADE,
-    old_tier text,
-    new_tier text NOT NULL,
-    reason text,
-    previous_month_spend_usd numeric(12, 2),
-    threshold_usd numeric(12, 2),
-    consecutive_low_months int,
-    changed_at timestamptz DEFAULT now(),
-    created_at timestamptz DEFAULT now()
-);
+alter table public.workspaces
+  add column if not exists enterprise_lock_through_month date null;
 
-CREATE INDEX IF NOT EXISTS idx_tier_history_workspace_id ON public.workspace_tier_history(workspace_id);
-CREATE INDEX IF NOT EXISTS idx_tier_history_changed_at ON public.workspace_tier_history(changed_at);
+alter table public.workspaces
+  add column if not exists tier_low_streak_evaluated_month date null;
 
--- 3. Function to calculate previous calendar month's spend for a team
-CREATE OR REPLACE FUNCTION calculate_workspace_previous_month_spend(p_workspace_id uuid)
-RETURNS numeric AS $$
-DECLARE
-    v_spend_nanos bigint;
-    v_spend_usd numeric(12, 2);
-    v_prev_month_start timestamptz;
-    v_prev_month_end timestamptz;
-BEGIN
-    -- Calculate previous calendar month boundaries
-    v_prev_month_start := date_trunc('month', now() - interval '1 month');
-    v_prev_month_end := date_trunc('month', now());
+update public.workspaces
+set
+  tier = 'basic',
+  tier_updated_at = now(),
+  consecutive_low_spend_months = 0,
+  enterprise_lock_through_month = null,
+  tier_low_streak_evaluated_month = null
+where
+  tier is null
+  or tier <> 'basic'
+  or tier_updated_at is null
+  or consecutive_low_spend_months is null
+  or consecutive_low_spend_months <> 0
+  or enterprise_lock_through_month is not null
+  or tier_low_streak_evaluated_month is not null;
 
-    -- Sum all successful request costs from previous month
-    SELECT COALESCE(SUM(cost_nanos), 0)
-    INTO v_spend_nanos
-    FROM public.gateway_requests
-    WHERE workspace_id = p_workspace_id
-      AND success = true
-      AND created_at >= v_prev_month_start
-      AND created_at < v_prev_month_end;
+drop function if exists public.calculate_tier_with_grace(uuid, bigint);
+drop function if exists public.cleanup_dormant_enterprise_workspaces();
+drop function if exists public.get_workspace_tier_info(uuid);
 
-    -- Convert nanos to USD
-    v_spend_usd := ROUND((v_spend_nanos::numeric / 1000000000.0)::numeric, 2);
+create or replace function public.calculate_tier_with_grace(
+  p_workspace_id uuid,
+  p_spend_30d_nanos bigint
+)
+returns text
+language plpgsql
+security definer
+set search_path = public
+as $$
+begin
+  update public.workspaces
+  set
+    tier = 'basic',
+    tier_updated_at = coalesce(tier_updated_at, now()),
+    consecutive_low_spend_months = 0,
+    enterprise_lock_through_month = null,
+    tier_low_streak_evaluated_month = null
+  where id = p_workspace_id;
 
-    RETURN v_spend_usd;
-END;
-$$ LANGUAGE plpgsql SECURITY DEFINER;
+  perform p_spend_30d_nanos;
+  return 'basic';
+end;
+$$;
 
--- 4. Function to update a single team's tier
-CREATE OR REPLACE FUNCTION update_workspace_tier(p_workspace_id uuid)
-RETURNS jsonb AS $$
-DECLARE
-    v_current_tier text;
-    v_new_tier text;
-    v_prev_month_spend numeric(12, 2);
-    v_consecutive_low integer;
-    v_threshold numeric(12, 2) := 10000.00; -- $10k threshold
-    v_changed boolean := false;
-    v_reason text;
-BEGIN
-    -- Get current tier and consecutive low-spend months
-    SELECT tier, consecutive_low_spend_months
-    INTO v_current_tier, v_consecutive_low
-    FROM public.workspaces
-    WHERE id = p_workspace_id;
+create or replace function public.cleanup_dormant_enterprise_workspaces()
+returns jsonb
+language plpgsql
+security definer
+set search_path = public
+as $$
+begin
+  return jsonb_build_object(
+    'total_teams_checked', 0,
+    'teams_downgraded', 0,
+    'downgraded_teams', '[]'::jsonb,
+    'processed_at', now()
+  );
+end;
+$$;
 
-    IF v_current_tier IS NULL THEN
-        RAISE EXCEPTION 'Team not found: %', p_workspace_id;
-    END IF;
+create or replace function public.get_workspace_tier_info(p_workspace_id uuid)
+returns jsonb
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_exists boolean := false;
+  v_tier_updated_at timestamptz;
+  v_current_month_nanos bigint := 0;
+  v_prev_month_nanos bigint := 0;
+  v_current_month_spend numeric(12, 2);
+  v_prev_month_spend numeric(12, 2);
+  v_current_month_start_ts timestamptz := (date_trunc('month', now() at time zone 'UTC') at time zone 'UTC');
+  v_prev_month_start_ts timestamptz := ((date_trunc('month', now() at time zone 'UTC') - interval '1 month') at time zone 'UTC');
+  v_next_month_start_ts timestamptz := ((date_trunc('month', now() at time zone 'UTC') + interval '1 month') at time zone 'UTC');
+begin
+  select exists(
+    select 1 from public.workspaces w where w.id = p_workspace_id
+  )
+  into v_exists;
 
-    -- Calculate previous month's spend
-    v_prev_month_spend := calculate_workspace_previous_month_spend(p_workspace_id);
+  if not v_exists then
+    raise exception 'Workspace not found: %', p_workspace_id;
+  end if;
 
-    -- Determine new tier based on logic:
-    -- - If spent >$10k in previous month → Enterprise
-    -- - If spent <$10k for 3 consecutive months → Basic
-    IF v_prev_month_spend >= v_threshold THEN
-        -- High spend → Enterprise tier
-        v_new_tier := 'enterprise';
-        v_consecutive_low := 0;
-        IF v_current_tier != 'enterprise' THEN
-            v_reason := format('Previous month spend $%s exceeded $10k threshold', v_prev_month_spend);
-            v_changed := true;
-        END IF;
-    ELSE
-        -- Low spend → increment counter
-        v_consecutive_low := v_consecutive_low + 1;
+  select coalesce(w.tier_updated_at, now())
+  into v_tier_updated_at
+  from public.workspaces w
+  where w.id = p_workspace_id;
 
-        IF v_consecutive_low >= 3 AND v_current_tier != 'basic' THEN
-            -- 3 months of low spend → downgrade to Basic
-            v_new_tier := 'basic';
-            v_reason := format('3 consecutive months below $10k threshold (current: $%s)', v_prev_month_spend);
-            v_changed := true;
-        ELSE
-            -- Keep current tier
-            v_new_tier := v_current_tier;
-        END IF;
-    END IF;
+  select coalesce(sum(gr.cost_nanos), 0)::bigint
+  into v_current_month_nanos
+  from public.gateway_requests gr
+  where gr.workspace_id = p_workspace_id
+    and gr.success is true
+    and gr.created_at >= v_current_month_start_ts
+    and gr.created_at < v_next_month_start_ts;
 
-    -- Update team record
-    UPDATE public.workspaces
-    SET
-        tier = v_new_tier,
-        tier_updated_at = CASE WHEN v_changed THEN now() ELSE tier_updated_at END,
-        consecutive_low_spend_months = v_consecutive_low
-    WHERE id = p_workspace_id;
+  select coalesce(sum(gr.cost_nanos), 0)::bigint
+  into v_prev_month_nanos
+  from public.gateway_requests gr
+  where gr.workspace_id = p_workspace_id
+    and gr.success is true
+    and gr.created_at >= v_prev_month_start_ts
+    and gr.created_at < v_current_month_start_ts;
 
-    -- Record tier change in history if changed
-    IF v_changed THEN
-        INSERT INTO public.workspace_tier_history (
-            workspace_id,
-            old_tier,
-            new_tier,
-            reason,
-            previous_month_spend_usd,
-            threshold_usd,
-            consecutive_low_months
-        ) VALUES (
-            p_workspace_id,
-            v_current_tier,
-            v_new_tier,
-            v_reason,
-            v_prev_month_spend,
-            v_threshold,
-            v_consecutive_low
-        );
-    END IF;
+  v_current_month_spend := round((v_current_month_nanos::numeric / 1000000000.0)::numeric, 2);
+  v_prev_month_spend := round((v_prev_month_nanos::numeric / 1000000000.0)::numeric, 2);
 
-    RETURN jsonb_build_object(
-        'workspace_id', p_workspace_id,
-        'old_tier', v_current_tier,
-        'new_tier', v_new_tier,
-        'changed', v_changed,
-        'reason', v_reason,
-        'previous_month_spend_usd', v_prev_month_spend,
-        'consecutive_low_months', v_consecutive_low
-    );
-END;
-$$ LANGUAGE plpgsql SECURITY DEFINER;
+  return jsonb_build_object(
+    'tier', 'basic',
+    'tier_display', 'Standard',
+    'markup_percentage', 5.00,
+    'tier_updated_at', v_tier_updated_at,
+    'consecutive_low_spend_months', 0,
+    'enterprise_lock_through_month', null,
+    'low_streak_evaluated_month', null,
+    'threshold_usd', 0,
+    'current_month_spend_usd', v_current_month_spend,
+    'previous_month_spend_usd', v_prev_month_spend,
+    'progress_to_enterprise_pct', 100,
+    'is_eligible_for_enterprise', false,
+    'months_until_downgrade', null
+  );
+end;
+$$;
 
--- 5. Function to clean up dormant Enterprise teams (run monthly via cron)
--- Purpose: Handle teams that stopped making requests while on Enterprise tier
--- Active teams are handled by per-request tier calculation in context.sql
-CREATE OR REPLACE FUNCTION cleanup_dormant_enterprise_workspaces()
-RETURNS jsonb AS $$
-DECLARE
-    v_workspace_id uuid;
-    v_spend_30d_nanos bigint;
-    v_threshold_nanos bigint := 10000000000000; -- $10k in nanos
-    v_tier text;
-    v_updated_count int := 0;
-    v_total_checked int := 0;
-    v_results jsonb[] := '{}';
-    v_result text;
-BEGIN
-    -- Process only Enterprise teams
-    FOR v_workspace_id, v_tier IN
-        SELECT id, tier FROM public.workspaces
-        WHERE tier = 'enterprise'
-        ORDER BY id
-    LOOP
-        v_total_checked := v_total_checked + 1;
+grant execute on function public.calculate_tier_with_grace(uuid, bigint) to service_role;
+grant execute on function public.cleanup_dormant_enterprise_workspaces() to service_role;
+grant execute on function public.get_workspace_tier_info(uuid) to service_role;
 
-        -- Calculate rolling 30-day spend
-        SELECT COALESCE(SUM(cost_nanos), 0)
-        INTO v_spend_30d_nanos
-        FROM public.gateway_requests
-        WHERE workspace_id = v_workspace_id
-          AND success = true
-          AND created_at >= now() - interval '30 days';
+comment on function public.calculate_tier_with_grace(uuid, bigint)
+  is 'Compatibility shim for workspace tier calculation. Flat single-tier pricing always resolves to the standard 5% plan.';
 
-        -- Use the tier calculation function (handles grace period logic)
-        v_result := calculate_tier_with_grace(v_workspace_id, v_spend_30d_nanos);
+comment on function public.cleanup_dormant_enterprise_workspaces()
+  is 'Compatibility shim retained after single-tier pricing rollout. Returns no-op cleanup results.';
 
-        -- Track if tier changed (downgraded to basic)
-        IF v_result = 'basic' THEN
-            v_updated_count := v_updated_count + 1;
-            v_results := array_append(v_results, jsonb_build_object(
-                'workspace_id', v_workspace_id,
-                'old_tier', 'enterprise',
-                'new_tier', 'basic',
-                'spend_30d_usd', ROUND((v_spend_30d_nanos::numeric / 1000000000.0)::numeric, 2)
-            ));
-        END IF;
-    END LOOP;
-
-    RETURN jsonb_build_object(
-        'total_teams_checked', v_total_checked,
-        'teams_downgraded', v_updated_count,
-        'downgraded_teams', to_jsonb(v_results),
-        'processed_at', now()
-    );
-END;
-$$ LANGUAGE plpgsql SECURITY DEFINER;
-
--- 6. Function to calculate tier based on rolling 30-day spend with grace period
-CREATE OR REPLACE FUNCTION calculate_tier_with_grace(
-    p_workspace_id uuid,
-    p_spend_30d_nanos bigint
-) RETURNS text AS $$
-DECLARE
-    v_stored_tier text;
-    v_consecutive_low int;
-    v_threshold_nanos bigint := 10000000000000; -- $10k in nanos (10,000 * 1,000,000,000)
-    v_new_tier text;
-    v_tier_changed boolean := false;
-    v_reason text;
-BEGIN
-    -- Get current tier and grace period counter
-    SELECT
-        COALESCE(tier, 'basic'),
-        COALESCE(consecutive_low_spend_months, 0)
-    INTO
-        v_stored_tier,
-        v_consecutive_low
-    FROM public.workspaces
-    WHERE id = p_workspace_id;
-
-    -- Determine new tier based on 30-day spend
-    IF p_spend_30d_nanos >= v_threshold_nanos THEN
-        -- Spending >= $10k → Enterprise tier
-        v_new_tier := 'enterprise';
-
-        IF v_stored_tier != 'enterprise' THEN
-            v_tier_changed := true;
-            v_reason := format('30-day spend $%s reached $10k threshold',
-                ROUND((p_spend_30d_nanos::numeric / 1000000000.0)::numeric, 2));
-        END IF;
-
-        -- Reset grace period counter
-        v_consecutive_low := 0;
-
-    ELSE
-        -- Spending < $10k
-        IF v_stored_tier = 'enterprise' THEN
-            -- Currently Enterprise → Check grace period
-            v_consecutive_low := v_consecutive_low + 1;
-
-            IF v_consecutive_low >= 3 THEN
-                -- Grace period expired → Downgrade to Basic
-                v_new_tier := 'basic';
-                v_tier_changed := true;
-                v_reason := format('3 consecutive checks below $10k threshold (current 30d: $%s)',
-                    ROUND((p_spend_30d_nanos::numeric / 1000000000.0)::numeric, 2));
-            ELSE
-                -- Still in grace period → Keep Enterprise
-                v_new_tier := 'enterprise';
-            END IF;
-        ELSE
-            -- Currently Basic and spend < $10k → Stay Basic
-            v_new_tier := 'basic';
-        END IF;
-    END IF;
-
-    -- Update team tier and grace counter
-    UPDATE public.workspaces
-    SET
-        tier = v_new_tier,
-        tier_updated_at = CASE WHEN v_tier_changed THEN now() ELSE tier_updated_at END,
-        consecutive_low_spend_months = v_consecutive_low
-    WHERE id = p_workspace_id;
-
-    -- Log tier change if it happened
-    IF v_tier_changed THEN
-        INSERT INTO public.workspace_tier_history (
-            workspace_id,
-            old_tier,
-            new_tier,
-            reason,
-            previous_month_spend_usd,
-            threshold_usd,
-            consecutive_low_months
-        ) VALUES (
-            p_workspace_id,
-            v_stored_tier,
-            v_new_tier,
-            v_reason,
-            ROUND((p_spend_30d_nanos::numeric / 1000000000.0)::numeric, 2),
-            10000.00,
-            v_consecutive_low
-        );
-    END IF;
-
-    RETURN v_new_tier;
-END;
-$$ LANGUAGE plpgsql SECURITY DEFINER;
-
--- 7. Function to get team tier info for UI
-CREATE OR REPLACE FUNCTION get_workspace_tier_info(p_workspace_id uuid)
-RETURNS jsonb AS $$
-DECLARE
-    v_tier text;
-    v_tier_updated_at timestamptz;
-    v_consecutive_low int;
-    v_current_month_spend numeric(12, 2);
-    v_prev_month_spend numeric(12, 2);
-    v_threshold numeric(12, 2) := 10000.00;
-    v_markup_pct numeric(4, 2);
-    v_current_month_start timestamptz;
-    v_current_month_nanos bigint;
-BEGIN
-    -- Get team tier data
-    SELECT tier, tier_updated_at, consecutive_low_spend_months
-    INTO v_tier, v_tier_updated_at, v_consecutive_low
-    FROM public.workspaces
-    WHERE id = p_workspace_id;
-
-    IF v_tier IS NULL THEN
-        RAISE EXCEPTION 'Team not found: %', p_workspace_id;
-    END IF;
-
-    -- Determine markup percentage
-    v_markup_pct := CASE WHEN v_tier = 'enterprise' THEN 5.00 ELSE 7.00 END;
-
-    -- Calculate current month spend (for progress tracking)
-    v_current_month_start := date_trunc('month', now());
-
-    SELECT COALESCE(SUM(cost_nanos), 0)
-    INTO v_current_month_nanos
-    FROM public.gateway_requests
-    WHERE workspace_id = p_workspace_id
-      AND success = true
-      AND created_at >= v_current_month_start;
-
-    v_current_month_spend := ROUND((v_current_month_nanos::numeric / 1000000000.0)::numeric, 2);
-
-    -- Get previous month spend
-    v_prev_month_spend := calculate_workspace_previous_month_spend(p_workspace_id);
-
-    RETURN jsonb_build_object(
-        'tier', v_tier,
-        'tier_display', CASE WHEN v_tier = 'enterprise' THEN 'Enterprise' ELSE 'Basic' END,
-        'markup_percentage', v_markup_pct,
-        'tier_updated_at', v_tier_updated_at,
-        'consecutive_low_spend_months', v_consecutive_low,
-        'threshold_usd', v_threshold,
-        'current_month_spend_usd', v_current_month_spend,
-        'previous_month_spend_usd', v_prev_month_spend,
-        'progress_to_enterprise_pct', LEAST(100, ROUND((v_current_month_spend / v_threshold * 100)::numeric, 1)),
-        'is_eligible_for_enterprise', v_current_month_spend >= v_threshold,
-        'months_until_downgrade', CASE
-            WHEN v_tier = 'enterprise' THEN GREATEST(0, 3 - v_consecutive_low)
-            ELSE NULL
-        END
-    );
-END;
-$$ LANGUAGE plpgsql SECURITY DEFINER;
-
--- 8. Grant execute permissions
-GRANT EXECUTE ON FUNCTION calculate_workspace_previous_month_spend(uuid) TO authenticated;
-GRANT EXECUTE ON FUNCTION update_workspace_tier(uuid) TO service_role;
-GRANT EXECUTE ON FUNCTION cleanup_dormant_enterprise_workspaces() TO service_role;
-GRANT EXECUTE ON FUNCTION calculate_tier_with_grace(uuid, bigint) TO anon, authenticated, service_role;
-GRANT EXECUTE ON FUNCTION get_workspace_tier_info(uuid) TO authenticated;
-
--- 9. Create index for efficient spend calculations
-CREATE INDEX IF NOT EXISTS idx_gateway_requests_team_success_created
-ON public.gateway_requests(workspace_id, success, created_at)
-WHERE success = true;
-
--- 10. Comments
-COMMENT ON FUNCTION calculate_tier_with_grace(uuid, bigint) IS 'Calculate team tier based on rolling 30-day spend with 3-check grace period for downgrades. Called automatically before each request in context.sql.';
-COMMENT ON FUNCTION cleanup_dormant_enterprise_workspaces() IS 'Monthly cleanup job to downgrade dormant Enterprise teams. Handles teams that stopped making requests while on Enterprise tier.';
-COMMENT ON FUNCTION get_workspace_tier_info(uuid) IS 'Get comprehensive tier information for display in UI dashboard';
-
--- ============================================================================
--- SUPABASE pg_cron SETUP (Required for dormant account cleanup)
--- ============================================================================
--- Active teams: Tier calculated before EVERY request via context.sql
--- Dormant teams: Cleaned up monthly via cron to prevent abuse
---
--- Run this in Supabase SQL Editor to enable monthly cleanup:
--- SELECT cron.schedule(
---     'cleanup-dormant-enterprise-teams',
---     '0 0 1 * *',  -- Midnight UTC on 1st of each month
---     $$SELECT cleanup_dormant_enterprise_workspaces()$$
--- );
---
--- To check scheduled jobs:
--- SELECT * FROM cron.job;
---
--- To view job run history:
--- SELECT * FROM cron.job_run_details ORDER BY start_time DESC LIMIT 10;
---
--- To unschedule:
--- SELECT cron.unschedule('cleanup-dormant-enterprise-teams');
+comment on function public.get_workspace_tier_info(uuid)
+  is 'Returns workspace pricing metadata for the flat standard plan, including 5% markup and spend summaries.';

--- a/apps/docs/v1/pricing/tiers.mdx
+++ b/apps/docs/v1/pricing/tiers.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Pricing Tiers"
-description: "Understand credit purchase fees, tier qualification, and how Gateway billing works"
+description: "Understand the flat 5% credit purchase fee and how Gateway billing works"
 ---
 
 # Pricing Tiers
@@ -8,60 +8,37 @@ description: "Understand credit purchase fees, tier qualification, and how Gatew
 Gateway billing has two parts:
 
 1. **Model usage pricing**: credits are consumed at model prices shown in the catalog.
-2. **Credit purchase fee**: a tier-based fee is applied only when buying credits.
+2. **Credit purchase fee**: a flat **5% top-up fee** is applied only when buying credits.
 
-## Tier Overview
+## Current Plan
 
-<CardGroup cols={2}>
-  <Card title="Basic Tier" icon="tag">
-    **7% credit purchase fee**
+<Card title="Standard Plan" icon="tag">
+  **5% credit purchase fee**
 
-    Default tier for teams. Applies when you top up credits.
-  </Card>
+  All workspaces use the same standard plan. There is no separate enterprise fee schedule for self-serve Gateway usage.
+</Card>
 
-  <Card title="Enterprise Tier" icon="star">
-    **5% credit purchase fee**
-
-    Reduced top-up fee for high-volume teams.
-  </Card>
-</CardGroup>
-
-## How Qualification Works
-
-Tier qualification is based on **calendar-month spend**:
+## How Billing Works
 
 <Steps>
-  <Step title="Track monthly spend">
-    We track your team's Gateway spend during the current calendar month.
+  <Step title="Buy credits">
+    When you top up, a **5% platform fee** is applied to the purchase.
   </Step>
 
-  <Step title="Apply threshold">
-    - Monthly spend **>= $10,000**: Enterprise tier (5% top-up fee)
-    - Monthly spend **< $10,000**: Basic tier (7% top-up fee)
+  <Step title="Use the Gateway">
+    Requests consume credits at the model prices listed in the catalog.
   </Step>
 
-  <Step title="Apply fee on top-up">
-    The active tier fee is applied when credits are purchased.
-    Model requests then consume credits at listed model rates.
+  <Step title="Review usage">
+    Your dashboard shows the current top-up fee, credit balance, and recent spend.
   </Step>
 </Steps>
-
-## Grace Period
-
-Enterprise teams include a **3-month grace period** to avoid rapid tier changes during short-term spend dips.
-
-<Info>
-  **Active teams**: tier status is reflected from backend billing state.
-
-  **Low-spend streaks**: extended time below threshold can move teams back to Basic.
-</Info>
 
 ## Example
 
 | Scenario | Top-Up Amount | Applied Fee | Credits Added (before usage) |
 |---|---:|---:|---:|
-| Basic tier | $100 | 7% ($7) | $100 credits |
-| Enterprise tier | $100 | 5% ($5) | $100 credits |
+| Standard plan | $100 | 5% ($5) | $100 credits |
 | Free model usage | No top-up | $0 | Uses free model allowance |
 
 ## Frequently Asked Questions
@@ -72,26 +49,26 @@ Enterprise teams include a **3-month grace period** to avoid rapid tier changes 
   </Accordion>
 
   <Accordion title="Do you mark up token pricing beyond model rates?">
-    Model usage rates follow the catalog pricing. The separate platform fee is the top-up fee shown by your active tier.
+    Model usage rates follow the catalog pricing. The separate platform fee is the 5% top-up fee applied when credits are purchased.
   </Accordion>
 
-  <Accordion title="When does my tier change?">
-    Tier status follows monthly spend qualification and backend billing state. You can view your current tier in settings.
+  <Accordion title="Is there an enterprise fee tier?">
+    Not for the current self-serve Gateway plan. All workspaces use the same 5% top-up fee.
   </Accordion>
 
-  <Accordion title="Can I request custom enterprise terms?">
-    Yes. For committed volume, invoicing, or procurement requirements, contact sales.
+  <Accordion title="Can I request custom commercial terms?">
+    Yes. For invoicing, procurement, or bespoke commercial requirements, contact sales.
   </Accordion>
 </AccordionGroup>
 
-## Viewing Your Tier
+## Viewing Your Pricing
 
-Check your current tier and top-up fee in your dashboard:
+Check your current top-up fee and billing status in your dashboard:
 
 1. Navigate to **Settings -> Pricing & Tiers**
-2. View your current fee rate and qualification progress
-3. Review monthly spend trends and upgrade path
+2. View the current fee rate and recent usage
+3. Review credit balance and spend trends
 
 <Card title="Questions?" icon="question">
-  Need help with billing or tiers? Contact support at support@example.com or join our [Discord community](https://discord.gg/aQyywCvgZ5).
+  Need help with billing or pricing? Contact support at support@example.com or join our [Discord community](https://discord.gg/aQyywCvgZ5).
 </Card>

--- a/apps/docs/v1/pricing/tiers.mdx
+++ b/apps/docs/v1/pricing/tiers.mdx
@@ -36,9 +36,9 @@ Gateway billing has two parts:
 
 ## Example
 
-| Scenario | Top-Up Amount | Applied Fee | Credits Added (before usage) |
+| Scenario | Total Charge | Applied Fee | Credits Added |
 |---|---:|---:|---:|
-| Standard plan | $100 | 5% ($5) | $100 credits |
+| Standard plan | $100 | 5% (~$4.76) | ~$95.24 credits |
 | Free model usage | No top-up | $0 | Uses free model allowance |
 
 ## Frequently Asked Questions

--- a/apps/web/src/app/(dashboard)/page.tsx
+++ b/apps/web/src/app/(dashboard)/page.tsx
@@ -35,6 +35,8 @@ export const metadata: Metadata = buildMetadata({
 const standardTier =
 	GATEWAY_TIERS.find((tier) => tier.key === "standard") ?? GATEWAY_TIERS[0];
 const standardFeePct = standardTier?.feePct ?? 5;
+const standardFeeText =
+	Number.isInteger(standardFeePct) ? standardFeePct.toFixed(0) : String(standardFeePct);
 
 const PRICING_POINTS = [
 	{
@@ -43,8 +45,8 @@ const PRICING_POINTS = [
 		icon: Coins,
 	},
 	{
-		title: `Flat ${standardFeePct.toFixed(0)}% fee`,
-		body: `Gateway pricing is a flat ${standardFeePct.toFixed(0)}% fee on credit purchases. No subscriptions, and no plan ladder to unlock the core product.`,
+		title: `Flat ${standardFeeText}% fee`,
+		body: `Gateway pricing is a flat ${standardFeeText}% fee on credit purchases. No subscriptions, and no plan ladder to unlock the core product.`,
 		icon: ShieldCheck,
 	},
 	{

--- a/apps/web/src/app/(dashboard)/page.tsx
+++ b/apps/web/src/app/(dashboard)/page.tsx
@@ -32,7 +32,9 @@ export const metadata: Metadata = buildMetadata({
 	],
 });
 
-const basicTier = GATEWAY_TIERS.find((tier) => tier.key === "basic");
+const standardTier =
+	GATEWAY_TIERS.find((tier) => tier.key === "standard") ?? GATEWAY_TIERS[0];
+const standardFeePct = standardTier?.feePct ?? 5;
 
 const PRICING_POINTS = [
 	{
@@ -41,8 +43,8 @@ const PRICING_POINTS = [
 		icon: Coins,
 	},
 	{
-		title: `Flat ${basicTier?.feePct.toFixed(0) ?? "7"}% fee`,
-		body: `Gateway pricing is a flat ${basicTier?.feePct.toFixed(0) ?? "7"}% fee on credit purchases. No subscriptions, and no plan ladder to unlock the core product.`,
+		title: `Flat ${standardFeePct.toFixed(0)}% fee`,
+		body: `Gateway pricing is a flat ${standardFeePct.toFixed(0)}% fee on credit purchases. No subscriptions, and no plan ladder to unlock the core product.`,
 		icon: ShieldCheck,
 	},
 	{

--- a/apps/web/src/app/api/webhooks/stripe-checkout/route.ts
+++ b/apps/web/src/app/api/webhooks/stripe-checkout/route.ts
@@ -248,7 +248,7 @@ function getSupabase() {
     });
 }
 
-/* Fees: Reverse-engineer the original amount from the total received, then apply tier-based fee */
+/* Fees: Reverse-engineer the original amount from the total received, then apply the flat top-up fee. */
 function computeNetAndFeeFromGross(grossNanos: number, feePct: number) {
     const minFeeNanos = 1_000_000_000; // $1 in nanos
 


### PR DESCRIPTION
## Summary
- fix the homepage gateway pricing card to read the current 5% fee
- use the active `standard` tier instead of the removed `basic` tier lookup
- remove the stale 7% fallback so future copy follows the configured tier fee

## Validation
- `pnpm --filter @ai-stats/web typecheck`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Dashboard pricing copy updated to show the standard 5% flat/top-up fee (replacing the prior 7% display).

* **Documentation**
  * Pricing docs, billing guidance, and help content simplified to a single Standard plan; credit purchases and auto-recharge now described as using a flat 5% top-up/platform fee.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->