### PR TITLE
data: add withheld GPT-5.5 Cyber model

### DIFF
--- a/packages/data/catalog/src/data/models/openai/gpt-5.5-cyber/model.json
+++ b/packages/data/catalog/src/data/models/openai/gpt-5.5-cyber/model.json
@@ -1,0 +1,33 @@
+{
+  "model_id": "openai/gpt-5.5-cyber",
+  "organisation_id": "openai",
+  "name": "GPT 5.5 Cyber",
+  "status": "Withheld",
+  "previous_model_id": "openai/gpt-5.4-cyber",
+  "announced_date": "2026-04-30T00:00:00",
+  "release_date": null,
+  "deprecation_date": null,
+  "retirement_date": null,
+  "license": "Proprietary",
+  "input_types": "text",
+  "output_types": "text",
+  "api_model_id": "openai/gpt-5.5-cyber",
+  "family_id": "openai/gpt-5-5",
+  "links": [
+    {
+      "platform": "announcement",
+      "url": "https://openai.com/index/introducing-gpt-5-5/"
+    },
+    {
+      "platform": "documentation",
+      "url": "https://openai.com/index/trusted-access-for-cyber"
+    }
+  ],
+  "details": [
+    {
+      "name": "availability",
+      "value": "Not publicly accessible; restricted rollout announced for critical cyber defenders via Trusted Access for Cyber"
+    }
+  ],
+  "benchmarks": []
+}

--- a/packages/data/catalog/src/data/models/openai/gpt-5.5-cyber/model.json
+++ b/packages/data/catalog/src/data/models/openai/gpt-5.5-cyber/model.json
@@ -4,7 +4,7 @@
   "name": "GPT 5.5 Cyber",
   "status": "Withheld",
   "previous_model_id": "openai/gpt-5.4-cyber",
-  "announced_date": "2026-04-30T00:00:00",
+  "announced_date": "2026-04-30T00:00:00Z",
   "release_date": null,
   "deprecation_date": null,
   "retirement_date": null,


### PR DESCRIPTION
## Summary
- add `openai/gpt-5.5-cyber` as a withheld model
- mark it as the successor to `openai/gpt-5.4-cyber`
- capture the April 30, 2026 announcement date and trusted-access positioning

## Validation
- `pnpm validate:data`
- `pnpm --filter @ai-stats/web run update-db -- --model=openai/gpt-5.5-cyber`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced the OpenAI GPT-5.5-Cyber model to the catalog system. Users can now discover and utilize this new model alongside existing options, with complete documentation and specification details available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->