### PR TITLE
Fix benchmark rank ordering semantics

### DIFF
--- a/apps/web/scripts/importer/compute/benchCompare.test.ts
+++ b/apps/web/scripts/importer/compute/benchCompare.test.ts
@@ -1,0 +1,23 @@
+import { computeBenchMap } from "./benchCompare";
+
+describe("computeBenchMap", () => {
+	it("ranks higher scores first when ascending_order is true", () => {
+		const map = computeBenchMap([
+			{ model_id: "model-low", benchmark_id: "bench-higher", score: "10", ascending_order: true },
+			{ model_id: "model-high", benchmark_id: "bench-higher", score: "20", ascending_order: true },
+		]);
+
+		expect(map["model-high"].benchmarks["bench-higher"].rank).toBe(1);
+		expect(map["model-low"].benchmarks["bench-higher"].rank).toBe(2);
+	});
+
+	it("ranks lower scores first when ascending_order is false", () => {
+		const map = computeBenchMap([
+			{ model_id: "model-low", benchmark_id: "bench-lower", score: "10", ascending_order: false },
+			{ model_id: "model-high", benchmark_id: "bench-lower", score: "20", ascending_order: false },
+		]);
+
+		expect(map["model-low"].benchmarks["bench-lower"].rank).toBe(1);
+		expect(map["model-high"].benchmarks["bench-lower"].rank).toBe(2);
+	});
+});

