### PR TITLE
fix web models filter button styling and pricing labels

### DIFF
--- a/apps/web/src/components/(data)/models/Models/ModelCard.tsx
+++ b/apps/web/src/components/(data)/models/Models/ModelCard.tsx
@@ -268,6 +268,14 @@ function normalizeFromPriceUnit(value: string | null | undefined): string | null
 		.trim()
 		.toLowerCase();
 	if (!normalized) return null;
+	if (
+		normalized === "1m token" ||
+		normalized === "1m tokens" ||
+		normalized === "per 1m token" ||
+		normalized === "per 1m tokens"
+	) {
+		return "1M tokens";
+	}
 	if (normalized === "token" || normalized === "tokens") return "1M tokens";
 	if (normalized === "sec" || normalized === "secs" || normalized === "seconds") {
 		return "second";

--- a/apps/web/src/components/(data)/models/Models/ModelCard.tsx
+++ b/apps/web/src/components/(data)/models/Models/ModelCard.tsx
@@ -472,19 +472,24 @@ function ModelCardImpl({
 		{ allowZero: true },
 	);
 	const tokenPriceCandidates = [model.lowest_input_price, model.lowest_output_price]
+		.filter((value) => value !== null && value !== undefined)
 		.map((value) => Number(value))
 		.filter((value) => Number.isFinite(value) && value >= 0);
 	const standardTokenPriceCandidates = [
 		model.lowest_standard_input_price,
 		model.lowest_standard_output_price,
 	]
+		.filter((value) => value !== null && value !== undefined)
 		.map((value) => Number(value))
 		.filter((value) => Number.isFinite(value) && value >= 0);
 	const fallbackFromPrice =
 		tokenPriceCandidates.length > 0
 			? formatFromPrice(Math.min(...tokenPriceCandidates), "1M tokens")
 			: null;
-	const hasFreeFromPrice = Number(model.lowest_from_price) === 0;
+	const normalizedFromPriceUnit = normalizeFromPriceUnit(model.lowest_from_price_unit);
+	const hasFreeFromPrice =
+		Number(model.lowest_from_price) === 0 &&
+		normalizedFromPriceUnit === "1M tokens";
 	const isFreeTextModel =
 		isTextModel &&
 		(

--- a/apps/web/src/components/(data)/models/Models/ModelsDisplay.tsx
+++ b/apps/web/src/components/(data)/models/Models/ModelsDisplay.tsx
@@ -1323,9 +1323,8 @@ export default function ModelsDisplay({
 						<div className="flex items-center gap-2">
 							<Button
 								type="button"
-								variant="outline"
 								size="sm"
-								className="h-8 flex-1 justify-center gap-1.5"
+								className="h-8 flex-1 justify-center gap-1.5 border border-border/70 bg-background text-foreground shadow-xs transition-colors hover:bg-muted/45 dark:border-border/70 dark:bg-background dark:text-foreground dark:hover:bg-muted/25"
 								onClick={() => setMobileFiltersOpen(true)}
 							>
 								<SlidersHorizontal className="h-3.5 w-3.5" />
@@ -1380,9 +1379,8 @@ export default function ModelsDisplay({
 								</div>
 								<Button
 									type="button"
-									variant="outline"
 									size="sm"
-									className="h-8 gap-1.5 lg:hidden"
+									className="h-8 gap-1.5 border border-border/70 bg-background text-foreground shadow-xs transition-colors hover:bg-muted/45 dark:border-border/70 dark:bg-background dark:text-foreground dark:hover:bg-muted/25 lg:hidden"
 									onClick={() => setMobileFiltersOpen(true)}
 								>
 									<SlidersHorizontal className="h-3.5 w-3.5" />
@@ -1481,10 +1479,11 @@ export default function ModelsDisplay({
 
 			<Button
 				type="button"
+				variant="outline"
 				size="sm"
 				onClick={() => setMobileFiltersOpen(true)}
 				className={cn(
-					"fixed bottom-6 left-4 z-40 inline-flex h-11 items-center gap-2 rounded-full border border-border/70 bg-background/95 px-4 text-foreground shadow-sm backdrop-blur transition-all duration-200 active:scale-95 sm:hidden",
+					"fixed bottom-6 left-4 z-40 inline-flex h-11 items-center gap-2 rounded-full border border-border/70 !bg-background px-4 !text-foreground shadow-sm transition-all duration-200 hover:scale-105 hover:shadow-md dark:!border-zinc-800 dark:!bg-zinc-950 dark:!text-zinc-50 active:scale-95 sm:hidden",
 					showMobileFilterFab && !mobileFiltersOpen
 						? "translate-y-0 opacity-100"
 						: "pointer-events-none translate-y-3 opacity-0",
@@ -1504,7 +1503,7 @@ export default function ModelsDisplay({
 				aria-label="Scroll to top"
 				onClick={handleScrollToTop}
 				className={cn(
-					"group fixed bottom-9 right-9 z-40 inline-flex h-11 w-11 items-center justify-center rounded-full border border-border/70 bg-background/95 text-foreground shadow-sm backdrop-blur transition-all duration-200 hover:scale-105 hover:shadow-md active:scale-95",
+					"group fixed bottom-6 right-9 z-40 inline-flex h-11 w-11 items-center justify-center rounded-full border border-border/70 bg-background/95 text-foreground shadow-sm backdrop-blur transition-all duration-200 hover:scale-105 hover:shadow-md active:scale-95",
 					showScrollTopButton
 						? "translate-y-0 opacity-100"
 						: "pointer-events-none translate-y-3 opacity-0",


### PR DESCRIPTION
## Summary

This PR packages the current models-page follow-up fixes from local review.

It tightens the mobile filter button styling so the floating Filters action is fully opaque in dark mode and visually aligned with the scroll-to-top control, while also keeping the top Filters triggers on a flatter, non-glassy treatment.

It also fixes an incorrect pricing classification on the models cards. Some non-free models, including `x-ai/grok-imagine-image` and `x-ai/grok-imagine-image-pro`, could render as `Pricing Free` because the card logic treated missing token prices as zero values and applied free-model logic too broadly when a model had text among its modalities. The updated logic now ignores null token prices and only treats a zero `from_price` as free when the unit is token-based.

## Validation

- Verified the models-page UI behavior in the local browser on `http://localhost:3100/models`
- Confirmed via local monitor-model RPC inspection that the Grok image models are not actually free in the data source
- Attempted a file-scoped ESLint run for the two touched components, but it did not return cleanly in this shell session


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

* **Bug Fixes**
  * Fixed price calculation to handle edge cases more reliably
  * Improved accuracy of free pricing tier detection

* **Style**
  * Redesigned mobile filter button styling for improved consistency
  * Enhanced floating Filters button appearance with refined colors and hover effects
  * Adjusted scroll-to-top button positioning on mobile devices

<!-- end of auto-generated comment: release notes by coderabbit.ai -->