### PR TITLE
Add Xiaomi MiMo V2.5 catalog updates

### DIFF
--- a/packages/data/catalog/src/data/manifest.json
+++ b/packages/data/catalog/src/data/manifest.json
@@ -214,8 +214,7 @@
       "deepseek/deepseek-v3.2",
       "deepseek/deepseek-v3.2-exp",
       "deepseek/deepseek-v3.2-speciale",
-      "deepseek/deepseek-v4-flash",
-      "deepseek/deepseek-v4-pro",
+      "deepseek/deepseek-v4",
       "deepseek/deepseek-vl2",
       "deepseek/deepseek-vl2-small",
       "deepseek/deepseek-vl2-tiny"

--- a/packages/data/catalog/src/data/manifest.json
+++ b/packages/data/catalog/src/data/manifest.json
@@ -214,7 +214,8 @@
       "deepseek/deepseek-v3.2",
       "deepseek/deepseek-v3.2-exp",
       "deepseek/deepseek-v3.2-speciale",
-      "deepseek/deepseek-v4",
+      "deepseek/deepseek-v4-flash",
+      "deepseek/deepseek-v4-pro",
       "deepseek/deepseek-vl2",
       "deepseek/deepseek-vl2-small",
       "deepseek/deepseek-vl2-tiny"
@@ -1010,7 +1011,12 @@
       "xiaomi/mimo-v2-flash",
       "xiaomi/mimo-v2-omni",
       "xiaomi/mimo-v2-pro",
