### PR TITLE
Validate organisation social link URLs

### DIFF
--- a/apps/web/src/app/(dashboard)/internal/data/actions.ts
+++ b/apps/web/src/app/(dashboard)/internal/data/actions.ts
@@ -16,6 +16,7 @@ import {
 	normalizeModelStatus,
 	type CapabilityStatusOption,
 } from "@/lib/models/editorOptions";
+import { normalizeHttpUrl } from "@/lib/utils/urlSafety";
 
 async function requireAdmin() {
 	const supabase = await createClient();
@@ -188,7 +189,7 @@ async function replaceOrganisationLinks(
 	const links = rawLinks
 		.map((link) => ({
 			platform: normalizeOrganisationPlatform(link.platform),
-			url: typeof link.url === "string" ? link.url.trim() : "",
+			url: normalizeHttpUrl(link.url),
 		}))
 		.filter((link): link is { platform: (typeof ORG_SOCIAL_PLATFORM_ORDER)[number]; url: string } => Boolean(link.platform && link.url))
 		.sort((a, b) => {

--- a/apps/web/src/components/(data)/organisation/OrganisationLinks.tsx
+++ b/apps/web/src/components/(data)/organisation/OrganisationLinks.tsx
@@ -4,6 +4,7 @@ import { Globe } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { OrganisationOverview as OrganisationOverviewType } from "@/lib/fetchers/organisations/getOrganisation";
 import { cn } from "@/lib/utils";
+import { normalizeHttpUrl } from "@/lib/utils/urlSafety";
 
 // Map platform names to Tailwind hover classes
 const PLATFORM_HOVER_CLASSES: Record<string, string> = {
@@ -117,6 +118,8 @@ export default function OrganisationLinks({
 					})
 					.map((link, idx) => {
 						const normalizedPlatform = normalizePlatform(link.platform);
+						const safeUrl = normalizeHttpUrl(link.url);
+						if (!safeUrl) return null;
 						const hoverClass =
 							PLATFORM_HOVER_CLASSES[
 								normalizedPlatform
@@ -135,7 +138,7 @@ export default function OrganisationLinks({
 								)}
 							>
 								<Link
-									href={link.url || "#"}
+									href={safeUrl}
 									target="_blank"
 									rel="noopener noreferrer"
 								>

--- a/apps/web/src/lib/utils/urlSafety.test.ts
+++ b/apps/web/src/lib/utils/urlSafety.test.ts
@@ -1,0 +1,23 @@
+import { normalizeHttpUrl } from "./urlSafety";
+
+describe("normalizeHttpUrl", () => {
+	it("accepts and normalizes https urls", () => {
+		expect(normalizeHttpUrl(" https://example.com/path ")).toBe("https://example.com/path");
+	});
+
+	it("accepts http urls", () => {
+		expect(normalizeHttpUrl("http://example.com")).toBe("http://example.com/");
+	});
+
+	it("rejects javascript and data schemes", () => {
+		expect(normalizeHttpUrl("javascript:alert(1)")).toBeNull();
+		expect(normalizeHttpUrl("data:text/html,<script>alert(1)</script>")).toBeNull();
+	});
+
+	it("rejects invalid or empty input", () => {
+		expect(normalizeHttpUrl("")).toBeNull();
+		expect(normalizeHttpUrl("   ")).toBeNull();
+		expect(normalizeHttpUrl("not a url")).toBeNull();
+		expect(normalizeHttpUrl(null)).toBeNull();
+	});
+});

--- a/apps/web/src/lib/utils/urlSafety.ts
+++ b/apps/web/src/lib/utils/urlSafety.ts
@@ -1,0 +1,16 @@
+export function normalizeHttpUrl(input: unknown): string | null {
+	if (typeof input !== "string") return null;
+
+	const trimmed = input.trim();
+	if (!trimmed) return null;
+
+	try {
+		const parsed = new URL(trimmed);
+		if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+			return null;
+		}
+		return parsed.toString();
+	} catch {
+		return null;
+	}
+}


### PR DESCRIPTION
## Summary
- validate organisation social links to allow only `http:` and `https:` URLs before persistence
- defensively revalidate stored organisation links before rendering them into `href`
- add focused regression coverage for URL scheme normalization

## Validation
- `pnpm --filter @ai-stats/web exec jest src/lib/utils/urlSafety.test.ts --runInBand`
- `pnpm --filter @ai-stats/web typecheck`