--- a/apps/web/scripts/importer/compute/benchCompare.ts
+++ b/apps/web/scripts/importer/compute/benchCompare.ts
@@ -1,3 +1,5 @@
+import { compareBenchmarkScores } from "../../../src/lib/benchmarks/scoreFormat";
+
 type Row = { model_id: string; benchmark_id: string; score: string; ascending_order: boolean };
 
 function toNum(s: string) {
@@ -28,7 +30,7 @@ export function computeBenchMap(all: Row[], window = 5) {
 
     // Sort each benchmark according to its ascending flag
     for (const b of Object.values(byBench)) {
-        b.rows.sort((a, b2) => (b.asc ? a.f - b2.f : b2.f - a.f));
+        b.rows.sort((a, b2) => compareBenchmarkScores(a.f, b2.f, b.asc));
     }
 
     const out: Record<string, any> = {};

--- a/apps/web/scripts/importer/recompute-benchmark-ranks-db.ts
+++ b/apps/web/scripts/importer/recompute-benchmark-ranks-db.ts
@@ -1,6 +1,6 @@
 import "dotenv/config";
 
-import { compareBenchmarkScores } from "../../src/lib/benchmarks/scoreFormat";
+import { compareBenchmarkScoresForBenchmark } from "../../src/lib/benchmarks/scoreFormat";
 import { assertOk, client, isDryRun, logWrite } from "./supa";
 import { chunk } from "./util";
 
@@ -88,9 +88,9 @@ async function fetchAllBenchmarkRows(
 
 async function fetchBenchmarkMeta(
 	benchmarkIds: string[],
-): Promise<Map<string, boolean>> {
+): Promise<Map<string, boolean | null>> {
 	const supa = client();
-	const out = new Map<string, boolean>();
+	const out = new Map<string, boolean | null>();
 	if (!benchmarkIds.length) return out;
 
 	for (const ids of chunk(Array.from(new Set(benchmarkIds)), 200)) {
@@ -103,7 +103,7 @@ async function fetchBenchmarkMeta(
 		) as BenchmarkMetaRow[];
 
 		for (const row of rows) {
-			out.set(row.id, row.ascending_order === true);
+			out.set(row.id, typeof row.ascending_order === "boolean" ? row.ascending_order : null);
 		}
 	}
 
@@ -142,7 +142,7 @@ async function benchmarkIdsForModel(modelId: string): Promise<string[]> {
 
 function buildRankedRows(
 	rows: BenchmarkResultRow[],
-	ascendingByBenchmark: Map<string, boolean>,
+	ascendingByBenchmark: Map<string, boolean | null>,
 ): BenchmarkResultRow[] {
 	const byBenchmark = new Map<string, BenchmarkResultRow[]>();
 
@@ -155,7 +155,6 @@ function buildRankedRows(
 	const ranked: BenchmarkResultRow[] = [];
 
 	for (const [benchmarkId, group] of byBenchmark) {
-		const ascending = ascendingByBenchmark.get(benchmarkId) ?? false;
 		const numeric = group
 			.map((row) => ({ row, numericScore: parseScore(row.score) }))
 			.filter(
@@ -164,7 +163,12 @@ function buildRankedRows(
 			)
 			.sort((a, b) => {
 				if (a.numericScore !== b.numericScore) {
-					return compareBenchmarkScores(a.numericScore, b.numericScore, ascending);
+					return compareBenchmarkScoresForBenchmark(
+						a.numericScore,
+						b.numericScore,
+						benchmarkId,
+						ascendingByBenchmark,
+					);
 				}
 				const resultKeyCompare = (a.row.result_key ?? "").localeCompare(
 					b.row.result_key ?? "",
@@ -244,7 +248,9 @@ async function main() {
 	);
 }
 
-main().catch((error) => {
-	console.error(error);
-	process.exit(1);
-});
+if (require.main === module) {
+	main().catch((error) => {
+		console.error(error);
+		process.exit(1);
+	});
+}

--- a/apps/web/scripts/importer/recompute-benchmark-ranks-db.ts
+++ b/apps/web/scripts/importer/recompute-benchmark-ranks-db.ts
@@ -1,5 +1,6 @@
 import "dotenv/config";
 
+import { compareBenchmarkScores } from "../../src/lib/benchmarks/scoreFormat";
 import { assertOk, client, isDryRun, logWrite } from "./supa";
 import { chunk } from "./util";
 
@@ -163,9 +164,7 @@ function buildRankedRows(
 			)
 			.sort((a, b) => {
 				if (a.numericScore !== b.numericScore) {
-					return ascending
-						? a.numericScore - b.numericScore
-						: b.numericScore - a.numericScore;
+					return compareBenchmarkScores(a.numericScore, b.numericScore, ascending);
 				}
 				const resultKeyCompare = (a.row.result_key ?? "").localeCompare(
 					b.row.result_key ?? "",

--- a/apps/web/scripts/importer/recompute-benchmark-ranks.ts
+++ b/apps/web/scripts/importer/recompute-benchmark-ranks.ts
@@ -1,6 +1,7 @@
 import { promises as fs } from "fs";
 import { join } from "path";
 
+import { compareBenchmarkScores } from "../../src/lib/benchmarks/scoreFormat";
 import { DIR_BENCHMARKS, DIR_MODELS } from "./paths";
 import { listDirs, readJson } from "./util";
 
@@ -168,7 +169,7 @@ function recomputeRanks(
 			.filter((row): row is RankedBenchmarkRow & { score: number } => row.score != null)
 			.sort((a, b) => {
 				if (a.score !== b.score) {
-					return ascending ? a.score - b.score : b.score - a.score;
+					return compareBenchmarkScores(a.score, b.score, ascending);
 				}
 				if (a.model_id !== b.model_id) return a.model_id.localeCompare(b.model_id);
 				const otherInfoCompare = (a.other_info ?? "").localeCompare(b.other_info ?? "");

--- a/apps/web/scripts/importer/recompute-benchmark-ranks.ts
+++ b/apps/web/scripts/importer/recompute-benchmark-ranks.ts
@@ -1,7 +1,7 @@
 import { promises as fs } from "fs";
 import { join } from "path";
 
-import { compareBenchmarkScores } from "../../src/lib/benchmarks/scoreFormat";
+import { compareBenchmarkScoresForBenchmark } from "../../src/lib/benchmarks/scoreFormat";
 import { DIR_BENCHMARKS, DIR_MODELS } from "./paths";
 import { listDirs, readJson } from "./util";
 
@@ -61,15 +61,18 @@ function parseScore(value: unknown): number | null {
 	return null;
 }
 
-async function loadBenchmarkMeta(): Promise<Map<string, boolean>> {
-	const out = new Map<string, boolean>();
+async function loadBenchmarkMeta(): Promise<Map<string, boolean | null>> {
+	const out = new Map<string, boolean | null>();
 	const benchmarkDirs = await listDirs(DIR_BENCHMARKS);
 
 	for (const benchmarkDir of benchmarkDirs) {
 		const benchmarkPath = join(benchmarkDir, "benchmark.json");
 		try {
 			const benchmark = await readJson<BenchmarkMetaJson>(benchmarkPath);
-			out.set(benchmark.benchmark_id, benchmark.ascending_order === true);
+			out.set(
+				benchmark.benchmark_id,
+				typeof benchmark.ascending_order === "boolean" ? benchmark.ascending_order : null,
+			);
 		} catch {
 			continue;
 		}
@@ -145,7 +148,7 @@ function collectRankRows(
 
 function recomputeRanks(
 	rows: RankedBenchmarkRow[],
-	ascendingByBenchmark: Map<string, boolean>,
+	ascendingByBenchmark: Map<string, boolean | null>,
 ): Map<ModelFile, Set<number>> {
 	const touchedEntries = new Map<ModelFile, Set<number>>();
 	const byBenchmark = new Map<string, RankedBenchmarkRow[]>();
@@ -164,12 +167,16 @@ function recomputeRanks(
 	}
 
 	for (const [benchmarkId, group] of byBenchmark) {
-		const ascending = ascendingByBenchmark.get(benchmarkId) ?? false;
 		const ranked = group
 			.filter((row): row is RankedBenchmarkRow & { score: number } => row.score != null)
 			.sort((a, b) => {
 				if (a.score !== b.score) {
-					return compareBenchmarkScores(a.score, b.score, ascending);
+					return compareBenchmarkScoresForBenchmark(
+						a.score,
+						b.score,
+						benchmarkId,
+						ascendingByBenchmark,
+					);
 				}
 				if (a.model_id !== b.model_id) return a.model_id.localeCompare(b.model_id);
 				const otherInfoCompare = (a.other_info ?? "").localeCompare(b.other_info ?? "");
@@ -240,7 +247,9 @@ async function main() {
 	);
 }
 
-main().catch((error) => {
-	console.error(error);
-	process.exit(1);
-});
+if (require.main === module) {
+	main().catch((error) => {
+		console.error(error);
+		process.exit(1);
+	});
+}

--- a/apps/web/src/lib/benchmarks/scoreFormat.test.ts
+++ b/apps/web/src/lib/benchmarks/scoreFormat.test.ts
@@ -1,6 +1,7 @@
 import {
 	benchmarkOrderFromAscending,
 	compareBenchmarkScores,
+	compareBenchmarkScoresForBenchmark,
 	getLowerIsBetter,
 } from "./scoreFormat";
 
@@ -22,5 +23,12 @@ describe("benchmark score ordering semantics", () => {
 	it("defaults missing ordering metadata to higher-is-better", () => {
 		expect(compareBenchmarkScores(10, 20, null)).toBeGreaterThan(0);
 		expect(compareBenchmarkScores(20, 10, undefined)).toBeLessThan(0);
+	});
+
+	it("preserves higher-is-better fallback when ordering metadata is missing from a benchmark map", () => {
+		const orderingByBenchmark = new Map<string, boolean | null>();
+
+		expect(compareBenchmarkScoresForBenchmark(10, 20, "bench-missing", orderingByBenchmark)).toBeGreaterThan(0);
+		expect(compareBenchmarkScoresForBenchmark(20, 10, "bench-missing", orderingByBenchmark)).toBeLessThan(0);
 	});
 });

--- a/apps/web/src/lib/benchmarks/scoreFormat.test.ts
+++ b/apps/web/src/lib/benchmarks/scoreFormat.test.ts
@@ -1,0 +1,26 @@
+import {
+	benchmarkOrderFromAscending,
+	compareBenchmarkScores,
+	getLowerIsBetter,
+} from "./scoreFormat";
+
+describe("benchmark score ordering semantics", () => {
+	it("treats ascending_order=true as higher-is-better", () => {
+		expect(benchmarkOrderFromAscending(true)).toBe("higher");
+		expect(getLowerIsBetter(null, true)).toBe(false);
+		expect(compareBenchmarkScores(10, 20, true)).toBeGreaterThan(0);
+		expect(compareBenchmarkScores(20, 10, true)).toBeLessThan(0);
+	});
+
+	it("treats ascending_order=false as lower-is-better", () => {
+		expect(benchmarkOrderFromAscending(false)).toBe("lower");
+		expect(getLowerIsBetter(null, false)).toBe(true);
+		expect(compareBenchmarkScores(10, 20, false)).toBeLessThan(0);
+		expect(compareBenchmarkScores(20, 10, false)).toBeGreaterThan(0);
+	});
+
+	it("defaults missing ordering metadata to higher-is-better", () => {
+		expect(compareBenchmarkScores(10, 20, null)).toBeGreaterThan(0);
+		expect(compareBenchmarkScores(20, 10, undefined)).toBeLessThan(0);
+	});
+});

--- a/apps/web/src/lib/benchmarks/scoreFormat.ts
+++ b/apps/web/src/lib/benchmarks/scoreFormat.ts
@@ -122,3 +122,23 @@ export function getLowerIsBetter(
 	if (order === "higher" || order === "descending") return false;
 	return order.includes("lower") || order.includes("ascending");
 }
+
+export function compareBenchmarkScores(
+	a: number,
+	b: number,
+	ascendingOrder: boolean | null | undefined
+): number {
+	if (a === b) return 0;
+
+	// In this codebase, ascending_order=true means "higher is better",
+	// and ascending_order=false means "lower is better".
+	if (ascendingOrder === true) {
+		return b - a;
+	}
+	if (ascendingOrder === false) {
+		return a - b;
+	}
+
+	// Fall back to higher-is-better when ordering metadata is missing.
+	return b - a;
+}

--- a/apps/web/src/lib/benchmarks/scoreFormat.ts
+++ b/apps/web/src/lib/benchmarks/scoreFormat.ts
@@ -142,3 +142,12 @@ export function compareBenchmarkScores(
 	// Fall back to higher-is-better when ordering metadata is missing.
 	return b - a;
 }
+
+export function compareBenchmarkScoresForBenchmark(
+	a: number,
+	b: number,
+	benchmarkId: string,
+	orderingByBenchmark: Map<string, boolean | null | undefined>
+): number {
+	return compareBenchmarkScores(a, b, orderingByBenchmark.get(benchmarkId));
+}


### PR DESCRIPTION
## Summary
- fix benchmark rank ordering so `ascending_order=true` means higher scores rank first
- apply the same comparator to both recompute scripts and the benchmark map helper
- add focused regressions for the shared ordering semantics

## Validation
- `pnpm --filter @ai-stats/web exec jest src/lib/benchmarks/scoreFormat.test.ts scripts/importer/compute/benchCompare.test.ts --runInBand`
- `pnpm --filter @ai-stats/web typecheck`
