### PR TITLE
fix(ci): update scorecard upload-sarif pin

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -32,6 +32,6 @@ jobs:
           publish_results: true
 
       - name: Upload SARIF to GitHub Security
-        uses: github/codeql-action/upload-sarif@b25d0ebf40e5b63ee81e1bd6e5d2a12b7c2aeb61
+        uses: github/codeql-action/upload-sarif@38697555549f1db7851b81482ff19f1fa5c4fedc
         with:
           sarif_file: scorecard-results.sarif


### PR DESCRIPTION
## Summary

This fixes the remaining `Scorecard` workflow failure on `main` after #413.

The first follow-up updated the `ossf/scorecard-action` pin, which removed the original imposter-commit rejection. The workflow was still failing during Scorecard result publication because the `Upload SARIF to GitHub Security` step was pinned to a `github/codeql-action/upload-sarif` commit that Scorecard also rejects during workflow verification.

This PR updates that `upload-sarif` pin to the current upstream commit used by OpenSSF's own `scorecard-analysis.yml` example workflow.

## Change

- update `github/codeql-action/upload-sarif` in `.github/workflows/scorecard.yml` from `b25d0ebf40e5b63ee81e1bd6e5d2a12b7c2aeb61` to `38697555549f1db7851b81482ff19f1fa5c4fedc`

## Validation

- confirmed the failing `main` Scorecard log was: `imposter commit ... does not belong to github/codeql-action/upload-sarif`
- confirmed OpenSSF's upstream `scorecard-analysis.yml` currently uses `github/codeql-action/upload-sarif@38697555549f1db7851b81482ff19f1fa5c4fedc`
