### PR TITLE
fix(ci): stabilize scorecard and aimock checks

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -25,7 +25,7 @@ jobs:
           persist-credentials: false
 
       - name: Run OpenSSF Scorecard
-        uses: ossf/scorecard-action@99c09fe975337306107572b4fdf4db224cf8e2f2
+        uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a
         with:
           results_file: scorecard-results.sarif
           results_format: sarif

--- a/apps/api/src/pipeline/execute/health.ts
+++ b/apps/api/src/pipeline/execute/health.ts
@@ -88,6 +88,7 @@ const l1State = new Map<string, L1StateEntry>();
 const pendingBackgroundSaves = new Map<string, { map: Record<string, string>; ttlSeconds: number }>();
 const activeBackgroundSave = new Set<string>();
 const keyUpdateQueues = new Map<string, Array<() => void>>();
+let healthStateEpoch = 0;
 
 async function withKeyUpdateLock<T>(key: string, fn: () => Promise<T>): Promise<T> {
     const queue = keyUpdateQueues.get(key);
@@ -269,10 +270,13 @@ async function persistMapWithMerge(
     key: string,
     candidateMap: Record<string, string>,
     ttlSeconds: number,
+    epoch = healthStateEpoch,
 ) {
+    if (epoch !== healthStateEpoch) return;
     try {
         let mapToWrite = { ...candidateMap };
         const raw = await getCache().get(key, "text");
+        if (epoch !== healthStateEpoch) return;
         if (raw) {
             try {
                 const existing = normalizeMap(JSON.parse(raw));
@@ -287,7 +291,9 @@ async function persistMapWithMerge(
                 // Ignore malformed existing payload; candidate map is authoritative.
             }
         }
+        if (epoch !== healthStateEpoch) return;
         await getCache().put(key, JSON.stringify(mapToWrite), { expirationTtl: ttlSeconds });
+        if (epoch !== healthStateEpoch) return;
         l1State.set(key, { map: { ...mapToWrite }, expiresAtMs: Date.now() + HEALTH_L1_TTL_MS });
     } catch {
         // Ignore KV write failures.
@@ -330,18 +336,20 @@ async function loadMapByKey(key: string): Promise<Record<string, string>> {
 function queueBackgroundSave(key: string) {
     if (activeBackgroundSave.has(key)) return;
     activeBackgroundSave.add(key);
+    const epoch = healthStateEpoch;
 
     dispatchBackground((async () => {
         try {
             while (true) {
+                if (epoch !== healthStateEpoch) return;
                 const pending = pendingBackgroundSaves.get(key);
                 if (!pending) return;
                 pendingBackgroundSaves.delete(key);
-                await persistMapWithMerge(key, pending.map, pending.ttlSeconds);
+                await persistMapWithMerge(key, pending.map, pending.ttlSeconds, epoch);
             }
         } finally {
             activeBackgroundSave.delete(key);
-            if (pendingBackgroundSaves.has(key)) {
+            if (epoch === healthStateEpoch && pendingBackgroundSaves.has(key)) {
                 queueBackgroundSave(key);
             }
         }
@@ -698,6 +706,14 @@ export async function maybeOpenOnRecentErrors(
 
     const errRate = 1 - (ok / Math.max(tot, 1));
     if (errRate >= threshold) await openBreaker(endpoint, provider, model);
+}
+
+export function resetHealthStateForTests(): void {
+    healthStateEpoch += 1;
+    l1State.clear();
+    pendingBackgroundSaves.clear();
+    activeBackgroundSave.clear();
+    keyUpdateQueues.clear();
 }
 
 export async function onCallStart(endpoint: Endpoint, provider: string, model: string) {

--- a/apps/api/tests/aimock/harness.ts
+++ b/apps/api/tests/aimock/harness.ts
@@ -6,6 +6,7 @@ import { Journal, LLMock, flattenHeaders, type Mountable, type RecordConfig } fr
 import { decodeProtocol, encodeProtocol } from "@protocols/index";
 import { resolveProviderExecutor } from "@executors/index";
 import { OPENAI_COMPAT_CONFIG } from "@providers/openai-compatible/config";
+import { resetHealthStateForTests } from "@pipeline/execute/health";
 import { setupRuntimeFromEnv, teardownTestRuntime } from "../helpers/runtime";
 import type { ExecutorCompletedResult, ExecutorResult } from "@executors/types";
 import type { Endpoint } from "@core/types";
@@ -317,6 +318,7 @@ export function resetAimockState(): void {
     if (!aimock) return;
     aimock.clearRequests();
     aimock.resetMatchCounts();
+    resetHealthStateForTests();
     teardownTestRuntime();
     setupRuntimeFromEnv(buildAimockBindings());
 }

--- a/apps/api/tests/aimock/pipeline-failover.spec.ts
+++ b/apps/api/tests/aimock/pipeline-failover.spec.ts
@@ -16,11 +16,25 @@ import {
 const PROTOCOL = "openai.chat.completions" as const;
 
 type FailoverCase = {
+    gatewayModel: string;
+    expectedPrimaryStatus: number;
     prompt: string;
     primaryModel: string;
     secondaryModel: string;
     expectedText: string;
 };
+
+async function waitForAimockRequests(expectedCount: number, timeoutMs = 250) {
+    const deadline = Date.now() + timeoutMs;
+    while (Date.now() < deadline) {
+        const requests = getAimock().getRequests();
+        if (requests.length >= expectedCount) {
+            return requests;
+        }
+        await new Promise((resolve) => setTimeout(resolve, 10));
+    }
+    return getAimock().getRequests();
+}
 
 function candidate(providerId: string, providerModelSlug: string, baseWeight: number): ProviderCandidate {
     const adapter = adapterFor(providerId, "chat.completions");
@@ -51,8 +65,11 @@ function candidate(providerId: string, providerModelSlug: string, baseWeight: nu
 
 function buildContext(testCase: FailoverCase): PipelineContext {
     const body = {
-        model: "aimock-openai-model",
+        model: testCase.gatewayModel,
         messages: [{ role: "user", content: testCase.prompt }],
+        provider: {
+            order: ["openai", "x-ai"],
+        },
     };
 
     return {
@@ -110,12 +127,16 @@ describe("AIMock pipeline failover", () => {
     if (isScenarioEnabled("failover")) {
         it.each<FailoverCase>([
             {
+                gatewayModel: "aimock-fallback-gateway-model",
+                expectedPrimaryStatus: 500,
                 prompt: "[aimock-fallback] route",
                 primaryModel: "aimock-primary-fallback",
                 secondaryModel: "aimock-secondary-fallback",
                 expectedText: "Fallback provider succeeded",
             },
             {
+                gatewayModel: "aimock-fallback-429-gateway-model",
+                expectedPrimaryStatus: 429,
                 prompt: "[aimock-fallback-429] route",
                 primaryModel: "aimock-primary-fallback-429",
                 secondaryModel: "aimock-secondary-fallback-429",
@@ -144,12 +165,27 @@ describe("AIMock pipeline failover", () => {
             const payload = encodeProtocol(PROTOCOL, outcome.result.ir as any, ctx.requestId);
             expect(payload?.choices?.[0]?.message?.content).toContain(testCase.expectedText);
 
-            const requests = getAimock().getRequests();
-            expect(requests.length).toBe(2);
-            expect(requests[0]?.body?.model).toBe(testCase.primaryModel);
-            expect(requests[1]?.body?.model).toBe(testCase.secondaryModel);
-            expect(requests[0]?.headers["x-test-id"]).toBe(ctx.meta.testId);
-            expect(requests[1]?.headers["x-test-id"]).toBe(ctx.meta.testId);
+            expect(ctx.attemptErrors).toEqual(expect.arrayContaining([
+                expect.objectContaining({
+                    provider: "openai",
+                    type: "upstream_non_2xx",
+                    status: testCase.expectedPrimaryStatus,
+                }),
+            ]));
+
+            const requests = await waitForAimockRequests(1);
+            const providerModels = requests.map((request) => request?.body?.model);
+            expect(providerModels).toContain(testCase.secondaryModel);
+
+            const primaryIndex = providerModels.indexOf(testCase.primaryModel);
+            const secondaryIndex = providerModels.indexOf(testCase.secondaryModel);
+            if (primaryIndex >= 0 && secondaryIndex >= 0) {
+                expect(primaryIndex).toBeLessThan(secondaryIndex);
+            }
+
+            for (const request of requests) {
+                expect(request?.headers["x-test-id"]).toBe(ctx.meta.testId);
+            }
         });
     }
 });


### PR DESCRIPTION
## Summary

This fixes two separate recent CI failures.

The first is the `Scorecard` workflow on `main`, which was failing because `.github/workflows/scorecard.yml` pinned `ossf/scorecard-action` to an invalid SHA that Scorecard rejects as an imposter commit. This updates the workflow to the upstream `v2.4.3` action commit.

The second is the flaky `API AIMock matrix` failure in `tests/aimock/pipeline-failover.spec.ts`. The test was assuming the router would always try `openai` before `x-ai`, but the default routing path is weighted and non-strict, so CI could legitimately select the fallback candidate first. That made the test intermittently fail with `expected 1 to be 2` even when the gateway behavior was otherwise healthy.

## Changes

- update the Scorecard workflow pin to the upstream `ossf/scorecard-action` `v2.4.3` commit
- add a test-only execute health reset so AIMock cases do not inherit in-memory health state across runs
- make the AIMock failover test deterministic by explicitly requesting provider order in the test request
- assert failover via the pipeline's recorded primary upstream error, while still checking AIMock request evidence without depending on a brittle synchronous two-request assumption

## Validation

- `pnpm --filter @ai-stats/gateway-api run typecheck`
- `pnpm --filter @ai-stats/gateway-api test:aimock`
- `pnpm --filter @ai-stats/gateway-api exec vitest run tests/aimock/pipeline-failover.spec.ts --fileParallelism=false` repeated 8 times cleanly


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test infrastructure with improved health-state reset mechanisms to prevent stale background writes from affecting test results
  * Refactored pipeline failover test cases to better validate error handling, upstream provider ordering, and model selection behavior

* **Chores**
  * Updated GitHub Actions security scanning workflow configuration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->