### PR TITLE
fix(api): harden free-model credit gating

### DIFF
--- a/apps/api/src/pipeline/before/guards.credit.test.ts
+++ b/apps/api/src/pipeline/before/guards.credit.test.ts
@@ -155,7 +155,32 @@ describe("guardContext credit gating for free models", () => {
 		expect(result.ok).toBe(true);
 	});
 
-	it("allows zero-credit requests when all routable pricing cards are free/zero-cost", async () => {
+	it("keeps insufficient_funds for :free model names without free pricing", async () => {
+		fetchGatewayContextMock.mockResolvedValue(
+			makeContext({
+				model: "provider/model-no-suffix:free",
+				creditOk: false,
+				pricingRules: [{ pricing_plan: "standard", price_per_unit: "0.01" }],
+			}) as any,
+		);
+
+		const result = await guardContext({
+			workspaceId: "team_123",
+			apiKeyId: "key_123",
+			endpoint: "responses",
+			capability: "text.generate",
+			model: "provider/model-no-suffix:free",
+			requestId: "req_fake_free_suffix",
+		});
+
+		expect(result.ok).toBe(false);
+		if (result.ok) return;
+		expect(result.response.status).toBe(402);
+		const payload = await result.response.json();
+		expect(payload.error).toBe("insufficient_funds");
+	});
+
+	it("keeps insufficient_funds when standard pricing is zero-cost", async () => {
 		fetchGatewayContextMock.mockResolvedValue(
 			makeContext({
 				model: "provider/model-no-suffix",
@@ -173,7 +198,11 @@ describe("guardContext credit gating for free models", () => {
 			requestId: "req_free_2",
 		});
 
-		expect(result.ok).toBe(true);
+		expect(result.ok).toBe(false);
+		if (result.ok) return;
+		expect(result.response.status).toBe(402);
+		const payload = await result.response.json();
+		expect(payload.error).toBe("insufficient_funds");
 	});
 
 	it("fails closed when a routable provider has missing pricing", async () => {

--- a/apps/api/src/pipeline/before/guards.credit.test.ts
+++ b/apps/api/src/pipeline/before/guards.credit.test.ts
@@ -205,6 +205,31 @@ describe("guardContext credit gating for free models", () => {
 		expect(payload.error).toBe("insufficient_funds");
 	});
 
+	it("keeps insufficient_funds for free-plan pricing with a positive price", async () => {
+		fetchGatewayContextMock.mockResolvedValue(
+			makeContext({
+				model: "provider/model-no-suffix",
+				creditOk: false,
+				pricingRules: [{ pricing_plan: "free", price_per_unit: "0.01" }],
+			}) as any,
+		);
+
+		const result = await guardContext({
+			workspaceId: "team_123",
+			apiKeyId: "key_123",
+			endpoint: "responses",
+			capability: "text.generate",
+			model: "provider/model-no-suffix",
+			requestId: "req_free_positive_price",
+		});
+
+		expect(result.ok).toBe(false);
+		if (result.ok) return;
+		expect(result.response.status).toBe(402);
+		const payload = await result.response.json();
+		expect(payload.error).toBe("insufficient_funds");
+	});
+
 	it("fails closed when a routable provider has missing pricing", async () => {
 		fetchGatewayContextMock.mockResolvedValue(
 			makeContext({

--- a/apps/api/src/pipeline/before/guards.ts
+++ b/apps/api/src/pipeline/before/guards.ts
@@ -25,11 +25,14 @@ const FORM_FORCE_ARRAY_FIELDS = new Set(["include", "timestamp_granularities"]);
 
 function isFreePriceCard(card: PriceCard | null | undefined): boolean {
     if (!card || !Array.isArray(card.rules) || card.rules.length === 0) return false;
-    return card.rules.every((rule) =>
-        String(rule.pricing_plan ?? "")
+    return card.rules.every((rule) => {
+        const pricingPlan = String(rule.pricing_plan ?? "")
             .trim()
-            .toLowerCase() === "free"
-    );
+            .toLowerCase();
+        const pricePerUnit = Number(rule.price_per_unit);
+
+        return pricingPlan === "free" && Number.isFinite(pricePerUnit) && pricePerUnit <= 0;
+    });
 }
 
 function allowsNoCreditForFreeRequest(args: { model: string; context: any; providers: any[] }): boolean {

--- a/apps/api/src/pipeline/before/guards.ts
+++ b/apps/api/src/pipeline/before/guards.ts
@@ -23,28 +23,16 @@ const TRUTHY_VALUES = new Set(["1", "true", "yes"]);
 const FORM_JSON_FIELDS = new Set(["provider", "debug", "include", "timestamp_granularities"]);
 const FORM_FORCE_ARRAY_FIELDS = new Set(["include", "timestamp_granularities"]);
 
-function isLikelyFreeModelId(value: unknown): boolean {
-    if (typeof value !== "string") return false;
-    return value.trim().toLowerCase().includes(":free");
-}
-
 function isFreePriceCard(card: PriceCard | null | undefined): boolean {
     if (!card || !Array.isArray(card.rules) || card.rules.length === 0) return false;
-    return card.rules.every((rule) => {
-        const pricingPlan = String(rule.pricing_plan ?? "")
+    return card.rules.every((rule) =>
+        String(rule.pricing_plan ?? "")
             .trim()
-            .toLowerCase();
-        if (pricingPlan === "free") return true;
-        const numericPrice = Number(rule.price_per_unit);
-        return Number.isFinite(numericPrice) && numericPrice <= 0;
-    });
+            .toLowerCase() === "free"
+    );
 }
 
 function allowsNoCreditForFreeRequest(args: { model: string; context: any; providers: any[] }): boolean {
-    if (isLikelyFreeModelId(args.model) || isLikelyFreeModelId(args.context?.resolvedModel)) {
-        return true;
-    }
-
     const routableProviders = Array.isArray(args.providers)
         ? args.providers
             .filter((provider: any) => typeof provider?.providerId === "string")

--- a/packages/data/catalog/src/data/pricing/mistral/mistral-mistral-moderation-2/text.moderate/pricing.json
+++ b/packages/data/catalog/src/data/pricing/mistral/mistral-mistral-moderation-2/text.moderate/pricing.json
@@ -11,7 +11,7 @@
       "unit_size": 1,
       "price_per_unit": 0,
       "currency": "USD",
-      "pricing_plan": "standard",
+      "pricing_plan": "free",
       "note": null,
       "match": [],
       "priority": 100,

--- a/packages/data/catalog/src/data/pricing/mistral/mistral-mistral-moderation/text.moderate/pricing.json
+++ b/packages/data/catalog/src/data/pricing/mistral/mistral-mistral-moderation/text.moderate/pricing.json
@@ -11,7 +11,7 @@
       "unit_size": 1,
       "price_per_unit": 0,
       "currency": "USD",
-      "pricing_plan": "standard",
+      "pricing_plan": "free",
       "note": null,
       "match": [],
       "priority": 100,

--- a/packages/data/catalog/src/data/pricing/novita/inclusionai-ling-2.6-1t/text.generate/pricing.json
+++ b/packages/data/catalog/src/data/pricing/novita/inclusionai-ling-2.6-1t/text.generate/pricing.json
@@ -1,1 +1,33 @@
-{   "key": "novita:inclusionai/ling-2.6-1t:text.generate",   "api_provider_id": "novita",   "provider_slug": "novita",   "api_model_id": "inclusionai/ling-2.6-1t",   "capability_id": "text.generate",   "rules": [     {       "meter": "input_text_tokens",       "unit": "token",       "unit_size": 1000000,       "price_per_unit": 0,       "currency": "USD",       "pricing_plan": "standard",       "note": null,       "match": [],       "priority": 100,       "effective_from": "2026-04-23T00:00:00"     },     {       "meter": "output_text_tokens",       "unit": "token",       "unit_size": 1000000,       "price_per_unit": 0,       "currency": "USD",       "pricing_plan": "standard",       "note": null,       "match": [],       "priority": 100,       "effective_from": "2026-04-23T00:00:00"     }   ] }
+{
+  "key": "novita:inclusionai/ling-2.6-1t:text.generate",
+  "api_provider_id": "novita",
+  "provider_slug": "novita",
+  "api_model_id": "inclusionai/ling-2.6-1t",
+  "capability_id": "text.generate",
+  "rules": [
+    {
+      "meter": "input_text_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 0.3,
+      "currency": "USD",
+      "pricing_plan": "standard",
+      "note": null,
+      "match": [],
+      "priority": 100,
+      "effective_from": "2026-04-23T00:00:00"
+    },
+    {
+      "meter": "output_text_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 2.5,
+      "currency": "USD",
+      "pricing_plan": "standard",
+      "note": null,
+      "match": [],
+      "priority": 100,
+      "effective_from": "2026-04-23T00:00:00"
+    }
+  ]
+}

--- a/packages/data/catalog/src/data/pricing/openai/openai-omni-moderation/moderations.create/pricing.json
+++ b/packages/data/catalog/src/data/pricing/openai/openai-omni-moderation/moderations.create/pricing.json
@@ -11,7 +11,7 @@
       "unit_size": 1,
       "price_per_unit": 0,
       "currency": "USD",
-      "pricing_plan": "standard",
+      "pricing_plan": "free",
       "note": "Free",
       "match": [],
       "priority": 100,

--- a/packages/data/catalog/src/data/pricing/openai/openai-omni-moderation/text.moderate/pricing.json
+++ b/packages/data/catalog/src/data/pricing/openai/openai-omni-moderation/text.moderate/pricing.json
@@ -11,7 +11,7 @@
       "unit_size": 1,
       "price_per_unit": 0,
       "currency": "USD",
-      "pricing_plan": "standard",
+      "pricing_plan": "free",
       "note": "Free",
       "match": [],
       "priority": 100,


### PR DESCRIPTION
## Summary
This fixes two related billing-control issues in the gateway's free-request logic.

First, the Novita `inclusionai/ling-2.6-1t` catalog entry had been introduced with zero-valued `standard` token pricing, which made a paid model appear free to the gateway. Second, the credit guard treated any model name containing `:free` as eligible for wallet-credit bypass before confirming that routed provider pricing was actually marked free. In combination, these behaviors weakened a core billing invariant: free-credit bypass should only happen when the server-side routed pricing metadata explicitly says the request is free.

## Root cause
The guard logic relied on two unsafe shortcuts:

1. A client-controlled model-name heuristic (`:free`) short-circuited the wallet credit check.
2. A zero-priced `standard` pricing card was treated like a free route instead of a mispriced paid route.

That meant a pricing/configuration mistake or crafted model identifier could skip insufficient-funds enforcement for requests that were not truly free.

## Fix
The PR hardens the logic and corrects the bad data:

- remove the `:free` model-name short-circuit from `allowsNoCreditForFreeRequest`
- require routed pricing cards to be explicitly `pricing_plan: "free"` before allowing no-credit execution
- add regression coverage proving that paid or zero-priced-`standard` cards still return `402 insufficient_funds`
- correct Novita Ling-2.6-1T pricing to the documented paid rates (`$0.30` input / `$2.50` output per 1M tokens)

## Validation
Commands run locally:

- `pnpm --filter @ai-stats/gateway-api exec vitest run src/pipeline/before/guards.credit.test.ts`
- `pnpm validate:pricing`

Both passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated free credit validation logic: models designated as free now require explicit free pricing configuration rather than relying on zero-cost pricing. This may affect previously free requests without proper pricing setup.

* **Chores**
  * Updated token pricing data for novita:inclusionai/ling-2.6-1t model.

* **Tests**
  * Added comprehensive test coverage for credit gating validation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->