### PR TITLE
web: fix main CI update card date narrowing

### DIFF
--- a/apps/web/src/components/updates/UpdateCard.tsx
+++ b/apps/web/src/components/updates/UpdateCard.tsx
@@ -72,12 +72,15 @@ export default function UpdateCard({
 }: Props) {
 	const isModelRelease = badges.some((b) => b.label === "Release");
 	const visibleBadges = hideBadges ? [] : badges;
-	const canShowProviderInlineTime =
-		providerDateInline && Boolean(dateIso) && Boolean(avatar?.name);
+	const providerInlineDateIso =
+		providerDateInline && avatar?.name && dateIso ? dateIso : null;
+	const canShowProviderInlineTime = Boolean(providerInlineDateIso);
+	const headerDateIso =
+		metaPlacement === "header" && dateIso && !canShowProviderInlineTime
+			? dateIso
+			: null;
 	const showHeaderTime =
-		metaPlacement === "header" &&
-		Boolean(dateIso) &&
-		!canShowProviderInlineTime;
+		Boolean(headerDateIso);
 	const showFooterMeta =
 		metaPlacement === "footer" &&
 		(Boolean(dateIso) || (Boolean(accentClass) && showAccentDot));
@@ -122,10 +125,10 @@ export default function UpdateCard({
 								);
 							})}
 						</div>
-						{showHeaderTime ? (
+						{headerDateIso ? (
 							<div className="shrink-0 text-xs text-zinc-500 dark:text-zinc-400">
 								<TimeDisplay
-									dateIso={dateIso as string}
+									dateIso={headerDateIso}
 									isModelRelease={isModelRelease}
 								/>
 							</div>
@@ -192,10 +195,10 @@ export default function UpdateCard({
 										{avatar.name}
 									</span>
 								</Link>
-								{canShowProviderInlineTime ? (
+								{providerInlineDateIso ? (
 									<div className="ml-auto shrink-0 whitespace-nowrap text-right text-xs text-zinc-500 dark:text-zinc-400">
 										<TimeDisplay
-											dateIso={dateIso}
+											dateIso={providerInlineDateIso}
 											isModelRelease={isModelRelease}
 										/>
 									</div>


### PR DESCRIPTION
## Summary
- fix the `UpdateCard` `dateIso` narrowing regression that broke the `apps/web` production build on `main`
- keep `TimeDisplay` strict and narrow the header and inline-provider date paths before rendering
- restore a green `pnpm --filter @ai-stats/web build`

## Validation
- `pnpm --filter @ai-stats/web build`

## Context
The failing `main` CI run (`25173301749`) was red in `deploy (web, Deploy Web)` during Next's `Running TypeScript` phase. The concrete failure was:

```text
./src/components/updates/UpdateCard.tsx:198:12
Type error: Type 'string | null | undefined' is not assignable to type 'string'.
```