-      "xiaomi/mimo-v2-tts"
+      "xiaomi/mimo-v2-tts",
+      "xiaomi/mimo-v2.5",
+      "xiaomi/mimo-v2.5-base",
+      "xiaomi/mimo-v2.5-pro",
+      "xiaomi/mimo-v2.5-pro-base",
+      "xiaomi/mimo-v2.5-tts"
     ],
     "z-ai": [
       "z-ai/glm-4-32b",

--- a/packages/data/catalog/src/data/models/xiaomi/mimo-v2.5-base/model.json
+++ b/packages/data/catalog/src/data/models/xiaomi/mimo-v2.5-base/model.json
@@ -1,0 +1,32 @@
+{
+  "model_id": "xiaomi/mimo-v2.5-base",
+  "organisation_id": "xiaomi",
+  "name": "MiMo V2.5 Base",
+  "status": "Available",
+  "previous_model_id": null,
+  "announced_date": "2026-04-22T00:00:00",
+  "release_date": "2026-04-22T00:00:00",
+  "deprecation_date": null,
+  "retirement_date": null,
+  "license": "MIT",
+  "input_types": "text,image,video,audio",
+  "output_types": "text",
+  "api_model_id": "xiaomi/mimo-v2.5-base",
+  "links": [
+    {
+      "platform": "announcement",
+      "url": "https://platform.xiaomimimo.com/docs/news/v2.5-news"
+    },
+    {
+      "platform": "weights",
+      "url": "https://huggingface.co/XiaomiMiMo/MiMo-V2.5-Base"
+    }
+  ],
+  "details": [
+    {
+      "name": "input_context_length",
+      "value": 256000
+    }
+  ],
+  "benchmarks": []
+}

--- a/packages/data/catalog/src/data/models/xiaomi/mimo-v2.5-pro-base/model.json
+++ b/packages/data/catalog/src/data/models/xiaomi/mimo-v2.5-pro-base/model.json
@@ -1,0 +1,32 @@
+{
+  "model_id": "xiaomi/mimo-v2.5-pro-base",
+  "organisation_id": "xiaomi",
+  "name": "MiMo V2.5 Pro Base",
+  "status": "Available",
+  "previous_model_id": null,
+  "announced_date": "2026-04-22T00:00:00",
+  "release_date": "2026-04-22T00:00:00",
+  "deprecation_date": null,
+  "retirement_date": null,
+  "license": "MIT",
+  "input_types": "text",
+  "output_types": "text",
+  "api_model_id": "xiaomi/mimo-v2.5-pro-base",
+  "links": [
+    {
+      "platform": "announcement",
+      "url": "https://platform.xiaomimimo.com/docs/news/v2.5-news"
+    },
+    {
+      "platform": "weights",
+      "url": "https://huggingface.co/XiaomiMiMo/MiMo-V2.5-Pro-Base"
+    }
+  ],
+  "details": [
+    {
+      "name": "input_context_length",
+      "value": 256000
+    }
+  ],
+  "benchmarks": []
+}

--- a/packages/data/catalog/src/data/models/xiaomi/mimo-v2.5-pro/model.json
+++ b/packages/data/catalog/src/data/models/xiaomi/mimo-v2.5-pro/model.json
@@ -1,0 +1,36 @@
+{
+  "model_id": "xiaomi/mimo-v2.5-pro",
+  "organisation_id": "xiaomi",
+  "name": "MiMo V2.5 Pro",
+  "status": "Available",
+  "previous_model_id": "xiaomi/mimo-v2-pro",
+  "announced_date": "2026-04-22T00:00:00",
+  "release_date": "2026-04-22T00:00:00",
+  "deprecation_date": null,
+  "retirement_date": null,
+  "license": "MIT",
+  "input_types": "text",
+  "output_types": "text",
+  "api_model_id": "xiaomi/mimo-v2.5-pro",
+  "links": [
+    {
+      "platform": "announcement",
+      "url": "https://platform.xiaomimimo.com/docs/news/v2.5-news"
+    },
+    {
+      "platform": "weights",
+      "url": "https://huggingface.co/XiaomiMiMo/MiMo-V2.5-Pro"
+    }
+  ],
+  "details": [
+    {
+      "name": "input_context_length",
+      "value": 1048576
+    },
+    {
+      "name": "output_context_length",
+      "value": 128000
+    }
+  ],
+  "benchmarks": []
+}

--- a/packages/data/catalog/src/data/models/xiaomi/mimo-v2.5-tts/model.json
+++ b/packages/data/catalog/src/data/models/xiaomi/mimo-v2.5-tts/model.json
@@ -1,0 +1,32 @@
+{
+  "model_id": "xiaomi/mimo-v2.5-tts",
+  "organisation_id": "xiaomi",
+  "name": "MiMo V2.5 TTS",
+  "status": "Available",
+  "previous_model_id": "xiaomi/mimo-v2-tts",
+  "announced_date": "2026-04-22T00:00:00",
+  "release_date": "2026-04-22T00:00:00",
+  "deprecation_date": null,
+  "retirement_date": null,
+  "license": null,
+  "input_types": "text",
+  "output_types": "audio_tts",
+  "api_model_id": "xiaomi/mimo-v2.5-tts",
+  "links": [
+    {
+      "platform": "announcement",
+      "url": "https://platform.xiaomimimo.com/docs/news/v2.5-news"
+    }
+  ],
+  "details": [
+    {
+      "name": "input_context_length",
+      "value": 8000
+    },
+    {
+      "name": "output_context_length",
+      "value": 8000
+    }
+  ],
+  "benchmarks": []
+}

--- a/packages/data/catalog/src/data/models/xiaomi/mimo-v2.5/model.json
+++ b/packages/data/catalog/src/data/models/xiaomi/mimo-v2.5/model.json
@@ -1,0 +1,36 @@
+{
+  "model_id": "xiaomi/mimo-v2.5",
+  "organisation_id": "xiaomi",
+  "name": "MiMo V2.5",
+  "status": "Available",
+  "previous_model_id": "xiaomi/mimo-v2-omni",
+  "announced_date": "2026-04-22T00:00:00",
+  "release_date": "2026-04-22T00:00:00",
+  "deprecation_date": null,
+  "retirement_date": null,
+  "license": "MIT",
+  "input_types": "text,image,video,audio",
+  "output_types": "text",
+  "api_model_id": "xiaomi/mimo-v2.5",
+  "links": [
+    {
+      "platform": "announcement",
+      "url": "https://platform.xiaomimimo.com/docs/news/v2.5-news"
+    },
+    {
+      "platform": "weights",
+      "url": "https://huggingface.co/XiaomiMiMo/MiMo-V2.5"
+    }
+  ],
+  "details": [
+    {
+      "name": "input_context_length",
+      "value": 1048576
+    },
+    {
+      "name": "output_context_length",
+      "value": 128000
+    }
+  ],
+  "benchmarks": []
+}


### PR DESCRIPTION
## Summary
- add Xiaomi MiMo V2.5 and MiMo V2.5 Pro model entries to the catalog
- add the new MiMo V2.5 Base and MiMo V2.5 Pro Base model records
- update the manifest and model metadata with MIT licensing and Hugging Face weights links

## Testing
- `git diff --check`
- full data validation not run
