### PR TITLE
[codex] Fix control model access and normalize model families

### DIFF
--- a/apps/api/src/pipeline/before/context.shared.test.ts
+++ b/apps/api/src/pipeline/before/context.shared.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import { supportsEndpointViaModalities } from "./context.shared";
+
+describe("supportsEndpointViaModalities", () => {
+	it("treats audio subtypes as audio output for audio.speech", () => {
+		expect(
+			supportsEndpointViaModalities({
+				endpoint: "audio.speech",
+				inputModalities: new Set(["text"]),
+				outputModalities: new Set(["audio_tts"]),
+			}),
+		).toBe(true);
+	});
+
+	it("treats audio subtypes as audio output for music.generate", () => {
+		expect(
+			supportsEndpointViaModalities({
+				endpoint: "music.generate",
+				inputModalities: new Set(["text"]),
+				outputModalities: new Set(["audio_music"]),
+			}),
+		).toBe(true);
+	});
+});

--- a/apps/api/src/pipeline/before/context.shared.test.ts
+++ b/apps/api/src/pipeline/before/context.shared.test.ts
@@ -21,4 +21,14 @@ describe("supportsEndpointViaModalities", () => {
 			}),
 		).toBe(true);
 	});
+
+	it("does not treat transcription audio subtypes as generated audio output", () => {
+		expect(
+			supportsEndpointViaModalities({
+				endpoint: "audio.speech",
+				inputModalities: new Set(["text"]),
+				outputModalities: new Set(["audio_stt"]),
+			}),
+		).toBe(false);
+	});
 });

--- a/apps/api/src/pipeline/before/context.shared.ts
+++ b/apps/api/src/pipeline/before/context.shared.ts
@@ -359,11 +359,22 @@ export function parseModalities(value: unknown): Set<string> {
 	return new Set<string>();
 }
 
