### PR TITLE
fix: align xAI Grok 4.x pricing tiers

### DIFF
--- a/packages/data/catalog/src/data/api_providers/x-ai/models.json
+++ b/packages/data/catalog/src/data/api_providers/x-ai/models.json
@@ -834,6 +834,98 @@
     ]
   },
   {
+    "api_model_id": "x-ai/grok-4.3",
+    "provider_api_model_id": "x-ai:x-ai/grok-4.3",
+    "provider_model_slug": "grok-4.3",
+    "internal_model_id": "x-ai/grok-4.3",
+    "is_active_gateway": true,
+    "quantization_scheme": null,
+    "input_modalities": "text,image",
+    "output_modalities": "text",
+    "context_length": 1000000,
+    "max_output_tokens": null,
+    "effective_from": "2026-04-30T00:00:00",
+    "effective_to": null,
+    "capabilities": [
+      {
+        "capability_id": "text.generate",
+        "status": "active",
+        "params": [
+          {
+            "param_id": "structured_outputs",
+            "provider_min": null,
+            "provider_max": null,
+            "provider_default": null,
+            "notes": null
+          },
+          {
+            "param_id": "response_format",
+            "provider_min": null,
+            "provider_max": null,
+            "provider_default": null,
+            "notes": null
+          },
+          {
+            "param_id": "max_tokens",
+            "provider_min": null,
+            "provider_max": null,
+            "provider_default": null,
+            "notes": null
+          },
+          {
+            "param_id": "temperature",
+            "provider_min": null,
+            "provider_max": null,
+            "provider_default": null,
+            "notes": null
+          },
+          {
+            "param_id": "top_p",
+            "provider_min": null,
+            "provider_max": null,
+            "provider_default": null,
+            "notes": null
+          },
+          {
+            "param_id": "seed",
+            "provider_min": null,
+            "provider_max": null,
+            "provider_default": null,
+            "notes": null
+          },
+          {
+            "param_id": "logprobs",
+            "provider_min": null,
+            "provider_max": null,
+            "provider_default": null,
+            "notes": null
+          },
+          {
+            "param_id": "top_logprobs",
+            "provider_min": null,
+            "provider_max": null,
+            "provider_default": null,
+            "notes": null
+          },
+          {
+            "param_id": "tools",
+            "provider_min": null,
+            "provider_max": null,
+            "provider_default": null,
+            "notes": null
+          },
+          {
+            "param_id": "tool_choice",
+            "provider_min": null,
+            "provider_max": null,
+            "provider_default": null,
+            "notes": null
+          }
+        ]
+      }
+    ]
+  },
+  {
     "api_model_id": "x-ai/grok-code-fast-1",
     "provider_api_model_id": "x-ai:x-ai/grok-code-fast-1",
     "provider_model_slug": "grok-code-fast-1-0825",

--- a/packages/data/catalog/src/data/manifest.json
+++ b/packages/data/catalog/src/data/manifest.json
@@ -2484,6 +2484,7 @@
     "x-ai:text.generate:x-ai-grok-4",
     "x-ai:text.generate:x-ai-grok-4.1",
     "x-ai:text.generate:x-ai-grok-4.1-thinking",
+    "x-ai:text.generate:x-ai-grok-4.3",
     "x-ai:text.generate:x-ai-grok-4.20-beta-0309",
     "x-ai:text.generate:x-ai-grok-4.20-multi-agent-beta-0309",
     "x-ai:text.generate:x-ai-grok-code-fast-1",

--- a/packages/data/catalog/src/data/pricing/x-ai/x-ai-grok-4.1-thinking/text.generate/pricing.json
+++ b/packages/data/catalog/src/data/pricing/x-ai/x-ai-grok-4.1-thinking/text.generate/pricing.json
@@ -16,7 +16,7 @@
       "match": [
         {
           "path": "input_tokens",
-          "op": "gt",
+          "op": "lte",
           "or_group": 1,
           "and_index": 1,
           "value": 128000
@@ -48,7 +48,7 @@
       "match": [
         {
           "path": "input_tokens",
-          "op": "gt",
+          "op": "lte",
           "or_group": 1,
           "and_index": 1,
           "value": 128000
@@ -68,24 +68,12 @@
       "match": [
         {
           "path": "input_tokens",
-          "op": "lte",
+          "op": "gt",
           "or_group": 1,
           "and_index": 1,
           "value": 128000
         }
       ],
-      "priority": 100,
-      "effective_from": "2025-11-17T00:00:00"
-    },
-    {
-      "meter": "cached_read_text_tokens",
-      "unit": "token",
-      "unit_size": 1000000,
-      "price_per_unit": 0.05,
-      "currency": "USD",
-      "pricing_plan": "standard",
-      "note": null,
-      "match": [],
       "priority": 100,
       "effective_from": "2025-11-17T00:00:00"
     },
@@ -100,7 +88,7 @@
       "match": [
         {
           "path": "input_tokens",
-          "op": "lte",
+          "op": "gt",
           "or_group": 1,
           "and_index": 1,
           "value": 128000

--- a/packages/data/catalog/src/data/pricing/x-ai/x-ai-grok-4.1/text.generate/pricing.json
+++ b/packages/data/catalog/src/data/pricing/x-ai/x-ai-grok-4.1/text.generate/pricing.json
@@ -78,18 +78,6 @@
       "effective_from": "2025-11-17T00:00:00"
     },
     {
-      "meter": "cached_read_text_tokens",
-      "unit": "token",
-      "unit_size": 1000000,
-      "price_per_unit": 0.05,
-      "currency": "USD",
-      "pricing_plan": "standard",
-      "note": null,
-      "match": [],
-      "priority": 100,
-      "effective_from": "2025-11-17T00:00:00"
-    },
-    {
       "meter": "output_text_tokens",
       "unit": "token",
       "unit_size": 1000000,

--- a/packages/data/catalog/src/data/pricing/x-ai/x-ai-grok-4.20-beta-0309/text.generate/pricing.json
+++ b/packages/data/catalog/src/data/pricing/x-ai/x-ai-grok-4.20-beta-0309/text.generate/pricing.json
@@ -9,7 +9,7 @@
       "meter": "input_text_tokens",
       "unit": "token",
       "unit_size": 1000000,
-      "price_per_unit": 2,
+      "price_per_unit": 1.25,
       "currency": "USD",
       "pricing_plan": "standard",
       "note": null,
@@ -33,15 +33,7 @@
       "currency": "USD",
       "pricing_plan": "standard",
       "note": null,
-      "match": [
-        {
-          "path": "input_tokens",
-          "op": "lte",
-          "or_group": 1,
-          "and_index": 1,
-          "value": 200000
-        }
-      ],
+      "match": [],
       "priority": 100,
       "effective_from": "2026-03-11T00:00:00"
     },
@@ -49,7 +41,7 @@
       "meter": "output_text_tokens",
       "unit": "token",
       "unit_size": 1000000,
-      "price_per_unit": 6,
+      "price_per_unit": 2.5,
       "currency": "USD",
       "pricing_plan": "standard",
       "note": null,
@@ -69,27 +61,7 @@
       "meter": "input_text_tokens",
       "unit": "token",
       "unit_size": 1000000,
-      "price_per_unit": 4,
-      "currency": "USD",
-      "pricing_plan": "standard",
-      "note": null,
-      "match": [
-        {
-          "path": "input_tokens",
-          "op": "gt",
-          "or_group": 1,
-          "and_index": 1,
-          "value": 200000
-        }
-      ],
-      "priority": 100,
-      "effective_from": "2026-03-11T00:00:00"
-    },
-    {
-      "meter": "cached_read_text_tokens",
-      "unit": "token",
-      "unit_size": 1000000,
-      "price_per_unit": 0.2,
+      "price_per_unit": 2.5,
       "currency": "USD",
       "pricing_plan": "standard",
       "note": null,
@@ -109,7 +81,7 @@
       "meter": "output_text_tokens",
       "unit": "token",
       "unit_size": 1000000,
-      "price_per_unit": 12,
+      "price_per_unit": 5,
       "currency": "USD",
       "pricing_plan": "standard",
       "note": null,

--- a/packages/data/catalog/src/data/pricing/x-ai/x-ai-grok-4.20-multi-agent-beta-0309/text.generate/pricing.json
+++ b/packages/data/catalog/src/data/pricing/x-ai/x-ai-grok-4.20-multi-agent-beta-0309/text.generate/pricing.json
@@ -9,7 +9,7 @@
       "meter": "input_text_tokens",
       "unit": "token",
       "unit_size": 1000000,
-      "price_per_unit": 2,
+      "price_per_unit": 1.25,
       "currency": "USD",
       "pricing_plan": "standard",
       "note": null,
@@ -33,15 +33,7 @@
       "currency": "USD",
       "pricing_plan": "standard",
       "note": null,
-      "match": [
-        {
-          "path": "input_tokens",
-          "op": "lte",
-          "or_group": 1,
-          "and_index": 1,
-          "value": 200000
-        }
-      ],
+      "match": [],
       "priority": 100,
       "effective_from": "2026-03-11T00:00:00"
     },
@@ -49,7 +41,7 @@
       "meter": "output_text_tokens",
       "unit": "token",
       "unit_size": 1000000,
-      "price_per_unit": 6,
+      "price_per_unit": 2.5,
       "currency": "USD",
       "pricing_plan": "standard",
       "note": null,
@@ -69,27 +61,7 @@
       "meter": "input_text_tokens",
       "unit": "token",
       "unit_size": 1000000,
-      "price_per_unit": 4,
-      "currency": "USD",
-      "pricing_plan": "standard",
-      "note": null,
-      "match": [
-        {
-          "path": "input_tokens",
-          "op": "gt",
-          "or_group": 1,
-          "and_index": 1,
-          "value": 200000
-        }
-      ],
-      "priority": 100,
-      "effective_from": "2026-03-11T00:00:00"
-    },
-    {
-      "meter": "cached_read_text_tokens",
-      "unit": "token",
-      "unit_size": 1000000,
-      "price_per_unit": 0.2,
+      "price_per_unit": 2.5,
       "currency": "USD",
       "pricing_plan": "standard",
       "note": null,
@@ -109,7 +81,7 @@
       "meter": "output_text_tokens",
       "unit": "token",
       "unit_size": 1000000,
-      "price_per_unit": 12,
+      "price_per_unit": 5,
       "currency": "USD",
       "pricing_plan": "standard",
       "note": null,

--- a/packages/data/catalog/src/data/pricing/x-ai/x-ai-grok-4.3/text.generate/pricing.json
+++ b/packages/data/catalog/src/data/pricing/x-ai/x-ai-grok-4.3/text.generate/pricing.json
@@ -1,15 +1,15 @@
 {
-  "key": "x-ai:x-ai/grok-4:text.generate",
+  "key": "x-ai:x-ai/grok-4.3:text.generate",
   "api_provider_id": "x-ai",
   "provider_slug": "x-ai",
-  "api_model_id": "x-ai/grok-4",
+  "api_model_id": "x-ai/grok-4.3",
   "capability_id": "text.generate",
   "rules": [
     {
       "meter": "input_text_tokens",
       "unit": "token",
       "unit_size": 1000000,
-      "price_per_unit": 3,
+      "price_per_unit": 1.25,
       "currency": "USD",
       "pricing_plan": "standard",
       "note": null,
@@ -19,49 +19,29 @@
           "op": "lte",
           "or_group": 1,
           "and_index": 1,
-          "value": 128000
+          "value": 200000
         }
       ],
       "priority": 100,
-      "effective_from": "2025-07-10T00:00:00"
-    },
-    {
-      "meter": "input_text_tokens",
-      "unit": "token",
-      "unit_size": 1000000,
-      "price_per_unit": 6,
-      "currency": "USD",
-      "pricing_plan": "standard",
-      "note": null,
-      "match": [
-        {
-          "path": "input_tokens",
-          "op": "gt",
-          "or_group": 1,
-          "and_index": 1,
-          "value": 128000
-        }
-      ],
-      "priority": 100,
-      "effective_from": "2025-07-10T00:00:00"
+      "effective_from": "2026-04-30T00:00:00"
     },
     {
       "meter": "cached_read_text_tokens",
       "unit": "token",
       "unit_size": 1000000,
-      "price_per_unit": 0.75,
+      "price_per_unit": 0.2,
       "currency": "USD",
       "pricing_plan": "standard",
       "note": null,
       "match": [],
       "priority": 100,
-      "effective_from": "2025-07-10T00:00:00"
+      "effective_from": "2026-04-30T00:00:00"
     },
     {
       "meter": "output_text_tokens",
       "unit": "token",
       "unit_size": 1000000,
-      "price_per_unit": 15,
+      "price_per_unit": 2.5,
       "currency": "USD",
       "pricing_plan": "standard",
       "note": null,
@@ -71,17 +51,17 @@
           "op": "lte",
           "or_group": 1,
           "and_index": 1,
-          "value": 128000
+          "value": 200000
         }
       ],
       "priority": 100,
-      "effective_from": "2025-07-10T00:00:00"
+      "effective_from": "2026-04-30T00:00:00"
     },
     {
-      "meter": "output_text_tokens",
+      "meter": "input_text_tokens",
       "unit": "token",
       "unit_size": 1000000,
-      "price_per_unit": 30,
+      "price_per_unit": 2.5,
       "currency": "USD",
       "pricing_plan": "standard",
       "note": null,
@@ -91,11 +71,31 @@
           "op": "gt",
           "or_group": 1,
           "and_index": 1,
-          "value": 128000
+          "value": 200000
         }
       ],
       "priority": 100,
-      "effective_from": "2025-07-10T00:00:00"
+      "effective_from": "2026-04-30T00:00:00"
+    },
+    {
+      "meter": "output_text_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 5,
+      "currency": "USD",
+      "pricing_plan": "standard",
+      "note": null,
+      "match": [
+        {
+          "path": "input_tokens",
+          "op": "gt",
+          "or_group": 1,
+          "and_index": 1,
+          "value": 200000
+        }
+      ],
+      "priority": 100,
+      "effective_from": "2026-04-30T00:00:00"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- align xAI Grok 4, 4.1, and 4.20 tiered pricing rules with the current catalog assumptions used for the PR
- add a dedicated xAI provider and pricing entry for `grok-4.3`
- keep the change isolated to xAI provider/pricing catalog files

## Validation
- `pnpm validate:pricing`
