### PR TITLE
Fix mobile auth header spacing and wordmark

### DIFF
--- a/apps/web/src/app/(auth)/sign-in/page.tsx
+++ b/apps/web/src/app/(auth)/sign-in/page.tsx
@@ -1,6 +1,6 @@
 // app/(auth)/sign-in/page.tsx
-import Link from "next/link";
 import ProviderLogos from "@/components/(gateway)/auth/providers";
+import { AuthWordmark } from "@/components/(gateway)/auth/AuthWordmark";
 import SupportedModelsStats from "@/components/landingPage/Auth/SupportedModelsStats";
 import KeyModels from "@/components/landingPage/Auth/KeyModels";
 import { Suspense } from "react";
@@ -36,20 +36,14 @@ export default async function Page({ searchParams }: SignInPageProps) {
 	return (
 		<div className="grid min-h-svh lg:grid-cols-2">
 			{/* LEFT COL */}
-			<div className="relative flex flex-col p-6 md:p-10">
+			<div className="flex flex-col p-6 md:p-10">
 				{/* Brand link overlayed top-left; doesn’t push content down */}
-				<Link
-					href="/"
-					className="absolute left-6 top-6 md:left-10 md:top-10 z-10 inline-flex items-center gap-2 font-medium"
-					aria-label="AI Stats home"
-				>
-					<span className="inline text-2xl font-semibold tracking-tight select-none">
-						AI Stats
-					</span>
-				</Link>
+				<div className="shrink-0">
+					<AuthWordmark />
+				</div>
 
 				{/* Centre the login card */}
-				<div className="flex flex-1 items-center justify-center">
+				<div className="flex flex-1 items-start justify-center pt-4 md:items-center md:pt-0">
 					<div className="mx-auto w-full max-w-xs">
 						<Suspense fallback={<div>Loading…</div>}>
 							<Login

--- a/apps/web/src/app/(auth)/sign-up/page.tsx
+++ b/apps/web/src/app/(auth)/sign-up/page.tsx
@@ -1,6 +1,6 @@
 // app/(auth)/sign-up/page.tsx
-import Link from "next/link";
 import ProviderLogos from "@/components/(gateway)/auth/providers";
+import { AuthWordmark } from "@/components/(gateway)/auth/AuthWordmark";
 import SupportedModelsStats from "@/components/landingPage/Auth/SupportedModelsStats";
 import KeyModels from "@/components/landingPage/Auth/KeyModels";
 import { Suspense } from "react";
@@ -31,20 +31,14 @@ export default async function Page({ searchParams }: SignUpPageProps) {
 	return (
 		<div className="grid min-h-svh lg:grid-cols-2">
 			{/* LEFT COL */}
-			<div className="relative flex flex-col p-6 md:p-10">
+			<div className="flex flex-col p-6 md:p-10">
 				{/* Brand link overlayed top-left; doesn’t push content down */}
-				<Link
-					href="/"
-					className="absolute left-6 top-6 md:left-10 md:top-10 z-10 inline-flex items-center gap-2 font-medium"
-					aria-label="AI Stats home"
-				>
-					<span className="inline text-2xl font-semibold tracking-tight select-none">
-						AI Stats
-					</span>
-				</Link>
+				<div className="shrink-0">
+					<AuthWordmark />
+				</div>
 
 				{/* Centre the login card */}
-				<div className="flex flex-1 items-center justify-center">
+				<div className="flex flex-1 items-start justify-center pt-10 md:items-center md:pt-0">
 					<div className="mx-auto w-full max-w-xs">
 						<Suspense fallback={<div>Loading…</div>}>
 							<SignUp returnUrl={returnUrl} />

--- a/apps/web/src/components/(gateway)/auth/AuthWordmark.tsx
+++ b/apps/web/src/components/(gateway)/auth/AuthWordmark.tsx
@@ -1,0 +1,29 @@
+import Image from "next/image";
+import Link from "next/link";
+
+export function AuthWordmark() {
+	return (
+		<Link
+			href="/"
+			aria-label="AI Stats home"
+			className="inline-flex items-center transition-opacity hover:opacity-80"
+		>
+			<Image
+				src="/wordmark_light.svg"
+				alt="AI Stats"
+				width={154}
+				height={40}
+				className="h-8 w-auto select-none dark:hidden"
+				priority
+			/>
+			<Image
+				src="/wordmark_dark.svg"
+				alt="AI Stats"
+				width={154}
+				height={40}
+				className="hidden h-8 w-auto select-none dark:block"
+				priority
+			/>
+		</Link>
+	);
+}

--- a/apps/web/src/components/(gateway)/auth/Login.tsx
+++ b/apps/web/src/components/(gateway)/auth/Login.tsx
@@ -45,10 +45,6 @@ export async function Login({
 		<div className="flex flex-col gap-6">
 			<div className="flex flex-col items-center gap-2 text-center">
 				<h1 className="text-2xl font-bold">Welcome back</h1>
-				<p className="text-sm text-muted-foreground">
-					Sign in or sign up to access the AI Stats Gateway and
-					start exploring the insights you need.
-				</p>
 			</div>
 
 			{signupNoticeText ? (


### PR DESCRIPTION
## Summary
- replace the auth page text label with the shared AI Stats wordmark
- stop overlaying the brand over the auth card on small screens
- tighten the mobile spacing above the sign-in heading and remove the extra subtitle copy

## Testing
- `git diff --check`
- verified the sign-in page in the in-app browser on `http://localhost:3100/sign-in`
- full repo lint/typecheck/build not run


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a responsive wordmark component to authentication pages displaying brand imagery that adapts to light and dark modes

* **Style**
  * Refined layout and alignment on sign-in and sign-up pages with responsive spacing and positioning adjustments
  * Removed descriptive text from login interface for a cleaner appearance

<!-- end of auto-generated comment: release notes by coderabbit.ai -->