### PR TITLE
[codex] Configure private Entire checkpoint remote

### DIFF
--- a/.entire/settings.json
+++ b/.entire/settings.json
@@ -1,4 +1,10 @@
 {
   "enabled": true,
+  "strategy_options": {
+    "checkpoint_remote": {
+      "provider": "github",
+      "repo": "AI-Stats/ai-stats-checkpoints-private"
+    }
+  },
   "telemetry": true
 }


### PR DESCRIPTION
## What changed
- configures Entire to push `entire/checkpoints/v1` to the private `AI-Stats/ai-stats-checkpoints-private` repository
- keeps the checkpoint remote setting in tracked project config so collaborators use the private checkpoint repo by default

## Why
- Entire checkpoint branches contain session metadata and should not be kept in the public project repository

## Impact
- future Entire checkpoint pushes for this repo go to the private checkpoint repository instead of the public repo
- no application code or runtime behavior changes

## Validation
- `Get-Content .entire/settings.json | ConvertFrom-Json | Out-Null`
- `git diff --check`
