### PR TITLE
[codex] update Arcee pricing data

### DIFF
--- a/packages/data/catalog/src/data/pricing/arcee-ai/arcee-ai-trinity-large-thinking/text.generate/pricing.json
+++ b/packages/data/catalog/src/data/pricing/arcee-ai/arcee-ai-trinity-large-thinking/text.generate/pricing.json
@@ -14,18 +14,20 @@
       "pricing_plan": "standard",
       "note": null,
       "match": [],
-      "priority": 100
+      "priority": 100,
+      "effective_from": "2026-04-22T00:00:00"
     },
     {
       "meter": "output_text_tokens",
       "unit": "token",
       "unit_size": 1000000,
-      "price_per_unit": 0.9,
+      "price_per_unit": 0.8,
       "currency": "USD",
       "pricing_plan": "standard",
       "note": null,
       "match": [],
-      "priority": 100
+      "priority": 100,
+      "effective_from": "2026-04-22T00:00:00"
     }
   ]
 }

--- a/packages/data/catalog/src/data/pricing/arcee-ai/arcee-ai-trinity-large/text.generate/pricing.json
+++ b/packages/data/catalog/src/data/pricing/arcee-ai/arcee-ai-trinity-large/text.generate/pricing.json
@@ -9,25 +9,25 @@
       "meter": "input_text_tokens",
       "unit": "token",
       "unit_size": 1000000,
-      "price_per_unit": 0.25,
+      "price_per_unit": 0.45,
       "currency": "USD",
       "pricing_plan": "standard",
       "note": null,
       "match": [],
       "priority": 100,
-      "effective_from": "2026-01-27T00:00:00"
+      "effective_from": "2026-04-22T00:00:00"
     },
     {
       "meter": "output_text_tokens",
       "unit": "token",
       "unit_size": 1000000,
-      "price_per_unit": 1,
+      "price_per_unit": 0.15,
       "currency": "USD",
       "pricing_plan": "standard",
       "note": null,
       "match": [],
       "priority": 100,
-      "effective_from": "2026-01-27T00:00:00"
+      "effective_from": "2026-04-22T00:00:00"
     }
   ]
 }


### PR DESCRIPTION
## What changed
- updated Arcee `Trinity-Large-Preview` pricing to `$0.45` input / `$0.15` output per 1M tokens
- updated Arcee `Trinity-Large-Thinking` output pricing to `$0.80` per 1M tokens
- set `effective_from` to `2026-04-22T00:00:00` for the changed Arcee pricing records

## Why
Arcee's live pricing page currently renders values that differ from the catalog data on `main`.

## Impact
This keeps the provider pricing catalog aligned with the current Arcee documentation for downstream UI, API, and SDK consumers.

## Root cause
The catalog still reflected older Arcee pricing, and an earlier doc text extraction path returned stale values rather than the page's currently rendered HTML table.

## Validation
- `pnpm validate:data`

## Source
- https://docs.arcee.ai/get-started/pricing