### PR TITLE
Fix auth page metrics

### DIFF
--- a/apps/web/src/components/landingPage/Auth/SupportedModelsStats.tsx
+++ b/apps/web/src/components/landingPage/Auth/SupportedModelsStats.tsx
@@ -3,12 +3,6 @@ import Link from "next/link";
 import { getSupportedModelsStatsCached } from "@/lib/fetchers/landing/sign-in/getSupportedModelsStats";
 import { resolveIncludeHidden } from "@/lib/fetchers/models/visibility";
 
-function roundBucket(value: number, bucket: number) {
-	if (bucket <= 0) return { value, rounded: false } as const;
-	const roundedValue = Math.round(value / bucket) * bucket;
-	return { value: roundedValue, rounded: roundedValue !== value } as const;
-}
-
 function formatWithK(value: number) {
 	if (value >= 1000) {
 		const v = value / 1000;
@@ -36,33 +30,25 @@ export default async function SupportedModelsStats() {
 		// noop - fallback to defaults
 	}
 
-	const modelsRounded = roundBucket(modelsCount, 25);
-	const orgsRounded = roundBucket(orgsCount, 10);
-	const apiRounded = roundBucket(apiCount, 25);
-
 	const stats = [
 		{
 			label: "Total Models",
-			raw: modelsRounded.value,
-			rounded: modelsRounded.rounded,
+			raw: modelsCount,
 			route: "/models",
 		},
 		{
 			label: "Organisations",
-			raw: orgsRounded.value,
-			rounded: orgsRounded.rounded,
+			raw: orgsCount,
 			route: "/providers",
 		},
 		{
 			label: "API Models",
-			raw: apiRounded.value,
-			rounded: apiRounded.rounded,
+			raw: apiCount,
 			route: "/prices",
 		},
 		{
 			label: "New (90d)",
 			raw: recentCount,
-			rounded: false,
 			route: "/models",
 		},
 	];
@@ -81,7 +67,6 @@ export default async function SupportedModelsStats() {
 							<CardTitle className="text-2xl font-bold">
 								<span className="text-2xl font-bold tabular-nums">
 									{formatWithK(stat.raw)}
-									{stat.rounded ? "+" : ""}
 								</span>
 							</CardTitle>
 						</CardHeader>

--- a/apps/web/src/lib/fetchers/landing/sign-in/getSupportedModelsStats.ts
+++ b/apps/web/src/lib/fetchers/landing/sign-in/getSupportedModelsStats.ts
@@ -22,10 +22,31 @@ type ActiveGatewayModelRow = {
     api_model_id?: string | null;
 };
 
+const PAGE_SIZE = 1000;
+
 function toDateMs(value: string | null | undefined): number | null {
     if (!value) return null;
     const ms = Date.parse(String(value).trim());
     return Number.isNaN(ms) ? null : ms;
+}
+
+async function fetchAllRows<T>(fetchPage: (from: number, to: number) => Promise<{ data: T[] | null; error: unknown }>) {
+    const rows: T[] = [];
+    let from = 0;
+
+    while (true) {
+        const to = from + PAGE_SIZE - 1;
+        const { data, error } = await fetchPage(from, to);
+        if (error) throw error;
+
+        const page = Array.isArray(data) ? data : [];
+        rows.push(...page);
+
+        if (page.length < PAGE_SIZE) break;
+        from += PAGE_SIZE;
+    }
+
+    return rows;
 }
 
 async function fetchStats(includeHidden: boolean): Promise<SupportedModelsStats> {
@@ -42,25 +63,24 @@ async function fetchStats(includeHidden: boolean): Promise<SupportedModelsStats>
     };
 
     try {
-        const [modelsRes, apiModelsRes] = await Promise.all([
-            applyHiddenFilter(
-                supabase
-                    .from('data_models')
-                    .select('model_id, organisation_id, announcement_date, release_date', { count: 'exact' }),
-                includeHidden
+        const [visibleModels, apiProviderModels] = await Promise.all([
+            fetchAllRows<VisibleModelStatRow>((from, to) =>
+                applyHiddenFilter(
+                    supabase
+                        .from('data_models')
+                        .select('model_id, organisation_id, announcement_date, release_date')
+                        .range(from, to),
+                    includeHidden
+                )
             ),
-            supabase
-                .from('data_api_provider_models')
-                .select('model_id, internal_model_id, api_model_id')
-                .eq('is_active_gateway', true),
+            fetchAllRows<ActiveGatewayModelRow>((from, to) =>
+                supabase
+                    .from('data_api_provider_models')
+                    .select('model_id, internal_model_id, api_model_id')
+                    .eq('is_active_gateway', true)
+                    .range(from, to)
+            ),
         ]);
-
-        const getCount = (res: { count: number | null; error: any } | any) => {
-            if (res?.error) return 0;
-            return res.count ?? 0;
-        };
-
-        const visibleModels: VisibleModelStatRow[] = Array.isArray(modelsRes.data) ? modelsRes.data : [];
         const visibleModelIds = new Set(
             visibleModels
                 .map((model) => model.model_id)
@@ -75,7 +95,7 @@ async function fetchStats(includeHidden: boolean): Promise<SupportedModelsStats>
                 )
         );
         const activeGatewayModels = new Set(
-            ((Array.isArray(apiModelsRes.data) ? apiModelsRes.data : []) as ActiveGatewayModelRow[])
+            apiProviderModels
                 .map((model) => model.model_id ?? model.internal_model_id ?? model.api_model_id)
                 .filter((modelId): modelId is string => typeof modelId === 'string' && visibleModelIds.has(modelId))
         );

--- a/apps/web/src/lib/fetchers/landing/sign-in/getSupportedModelsStats.ts
+++ b/apps/web/src/lib/fetchers/landing/sign-in/getSupportedModelsStats.ts
@@ -30,7 +30,9 @@ function toDateMs(value: string | null | undefined): number | null {
     return Number.isNaN(ms) ? null : ms;
 }
 
-async function fetchAllRows<T>(fetchPage: (from: number, to: number) => Promise<{ data: T[] | null; error: unknown }>) {
+async function fetchAllRows<T>(
+    fetchPage: (from: number, to: number) => PromiseLike<{ data: T[] | null; error: unknown }>
+) {
     const rows: T[] = [];
     let from = 0;
 

--- a/apps/web/src/lib/fetchers/landing/sign-in/getSupportedModelsStats.ts
+++ b/apps/web/src/lib/fetchers/landing/sign-in/getSupportedModelsStats.ts
@@ -9,6 +9,25 @@ export interface SupportedModelsStats {
     recentCount: number;
 }
 
+type VisibleModelStatRow = {
+    model_id: string | null;
+    organisation_id: string | null;
+    announcement_date: string | null;
+    release_date: string | null;
+};
+
+type ActiveGatewayModelRow = {
+    model_id?: string | null;
+    internal_model_id?: string | null;
+    api_model_id?: string | null;
+};
+
+function toDateMs(value: string | null | undefined): number | null {
+    if (!value) return null;
+    const ms = Date.parse(String(value).trim());
+    return Number.isNaN(ms) ? null : ms;
+}
+
 async function fetchStats(includeHidden: boolean): Promise<SupportedModelsStats> {
     const supabase = await createClient();
 
@@ -23,23 +42,17 @@ async function fetchStats(includeHidden: boolean): Promise<SupportedModelsStats>
     };
 
     try {
-        const [modelsRes, orgsRes, apiModelsRes, recentRes] = await Promise.all([
-            applyHiddenFilter(
-                supabase.from('data_models').select('*', { count: 'exact', head: true }),
-                includeHidden
-            ),
-            supabase.from('data_organisations').select('*', { count: 'exact', head: true }),
-            supabase
-                .from('data_api_provider_models')
-                .select('*', { count: 'exact', head: true })
-                .eq('is_active_gateway', true),
+        const [modelsRes, apiModelsRes] = await Promise.all([
             applyHiddenFilter(
                 supabase
                     .from('data_models')
-                    .select('*', { count: 'exact', head: true })
-                    .gte('created_at', cutoff),
+                    .select('model_id, organisation_id, announcement_date, release_date', { count: 'exact' }),
                 includeHidden
             ),
+            supabase
+                .from('data_api_provider_models')
+                .select('model_id, internal_model_id, api_model_id')
+                .eq('is_active_gateway', true),
         ]);
 
         const getCount = (res: { count: number | null; error: any } | any) => {
@@ -47,11 +60,42 @@ async function fetchStats(includeHidden: boolean): Promise<SupportedModelsStats>
             return res.count ?? 0;
         };
 
+        const visibleModels: VisibleModelStatRow[] = Array.isArray(modelsRes.data) ? modelsRes.data : [];
+        const visibleModelIds = new Set(
+            visibleModels
+                .map((model) => model.model_id)
+                .filter((modelId): modelId is string => typeof modelId === 'string' && modelId.length > 0)
+        );
+        const organisationIds = new Set(
+            visibleModels
+                .map((model) => model.organisation_id)
+                .filter(
+                    (organisationId): organisationId is string =>
+                        typeof organisationId === 'string' && organisationId.length > 0
+                )
+        );
+        const activeGatewayModels = new Set(
+            ((Array.isArray(apiModelsRes.data) ? apiModelsRes.data : []) as ActiveGatewayModelRow[])
+                .map((model) => model.model_id ?? model.internal_model_id ?? model.api_model_id)
+                .filter((modelId): modelId is string => typeof modelId === 'string' && visibleModelIds.has(modelId))
+        );
+        const cutoffMs = Date.parse(cutoff);
+        const nowMs = now;
+        const recentCount = visibleModels.filter((model) => {
+            const announcementMs = toDateMs(model.announcement_date);
+            const releaseMs = toDateMs(model.release_date);
+
+            const isRecent = (dateMs: number | null) =>
+                dateMs !== null && dateMs >= cutoffMs && dateMs <= nowMs;
+
+            return isRecent(announcementMs) || isRecent(releaseMs);
+        }).length;
+
         return {
-            modelsCount: getCount(modelsRes),
-            orgsCount: getCount(orgsRes),
-            apiCount: getCount(apiModelsRes),
-            recentCount: getCount(recentRes),
+            modelsCount: visibleModels.length,
+            orgsCount: organisationIds.size,
+            apiCount: activeGatewayModels.size,
+            recentCount,
         };
     } catch (err) {
         // swallow and return defaults; caller will handle fallback behaviour


### PR DESCRIPTION
## Summary
- stop rounding the auth page metrics so the sign-in/sign-up stats show exact values
- compute organisation and API model counts from the visible catalog rather than raw mapping row counts
- change `New (90d)` to use model announcement/release dates instead of row `created_at`

## Verification
- `pnpm --filter @ai-stats/web typecheck`