### PR TITLE
fix(post-merge): address follow-up runtime issues

### DIFF
--- a/apps/api/src/core/async-notifications.ts
+++ b/apps/api/src/core/async-notifications.ts
@@ -297,14 +297,15 @@ function isWebhookEventSubscribed(args: {
 function resolveVideoBilling(record: AsyncOperationRecord, meta: AsyncNotificationMeta) {
 	const estimated = toFiniteNumber(meta.costUsd);
 	const status = toPublicVideoStatus(record.status);
-	const settled = status === "completed" ? estimated : status === "failed" || status === "cancelled" ? 0 : null;
+	const isVoided = status === "failed" || status === "cancelled" || status === "expired";
+	const settled = status === "completed" ? estimated : isVoided ? 0 : null;
 	return {
 		currency: "usd",
 		estimated_provider_cost: estimated != null ? estimated.toFixed(2) : null,
 		estimated_user_cost: estimated != null ? estimated.toFixed(2) : null,
 		settled_provider_cost: settled != null ? settled.toFixed(2) : null,
 		settled_user_cost: settled != null ? settled.toFixed(2) : null,
-		state: status === "completed" ? "settled" : status === "failed" || status === "cancelled" ? "void" : "estimated",
+		state: status === "completed" ? "settled" : isVoided ? "void" : "estimated",
 		billable: status === "completed",
 		...(record.billedAt ? { billed_at: record.billedAt } : {}),
 	};

--- a/apps/api/src/core/async-operations.ts
+++ b/apps/api/src/core/async-operations.ts
@@ -121,7 +121,7 @@ export async function listAsyncOperations(args: {
 	kind: AsyncOperationKind;
 	limit?: number;
 	providers?: string[];
-	statuses?: string[];
+	statuses?: Array<string | null>;
 	unbilledOnly?: boolean;
 }): Promise<AsyncOperationRecord[]> {
 	const limit = Number.isFinite(args.limit) ? Math.max(1, Math.min(500, Math.trunc(args.limit!))) : 100;
@@ -146,10 +146,17 @@ export async function listAsyncOperations(args: {
 		}
 	}
 	if (args.statuses && args.statuses.length > 0) {
+		const includeNullStatus = args.statuses.some((value) => value == null);
 		const statuses = args.statuses
 			.map((value) => normalizeText(value))
 			.filter((value): value is string => Boolean(value));
-		if (statuses.length > 0) {
+		if (includeNullStatus && statuses.length > 0) {
+			query = query.or(
+				`status.is.null,status.in.(${statuses.map((value) => `"${value}"`).join(",")})`,
+			);
+		} else if (includeNullStatus) {
+			query = query.is("status", null);
+		} else if (statuses.length > 0) {
 			query = query.in("status", statuses);
 		}
 	}
@@ -163,7 +170,7 @@ export async function listTeamAsyncOperations(args: {
 	workspaceId: string;
 	kind: AsyncOperationKind;
 	limit?: number;
-	statuses?: string[];
+	statuses?: Array<string | null>;
 }): Promise<AsyncOperationRecord[]> {
 	const workspaceId = normalizeText(args.workspaceId);
 	if (!workspaceId) return [];
@@ -180,10 +187,17 @@ export async function listTeamAsyncOperations(args: {
 		.limit(limit);
 
 	if (args.statuses && args.statuses.length > 0) {
+		const includeNullStatus = args.statuses.some((value) => value == null);
 		const statuses = args.statuses
 			.map((value) => normalizeText(value))
 			.filter((value): value is string => Boolean(value));
-		if (statuses.length > 0) {
+		if (includeNullStatus && statuses.length > 0) {
+			query = query.or(
+				`status.is.null,status.in.(${statuses.map((value) => `"${value}"`).join(",")})`,
+			);
+		} else if (includeNullStatus) {
+			query = query.is("status", null);
+		} else if (statuses.length > 0) {
 			query = query.in("status", statuses);
 		}
 	}

--- a/apps/api/src/core/batch-jobs.ts
+++ b/apps/api/src/core/batch-jobs.ts
@@ -243,6 +243,7 @@ export async function listPendingBatchJobs(limit = 100): Promise<BatchJobRecord[
 	const records = await listAsyncOperations({
 		kind: "batch",
 		limit,
+		statuses: ["", "validating", "pending", "in_progress", "finalizing", "cancelling"],
 	});
 	return records
 		.map((record) => toBatchJobRecord(record))

--- a/apps/api/src/core/batch-jobs.ts
+++ b/apps/api/src/core/batch-jobs.ts
@@ -243,7 +243,7 @@ export async function listPendingBatchJobs(limit = 100): Promise<BatchJobRecord[
 	const records = await listAsyncOperations({
 		kind: "batch",
 		limit,
-		statuses: ["", "validating", "pending", "in_progress", "finalizing", "cancelling"],
+		statuses: [null, "validating", "pending", "in_progress", "finalizing", "cancelling"],
 	});
 	return records
 		.map((record) => toBatchJobRecord(record))

--- a/apps/web/src/app/(dashboard)/gateway/usage/server-actions.ts
+++ b/apps/web/src/app/(dashboard)/gateway/usage/server-actions.ts
@@ -237,7 +237,7 @@ export async function fetchPaginatedRequests(
 		} = await fallback;
 		if (fallbackError) {
 			console.error("Error fetching paginated requests (fallback):", fallbackError);
-			const legacyFallback = supabase
+			let legacyFallback = supabase
 				.from("gateway_requests")
 				.select(
 					`
@@ -267,13 +267,13 @@ export async function fetchPaginatedRequests(
 				.gte("created_at", params.timeRange.from)
 				.lte("created_at", params.timeRange.to)
 				.not("endpoint", "in", buildNotInFilter(LONG_RUNNING_REQUEST_ENDPOINTS));
-			if (params.modelFilter) legacyFallback.eq("model_id", params.modelFilter);
-			if (params.providerFilter) legacyFallback.eq("provider", params.providerFilter);
-			if (params.keyFilter) legacyFallback.eq("key_id", params.keyFilter);
-			if (params.requestFilter) legacyFallback.eq("request_id", params.requestFilter);
-			if (params.sessionFilter) legacyFallback.eq("session_id", params.sessionFilter);
-			if (params.statusFilter === "success") legacyFallback.eq("success", true);
-			else if (params.statusFilter === "error") legacyFallback.eq("success", false);
+			if (params.modelFilter) legacyFallback = legacyFallback.eq("model_id", params.modelFilter);
+			if (params.providerFilter) legacyFallback = legacyFallback.eq("provider", params.providerFilter);
+			if (params.keyFilter) legacyFallback = legacyFallback.eq("key_id", params.keyFilter);
+			if (params.requestFilter) legacyFallback = legacyFallback.eq("request_id", params.requestFilter);
+			if (params.sessionFilter) legacyFallback = legacyFallback.eq("session_id", params.sessionFilter);
+			if (params.statusFilter === "success") legacyFallback = legacyFallback.eq("success", true);
+			else if (params.statusFilter === "error") legacyFallback = legacyFallback.eq("success", false);
 			const {
 				data: legacyData,
 				error: legacyError,

--- a/apps/web/src/app/api/chat/video/route.ts
+++ b/apps/web/src/app/api/chat/video/route.ts
@@ -55,8 +55,12 @@ function normalizeStatusFilter(value: string): "queued" | "in_progress" | "compl
 }
 
 function resolveVideoListPath(request: NextRequest): string {
-	const limitValue = Number(request.nextUrl.searchParams.get("limit") ?? "");
-	const limit = Number.isFinite(limitValue) ? Math.max(1, Math.min(200, Math.trunc(limitValue))) : 50;
+	const rawLimit = request.nextUrl.searchParams.get("limit");
+	const limitValue = rawLimit == null ? null : Number(rawLimit);
+	const limit =
+		limitValue != null && Number.isFinite(limitValue)
+			? Math.max(1, Math.min(200, Math.trunc(limitValue)))
+			: 50;
 	const statuses = request.nextUrl.searchParams
 		.getAll("status")
 		.flatMap((value) => value.split(",").map((part) => part.trim()).filter(Boolean))

--- a/apps/web/src/components/(data)/model/playground/ModelPlayground.tsx
+++ b/apps/web/src/components/(data)/model/playground/ModelPlayground.tsx
@@ -468,11 +468,12 @@ function extractVideoResourceId(payload: unknown): string | null {
 }
 
 async function parseApiPayload(response: Response): Promise<unknown> {
+	const readable = response.clone();
 	const contentType = response.headers.get("content-type") ?? "";
 	if (contentType.includes("application/json")) {
-		return response.json();
+		return readable.json();
 	}
-	return { output_text: await response.text() };
+	return { output_text: await readable.text() };
 }
 
 async function fetchVideoContentObjectUrl(
@@ -2398,7 +2399,7 @@ export default function ModelPlayground({
 	const safeVideoResponseUrls = useMemo(
 		() =>
 			videoResponseUrls
-				.map((url) => normalizePlaygroundMediaUrl(url))
+				.map((url) => (url.startsWith("blob:") ? url : normalizePlaygroundMediaUrl(url)))
 				.filter((url): url is string => Boolean(url)),
 		[videoResponseUrls],
 	);

--- a/supabase/migrations/20260504191500_restore_oauth_apps_with_stats_view.sql
+++ b/supabase/migrations/20260504191500_restore_oauth_apps_with_stats_view.sql
@@ -7,13 +7,15 @@ with (security_invoker = true)
 as
 select
   oam.*,
-  count(oa.id) filter (where oa.revoked_at is null) as active_authorizations,
-  count(oa.id) as total_authorizations,
+  count(distinct oa.id) filter (where oa.revoked_at is null) as active_authorizations,
+  count(distinct oa.id) as total_authorizations,
   max(oa.last_used_at) as last_used_at,
-  count(distinct gr.id) filter (where gr.created_at > now() - interval '30 days') as requests_last_30d
+  count(distinct gr.id) as requests_last_30d
 from public.oauth_app_metadata oam
 left join public.oauth_authorizations oa on oa.client_id = oam.client_id
-left join public.gateway_requests gr on gr.oauth_client_id = oam.client_id
+left join public.gateway_requests gr
+  on gr.oauth_client_id = oam.client_id
+ and gr.created_at > now() - interval '30 days'
 where oam.status = 'active'
 group by oam.id;
 

--- a/supabase/migrations/20260504191500_restore_oauth_apps_with_stats_view.sql
+++ b/supabase/migrations/20260504191500_restore_oauth_apps_with_stats_view.sql
@@ -1,0 +1,22 @@
+-- Restore oauth_apps_with_stats for runtime compatibility with the OAuth apps UI.
+
+drop view if exists public.oauth_apps_with_stats;
+
+create view public.oauth_apps_with_stats
+with (security_invoker = true)
+as
+select
+  oam.*,
+  count(oa.id) filter (where oa.revoked_at is null) as active_authorizations,
+  count(oa.id) as total_authorizations,
+  max(oa.last_used_at) as last_used_at,
+  count(distinct gr.id) filter (where gr.created_at > now() - interval '30 days') as requests_last_30d
+from public.oauth_app_metadata oam
+left join public.oauth_authorizations oa on oa.client_id = oam.client_id
+left join public.gateway_requests gr on gr.oauth_client_id = oam.client_id
+where oam.status = 'active'
+group by oam.id;
+
+grant select on public.oauth_apps_with_stats to authenticated;
+
+comment on view public.oauth_apps_with_stats is 'OAuth apps with authorization and usage statistics. SECURITY INVOKER - respects RLS policies on underlying tables.';

--- a/supabase/migrations/20260504192000_fix_wallet_reservation_null_safe_updates.sql
+++ b/supabase/migrations/20260504192000_fix_wallet_reservation_null_safe_updates.sql
@@ -50,13 +50,13 @@ begin
     for update;
 
     if not found then
-      select false, false, 'wallet_not_found'::text, p_amount_nanos,
+      return query select false, false, 'wallet_not_found'::text, p_amount_nanos,
         null::bigint, null::bigint, null::bigint, null::bigint;
       return;
     end if;
 
     if v_existing.status = 'reserved' then
-      select true, false, 'already_reserved'::text, v_existing.amount_nanos,
+      return query select true, false, 'already_reserved'::text, v_existing.amount_nanos,
         coalesce(v_wallet.balance_nanos, 0)::bigint,
         coalesce(v_wallet.balance_nanos, 0)::bigint,
         coalesce(v_wallet.reserved_nanos, 0)::bigint,
@@ -64,7 +64,7 @@ begin
       return;
     end if;
 
-    select false, false, 'reservation_not_active'::text, v_existing.amount_nanos,
+    return query select false, false, 'reservation_not_active'::text, v_existing.amount_nanos,
       coalesce(v_wallet.balance_nanos, 0)::bigint,
       coalesce(v_wallet.balance_nanos, 0)::bigint,
       coalesce(v_wallet.reserved_nanos, 0)::bigint,
@@ -78,7 +78,7 @@ begin
   for update;
 
   if not found then
-    select false, false, 'wallet_not_found'::text, p_amount_nanos,
+    return query select false, false, 'wallet_not_found'::text, p_amount_nanos,
       null::bigint, null::bigint, null::bigint, null::bigint;
     return;
   end if;
@@ -86,7 +86,7 @@ begin
   v_available := coalesce(v_wallet.balance_nanos, 0) - coalesce(v_wallet.reserved_nanos, 0);
 
   if v_available < p_amount_nanos then
-    select false, false, 'insufficient_balance'::text, p_amount_nanos,
+    return query select false, false, 'insufficient_balance'::text, p_amount_nanos,
       coalesce(v_wallet.balance_nanos, 0)::bigint,
       coalesce(v_wallet.balance_nanos, 0)::bigint,
       coalesce(v_wallet.reserved_nanos, 0)::bigint,
@@ -122,7 +122,7 @@ begin
   returning *
   into v_wallet;
 
-  select true, true, null::text, p_amount_nanos,
+  return query select true, true, null::text, p_amount_nanos,
     v_before_balance,
     coalesce(v_wallet.balance_nanos, 0),
     v_before_reserved,
@@ -168,7 +168,7 @@ begin
   for update;
 
   if not found then
-    select false, false, 'reservation_not_found'::text, null::bigint,
+    return query select false, false, 'reservation_not_found'::text, null::bigint,
       null::bigint, null::bigint, null::bigint, null::bigint;
     return;
   end if;
@@ -179,13 +179,13 @@ begin
   for update;
 
   if not found then
-    select false, false, 'wallet_not_found'::text, v_existing.amount_nanos,
+    return query select false, false, 'wallet_not_found'::text, v_existing.amount_nanos,
       null::bigint, null::bigint, null::bigint, null::bigint;
     return;
   end if;
 
   if v_existing.status = 'captured' then
-    select true, false, 'already_captured'::text, v_existing.amount_nanos,
+    return query select true, false, 'already_captured'::text, v_existing.amount_nanos,
       coalesce(v_wallet.balance_nanos, 0)::bigint,
       coalesce(v_wallet.balance_nanos, 0)::bigint,
       coalesce(v_wallet.reserved_nanos, 0)::bigint,
@@ -194,7 +194,7 @@ begin
   end if;
 
   if v_existing.status <> 'reserved' then
-    select false, false, 'reservation_not_active'::text, v_existing.amount_nanos,
+    return query select false, false, 'reservation_not_active'::text, v_existing.amount_nanos,
       coalesce(v_wallet.balance_nanos, 0)::bigint,
       coalesce(v_wallet.balance_nanos, 0)::bigint,
       coalesce(v_wallet.reserved_nanos, 0)::bigint,
@@ -205,8 +205,11 @@ begin
   v_amount := v_existing.amount_nanos;
 
   if coalesce(v_wallet.reserved_nanos, 0) < v_amount then
-    select false, false, 'reserved_balance_mismatch'::text, v_amount,
-      v_wallet.balance_nanos, v_wallet.balance_nanos, v_wallet.reserved_nanos, v_wallet.reserved_nanos;
+    return query select false, false, 'reserved_balance_mismatch'::text, v_amount,
+      coalesce(v_wallet.balance_nanos, 0)::bigint,
+      coalesce(v_wallet.balance_nanos, 0)::bigint,
+      coalesce(v_wallet.reserved_nanos, 0)::bigint,
+      coalesce(v_wallet.reserved_nanos, 0)::bigint;
     return;
   end if;
 
@@ -226,7 +229,7 @@ begin
   where reservation_id = p_reservation_id
     and workspace_id = p_workspace_id;
 
-  select true, true, null::text, v_amount,
+  return query select true, true, null::text, v_amount,
     coalesce(v_wallet.balance_nanos, 0) + v_amount,
     coalesce(v_wallet.balance_nanos, 0),
     coalesce(v_wallet.reserved_nanos, 0) + v_amount,
@@ -272,7 +275,7 @@ begin
   for update;
 
   if not found then
-    select false, false, 'reservation_not_found'::text, null::bigint,
+    return query select false, false, 'reservation_not_found'::text, null::bigint,
       null::bigint, null::bigint, null::bigint, null::bigint;
     return;
   end if;
@@ -283,13 +286,13 @@ begin
   for update;
 
   if not found then
-    select false, false, 'wallet_not_found'::text, v_existing.amount_nanos,
+    return query select false, false, 'wallet_not_found'::text, v_existing.amount_nanos,
       null::bigint, null::bigint, null::bigint, null::bigint;
     return;
   end if;
 
   if v_existing.status = 'released' then
-    select true, false, 'already_released'::text, v_existing.amount_nanos,
+    return query select true, false, 'already_released'::text, v_existing.amount_nanos,
       coalesce(v_wallet.balance_nanos, 0)::bigint,
       coalesce(v_wallet.balance_nanos, 0)::bigint,
       coalesce(v_wallet.reserved_nanos, 0)::bigint,
@@ -298,7 +301,7 @@ begin
   end if;
 
   if v_existing.status <> 'reserved' then
-    select false, false, 'reservation_not_active'::text, v_existing.amount_nanos,
+    return query select false, false, 'reservation_not_active'::text, v_existing.amount_nanos,
       coalesce(v_wallet.balance_nanos, 0)::bigint,
       coalesce(v_wallet.balance_nanos, 0)::bigint,
       coalesce(v_wallet.reserved_nanos, 0)::bigint,
@@ -309,8 +312,11 @@ begin
   v_amount := v_existing.amount_nanos;
 
   if coalesce(v_wallet.reserved_nanos, 0) < v_amount then
-    select false, false, 'reserved_balance_mismatch'::text, v_amount,
-      v_wallet.balance_nanos, v_wallet.balance_nanos, v_wallet.reserved_nanos, v_wallet.reserved_nanos;
+    return query select false, false, 'reserved_balance_mismatch'::text, v_amount,
+      coalesce(v_wallet.balance_nanos, 0)::bigint,
+      coalesce(v_wallet.balance_nanos, 0)::bigint,
+      coalesce(v_wallet.reserved_nanos, 0)::bigint,
+      coalesce(v_wallet.reserved_nanos, 0)::bigint;
     return;
   end if;
 
@@ -329,7 +335,7 @@ begin
   where reservation_id = p_reservation_id
     and workspace_id = p_workspace_id;
 
-  select true, true, null::text, v_amount,
+  return query select true, true, null::text, v_amount,
     coalesce(v_wallet.balance_nanos, 0),
     coalesce(v_wallet.balance_nanos, 0),
     coalesce(v_wallet.reserved_nanos, 0) + v_amount,

--- a/supabase/migrations/20260504192000_fix_wallet_reservation_null_safe_updates.sql
+++ b/supabase/migrations/20260504192000_fix_wallet_reservation_null_safe_updates.sql
@@ -1,0 +1,338 @@
+-- Make wallet reservation arithmetic null-safe for legacy rows.
+
+create or replace function public.gateway_wallet_reserve_once(
+  p_workspace_id uuid,
+  p_reservation_id text,
+  p_amount_nanos bigint,
+  p_hold_ref_id text default null
+)
+returns table (
+  ok boolean,
+  applied boolean,
+  reason text,
+  amount_nanos bigint,
+  before_balance_nanos bigint,
+  after_balance_nanos bigint,
+  before_reserved_nanos bigint,
+  after_reserved_nanos bigint
+)
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_wallet public.wallets%rowtype;
+  v_existing public.gateway_wallet_reservations%rowtype;
+  v_available bigint;
+  v_before_balance bigint;
+  v_before_reserved bigint;
+begin
+  if p_workspace_id is null then
+    raise exception 'workspace_id_required' using errcode = 'P0001';
+  end if;
+  if coalesce(trim(p_reservation_id), '') = '' then
+    raise exception 'reservation_id_required' using errcode = 'P0001';
+  end if;
+  if p_amount_nanos is null or p_amount_nanos <= 0 then
+    raise exception 'amount_nanos_must_be_positive' using errcode = 'P0001';
+  end if;
+
+  select * into v_existing
+  from public.gateway_wallet_reservations
+  where reservation_id = p_reservation_id
+    and workspace_id = p_workspace_id
+  for update;
+
+  if found then
+    select * into v_wallet
+    from public.wallets
+    where workspace_id = p_workspace_id
+    for update;
+
+    if not found then
+      select false, false, 'wallet_not_found'::text, p_amount_nanos,
+        null::bigint, null::bigint, null::bigint, null::bigint;
+      return;
+    end if;
+
+    if v_existing.status = 'reserved' then
+      select true, false, 'already_reserved'::text, v_existing.amount_nanos,
+        coalesce(v_wallet.balance_nanos, 0)::bigint,
+        coalesce(v_wallet.balance_nanos, 0)::bigint,
+        coalesce(v_wallet.reserved_nanos, 0)::bigint,
+        coalesce(v_wallet.reserved_nanos, 0)::bigint;
+      return;
+    end if;
+
+    select false, false, 'reservation_not_active'::text, v_existing.amount_nanos,
+      coalesce(v_wallet.balance_nanos, 0)::bigint,
+      coalesce(v_wallet.balance_nanos, 0)::bigint,
+      coalesce(v_wallet.reserved_nanos, 0)::bigint,
+      coalesce(v_wallet.reserved_nanos, 0)::bigint;
+    return;
+  end if;
+
+  select * into v_wallet
+  from public.wallets
+  where workspace_id = p_workspace_id
+  for update;
+
+  if not found then
+    select false, false, 'wallet_not_found'::text, p_amount_nanos,
+      null::bigint, null::bigint, null::bigint, null::bigint;
+    return;
+  end if;
+
+  v_available := coalesce(v_wallet.balance_nanos, 0) - coalesce(v_wallet.reserved_nanos, 0);
+
+  if v_available < p_amount_nanos then
+    select false, false, 'insufficient_balance'::text, p_amount_nanos,
+      coalesce(v_wallet.balance_nanos, 0)::bigint,
+      coalesce(v_wallet.balance_nanos, 0)::bigint,
+      coalesce(v_wallet.reserved_nanos, 0)::bigint,
+      coalesce(v_wallet.reserved_nanos, 0)::bigint;
+    return;
+  end if;
+
+  insert into public.gateway_wallet_reservations (
+    reservation_id,
+    workspace_id,
+    amount_nanos,
+    status,
+    hold_ref_id,
+    created_at,
+    updated_at
+  ) values (
+    p_reservation_id,
+    p_workspace_id,
+    p_amount_nanos,
+    'reserved',
+    nullif(trim(coalesce(p_hold_ref_id, '')), ''),
+    now(),
+    now()
+  );
+
+  v_before_balance := coalesce(v_wallet.balance_nanos, 0);
+  v_before_reserved := coalesce(v_wallet.reserved_nanos, 0);
+
+  update public.wallets
+  set reserved_nanos = coalesce(reserved_nanos, 0) + p_amount_nanos,
+      updated_at = now()
+  where workspace_id = p_workspace_id
+  returning *
+  into v_wallet;
+
+  select true, true, null::text, p_amount_nanos,
+    v_before_balance,
+    coalesce(v_wallet.balance_nanos, 0),
+    v_before_reserved,
+    coalesce(v_wallet.reserved_nanos, 0);
+end;
+$$;
+
+create or replace function public.gateway_wallet_capture_once(
+  p_workspace_id uuid,
+  p_reservation_id text,
+  p_capture_ref_id text default null
+)
+returns table (
+  ok boolean,
+  applied boolean,
+  reason text,
+  amount_nanos bigint,
+  before_balance_nanos bigint,
+  after_balance_nanos bigint,
+  before_reserved_nanos bigint,
+  after_reserved_nanos bigint
+)
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_wallet public.wallets%rowtype;
+  v_existing public.gateway_wallet_reservations%rowtype;
+  v_amount bigint;
+begin
+  if p_workspace_id is null then
+    raise exception 'workspace_id_required' using errcode = 'P0001';
+  end if;
+  if coalesce(trim(p_reservation_id), '') = '' then
+    raise exception 'reservation_id_required' using errcode = 'P0001';
+  end if;
+
+  select * into v_existing
+  from public.gateway_wallet_reservations
+  where reservation_id = p_reservation_id
+    and workspace_id = p_workspace_id
+  for update;
+
+  if not found then
+    select false, false, 'reservation_not_found'::text, null::bigint,
+      null::bigint, null::bigint, null::bigint, null::bigint;
+    return;
+  end if;
+
+  select * into v_wallet
+  from public.wallets
+  where workspace_id = p_workspace_id
+  for update;
+
+  if not found then
+    select false, false, 'wallet_not_found'::text, v_existing.amount_nanos,
+      null::bigint, null::bigint, null::bigint, null::bigint;
+    return;
+  end if;
+
+  if v_existing.status = 'captured' then
+    select true, false, 'already_captured'::text, v_existing.amount_nanos,
+      coalesce(v_wallet.balance_nanos, 0)::bigint,
+      coalesce(v_wallet.balance_nanos, 0)::bigint,
+      coalesce(v_wallet.reserved_nanos, 0)::bigint,
+      coalesce(v_wallet.reserved_nanos, 0)::bigint;
+    return;
+  end if;
+
+  if v_existing.status <> 'reserved' then
+    select false, false, 'reservation_not_active'::text, v_existing.amount_nanos,
+      coalesce(v_wallet.balance_nanos, 0)::bigint,
+      coalesce(v_wallet.balance_nanos, 0)::bigint,
+      coalesce(v_wallet.reserved_nanos, 0)::bigint,
+      coalesce(v_wallet.reserved_nanos, 0)::bigint;
+    return;
+  end if;
+
+  v_amount := v_existing.amount_nanos;
+
+  if coalesce(v_wallet.reserved_nanos, 0) < v_amount then
+    select false, false, 'reserved_balance_mismatch'::text, v_amount,
+      v_wallet.balance_nanos, v_wallet.balance_nanos, v_wallet.reserved_nanos, v_wallet.reserved_nanos;
+    return;
+  end if;
+
+  update public.wallets
+  set balance_nanos = coalesce(balance_nanos, 0) - v_amount,
+      reserved_nanos = coalesce(reserved_nanos, 0) - v_amount,
+      updated_at = now()
+  where workspace_id = p_workspace_id
+  returning *
+  into v_wallet;
+
+  update public.gateway_wallet_reservations
+  set status = 'captured',
+      capture_ref_id = nullif(trim(coalesce(p_capture_ref_id, '')), ''),
+      captured_at = now(),
+      updated_at = now()
+  where reservation_id = p_reservation_id
+    and workspace_id = p_workspace_id;
+
+  select true, true, null::text, v_amount,
+    coalesce(v_wallet.balance_nanos, 0) + v_amount,
+    coalesce(v_wallet.balance_nanos, 0),
+    coalesce(v_wallet.reserved_nanos, 0) + v_amount,
+    coalesce(v_wallet.reserved_nanos, 0);
+end;
+$$;
+
+create or replace function public.gateway_wallet_release_once(
+  p_workspace_id uuid,
+  p_reservation_id text,
+  p_release_ref_id text default null
+)
+returns table (
+  ok boolean,
+  applied boolean,
+  reason text,
+  amount_nanos bigint,
+  before_balance_nanos bigint,
+  after_balance_nanos bigint,
+  before_reserved_nanos bigint,
+  after_reserved_nanos bigint
+)
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_wallet public.wallets%rowtype;
+  v_existing public.gateway_wallet_reservations%rowtype;
+  v_amount bigint;
+begin
+  if p_workspace_id is null then
+    raise exception 'workspace_id_required' using errcode = 'P0001';
+  end if;
+  if coalesce(trim(p_reservation_id), '') = '' then
+    raise exception 'reservation_id_required' using errcode = 'P0001';
+  end if;
+
+  select * into v_existing
+  from public.gateway_wallet_reservations
+  where reservation_id = p_reservation_id
+    and workspace_id = p_workspace_id
+  for update;
+
+  if not found then
+    select false, false, 'reservation_not_found'::text, null::bigint,
+      null::bigint, null::bigint, null::bigint, null::bigint;
+    return;
+  end if;
+
+  select * into v_wallet
+  from public.wallets
+  where workspace_id = p_workspace_id
+  for update;
+
+  if not found then
+    select false, false, 'wallet_not_found'::text, v_existing.amount_nanos,
+      null::bigint, null::bigint, null::bigint, null::bigint;
+    return;
+  end if;
+
+  if v_existing.status = 'released' then
+    select true, false, 'already_released'::text, v_existing.amount_nanos,
+      coalesce(v_wallet.balance_nanos, 0)::bigint,
+      coalesce(v_wallet.balance_nanos, 0)::bigint,
+      coalesce(v_wallet.reserved_nanos, 0)::bigint,
+      coalesce(v_wallet.reserved_nanos, 0)::bigint;
+    return;
+  end if;
+
+  if v_existing.status <> 'reserved' then
+    select false, false, 'reservation_not_active'::text, v_existing.amount_nanos,
+      coalesce(v_wallet.balance_nanos, 0)::bigint,
+      coalesce(v_wallet.balance_nanos, 0)::bigint,
+      coalesce(v_wallet.reserved_nanos, 0)::bigint,
+      coalesce(v_wallet.reserved_nanos, 0)::bigint;
+    return;
+  end if;
+
+  v_amount := v_existing.amount_nanos;
+
+  if coalesce(v_wallet.reserved_nanos, 0) < v_amount then
+    select false, false, 'reserved_balance_mismatch'::text, v_amount,
+      v_wallet.balance_nanos, v_wallet.balance_nanos, v_wallet.reserved_nanos, v_wallet.reserved_nanos;
+    return;
+  end if;
+
+  update public.wallets
+  set reserved_nanos = coalesce(reserved_nanos, 0) - v_amount,
+      updated_at = now()
+  where workspace_id = p_workspace_id
+  returning *
+  into v_wallet;
+
+  update public.gateway_wallet_reservations
+  set status = 'released',
+      release_ref_id = nullif(trim(coalesce(p_release_ref_id, '')), ''),
+      released_at = now(),
+      updated_at = now()
+  where reservation_id = p_reservation_id
+    and workspace_id = p_workspace_id;
+
+  select true, true, null::text, v_amount,
+    coalesce(v_wallet.balance_nanos, 0),
+    coalesce(v_wallet.balance_nanos, 0),
+    coalesce(v_wallet.reserved_nanos, 0) + v_amount,
+    coalesce(v_wallet.reserved_nanos, 0);
+end;
+$$;


### PR DESCRIPTION
## Summary
- fix several post-merge runtime issues surfaced in review comments
- restore OAuth apps view compatibility so the settings UI does not break if the legacy view is queried
- harden video playground polling and async billing edge cases

## Included fixes
- fix `/api/chat/video` list `limit` defaulting so a missing param no longer collapses to `1`
- treat expired video jobs as voided billing in async notification payloads
- fix the legacy usage logs fallback query builder so request/session/provider filters actually apply
- push batch pending-status filtering into `listAsyncOperations(...)` before limiting
- avoid consuming video poll error bodies before `readErrorMessage(...)`
- preserve `blob:` fallback video URLs in the playground render path
- add compatibility migrations for `oauth_apps_with_stats` and null-safe wallet reservation arithmetic

## Validation
- `pnpm --filter @ai-stats/gateway-api typecheck`
- `pnpm --filter @ai-stats/web typecheck`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed video list limit parameter defaulting to proper value
  * Fixed request filters not applying in fallback queries
  * Fixed response parsing to prevent data loss
  * Improved wallet reservation state transitions with null-safety handling
  * Corrected expired video billing treatment

* **New Features**
  * Added OAuth app statistics view with authorization and usage metrics
  * Added wallet reservation state management functions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->