-function normalizeModalityBase(value: string): string {
+function normalizeInputModalityBase(value: string): string {
 	const normalized = String(value ?? "").trim().toLowerCase();
 	if (normalized === "text" || normalized.startsWith("text_")) return "text";
 	if (normalized === "image" || normalized.startsWith("image_")) return "image";
 	if (normalized === "audio" || normalized.startsWith("audio_")) return "audio";
+	if (normalized === "video" || normalized.startsWith("video_")) return "video";
+	return normalized;
+}
+
+function normalizeOutputModalityBase(value: string): string {
+	const normalized = String(value ?? "").trim().toLowerCase();
+	if (normalized === "text" || normalized.startsWith("text_")) return "text";
+	if (normalized === "image" || normalized.startsWith("image_")) return "image";
+	if (normalized === "audio" || normalized === "audio_tts" || normalized === "audio_music") {
+		return "audio";
+	}
 	if (normalized === "video" || normalized.startsWith("video_")) return "video";
 	return normalized;
 }
@@ -374,8 +385,8 @@ export function supportsEndpointViaModalities(args: {
 	outputModalities: Set<string>;
 }): boolean {
 	const endpoint = String(args.endpoint ?? "").trim().toLowerCase();
-	const input = new Set(Array.from(args.inputModalities).map(normalizeModalityBase));
-	const output = new Set(Array.from(args.outputModalities).map(normalizeModalityBase));
+	const input = new Set(Array.from(args.inputModalities).map(normalizeInputModalityBase));
+	const output = new Set(Array.from(args.outputModalities).map(normalizeOutputModalityBase));
 
 	const hasInput = (...values: string[]) => values.some((value) => input.has(value));
 	const hasOutput = (...values: string[]) => values.some((value) => output.has(value));

--- a/apps/api/src/pipeline/before/context.shared.ts
+++ b/apps/api/src/pipeline/before/context.shared.ts
@@ -359,14 +359,23 @@ export function parseModalities(value: unknown): Set<string> {
 	return new Set<string>();
 }
 
+function normalizeModalityBase(value: string): string {
+	const normalized = String(value ?? "").trim().toLowerCase();
+	if (normalized === "text" || normalized.startsWith("text_")) return "text";
+	if (normalized === "image" || normalized.startsWith("image_")) return "image";
+	if (normalized === "audio" || normalized.startsWith("audio_")) return "audio";
+	if (normalized === "video" || normalized.startsWith("video_")) return "video";
+	return normalized;
+}
+
 export function supportsEndpointViaModalities(args: {
 	endpoint: string;
 	inputModalities: Set<string>;
 	outputModalities: Set<string>;
 }): boolean {
 	const endpoint = String(args.endpoint ?? "").trim().toLowerCase();
-	const input = args.inputModalities;
-	const output = args.outputModalities;
+	const input = new Set(Array.from(args.inputModalities).map(normalizeModalityBase));
+	const output = new Set(Array.from(args.outputModalities).map(normalizeModalityBase));
 
 	const hasInput = (...values: string[]) => values.some((value) => input.has(value));
 	const hasOutput = (...values: string[]) => values.some((value) => output.has(value));

--- a/apps/api/src/pipeline/execute/modalities.test.ts
+++ b/apps/api/src/pipeline/execute/modalities.test.ts
@@ -82,6 +82,26 @@ describe("filterCandidatesByModalities", () => {
 
 		expect(filtered).toHaveLength(0);
 	});
+
+	it("keeps audio-output candidates that use audio subtype modalities", () => {
+		const filtered = filterCandidatesByModalities(
+			[
+				candidate({
+					providerId: "google-ai-studio",
+					inputModalities: ["text"],
+					outputModalities: ["audio_tts"],
+				}),
+			],
+			{
+				model: "google/gemini-3.1-flash-tts-preview",
+				stream: false,
+				messages: [{ role: "user", content: [{ type: "text", text: "Say hello" }] }],
+				modalities: ["audio"],
+			},
+		);
+
+		expect(filtered).toHaveLength(1);
+	});
 });
 
 describe("filterEmbeddingCandidatesByModalities", () => {

--- a/apps/api/src/pipeline/execute/modalities.test.ts
+++ b/apps/api/src/pipeline/execute/modalities.test.ts
@@ -102,6 +102,26 @@ describe("filterCandidatesByModalities", () => {
 
 		expect(filtered).toHaveLength(1);
 	});
+
+	it("does not treat transcription audio subtypes as generated audio output", () => {
+		const filtered = filterCandidatesByModalities(
+			[
+				candidate({
+					providerId: "google-ai-studio",
+					inputModalities: ["text"],
+					outputModalities: ["audio_stt"],
+				}),
+			],
+			{
+				model: "google/gemini-3.1-flash-tts-preview",
+				stream: false,
+				messages: [{ role: "user", content: [{ type: "text", text: "Say hello" }] }],
+				modalities: ["audio"],
+			},
+		);
+
+		expect(filtered).toHaveLength(0);
+	});
 });
 
 describe("filterEmbeddingCandidatesByModalities", () => {

--- a/apps/api/src/pipeline/execute/modalities.ts
+++ b/apps/api/src/pipeline/execute/modalities.ts
@@ -47,13 +47,21 @@ function isGoogleEmbeddingsModel(candidate: ProviderCandidate, modelId: string):
 	return haystack.includes("gemini-embedding");
 }
 
+function toBaseModality(value: string): Modality | null {
+	if (value === "text" || value.startsWith("text_")) return "text";
+	if (value === "image" || value.startsWith("image_")) return "image";
+	if (value === "audio" || value.startsWith("audio_")) return "audio";
+	if (value === "video" || value.startsWith("video_")) return "video";
+	return null;
+}
+
 function normalizeModalities(values?: string[] | null): Set<Modality> {
 	if (!values || values.length === 0) return new Set();
 	const normalized = new Set<Modality>();
 	for (const value of values) {
-		const lower = String(value).trim().toLowerCase();
-		if (lower === "text" || lower === "image" || lower === "audio" || lower === "video") {
-			normalized.add(lower);
+		const base = toBaseModality(String(value).trim().toLowerCase());
+		if (base) {
+			normalized.add(base);
 		}
 	}
 	return normalized;

--- a/apps/api/src/pipeline/execute/modalities.ts
+++ b/apps/api/src/pipeline/execute/modalities.ts
@@ -47,7 +47,7 @@ function isGoogleEmbeddingsModel(candidate: ProviderCandidate, modelId: string):
 	return haystack.includes("gemini-embedding");
 }
 
-function toBaseModality(value: string): Modality | null {
+function toBaseInputModality(value: string): Modality | null {
 	if (value === "text" || value.startsWith("text_")) return "text";
 	if (value === "image" || value.startsWith("image_")) return "image";
 	if (value === "audio" || value.startsWith("audio_")) return "audio";
@@ -55,11 +55,22 @@ function toBaseModality(value: string): Modality | null {
 	return null;
 }
 
-function normalizeModalities(values?: string[] | null): Set<Modality> {
+function toBaseOutputModality(value: string): Modality | null {
+	if (value === "text" || value.startsWith("text_")) return "text";
+	if (value === "image" || value.startsWith("image_")) return "image";
+	if (value === "audio" || value === "audio_tts" || value === "audio_music") return "audio";
+	if (value === "video" || value.startsWith("video_")) return "video";
+	return null;
+}
+
+function normalizeModalities(
+	values: string[] | null | undefined,
+	mapper: (value: string) => Modality | null,
+): Set<Modality> {
 	if (!values || values.length === 0) return new Set();
 	const normalized = new Set<Modality>();
 	for (const value of values) {
-		const base = toBaseModality(String(value).trim().toLowerCase());
+		const base = mapper(String(value).trim().toLowerCase());
 		if (base) {
 			normalized.add(base);
 		}
@@ -208,8 +219,8 @@ export function filterCandidatesByModalities(
 	const needsNonTextOutput = Array.from(requirements.output).some((m) => m !== "text");
 
 	return candidates.filter((candidate) => {
-		let input = normalizeModalities(candidate.inputModalities ?? undefined);
-		let output = normalizeModalities(candidate.outputModalities ?? undefined);
+		let input = normalizeModalities(candidate.inputModalities ?? undefined, toBaseInputModality);
+		let output = normalizeModalities(candidate.outputModalities ?? undefined, toBaseOutputModality);
 
 		// Fallback for Google Nano Banana image-preview models where modality
 		// metadata can be temporarily missing/stale in provider rows.
@@ -242,7 +253,7 @@ export function filterEmbeddingCandidatesByModalities(
 	const needsNonTextInput = Array.from(requirements.input).some((m) => m !== "text");
 
 	return candidates.filter((candidate) => {
-		let input = normalizeModalities(candidate.inputModalities ?? undefined);
+		let input = normalizeModalities(candidate.inputModalities ?? undefined, toBaseInputModality);
 
 		// Fallback for Gemini embedding families while provider modality metadata catches up.
 		if (isGoogleEmbeddingsModel(candidate, ir.model) && input.size === 0) {

--- a/apps/api/src/routes/v1/control/models-data.test.ts
+++ b/apps/api/src/routes/v1/control/models-data.test.ts
@@ -1,0 +1,43 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const guardAuthMock = vi.fn();
+const getSupabaseAdminMock = vi.fn();
+
+vi.mock("@pipeline/before/guards", () => ({
+	guardAuth: (...args: any[]) => guardAuthMock(...args),
+}));
+
+vi.mock("@/runtime/env", async () => {
+	const actual = await vi.importActual<typeof import("@/runtime/env")>("@/runtime/env");
+	return {
+		...actual,
+		getSupabaseAdmin: (...args: any[]) => getSupabaseAdminMock(...args),
+	};
+});
+
+import { handleDataModels } from "./models-data";
+
+describe("handleDataModels", () => {
+	beforeEach(() => {
+		guardAuthMock.mockReset();
+		getSupabaseAdminMock.mockReset();
+	});
+
+	it("forbids include_hidden for non-internal callers", async () => {
+		guardAuthMock.mockResolvedValue({
+			ok: true,
+			value: {
+				internal: false,
+			},
+		});
+
+		const response = await handleDataModels(
+			new Request("https://api.example.com/v1/control/data/models?include_hidden=true"),
+		);
+
+		expect(response.status).toBe(403);
+		expect(getSupabaseAdminMock).not.toHaveBeenCalled();
+		const payload = await response.json();
+		expect(payload.error).toBe("forbidden");
+	});
+});

--- a/apps/api/src/routes/v1/control/models-data.ts
+++ b/apps/api/src/routes/v1/control/models-data.ts
@@ -154,7 +154,7 @@ function buildLifecycleMessage(
     return null;
 }
 
-async function handleDataModels(req: Request) {
+export async function handleDataModels(req: Request) {
     const url = new URL(req.url);
     const auth = await guardAuth(req, { useKvCache: false });
     if (!auth.ok) {
@@ -182,6 +182,17 @@ async function handleDataModels(req: Request) {
     };
 
     const includeHidden = parseBooleanParam(url.searchParams.get("include_hidden"), false);
+    if (includeHidden && !auth.value.internal) {
+        return json(
+            {
+                ok: false,
+                error: "forbidden",
+                message: "include_hidden requires internal authentication",
+            },
+            403,
+            { "Cache-Control": "no-store" }
+        );
+    }
     const statuses = parseMultiValue(url.searchParams, "status");
     const organisationIds = parseMultiValue(url.searchParams, "organisation");
     const modelIds = [...parseMultiValue(url.searchParams, "model_id"), ...parseMultiValue(url.searchParams, "id")];

--- a/packages/data/catalog/src/data/families/anthropic-claude-4.5/family.json
+++ b/packages/data/catalog/src/data/families/anthropic-claude-4.5/family.json
@@ -1,0 +1,5 @@
+{
+  "family_id": "anthropic/claude-4.5",
+  "family_name": "Claude 4.5",
+  "organisation_id": "anthropic"
+}

--- a/packages/data/catalog/src/data/families/anthropic-claude-4.6/family.json
+++ b/packages/data/catalog/src/data/families/anthropic-claude-4.6/family.json
@@ -1,0 +1,5 @@
+{
+  "family_id": "anthropic/claude-4.6",
+  "family_name": "Claude 4.6",
+  "organisation_id": "anthropic"
+}

--- a/packages/data/catalog/src/data/families/google-lyria-3/family.json
+++ b/packages/data/catalog/src/data/families/google-lyria-3/family.json
@@ -1,0 +1,5 @@
+{
+  "family_id": "google/lyria-3",
+  "family_name": "Lyria 3",
+  "organisation_id": "google"
+}

--- a/packages/data/catalog/src/data/families/google-veo-3.1/family.json
+++ b/packages/data/catalog/src/data/families/google-veo-3.1/family.json
@@ -1,0 +1,5 @@
+{
+  "family_id": "google/veo-3.1",
+  "family_name": "Veo 3.1",
+  "organisation_id": "google"
+}

--- a/packages/data/catalog/src/data/families/ibm-granite-3.0/family.json
+++ b/packages/data/catalog/src/data/families/ibm-granite-3.0/family.json
@@ -1,5 +1,5 @@
 {
-  "family_id": "ibm/granite-3.0",
+  "family_id": "ibm/granite-3-0",
   "family_name": "Granite 3.0",
   "organisation_id": "ibm"
 }

--- a/packages/data/catalog/src/data/families/ibm-granite-3.1/family.json
+++ b/packages/data/catalog/src/data/families/ibm-granite-3.1/family.json
@@ -1,5 +1,5 @@
 {
-  "family_id": "ibm/granite-3.1",
+  "family_id": "ibm/granite-3-1",
   "family_name": "Granite 3.1",
   "organisation_id": "ibm"
 }

--- a/packages/data/catalog/src/data/families/ibm-granite-3.2/family.json
+++ b/packages/data/catalog/src/data/families/ibm-granite-3.2/family.json
@@ -1,5 +1,5 @@
 {
-  "family_id": "ibm/granite-3.2",
+  "family_id": "ibm/granite-3-2",
   "family_name": "Granite 3.2",
   "organisation_id": "ibm"
 }

--- a/packages/data/catalog/src/data/families/ibm-granite-3.3/family.json
+++ b/packages/data/catalog/src/data/families/ibm-granite-3.3/family.json
@@ -1,5 +1,5 @@
 {
-  "family_id": "ibm/granite-3.3",
+  "family_id": "ibm/granite-3-3",
   "family_name": "Granite 3.3",
   "organisation_id": "ibm"
 }

--- a/packages/data/catalog/src/data/families/ibm-granite-4.0/family.json
+++ b/packages/data/catalog/src/data/families/ibm-granite-4.0/family.json
@@ -1,5 +1,5 @@
 {
-  "family_id": "ibm/granite-4.0",
+  "family_id": "ibm/granite-4-0",
   "family_name": "Granite 4.0",
   "organisation_id": "ibm"
 }

--- a/packages/data/catalog/src/data/families/ibm-granite-4.1/family.json
+++ b/packages/data/catalog/src/data/families/ibm-granite-4.1/family.json
@@ -1,0 +1,5 @@
+{
+  "family_id": "ibm/granite-4-1",
+  "family_name": "Granite 4.1",
+  "organisation_id": "ibm"
+}

--- a/packages/data/catalog/src/data/families/openai-gpt-5.5/family.json
+++ b/packages/data/catalog/src/data/families/openai-gpt-5.5/family.json
@@ -1,0 +1,5 @@
+{
+  "family_id": "openai/gpt-5.5",
+  "family_name": "GPT 5.5",
+  "organisation_id": "openai"
+}

--- a/packages/data/catalog/src/data/models/anthropic/claude-3-haiku/model.json
+++ b/packages/data/catalog/src/data/models/anthropic/claude-3-haiku/model.json
@@ -12,7 +12,7 @@
   "input_types": "text,image",
   "output_types": "text",
   "api_model_id": "anthropic/claude-3-haiku",
-  "family_id": "anthropic/claude-3-0",
+  "family_id": "anthropic/claude-3.0",
   "links": [
     {
       "platform": "api_reference",

--- a/packages/data/catalog/src/data/models/anthropic/claude-3-opus/model.json
+++ b/packages/data/catalog/src/data/models/anthropic/claude-3-opus/model.json
@@ -12,7 +12,7 @@
   "input_types": "text,image",
   "output_types": "text",
   "api_model_id": "anthropic/claude-3-opus",
-  "family_id": "anthropic/claude-3-0",
+  "family_id": "anthropic/claude-3.0",
   "links": [
     {
       "platform": "api_reference",

--- a/packages/data/catalog/src/data/models/anthropic/claude-3-sonnet/model.json
+++ b/packages/data/catalog/src/data/models/anthropic/claude-3-sonnet/model.json
@@ -12,7 +12,7 @@
   "input_types": "text,image",
   "output_types": "text",
   "api_model_id": "anthropic/claude-3-sonnet",
-  "family_id": "anthropic/claude-3-0",
+  "family_id": "anthropic/claude-3.0",
   "links": [
     {
       "platform": "api_reference",

--- a/packages/data/catalog/src/data/models/anthropic/claude-3.5-haiku/model.json
+++ b/packages/data/catalog/src/data/models/anthropic/claude-3.5-haiku/model.json
@@ -12,7 +12,7 @@
   "input_types": "text,image",
   "output_types": "text",
   "api_model_id": "anthropic/claude-3.5-haiku",
-  "family_id": "anthropic/claude-3-5",
+  "family_id": "anthropic/claude-3.5",
   "links": [
     {
       "platform": "api_reference",

--- a/packages/data/catalog/src/data/models/anthropic/claude-3.5-sonnet-2024-06-20/model.json
+++ b/packages/data/catalog/src/data/models/anthropic/claude-3.5-sonnet-2024-06-20/model.json
@@ -12,7 +12,7 @@
   "input_types": "text,image",
   "output_types": "text",
   "api_model_id": "anthropic/claude-3.5-sonnet-2024-06-20",
-  "family_id": "anthropic/claude-3-5",
+  "family_id": "anthropic/claude-3.5",
   "links": [
     {
       "platform": "api_reference",

--- a/packages/data/catalog/src/data/models/anthropic/claude-3.5-sonnet-2024-10-22/model.json
+++ b/packages/data/catalog/src/data/models/anthropic/claude-3.5-sonnet-2024-10-22/model.json
@@ -12,7 +12,7 @@
   "input_types": "text,image",
   "output_types": "text",
   "api_model_id": "anthropic/claude-3.5-sonnet-2024-10-22",
-  "family_id": "anthropic/claude-3-5",
+  "family_id": "anthropic/claude-3.5",
   "links": [],
   "details": [],
   "benchmarks": [

--- a/packages/data/catalog/src/data/models/anthropic/claude-haiku-4.5/model.json
+++ b/packages/data/catalog/src/data/models/anthropic/claude-haiku-4.5/model.json
@@ -12,6 +12,7 @@
   "input_types": "text",
   "output_types": "text",
   "api_model_id": "anthropic/claude-haiku-4.5",
+  "family_id": "anthropic/claude-4.5",
   "links": [
     {
       "platform": "announcement",

--- a/packages/data/catalog/src/data/models/anthropic/claude-opus-4.5/model.json
+++ b/packages/data/catalog/src/data/models/anthropic/claude-opus-4.5/model.json
@@ -12,6 +12,7 @@
   "input_types": "text,image",
   "output_types": "text",
   "api_model_id": "anthropic/claude-opus-4.5",
+  "family_id": "anthropic/claude-4.5",
   "links": [
     {
       "platform": "announcement",

--- a/packages/data/catalog/src/data/models/anthropic/claude-opus-4.6/model.json
+++ b/packages/data/catalog/src/data/models/anthropic/claude-opus-4.6/model.json
@@ -12,6 +12,7 @@
   "input_types": "text,image",
   "output_types": "text",
   "api_model_id": "anthropic/claude-opus-4.6",
+  "family_id": "anthropic/claude-4.6",
   "links": [],
   "details": [
     {

--- a/packages/data/catalog/src/data/models/anthropic/claude-opus-4/model.json
+++ b/packages/data/catalog/src/data/models/anthropic/claude-opus-4/model.json
@@ -12,7 +12,7 @@
   "input_types": "text,image",
   "output_types": "text",
   "api_model_id": "anthropic/claude-opus-4",
-  "family_id": "anthropic/claude-4-0",
+  "family_id": "anthropic/claude-4.0",
   "links": [
     {
       "platform": "api_reference",

--- a/packages/data/catalog/src/data/models/anthropic/claude-sonnet-4.5/model.json
+++ b/packages/data/catalog/src/data/models/anthropic/claude-sonnet-4.5/model.json
@@ -12,6 +12,7 @@
   "input_types": "text",
   "output_types": "text",
   "api_model_id": "anthropic/claude-sonnet-4.5",
+  "family_id": "anthropic/claude-4.5",
   "links": [
     {
       "platform": "announcement",

--- a/packages/data/catalog/src/data/models/anthropic/claude-sonnet-4.6/model.json
+++ b/packages/data/catalog/src/data/models/anthropic/claude-sonnet-4.6/model.json
@@ -12,6 +12,7 @@
   "input_types": "text,image",
   "output_types": "text",
   "api_model_id": "anthropic/claude-sonnet-4.6",
+  "family_id": "anthropic/claude-4.6",
   "links": [],
   "details": [
     {

--- a/packages/data/catalog/src/data/models/anthropic/claude-sonnet-4/model.json
+++ b/packages/data/catalog/src/data/models/anthropic/claude-sonnet-4/model.json
@@ -12,7 +12,7 @@
   "input_types": "text,image",
   "output_types": "text",
   "api_model_id": "anthropic/claude-sonnet-4",
-  "family_id": "anthropic/claude-4-0",
+  "family_id": "anthropic/claude-4.0",
   "links": [
     {
       "platform": "api_reference",

--- a/packages/data/catalog/src/data/models/google/gemini-1.0-nano/model.json
+++ b/packages/data/catalog/src/data/models/google/gemini-1.0-nano/model.json
@@ -12,7 +12,7 @@
   "input_types": "text",
   "output_types": "text",
   "api_model_id": "google/gemini-1.0-nano",
-  "family_id": "google/gemini-1-0",
+  "family_id": "google/gemini-1.0",
   "links": [],
   "details": [],
   "benchmarks": [

--- a/packages/data/catalog/src/data/models/google/gemini-1.0-pro-vision-001/model.json
+++ b/packages/data/catalog/src/data/models/google/gemini-1.0-pro-vision-001/model.json
@@ -12,6 +12,7 @@
   "input_types": null,
   "output_types": null,
   "api_model_id": "google/gemini-1.0-pro-vision-001",
+  "family_id": "google/gemini-1.0",
   "links": [],
   "details": [],
   "benchmarks": [

--- a/packages/data/catalog/src/data/models/google/gemini-1.0-pro/model.json
+++ b/packages/data/catalog/src/data/models/google/gemini-1.0-pro/model.json
@@ -12,7 +12,7 @@
   "input_types": "text",
   "output_types": "text",
   "api_model_id": "google/gemini-1.0-pro",
-  "family_id": "google/gemini-1-0",
+  "family_id": "google/gemini-1.0",
   "links": [
     {
       "platform": "api_reference",

--- a/packages/data/catalog/src/data/models/google/gemini-1.0-ultra/model.json
+++ b/packages/data/catalog/src/data/models/google/gemini-1.0-ultra/model.json
@@ -12,7 +12,7 @@
   "input_types": "text",
   "output_types": "text",
   "api_model_id": "google/gemini-1.0-ultra",
-  "family_id": "google/gemini-1-0",
+  "family_id": "google/gemini-1.0",
   "links": [],
   "details": [
     {

--- a/packages/data/catalog/src/data/models/google/gemini-1.5-flash-001/model.json
+++ b/packages/data/catalog/src/data/models/google/gemini-1.5-flash-001/model.json
@@ -12,7 +12,7 @@
   "input_types": null,
   "output_types": null,
   "api_model_id": "google/gemini-1.5-flash-001",
-  "family_id": "google/gemini-1-5",
+  "family_id": "google/gemini-1.5",
   "links": [],
   "details": [],
   "benchmarks": [

--- a/packages/data/catalog/src/data/models/google/gemini-1.5-flash-002/model.json
+++ b/packages/data/catalog/src/data/models/google/gemini-1.5-flash-002/model.json
@@ -12,7 +12,7 @@
   "input_types": "text,image,video,audio",
   "output_types": "text",
   "api_model_id": "google/gemini-1.5-flash-002",
-  "family_id": "google/gemini-1-5",
+  "family_id": "google/gemini-1.5",
   "links": [
     {
       "platform": "api_reference",

--- a/packages/data/catalog/src/data/models/google/gemini-1.5-flash-8b-exp-2024-08-27/model.json
+++ b/packages/data/catalog/src/data/models/google/gemini-1.5-flash-8b-exp-2024-08-27/model.json
@@ -12,7 +12,7 @@
   "input_types": null,
   "output_types": null,
   "api_model_id": "google/gemini-1.5-flash-8b-exp-2024-08-27",
-  "family_id": "google/gemini-1-5",
+  "family_id": "google/gemini-1.5",
   "links": [],
   "details": [],
   "benchmarks": [

--- a/packages/data/catalog/src/data/models/google/gemini-1.5-flash-8b-exp-2024-09-24/model.json
+++ b/packages/data/catalog/src/data/models/google/gemini-1.5-flash-8b-exp-2024-09-24/model.json
@@ -12,7 +12,7 @@
   "input_types": null,
   "output_types": null,
   "api_model_id": "google/gemini-1.5-flash-8b-exp-2024-09-24",
-  "family_id": "google/gemini-1-5",
+  "family_id": "google/gemini-1.5",
   "links": [],
   "details": [],
   "benchmarks": [

--- a/packages/data/catalog/src/data/models/google/gemini-1.5-flash-8b/model.json
+++ b/packages/data/catalog/src/data/models/google/gemini-1.5-flash-8b/model.json
@@ -12,7 +12,7 @@
   "input_types": "text,image,video,audio",
   "output_types": "text",
   "api_model_id": "google/gemini-1.5-flash-8b",
-  "family_id": "google/gemini-1-5",
+  "family_id": "google/gemini-1.5",
   "links": [
     {
       "platform": "api_reference",

--- a/packages/data/catalog/src/data/models/google/gemini-1.5-flash-preview-2024-05-14/model.json
+++ b/packages/data/catalog/src/data/models/google/gemini-1.5-flash-preview-2024-05-14/model.json
@@ -12,6 +12,7 @@
   "input_types": null,
   "output_types": null,
   "api_model_id": "google/gemini-1.5-flash-preview-2024-05-14",
+  "family_id": "google/gemini-1.5",
   "links": [],
   "details": [],
   "benchmarks": [

--- a/packages/data/catalog/src/data/models/google/gemini-1.5-pro-001/model.json
+++ b/packages/data/catalog/src/data/models/google/gemini-1.5-pro-001/model.json
@@ -12,7 +12,7 @@
   "input_types": null,
   "output_types": null,
   "api_model_id": "google/gemini-1.5-pro-001",
-  "family_id": "google/gemini-1-5",
+  "family_id": "google/gemini-1.5",
   "links": [],
   "details": [],
   "benchmarks": [

--- a/packages/data/catalog/src/data/models/google/gemini-1.5-pro-002/model.json
+++ b/packages/data/catalog/src/data/models/google/gemini-1.5-pro-002/model.json
@@ -12,7 +12,7 @@
   "input_types": "text,image,video,audio",
   "output_types": "text",
   "api_model_id": "google/gemini-1.5-pro-002",
-  "family_id": "google/gemini-1-5",
+  "family_id": "google/gemini-1.5",
   "links": [],
   "details": [
     {

--- a/packages/data/catalog/src/data/models/google/gemini-1.5-pro-exp-2024-08-01/model.json
+++ b/packages/data/catalog/src/data/models/google/gemini-1.5-pro-exp-2024-08-01/model.json
@@ -12,7 +12,7 @@
   "input_types": null,
   "output_types": null,
   "api_model_id": "google/gemini-1.5-pro-exp-2024-08-01",
-  "family_id": "google/gemini-1-5",
+  "family_id": "google/gemini-1.5",
   "links": [],
   "details": [],
   "benchmarks": [

--- a/packages/data/catalog/src/data/models/google/gemini-1.5-pro-exp-2024-08-27/model.json
+++ b/packages/data/catalog/src/data/models/google/gemini-1.5-pro-exp-2024-08-27/model.json
@@ -12,7 +12,7 @@
   "input_types": null,
   "output_types": null,
   "api_model_id": "google/gemini-1.5-pro-exp-2024-08-27",
-  "family_id": "google/gemini-1-5",
+  "family_id": "google/gemini-1.5",
   "links": [],
   "details": [],
   "benchmarks": [

--- a/packages/data/catalog/src/data/models/google/gemini-2.0-flash-exp-image-generation/model.json
+++ b/packages/data/catalog/src/data/models/google/gemini-2.0-flash-exp-image-generation/model.json
@@ -12,7 +12,7 @@
   "input_types": null,
   "output_types": null,
   "api_model_id": "google/gemini-2.0-flash-exp-image-generation",
-  "family_id": "google/gemini-2-0",
+  "family_id": "google/gemini-2.0",
   "links": [],
   "details": [],
   "benchmarks": []

--- a/packages/data/catalog/src/data/models/google/gemini-2.0-flash-exp/model.json
+++ b/packages/data/catalog/src/data/models/google/gemini-2.0-flash-exp/model.json
@@ -12,7 +12,7 @@
   "input_types": null,
   "output_types": null,
   "api_model_id": "google/gemini-2.0-flash-exp",
-  "family_id": "google/gemini-2-0",
+  "family_id": "google/gemini-2.0",
   "links": [],
   "details": [],
   "benchmarks": [

--- a/packages/data/catalog/src/data/models/google/gemini-2.0-flash-lite/model.json
+++ b/packages/data/catalog/src/data/models/google/gemini-2.0-flash-lite/model.json
@@ -12,7 +12,7 @@
   "input_types": null,
   "output_types": null,
   "api_model_id": "google/gemini-2.0-flash-lite",
-  "family_id": "google/gemini-2-0",
+  "family_id": "google/gemini-2.0",
   "links": [
     {
       "platform": "api_reference",

--- a/packages/data/catalog/src/data/models/google/gemini-2.0-flash-live-001/model.json
+++ b/packages/data/catalog/src/data/models/google/gemini-2.0-flash-live-001/model.json
@@ -12,7 +12,7 @@
   "input_types": null,
   "output_types": null,
   "api_model_id": "google/gemini-2.0-flash-live-001",
-  "family_id": "google/gemini-2-0",
+  "family_id": "google/gemini-2.0",
   "links": [],
   "details": [],
   "benchmarks": []

--- a/packages/data/catalog/src/data/models/google/gemini-2.0-flash-preview-image-generation/model.json
+++ b/packages/data/catalog/src/data/models/google/gemini-2.0-flash-preview-image-generation/model.json
@@ -12,7 +12,7 @@
   "input_types": null,
   "output_types": null,
   "api_model_id": "google/gemini-2.0-flash-preview-image-generation",
-  "family_id": "google/gemini-2-0",
+  "family_id": "google/gemini-2.0",
   "links": [],
   "details": [],
   "benchmarks": []

--- a/packages/data/catalog/src/data/models/google/gemini-2.0-flash-thinking-exp-2024-12-19/model.json
+++ b/packages/data/catalog/src/data/models/google/gemini-2.0-flash-thinking-exp-2024-12-19/model.json
@@ -12,7 +12,7 @@
   "input_types": null,
   "output_types": null,
   "api_model_id": "google/gemini-2.0-flash-thinking-exp-2024-12-19",
-  "family_id": "google/gemini-2-0",
+  "family_id": "google/gemini-2.0",
   "links": [],
   "details": [],
   "benchmarks": [

--- a/packages/data/catalog/src/data/models/google/gemini-2.0-flash-thinking-exp-2025-01-21/model.json
+++ b/packages/data/catalog/src/data/models/google/gemini-2.0-flash-thinking-exp-2025-01-21/model.json
@@ -12,7 +12,7 @@
   "input_types": null,
   "output_types": null,
   "api_model_id": "google/gemini-2.0-flash-thinking-exp-2025-01-21",
-  "family_id": "google/gemini-2-0",
+  "family_id": "google/gemini-2.0",
   "links": [],
   "details": [],
   "benchmarks": [

--- a/packages/data/catalog/src/data/models/google/gemini-2.0-flash/model.json
+++ b/packages/data/catalog/src/data/models/google/gemini-2.0-flash/model.json
@@ -12,7 +12,7 @@
   "input_types": null,
   "output_types": null,
   "api_model_id": "google/gemini-2.0-flash",
-  "family_id": "google/gemini-2-0",
+  "family_id": "google/gemini-2.0",
   "links": [
     {
       "platform": "api_reference",

--- a/packages/data/catalog/src/data/models/google/gemini-2.0-pro-exp/model.json
+++ b/packages/data/catalog/src/data/models/google/gemini-2.0-pro-exp/model.json
@@ -12,7 +12,7 @@
   "input_types": null,
   "output_types": null,
   "api_model_id": "google/gemini-2.0-pro-exp",
-  "family_id": "google/gemini-2-0",
+  "family_id": "google/gemini-2.0",
   "links": [],
   "details": [],
   "benchmarks": [

--- a/packages/data/catalog/src/data/models/google/gemini-2.5-computer-use-preview/model.json
+++ b/packages/data/catalog/src/data/models/google/gemini-2.5-computer-use-preview/model.json
@@ -12,6 +12,7 @@
   "input_types": null,
   "output_types": null,
   "api_model_id": "google/gemini-2.5-computer-use-preview",
+  "family_id": "google/gemini-2.5",
   "links": [],
   "details": [],
   "benchmarks": [

--- a/packages/data/catalog/src/data/models/google/gemini-2.5-flash-exp-native-audio-thinking-dialog/model.json
+++ b/packages/data/catalog/src/data/models/google/gemini-2.5-flash-exp-native-audio-thinking-dialog/model.json
@@ -12,7 +12,7 @@
   "input_types": null,
   "output_types": null,
   "api_model_id": "google/gemini-2.5-flash-exp-native-audio-thinking-dialog",
-  "family_id": "google/gemini-2-5",
+  "family_id": "google/gemini-2.5",
   "links": [],
   "details": [],
   "benchmarks": [

--- a/packages/data/catalog/src/data/models/google/gemini-2.5-flash-image-preview/model.json
+++ b/packages/data/catalog/src/data/models/google/gemini-2.5-flash-image-preview/model.json
@@ -12,7 +12,7 @@
   "input_types": "text,image",
   "output_types": "text,image",
   "api_model_id": "google/gemini-2.5-flash-image-preview",
-  "family_id": "google/gemini-2-5",
+  "family_id": "google/gemini-2.5",
   "links": [],
   "details": [],
   "benchmarks": [

--- a/packages/data/catalog/src/data/models/google/gemini-2.5-flash-image/model.json
+++ b/packages/data/catalog/src/data/models/google/gemini-2.5-flash-image/model.json
@@ -12,7 +12,7 @@
   "input_types": "text,image",
   "output_types": "text,image",
   "api_model_id": "google/gemini-2.5-flash-image",
-  "family_id": "google/gemini-2-5",
+  "family_id": "google/gemini-2.5",
   "links": [],
   "details": [],
   "benchmarks": [

--- a/packages/data/catalog/src/data/models/google/gemini-2.5-flash-lite-preview-2025-06-17/model.json
+++ b/packages/data/catalog/src/data/models/google/gemini-2.5-flash-lite-preview-2025-06-17/model.json
@@ -12,7 +12,7 @@
   "input_types": "text,audio,image,video",
   "output_types": "text",
   "api_model_id": "google/gemini-2.5-flash-lite-preview-2025-06-17",
-  "family_id": "google/gemini-2-5",
+  "family_id": "google/gemini-2.5",
   "links": [
     {
       "platform": "api_reference",

--- a/packages/data/catalog/src/data/models/google/gemini-2.5-flash-lite-preview-2025-09-25/model.json
+++ b/packages/data/catalog/src/data/models/google/gemini-2.5-flash-lite-preview-2025-09-25/model.json
@@ -12,7 +12,7 @@
   "input_types": null,
   "output_types": null,
   "api_model_id": "google/gemini-2.5-flash-lite-preview-2025-09-25",
-  "family_id": "google/gemini-2-5",
+  "family_id": "google/gemini-2.5",
   "links": [],
   "details": [],
   "benchmarks": [

--- a/packages/data/catalog/src/data/models/google/gemini-2.5-flash-native-audio-preview-2025-09-03/model.json
+++ b/packages/data/catalog/src/data/models/google/gemini-2.5-flash-native-audio-preview-2025-09-03/model.json
@@ -12,7 +12,7 @@
   "input_types": null,
   "output_types": null,
   "api_model_id": "google/gemini-2.5-flash-native-audio-preview-2025-09-03",
-  "family_id": "google/gemini-2-5",
+  "family_id": "google/gemini-2.5",
   "links": [],
   "details": [],
   "benchmarks": [

--- a/packages/data/catalog/src/data/models/google/gemini-2.5-flash-preview-2025-04-17/model.json
+++ b/packages/data/catalog/src/data/models/google/gemini-2.5-flash-preview-2025-04-17/model.json
@@ -12,7 +12,7 @@
   "input_types": null,
   "output_types": null,
   "api_model_id": "google/gemini-2.5-flash-preview-2025-04-17",
-  "family_id": "google/gemini-2-5",
+  "family_id": "google/gemini-2.5",
   "links": [
     {
       "platform": "api_reference",

--- a/packages/data/catalog/src/data/models/google/gemini-2.5-flash-preview-2025-05-20/model.json
+++ b/packages/data/catalog/src/data/models/google/gemini-2.5-flash-preview-2025-05-20/model.json
@@ -12,7 +12,7 @@
   "input_types": "text,image,video,audio",
   "output_types": "text",
   "api_model_id": "google/gemini-2.5-flash-preview-2025-05-20",
-  "family_id": "google/gemini-2-5",
+  "family_id": "google/gemini-2.5",
   "links": [
     {
       "platform": "api_reference",

--- a/packages/data/catalog/src/data/models/google/gemini-2.5-flash-preview-2025-09-25/model.json
+++ b/packages/data/catalog/src/data/models/google/gemini-2.5-flash-preview-2025-09-25/model.json
@@ -12,7 +12,7 @@
   "input_types": null,
   "output_types": null,
   "api_model_id": "google/gemini-2.5-flash-preview-2025-09-25",
-  "family_id": "google/gemini-2-5",
+  "family_id": "google/gemini-2.5",
   "links": [],
   "details": [],
   "benchmarks": [

--- a/packages/data/catalog/src/data/models/google/gemini-2.5-flash-preview-native-audio-dialog/model.json
+++ b/packages/data/catalog/src/data/models/google/gemini-2.5-flash-preview-native-audio-dialog/model.json
@@ -12,7 +12,7 @@
   "input_types": null,
   "output_types": null,
   "api_model_id": "google/gemini-2.5-flash-preview-native-audio-dialog",
-  "family_id": "google/gemini-2-5",
+  "family_id": "google/gemini-2.5",
   "links": [],
   "details": [],
   "benchmarks": [

--- a/packages/data/catalog/src/data/models/google/gemini-2.5-flash-preview-tts-2025-05-20/model.json
+++ b/packages/data/catalog/src/data/models/google/gemini-2.5-flash-preview-tts-2025-05-20/model.json
@@ -12,7 +12,7 @@
   "input_types": null,
   "output_types": "audio_tts",
   "api_model_id": "google/gemini-2.5-flash-preview-tts-2025-05-20",
-  "family_id": "google/gemini-2-5",
+  "family_id": "google/gemini-2.5",
   "links": [],
   "details": [],
   "benchmarks": [

--- a/packages/data/catalog/src/data/models/google/gemini-2.5-flash-preview-tts-2025-12-10/model.json
+++ b/packages/data/catalog/src/data/models/google/gemini-2.5-flash-preview-tts-2025-12-10/model.json
@@ -12,6 +12,7 @@
   "input_types": null,
   "output_types": "audio_tts",
   "api_model_id": "google/gemini-2.5-flash-preview-tts-2025-12-10",
+  "family_id": "google/gemini-2.5",
   "links": [],
   "details": [],
   "benchmarks": [

--- a/packages/data/catalog/src/data/models/google/gemini-2.5-pro-experimental-2025-03-25/model.json
+++ b/packages/data/catalog/src/data/models/google/gemini-2.5-pro-experimental-2025-03-25/model.json
@@ -12,7 +12,7 @@
   "input_types": null,
   "output_types": null,
   "api_model_id": "google/gemini-2.5-pro-experimental-2025-03-25",
-  "family_id": "google/gemini-2-5",
+  "family_id": "google/gemini-2.5",
   "links": [],
   "details": [],
   "benchmarks": [

--- a/packages/data/catalog/src/data/models/google/gemini-2.5-pro-preview-2025-05-06/model.json
+++ b/packages/data/catalog/src/data/models/google/gemini-2.5-pro-preview-2025-05-06/model.json
@@ -12,7 +12,7 @@
   "input_types": null,
   "output_types": null,
   "api_model_id": "google/gemini-2.5-pro-preview-2025-05-06",
-  "family_id": "google/gemini-2-5",
+  "family_id": "google/gemini-2.5",
   "links": [],
   "details": [],
   "benchmarks": [

--- a/packages/data/catalog/src/data/models/google/gemini-2.5-pro-preview-2025-06-05/model.json
+++ b/packages/data/catalog/src/data/models/google/gemini-2.5-pro-preview-2025-06-05/model.json
@@ -12,7 +12,7 @@
   "input_types": "text,image,video,audio",
   "output_types": "text",
   "api_model_id": "google/gemini-2.5-pro-preview-2025-06-05",
-  "family_id": "google/gemini-2-5",
+  "family_id": "google/gemini-2.5",
   "links": [],
   "details": [],
   "benchmarks": [

--- a/packages/data/catalog/src/data/models/google/gemini-2.5-pro-preview-tts-2025-05-20/model.json
+++ b/packages/data/catalog/src/data/models/google/gemini-2.5-pro-preview-tts-2025-05-20/model.json
@@ -12,7 +12,7 @@
   "input_types": null,
   "output_types": "audio_tts",
   "api_model_id": "google/gemini-2.5-pro-preview-tts-2025-05-20",
-  "family_id": "google/gemini-2-5",
+  "family_id": "google/gemini-2.5",
   "links": [],
   "details": [],
   "benchmarks": [

--- a/packages/data/catalog/src/data/models/google/gemini-2.5-pro-preview-tts/model.json
+++ b/packages/data/catalog/src/data/models/google/gemini-2.5-pro-preview-tts/model.json
@@ -12,6 +12,7 @@
   "input_types": null,
   "output_types": "audio_tts",
   "api_model_id": "google/gemini-2.5-pro-preview-tts",
+  "family_id": "google/gemini-2.5",
   "links": [],
   "details": [],
   "benchmarks": [

--- a/packages/data/catalog/src/data/models/google/gemini-3-flash-preview/model.json
+++ b/packages/data/catalog/src/data/models/google/gemini-3-flash-preview/model.json
@@ -12,7 +12,7 @@
   "input_types": "text,image,video,audio",
   "output_types": "text",
   "api_model_id": "google/gemini-3-flash-preview",
-  "family_id": "google/gemini-3-0",
+  "family_id": "google/gemini-3.0",
   "links": [
     {
       "platform": "announcement",

--- a/packages/data/catalog/src/data/models/google/gemini-3-pro-image-preview/model.json
+++ b/packages/data/catalog/src/data/models/google/gemini-3-pro-image-preview/model.json
@@ -12,7 +12,7 @@
   "input_types": "text,image",
   "output_types": "text,image",
   "api_model_id": "google/gemini-3-pro-image-preview",
-  "family_id": "google/gemini-3-0",
+  "family_id": "google/gemini-3.0",
   "links": [],
   "details": [],
   "benchmarks": [

--- a/packages/data/catalog/src/data/models/google/gemini-3-pro-preview/model.json
+++ b/packages/data/catalog/src/data/models/google/gemini-3-pro-preview/model.json
@@ -12,7 +12,7 @@
   "input_types": "text,image,video,audio",
   "output_types": "text",
   "api_model_id": "google/gemini-3-pro-preview",
-  "family_id": "google/gemini-3-0",
+  "family_id": "google/gemini-3.0",
   "links": [
     {
       "platform": "paper",

--- a/packages/data/catalog/src/data/models/google/gemini-3.1-flash-image-preview/model.json
+++ b/packages/data/catalog/src/data/models/google/gemini-3.1-flash-image-preview/model.json
@@ -12,6 +12,7 @@
   "input_types": "text,image",
   "output_types": "text,image",
   "api_model_id": "google/gemini-3.1-flash-image-preview",
+  "family_id": "google/gemini-3.1",
   "links": [
     {
       "platform": "model_card",

--- a/packages/data/catalog/src/data/models/google/gemini-3.1-flash-lite-preview/model.json
+++ b/packages/data/catalog/src/data/models/google/gemini-3.1-flash-lite-preview/model.json
@@ -12,6 +12,7 @@
   "input_types": "text,image,video,audio",
   "output_types": "text",
   "api_model_id": "google/gemini-3.1-flash-lite-preview",
+  "family_id": "google/gemini-3.1",
   "links": [
     {
       "platform": "model_card",

--- a/packages/data/catalog/src/data/models/google/gemini-3.1-flash-tts-preview/model.json
+++ b/packages/data/catalog/src/data/models/google/gemini-3.1-flash-tts-preview/model.json
@@ -12,6 +12,7 @@
   "input_types": "text",
   "output_types": "audio_tts",
   "api_model_id": "google/gemini-3.1-flash-tts-preview",
+  "family_id": "google/gemini-3.1",
   "links": [
     {
       "platform": "api_reference",

--- a/packages/data/catalog/src/data/models/google/gemini-3.1-pro-preview-customtools/model.json
+++ b/packages/data/catalog/src/data/models/google/gemini-3.1-pro-preview-customtools/model.json
@@ -12,6 +12,7 @@
   "input_types": "text,image,audio,video",
   "output_types": "text",
   "api_model_id": "google/gemini-3.1-pro-preview-customtools",
+  "family_id": "google/gemini-3.1",
   "links": [],
   "details": [],
   "benchmarks": [

--- a/packages/data/catalog/src/data/models/google/gemini-3.1-pro-preview/model.json
+++ b/packages/data/catalog/src/data/models/google/gemini-3.1-pro-preview/model.json
@@ -12,7 +12,7 @@
   "input_types": "text,image,video,audio",
   "output_types": "text",
   "api_model_id": "google/gemini-3.1-pro-preview",
-  "family_id": "google/gemini-3-0",
+  "family_id": "google/gemini-3.1",
   "links": [
     {
       "platform": "model_card",

--- a/packages/data/catalog/src/data/models/google/lyria-3-clip-preview/model.json
+++ b/packages/data/catalog/src/data/models/google/lyria-3-clip-preview/model.json
@@ -12,6 +12,7 @@
   "input_types": "text,image",
   "output_types": "text,audio_music",
   "api_model_id": "google/lyria-3-clip-preview",
+  "family_id": "google/lyria-3",
   "links": [],
   "details": [],
   "benchmarks": []

--- a/packages/data/catalog/src/data/models/google/lyria-3-pro-preview/model.json
+++ b/packages/data/catalog/src/data/models/google/lyria-3-pro-preview/model.json
@@ -12,6 +12,7 @@
   "input_types": "text,image",
   "output_types": "text,audio_music",
   "api_model_id": "google/lyria-3-pro-preview",
+  "family_id": "google/lyria-3",
   "links": [],
   "details": [],
   "benchmarks": []

--- a/packages/data/catalog/src/data/models/google/lyria-3/model.json
+++ b/packages/data/catalog/src/data/models/google/lyria-3/model.json
@@ -12,6 +12,7 @@
   "input_types": null,
   "output_types": "audio_music",
   "api_model_id": "google/lyria-3",
+  "family_id": "google/lyria-3",
   "links": [],
   "details": [],
   "benchmarks": []

--- a/packages/data/catalog/src/data/models/google/veo-3.1-fast-preview/model.json
+++ b/packages/data/catalog/src/data/models/google/veo-3.1-fast-preview/model.json
@@ -12,6 +12,7 @@
   "input_types": null,
   "output_types": null,
   "api_model_id": "google/veo-3.1-fast-preview",
+  "family_id": "google/veo-3.1",
   "links": [],
   "details": [],
   "benchmarks": []

--- a/packages/data/catalog/src/data/models/google/veo-3.1-lite-preview/model.json
+++ b/packages/data/catalog/src/data/models/google/veo-3.1-lite-preview/model.json
@@ -12,6 +12,7 @@
   "input_types": "text,image",
   "output_types": "video,audio",
   "api_model_id": "google/veo-3.1-lite-preview",
+  "family_id": "google/veo-3.1",
   "links": [],
   "details": [],
   "benchmarks": [

--- a/packages/data/catalog/src/data/models/google/veo-3.1-preview/model.json
+++ b/packages/data/catalog/src/data/models/google/veo-3.1-preview/model.json
@@ -12,6 +12,7 @@
   "input_types": null,
   "output_types": null,
   "api_model_id": "google/veo-3.1-preview",
+  "family_id": "google/veo-3.1",
   "links": [],
   "details": [],
   "benchmarks": []

--- a/packages/data/catalog/src/data/models/openai/gpt-4.1-mini/model.json
+++ b/packages/data/catalog/src/data/models/openai/gpt-4.1-mini/model.json
@@ -12,7 +12,7 @@
   "input_types": "image,text",
   "output_types": "text",
   "api_model_id": "openai/gpt-4.1-mini",
-  "family_id": "openai/gpt-4-1",
+  "family_id": "openai/gpt-4.1",
   "links": [],
   "details": [
     {

--- a/packages/data/catalog/src/data/models/openai/gpt-4.1-nano/model.json
+++ b/packages/data/catalog/src/data/models/openai/gpt-4.1-nano/model.json
@@ -12,7 +12,7 @@
   "input_types": "image,text",
   "output_types": "text",
   "api_model_id": "openai/gpt-4.1-nano",
-  "family_id": "openai/gpt-4-1",
+  "family_id": "openai/gpt-4.1",
   "links": [],
   "details": [
     {

--- a/packages/data/catalog/src/data/models/openai/gpt-4.1/model.json
+++ b/packages/data/catalog/src/data/models/openai/gpt-4.1/model.json
@@ -12,7 +12,7 @@
   "input_types": "image,text",
   "output_types": "text",
   "api_model_id": "openai/gpt-4.1",
-  "family_id": "openai/gpt-4-1",
+  "family_id": "openai/gpt-4.1",
   "links": [],
   "details": [
     {

--- a/packages/data/catalog/src/data/models/openai/gpt-5.1-chat/model.json
+++ b/packages/data/catalog/src/data/models/openai/gpt-5.1-chat/model.json
@@ -12,7 +12,7 @@
   "input_types": "text,image",
   "output_types": "text",
   "api_model_id": "openai/gpt-5.1-chat",
-  "family_id": "openai/gpt-5-1",
+  "family_id": "openai/gpt-5.1",
   "links": [],
   "details": [],
   "benchmarks": [

--- a/packages/data/catalog/src/data/models/openai/gpt-5.1-codex-max/model.json
+++ b/packages/data/catalog/src/data/models/openai/gpt-5.1-codex-max/model.json
@@ -12,7 +12,7 @@
   "input_types": "text,image",
   "output_types": "text",
   "api_model_id": "openai/gpt-5.1-codex-max",
-  "family_id": "openai/gpt-5-1",
+  "family_id": "openai/gpt-5.1",
   "links": [
     {
       "platform": "announcement",

--- a/packages/data/catalog/src/data/models/openai/gpt-5.1-codex-mini/model.json
+++ b/packages/data/catalog/src/data/models/openai/gpt-5.1-codex-mini/model.json
@@ -12,7 +12,7 @@
   "input_types": "text,image",
   "output_types": "text",
   "api_model_id": "openai/gpt-5.1-codex-mini",
-  "family_id": "openai/gpt-5-1",
+  "family_id": "openai/gpt-5.1",
   "links": [],
   "details": [],
   "benchmarks": [

--- a/packages/data/catalog/src/data/models/openai/gpt-5.1-codex/model.json
+++ b/packages/data/catalog/src/data/models/openai/gpt-5.1-codex/model.json
@@ -12,7 +12,7 @@
   "input_types": "text,image",
   "output_types": "text",
   "api_model_id": "openai/gpt-5.1-codex",
-  "family_id": "openai/gpt-5-1",
+  "family_id": "openai/gpt-5.1",
   "links": [],
   "details": [],
   "benchmarks": [

--- a/packages/data/catalog/src/data/models/openai/gpt-5.1/model.json
+++ b/packages/data/catalog/src/data/models/openai/gpt-5.1/model.json
@@ -12,7 +12,7 @@
   "input_types": "text,image",
   "output_types": "text",
   "api_model_id": "openai/gpt-5.1",
-  "family_id": "openai/gpt-5-1",
+  "family_id": "openai/gpt-5.1",
   "links": [
     {
       "platform": "announcement",

--- a/packages/data/catalog/src/data/models/openai/gpt-5.2-chat/model.json
+++ b/packages/data/catalog/src/data/models/openai/gpt-5.2-chat/model.json
@@ -12,7 +12,7 @@
   "input_types": "text,image",
   "output_types": "text",
   "api_model_id": "openai/gpt-5.2-chat",
-  "family_id": "openai/gpt-5-2",
+  "family_id": "openai/gpt-5.2",
   "links": [
     {
       "platform": "announcement",

--- a/packages/data/catalog/src/data/models/openai/gpt-5.2-codex/model.json
+++ b/packages/data/catalog/src/data/models/openai/gpt-5.2-codex/model.json
@@ -12,7 +12,7 @@
   "input_types": "text,image",
   "output_types": "text",
   "api_model_id": "openai/gpt-5.2-codex",
-  "family_id": "openai/gpt-5-2",
+  "family_id": "openai/gpt-5.2",
   "links": [
     {
       "platform": "announcement",

--- a/packages/data/catalog/src/data/models/openai/gpt-5.2-mini/model.json
+++ b/packages/data/catalog/src/data/models/openai/gpt-5.2-mini/model.json
@@ -12,7 +12,7 @@
   "input_types": null,
   "output_types": null,
   "api_model_id": "openai/gpt-5.2-mini",
-  "family_id": "openai/gpt-5-2",
+  "family_id": "openai/gpt-5.2",
   "links": [],
   "details": [],
   "benchmarks": []

--- a/packages/data/catalog/src/data/models/openai/gpt-5.2-pro/model.json
+++ b/packages/data/catalog/src/data/models/openai/gpt-5.2-pro/model.json
@@ -12,7 +12,7 @@
   "input_types": "text,image",
   "output_types": "text",
   "api_model_id": "openai/gpt-5.2-pro",
-  "family_id": "openai/gpt-5-2",
+  "family_id": "openai/gpt-5.2",
   "links": [
     {
       "platform": "announcement",

--- a/packages/data/catalog/src/data/models/openai/gpt-5.2/model.json
+++ b/packages/data/catalog/src/data/models/openai/gpt-5.2/model.json
@@ -12,7 +12,7 @@
   "input_types": "text,image",
   "output_types": "text",
   "api_model_id": "openai/gpt-5.2",
-  "family_id": "openai/gpt-5-2",
+  "family_id": "openai/gpt-5.2",
   "links": [
     {
       "platform": "announcement",

--- a/packages/data/catalog/src/data/models/openai/gpt-5.3-chat/model.json
+++ b/packages/data/catalog/src/data/models/openai/gpt-5.3-chat/model.json
@@ -12,6 +12,7 @@
   "input_types": "text,image",
   "output_types": "text",
   "api_model_id": "openai/gpt-5.3-chat",
+  "family_id": "openai/gpt-5.3",
   "links": [
     {
       "platform": "announcement",

--- a/packages/data/catalog/src/data/models/openai/gpt-5.3-codex-spark/model.json
+++ b/packages/data/catalog/src/data/models/openai/gpt-5.3-codex-spark/model.json
@@ -12,7 +12,7 @@
   "input_types": "text",
   "output_types": "text",
   "api_model_id": "openai/gpt-5.3-codex-spark",
-  "family_id": "openai/gpt-5-3",
+  "family_id": "openai/gpt-5.3",
   "links": [
     {
       "platform": "announcement",

--- a/packages/data/catalog/src/data/models/openai/gpt-5.3-codex/model.json
+++ b/packages/data/catalog/src/data/models/openai/gpt-5.3-codex/model.json
@@ -12,7 +12,7 @@
   "input_types": "text,image",
   "output_types": "text",
   "api_model_id": "openai/gpt-5.3-codex",
-  "family_id": "openai/gpt-5-3",
+  "family_id": "openai/gpt-5.3",
   "links": [],
   "details": [],
   "benchmarks": [

--- a/packages/data/catalog/src/data/models/openai/gpt-5.4-cyber/model.json
+++ b/packages/data/catalog/src/data/models/openai/gpt-5.4-cyber/model.json
@@ -12,6 +12,7 @@
   "input_types": "text",
   "output_types": "text",
   "api_model_id": "openai/gpt-5.4-cyber",
+  "family_id": "openai/gpt-5.4",
   "links": [
     {
       "platform": "announcement",

--- a/packages/data/catalog/src/data/models/openai/gpt-5.4-mini/model.json
+++ b/packages/data/catalog/src/data/models/openai/gpt-5.4-mini/model.json
@@ -12,6 +12,7 @@
   "input_types": "text,image",
   "output_types": "text",
   "api_model_id": "openai/gpt-5.4-mini",
+  "family_id": "openai/gpt-5.4",
   "links": [
     {
       "platform": "announcement",

--- a/packages/data/catalog/src/data/models/openai/gpt-5.4-nano/model.json
+++ b/packages/data/catalog/src/data/models/openai/gpt-5.4-nano/model.json
@@ -12,6 +12,7 @@
   "input_types": "text,image",
   "output_types": "text",
   "api_model_id": "openai/gpt-5.4-nano",
+  "family_id": "openai/gpt-5.4",
   "links": [
     {
       "platform": "announcement",

--- a/packages/data/catalog/src/data/models/openai/gpt-5.4-pro/model.json
+++ b/packages/data/catalog/src/data/models/openai/gpt-5.4-pro/model.json
@@ -12,6 +12,7 @@
   "input_types": "text,image",
   "output_types": "text",
   "api_model_id": "openai/gpt-5.4-pro",
+  "family_id": "openai/gpt-5.4",
   "links": [
     {
       "platform": "announcement",

--- a/packages/data/catalog/src/data/models/openai/gpt-5.4/model.json
+++ b/packages/data/catalog/src/data/models/openai/gpt-5.4/model.json
@@ -12,6 +12,7 @@
   "input_types": "text,image",
   "output_types": "text",
   "api_model_id": "openai/gpt-5.4",
+  "family_id": "openai/gpt-5.4",
   "links": [
     {
       "platform": "announcement",

--- a/packages/data/catalog/src/data/models/openai/gpt-5.5-cyber/model.json
+++ b/packages/data/catalog/src/data/models/openai/gpt-5.5-cyber/model.json
@@ -12,7 +12,7 @@
   "input_types": "text",
   "output_types": "text",
   "api_model_id": "openai/gpt-5.5-cyber",
-  "family_id": "openai/gpt-5-5",
+  "family_id": "openai/gpt-5.5",
   "links": [
     {
       "platform": "announcement",

--- a/packages/data/catalog/src/data/models/openai/gpt-5.5-pro/model.json
+++ b/packages/data/catalog/src/data/models/openai/gpt-5.5-pro/model.json
@@ -12,7 +12,7 @@
   "input_types": null,
   "output_types": null,
   "api_model_id": "openai/gpt-5.5-pro",
-  "family_id": "openai/gpt-5-5",
+  "family_id": "openai/gpt-5.5",
   "links": [
     {
       "platform": "announcement",

--- a/packages/data/catalog/src/data/models/openai/gpt-5.5/model.json
+++ b/packages/data/catalog/src/data/models/openai/gpt-5.5/model.json
@@ -12,7 +12,7 @@
   "input_types": null,
   "output_types": null,
   "api_model_id": "openai/gpt-5.5",
-  "family_id": "openai/gpt-5-5",
+  "family_id": "openai/gpt-5.5",
   "links": [
     {
       "platform": "announcement",

--- a/packages/data/catalog/src/data/models/openai/gpt-5/model.json
+++ b/packages/data/catalog/src/data/models/openai/gpt-5/model.json
@@ -12,7 +12,7 @@
   "input_types": "text,image",
   "output_types": "text",
   "api_model_id": "openai/gpt-5",
-  "family_id": "openai/gpt-5-2",
+  "family_id": "openai/gpt-5",
   "links": [
     {
       "platform": "api_reference",


### PR DESCRIPTION
## What changed

- restricted `include_hidden=true` on the control models endpoint to internal auth only
- added regression tests for hidden-model access and audio subtype modality handling
- normalized model family IDs so they match canonical family records and actually import cleanly
- added missing family records for `GPT 5.5`, `Veo 3.1`, `Lyria 3`, `Claude 4.5`, `Claude 4.6`, and `Granite 4.1`
- attached logical multi-model series to those families across OpenAI, Google, and Anthropic where the grouping is clearly justified

## Why

This PR closes a low-severity control-plane metadata disclosure, fixes the audio subtype routing regression, repairs missing family references for Granite 4.1, and improves model-family grouping in the catalog without creating overly broad or singleton-only family buckets.

## Impact

- hidden model metadata is no longer exposed to non-internal callers via `include_hidden=true`
- audio subtype metadata such as `audio_tts` and `audio_music` now maps back to base `audio` in gateway modality matching
- family grouping in the catalog and imported DB is more consistent for GPT, Gemini, Claude, Veo, Lyria, and Granite series

## Validation

- `pnpm --filter @ai-stats/gateway-api exec vitest run src/routes/v1/control/models-data.test.ts src/pipeline/before/context.shared.test.ts src/pipeline/execute/modalities.test.ts`
- `pnpm --filter @ai-stats/gateway-api typecheck`
- `pnpm validate:data`
- `pnpm run update-db -- --section=families`
- `pnpm run update-db -- --section=models`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for audio modality variants in endpoint compatibility checks.
  * Added authorization controls for hidden models endpoint—external callers cannot access restricted model data.
  * Added new model families: Claude 4.5, Claude 4.6, Lyria 3, Veo 3.1, Granite 4.1, and GPT 5.5.

* **Improvements**
  * Standardized model family ID formatting across catalog (e.g., `claude-3-0` → `claude-3.0`).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->