### PR TITLE
[codex] Add CrofAI catalog and discovery coverage

### DIFF
--- a/apps/api/src/pipeline/before/context.sql
+++ b/apps/api/src/pipeline/before/context.sql
@@ -433,6 +433,10 @@ begin
           with rules as (
             select r.*
             from public.data_api_pricing_rules r
+            -- TODO: Redesign pricing selection to key on provider_api_model_id or
+            -- explicit variant metadata so provider-only SKUs (for example CrofAI
+            -- precision tiers) can share a parent internal model without forcing
+            -- distinct api_model_id values just to preserve pricing separation.
             where r.model_key =
               pr.provider_id || ':' || resolved_model || ':' || gateway_fetch_request_context.endpoint
               and r.capability_id = gateway_fetch_request_context.endpoint

--- a/packages/data/catalog/src/data/api_providers/crofai/models.json
+++ b/packages/data/catalog/src/data/api_providers/crofai/models.json
@@ -21,7 +21,7 @@
     ]
   },
   {
-    "api_model_id": "deepseek/deepseek-v4-pro",
+    "api_model_id": "deepseek/deepseek-v4-pro-precision",
     "provider_api_model_id": "crofai:deepseek-v4-pro-precision",
     "provider_model_slug": "deepseek-v4-pro-precision",
     "internal_model_id": "deepseek/deepseek-v4-pro",
@@ -105,7 +105,7 @@
     ]
   },
   {
-    "api_model_id": "z-ai/glm-5.1",
+    "api_model_id": "z-ai/glm-5.1-precision",
     "provider_api_model_id": "crofai:glm-5.1-precision",
     "provider_model_slug": "glm-5.1-precision",
     "internal_model_id": "z-ai/glm-5.1",
@@ -168,7 +168,7 @@
     ]
   },
   {
-    "api_model_id": "moonshotai/kimi-k2.6",
+    "api_model_id": "moonshotai/kimi-k2.6-precision",
     "provider_api_model_id": "crofai:kimi-k2.6-precision",
     "provider_model_slug": "kimi-k2.6-precision",
     "internal_model_id": "moonshotai/kimi-k2.6",


### PR DESCRIPTION
## What changed

- add CrofAI as a discovered provider in model discovery, including unauthenticated `/v1/models` support and provider pricing-watch coverage alongside AtlasCloud
- add CrofAI catalog data for the currently documented model set, marked `coming_soon`, including quantization, context length, max output, organisation metadata, and pricing files
- add CrofAI DeepSeek V4 variants now exposed by CrofAI (`deepseek-v4-pro-precision` and `deepseek-v4-flash`) and correct CrofAI `deepseek-v4-pro` pricing to the current live values
- extend the official DeepSeek `deepseek-v4-pro` 75% discount window to May 31, 2026 15:59 UTC

## Why

CrofAI was missing from the provider catalog and model-discovery pipeline, so its models and pricing were not being tracked. DeepSeek's V4 Pro discount end date had also changed in the upstream docs and needed to be kept current.

## Impact

- CrofAI now appears in provider discovery and pricing monitoring
- CrofAI model metadata and pricing are captured in the catalog as coming soon
- DeepSeek V4 Pro discount timing in the catalog matches the current official docs

## Validation

- `pnpm validate:data`
- `pnpm validate:pricing`
- `pnpm exec tsx scripts/model-discovery/validate-providers.ts`
