### PR TITLE
fix(pricing): support aggregate token billing for multimodal models

### DIFF
--- a/apps/api/src/pipeline/audit/axiom.ts
+++ b/apps/api/src/pipeline/audit/axiom.ts
@@ -232,6 +232,8 @@ export function buildAxiomEvent(a: AxiomArgs) {
     }
     const costInputText = lineNanosByDim.get("input_text_tokens") ?? 0;
     const costOutputText = lineNanosByDim.get("output_text_tokens") ?? 0;
+    const costInputAggregate = lineNanosByDim.get("input_tokens") ?? 0;
+    const costOutputAggregate = lineNanosByDim.get("output_tokens") ?? 0;
     const costInputImage = lineNanosByDim.get("input_image_tokens") ?? 0;
     const costOutputImage = (lineNanosByDim.get("output_image_tokens") ?? 0) + (lineNanosByDim.get("output_image") ?? 0);
     const costInputAudio = lineNanosByDim.get("input_audio_tokens") ?? 0;
@@ -240,8 +242,20 @@ export function buildAxiomEvent(a: AxiomArgs) {
     const costOutputVideo = (lineNanosByDim.get("output_video_tokens") ?? 0) + (lineNanosByDim.get("output_video_seconds") ?? 0);
     const costCachedRead = lineNanosByDim.get("cached_read_text_tokens") ?? 0;
     const costCachedWrite = lineNanosByDim.get("cached_write_text_tokens") ?? 0;
-    const costInputTotal = costInputText + costInputImage + costInputAudio + costInputVideo + costCachedRead;
-    const costOutputTotal = costOutputText + costOutputImage + costOutputAudio + costOutputVideo + costCachedWrite;
+    const costInputTotal =
+        costInputText +
+        costInputAggregate +
+        costInputImage +
+        costInputAudio +
+        costInputVideo +
+        costCachedRead;
+    const costOutputTotal =
+        costOutputText +
+        costOutputAggregate +
+        costOutputImage +
+        costOutputAudio +
+        costOutputVideo +
+        costCachedWrite;
 
     // Derived metrics
     const tokensIn = a.usage?.input_text_tokens ?? 0;

--- a/apps/api/src/pipeline/pricing/engine.aggregate.test.ts
+++ b/apps/api/src/pipeline/pricing/engine.aggregate.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+import { computeBillSummary } from "./engine";
+import type { PriceCard } from "./types";
+
+const aggregateCard: PriceCard = {
+	provider: "gmicloud",
+	model: "nvidia/nemotron-3-nano-omni-30b-a3b-reasoning",
+	endpoint: "text.generate",
+	effective_from: null,
+	effective_to: null,
+	currency: "USD",
+	version: null,
+	rules: [
+		{
+			id: "aggregate-input",
+			pricing_plan: "standard",
+			meter: "input_tokens",
+			unit: "token",
+			unit_size: 1_000_000,
+			price_per_unit: "0.1",
+			currency: "USD",
+			match: [],
+			priority: 100,
+		},
+		{
+			id: "aggregate-output",
+			pricing_plan: "standard",
+			meter: "output_tokens",
+			unit: "token",
+			unit_size: 1_000_000,
+			price_per_unit: "0.4",
+			currency: "USD",
+			match: [],
+			priority: 100,
+		},
+	],
+};
+
+describe("pricing engine aggregate token meters", () => {
+	it("bills aggregate input/output tokens without requiring split modality meters", () => {
+		const result = computeBillSummary(
+			{
+				input_tokens: 281,
+				input_text_tokens: 281,
+				output_tokens: 8,
+				output_text_tokens: 8,
+				total_tokens: 289,
+			},
+			aggregateCard,
+			{},
+			"standard",
+		);
+
+		expect(result.lines).toHaveLength(2);
+		expect(result.lines.find((line) => line.dimension === "input_tokens")?.rule_id).toBe("aggregate-input");
+		expect(result.lines.find((line) => line.dimension === "output_tokens")?.rule_id).toBe("aggregate-output");
+		expect(result.lines.find((line) => line.dimension === "input_text_tokens")).toBeUndefined();
+		expect(result.lines.find((line) => line.dimension === "output_text_tokens")).toBeUndefined();
+		expect(result.cost_usd_str).toBe("0.000031300");
+	});
+});

--- a/apps/api/src/pipeline/pricing/engine.ts
+++ b/apps/api/src/pipeline/pricing/engine.ts
@@ -7,7 +7,9 @@ import { matchesConditions, shallowMerge, evaluateConditions } from "./condition
 import type { PriceCard, PriceRule, PricingBreakdownLine, PricingDimensionKey, PricingResult } from "./types";
 
 const KNOWN_METERS = new Set<string>([
+    "input_tokens",
     "input_text_tokens", "input_image_tokens", "input_audio_tokens", "input_video_tokens",
+    "output_tokens",
     "output_text_tokens", "output_image_tokens", "output_audio_tokens", "output_video_tokens",
     "output_image", "output_video_seconds",
     "cached_write_text_tokens", "cached_write_image_tokens", "cached_write_audio_tokens", "cached_write_video_tokens",

--- a/apps/api/src/pipeline/pricing/types.ts
+++ b/apps/api/src/pipeline/pricing/types.ts
@@ -16,10 +16,12 @@ export type PriceBand = {
 };
 
 export type PricingDimensionKey =
+    | "input_tokens"
     | "input_text_tokens"
     | "input_image_tokens"
     | "input_audio_tokens"
     | "input_video_tokens"
+    | "output_tokens"
     | "output_text_tokens"
     | "output_image_tokens"
     | "output_audio_tokens"

--- a/apps/api/src/routes/v1/control/models.catalogue.ts
+++ b/apps/api/src/routes/v1/control/models.catalogue.ts
@@ -117,12 +117,14 @@ export type CatalogueFilters = {
 };
 
 const PRICING_METERS = [
+    "input_tokens",
     "input_text_tokens",
     "input_image_tokens",
     "input_image",
     "input_video_tokens",
     "input_audio_tokens",
     "input_audio_seconds",
+    "output_tokens",
     "output_text_tokens",
     "output_image_tokens",
     "output_image",
@@ -133,7 +135,10 @@ const PRICING_METERS = [
     "cached_write_text_tokens",
 ];
 
-const TOP_PROVIDER_METERS = ["input_text_tokens", "output_text_tokens"];
+const TOP_PROVIDER_METERS = [
+    ["input_tokens", "input_text_tokens"],
+    ["output_tokens", "output_text_tokens"],
+] as const;
 
 function toStringArray(value: unknown): string[] {
     if (Array.isArray(value)) {
@@ -316,8 +321,10 @@ function getTopProvider(providerMeters: Map<string, Map<string, number>>): strin
     for (const [providerId, meters] of providerMeters) {
         let total = 0;
         let hasAny = false;
-        for (const meter of TOP_PROVIDER_METERS) {
-            const price = meters.get(meter);
+        for (const group of TOP_PROVIDER_METERS) {
+            const price = group
+                .map((meter) => meters.get(meter))
+                .find((candidate): candidate is number => candidate !== undefined);
             if (price === undefined) continue;
             total += price;
             hasAny = true;

--- a/apps/api/src/routes/v1/control/models.ts
+++ b/apps/api/src/routes/v1/control/models.ts
@@ -192,8 +192,8 @@ function inferModality(inputTypes: string[], outputTypes: string[]): string {
 function toCompatibilityPricing(pricing: PricingSummary): CompatibilityPricing {
     const meters = pricing.meters;
     return {
-        prompt: meterToUnitPrice(meters.input_text_tokens),
-        completion: meterToUnitPrice(meters.output_text_tokens),
+        prompt: meterToUnitPrice(meters.input_tokens ?? meters.input_text_tokens),
+        completion: meterToUnitPrice(meters.output_tokens ?? meters.output_text_tokens),
         request: null,
         image: meterToUnitPrice(
             meters.output_image ?? meters.input_image ?? meters.input_image_tokens ?? meters.output_image_tokens

--- a/apps/web/src/app/(dashboard)/internal/data/models/new/NewModelForm.tsx
+++ b/apps/web/src/app/(dashboard)/internal/data/models/new/NewModelForm.tsx
@@ -137,7 +137,9 @@ const PARAMETER_FLAGS = [
 ];
 
 const METER_DEFAULTS: Record<string, { unit: string; unit_size: number }> = {
+	input_tokens: { unit: "token", unit_size: 1_000_000 },
 	input_text_tokens: { unit: "token", unit_size: 1_000_000 },
+	output_tokens: { unit: "token", unit_size: 1_000_000 },
 	output_text_tokens: { unit: "token", unit_size: 1_000_000 },
 	image_pixels: { unit: "pixel", unit_size: 1_000_000 },
 	video_pixels: { unit: "pixel", unit_size: 1_000_000 },

--- a/apps/web/src/components/(data)/model/edit/tabs/PricingTab.tsx
+++ b/apps/web/src/components/(data)/model/edit/tabs/PricingTab.tsx
@@ -111,7 +111,9 @@ const OP_OPTIONS = [
 ] as const
 
 const METER_DEFAULTS: Record<string, { unit: string; unit_size: number }> = {
+  input_tokens: { unit: "token", unit_size: 1_000_000 },
   input_text_tokens: { unit: "token", unit_size: 1_000_000 },
+  output_tokens: { unit: "token", unit_size: 1_000_000 },
   output_text_tokens: { unit: "token", unit_size: 1_000_000 },
   image_pixels: { unit: "pixel", unit_size: 1_000_000 },
   video_pixels: { unit: "pixel", unit_size: 1_000_000 },

--- a/apps/web/src/components/(data)/model/pricing/ModelPricingClient.tsx
+++ b/apps/web/src/components/(data)/model/pricing/ModelPricingClient.tsx
@@ -64,6 +64,8 @@ const DEFAULT_SORT_DIRECTIONS: Record<Exclude<SortOption, "default">, SortDirect
 };
 
 const PRICING_METER_PREFERENCE = [
+    "input_tokens",
+    "output_tokens",
     "input_text_tokens",
     "output_text_tokens",
     "cached_read_text_tokens",

--- a/apps/web/src/lib/fetchers/api-providers/getAPIProvider.ts
+++ b/apps/web/src/lib/fetchers/api-providers/getAPIProvider.ts
@@ -128,7 +128,9 @@ function toBasicUnitLabel(rule: PricingRuleRow): string | null {
 function toMeterLabel(meter: string): string {
 	const normalized = meter.trim().toLowerCase();
 	const specificLabels: Record<string, string> = {
+		input_tokens: "Input Tokens",
 		input_text_tokens: "Input Text Tokens",
+		output_tokens: "Output Tokens",
 		output_text_tokens: "Output Text Tokens",
 		cached_read_text_tokens: "Cached Read Text Tokens",
 		cached_write_text_tokens: "Cached Write Text Tokens",

--- a/apps/web/src/lib/pricing/meters.ts
+++ b/apps/web/src/lib/pricing/meters.ts
@@ -1,11 +1,13 @@
 // Add/remove pricing meters in this list only.
 const CORE_PRICING_METER_VALUES = [
+  "input_tokens",
   "input_text_tokens",
   "input_image_tokens",
   "image_pixels",
   "video_pixels",
   "input_video_tokens",
   "input_audio_tokens",
+  "output_tokens",
   "output_text_tokens",
   "cached_read_text_tokens",
   "output_image",

--- a/packages/data/catalog/src/data/__tests__/validate.test.ts
+++ b/packages/data/catalog/src/data/__tests__/validate.test.ts
@@ -45,6 +45,22 @@ describe('pricing safety checks', () => {
         expect(errs.some((e) => /unknown meter/.test(e))).toBe(true);
     });
 
+    test('mixed aggregate and detailed input meters -> error', () => {
+        const bad = {
+            key: 'p:m:e',
+            api_provider_id: 'p',
+            model_id: 'm',
+            endpoint: 'e',
+            is_active_gateway: false,
+            rules: [
+                { meter: 'input_tokens', unit_size: 1, price_usd_per_unit: 0.0025, bill: { mode: 'all' } },
+                { meter: 'input_text_tokens', unit_size: 1, price_usd_per_unit: 0.0025, bill: { mode: 'all' } },
+            ],
+        };
+        const errs = checkPricingEntrySafety(bad);
+        expect(errs.some((e) => /mixed aggregate and detailed input meters/.test(e))).toBe(true);
+    });
+
     test('heuristic: output price should not be lower than input price', () => {
         const bad = {
             key: 'p:m:e',

--- a/packages/data/catalog/src/data/pricing/deepinfra/nvidia-nemotron-3-nano-omni-30b-a3b-reasoning/text.generate/pricing.json
+++ b/packages/data/catalog/src/data/pricing/deepinfra/nvidia-nemotron-3-nano-omni-30b-a3b-reasoning/text.generate/pricing.json
@@ -6,7 +6,7 @@
   "capability_id": "text.generate",
   "rules": [
     {
-      "meter": "input_text_tokens",
+      "meter": "input_tokens",
       "unit": "token",
       "unit_size": 1000000,
       "price_per_unit": 0.2,
@@ -17,7 +17,7 @@
       "priority": 100
     },
     {
-      "meter": "output_text_tokens",
+      "meter": "output_tokens",
       "unit": "token",
       "unit_size": 1000000,
       "price_per_unit": 0.8,

--- a/packages/data/catalog/src/data/pricing/gmicloud/nvidia-nemotron-3-nano-omni-30b-a3b-reasoning/text.generate/pricing.json
+++ b/packages/data/catalog/src/data/pricing/gmicloud/nvidia-nemotron-3-nano-omni-30b-a3b-reasoning/text.generate/pricing.json
@@ -6,7 +6,7 @@
   "capability_id": "text.generate",
   "rules": [
     {
-      "meter": "input_text_tokens",
+      "meter": "input_tokens",
       "unit": "token",
       "unit_size": 1000000,
       "price_per_unit": 0.1,
@@ -17,7 +17,7 @@
       "priority": 100
     },
     {
-      "meter": "output_text_tokens",
+      "meter": "output_tokens",
       "unit": "token",
       "unit_size": 1000000,
       "price_per_unit": 0.4,

--- a/packages/data/catalog/src/data/pricing/nebius-token-factory/nvidia-nemotron-3-nano-omni-30b-a3b-reasoning/text.generate/pricing.json
+++ b/packages/data/catalog/src/data/pricing/nebius-token-factory/nvidia-nemotron-3-nano-omni-30b-a3b-reasoning/text.generate/pricing.json
@@ -6,7 +6,7 @@
   "capability_id": "text.generate",
   "rules": [
     {
-      "meter": "input_text_tokens",
+      "meter": "input_tokens",
       "unit": "token",
       "unit_size": 1000000,
       "price_per_unit": 0.06,
@@ -17,7 +17,7 @@
       "priority": 100
     },
     {
-      "meter": "output_text_tokens",
+      "meter": "output_tokens",
       "unit": "token",
       "unit_size": 1000000,
       "price_per_unit": 0.24,

--- a/packages/data/catalog/src/data/validate.ts
+++ b/packages/data/catalog/src/data/validate.ts
@@ -6,6 +6,20 @@ import { PRICING_METER_VALUES } from '../../../../../apps/web/src/lib/pricing/me
 const DATA_ROOT = path.resolve(fileURLToPath(new URL('.', import.meta.url)));
 
 const KNOWN_METERS = new Set<string>(PRICING_METER_VALUES);
+const INPUT_AGGREGATE_METERS = new Set<string>(['input_tokens']);
+const INPUT_DETAILED_METERS = new Set<string>([
+    'input_text_tokens',
+    'input_image_tokens',
+    'input_audio_tokens',
+    'input_video_tokens',
+]);
+const OUTPUT_AGGREGATE_METERS = new Set<string>(['output_tokens']);
+const OUTPUT_DETAILED_METERS = new Set<string>([
+    'output_text_tokens',
+    'output_image_tokens',
+    'output_audio_tokens',
+    'output_video_tokens',
+]);
 
 const ALLOWED_BILL_MODES = new Set<string>(['all', 'over', 'between']);
 
@@ -30,6 +44,7 @@ export function isMajorError(msg: string): boolean {
         /pricing.*active.*no rules/i,
         /pricing.*invalid key/i,
         /pricing.*unknown meter/i,
+        /pricing.*mixed aggregate and detailed.*meters/i,
         /pricing.*non-positive price/i,
         /pricing.*unit_size.*invalid/i,
         /pricing.*bill mode.*invalid/i,
@@ -72,12 +87,14 @@ export function checkPricingEntrySafety(p: any): string[] {
     }
 
     if (Array.isArray(p.rules)) {
+        const metersInEntry = new Set<string>();
         for (const r of p.rules) {
             const meter = r?.meter;
             if (typeof meter !== 'string' || !KNOWN_METERS.has(meter)) {
                 errs.push(`pricing: unknown meter '${meter}' for ${api_provider_id ?? '?'}:${model_id ?? '?'}:${endpoint ?? '?'}`);
                 continue;
             }
+            metersInEntry.add(meter);
             const unit_size = parseNumericValue(r?.unit_size);
             if (unit_size === undefined || unit_size <= 0) {
                 errs.push(
@@ -92,9 +109,25 @@ export function checkPricingEntrySafety(p: any): string[] {
             }
             if (r?.bill && typeof r.bill.mode === 'string' && !ALLOWED_BILL_MODES.has(r.bill.mode)) {
                 errs.push(
-                    `pricing: bill mode invalid ('${r.bill.mode}') for ${api_provider_id ?? '?'}:${model_id ?? '?'}:${endpoint ?? '?'}`
+                    `pricing: bill mode invalid ('${r.bill.mode}') for ${api_provider_id ?? '?'}:${model_id ?? '?'}:${endpoint ?? '?'}` 
                 );
             }
+        }
+
+        const hasAggregateInput = [...INPUT_AGGREGATE_METERS].some((meter) => metersInEntry.has(meter));
+        const hasDetailedInput = [...INPUT_DETAILED_METERS].some((meter) => metersInEntry.has(meter));
+        if (hasAggregateInput && hasDetailedInput) {
+            errs.push(
+                `pricing: mixed aggregate and detailed input meters for ${api_provider_id ?? '?'}:${model_id ?? '?'}:${endpoint ?? '?'}`
+            );
+        }
+
+        const hasAggregateOutput = [...OUTPUT_AGGREGATE_METERS].some((meter) => metersInEntry.has(meter));
+        const hasDetailedOutput = [...OUTPUT_DETAILED_METERS].some((meter) => metersInEntry.has(meter));
+        if (hasAggregateOutput && hasDetailedOutput) {
+            errs.push(
+                `pricing: mixed aggregate and detailed output meters for ${api_provider_id ?? '?'}:${model_id ?? '?'}:${endpoint ?? '?'}`
+            );
         }
 
         const findPrice = (m: string) => {


### PR DESCRIPTION
## Summary
- add aggregate pricing meter support for `input_tokens` and `output_tokens`
- switch Nemotron 3 Nano Omni pricing on `gmicloud`, `deepinfra`, and `nebius-token-factory` to aggregate token billing
- keep the catalogue/editor/pricing surfaces in sync with the new aggregate meters
- add validation to block mixed aggregate+detailed token meter cards and add a focused engine test

## Validation
- `pnpm validate:data`
- `pnpm validate:pricing`
- `pnpm --filter @ai-stats/gateway-api run typecheck`
- `pnpm --filter @ai-stats/gateway-api exec vitest run src/pipeline/pricing/engine.aggregate.test.ts`

## Live checks
- direct `gmicloud` image request for Nemotron Omni returned only aggregate usage: `prompt_tokens` / `completion_tokens`
- direct `deepinfra` image request for Nemotron Omni returned only aggregate usage: `prompt_tokens` / `completion_tokens`
- direct `nebius-token-factory` image request for Nemotron Omni returned only aggregate usage: `prompt_tokens` / `completion_tokens`
- local gateway probe for `openai/gpt-5.4-nano` with an image succeeded and still priced correctly via `input_text_tokens` + `output_text_tokens`
