### PR TITLE
fix(web): add playground retry actions and correct contact time

### DIFF
--- a/apps/web/src/app/(dashboard)/contact/page.tsx
+++ b/apps/web/src/app/(dashboard)/contact/page.tsx
@@ -28,7 +28,7 @@ async function ContactPersonalization() {
 	await connection();
 
 	const { isOpen, minutesUntilNextWindow } = getSupportAvailability();
-	const { date } = getLondonInfo();
+	const { label: londonLabel } = getLondonInfo();
 	const backOnlineLabel = formatSupportWait(minutesUntilNextWindow);
 	const statusLabel = isOpen
 		? "Available now"
@@ -43,14 +43,6 @@ async function ContactPersonalization() {
 		: backOnlineLabel
 			? `Support will be back online in ${backOnlineLabel}. Replies may be delayed, but you will still get a direct human response from me as soon as possible.`
 			: "I'm away right now. Replies may be delayed, but you will still get a direct human response from me as soon as possible.";
-	const londonLabel = date.toLocaleString("en-GB", {
-		hour: "2-digit",
-		minute: "2-digit",
-		day: "2-digit",
-		month: "short",
-		weekday: "short",
-	});
-
 	const workspaceId = await getWorkspaceIdFromCookie();
 	const supabase = await createClient();
 	const {

--- a/apps/web/src/components/(data)/model/playground/ModelPlayground.tsx
+++ b/apps/web/src/components/(data)/model/playground/ModelPlayground.tsx
@@ -13,9 +13,11 @@ import {
 	Mic,
 	MessageSquare,
 	Music2,
+	RotateCcw,
 	ShieldAlert,
 	Sparkles,
 	TerminalSquare,
+	Trash2,
 } from "lucide-react";
 import { Logo } from "@/components/Logo";
 import CodeBlock from "@/components/(data)/model/quickstart/CodeBlock";
@@ -2196,6 +2198,12 @@ export default function ModelPlayground({
 		}
 	};
 
+	const clearImageGeneration = () => {
+		setImageError(null);
+		setImageResponseUrls([]);
+		setImageResponseText("");
+	};
+
 	const handleGenerateVideo = async () => {
 		if (!trimmedVideoPrompt || videoIsGenerating || !resolvedVideoModelId) return;
 		videoPollControllerRef.current?.abort();
@@ -2281,6 +2289,14 @@ export default function ModelPlayground({
 				setVideoIsGenerating(false);
 			}
 		}
+	};
+
+	const clearVideoGeneration = () => {
+		videoPollControllerRef.current?.abort();
+		videoPollControllerRef.current = null;
+		setVideoError(null);
+		replaceVideoResponseUrls([]);
+		setVideoResponseText("");
 	};
 
 	const handleGenerateEmbeddings = async () => {
@@ -2402,6 +2418,10 @@ export default function ModelPlayground({
 				.filter((url): url is string => Boolean(url)),
 		[videoResponseUrls],
 	);
+	const showImageFailureState =
+		Boolean(imageError) &&
+		!imageIsGenerating &&
+		!safeImageResponseUrls.length;
 	const showImageThinkingState =
 		imageIsGenerating && !safeImageResponseUrls.length && !imageResponseText;
 	const showEmptyImageResponse =
@@ -2411,6 +2431,10 @@ export default function ModelPlayground({
 		!imageError;
 	const showVideoThinkingState =
 		videoIsGenerating && !safeVideoResponseUrls.length && !videoResponseText;
+	const showVideoFailureState =
+		Boolean(videoError) &&
+		!videoIsGenerating &&
+		!safeVideoResponseUrls.length;
 	const showEmptyVideoResponse =
 		!videoIsGenerating &&
 		!safeVideoResponseUrls.length &&
@@ -2491,6 +2515,49 @@ export default function ModelPlayground({
 					className="h-2.5 w-2.5 animate-bounce rounded-full bg-current"
 					style={{ animationDelay: "280ms" }}
 				/>
+			</div>
+		</div>
+	);
+	const renderFailurePanel = ({
+		message,
+		onRetry,
+		onDelete,
+		isBusy,
+	}: {
+		message: string;
+		onRetry: () => void;
+		onDelete: () => void;
+		isBusy: boolean;
+	}) => (
+		<div className="flex min-h-[320px] flex-col justify-between rounded-md border border-black/20 bg-black/[0.03] p-4 dark:border-white/20 dark:bg-white/[0.05]">
+			<div className="space-y-2">
+				<p className="text-sm font-medium text-black dark:text-white">
+					Generation failed
+				</p>
+				<p className="text-sm leading-6 text-black/70 dark:text-white/70">
+					{message}
+				</p>
+			</div>
+			<div className="flex flex-wrap items-center gap-2 pt-4">
+				<Button
+					type="button"
+					onClick={onRetry}
+					disabled={isBusy}
+					className="h-9 bg-black text-white hover:bg-zinc-800 dark:bg-white dark:text-black dark:hover:bg-zinc-200"
+				>
+					<RotateCcw className="h-4 w-4" />
+					Retry
+				</Button>
+				<Button
+					type="button"
+					variant="outline"
+					onClick={onDelete}
+					disabled={isBusy}
+					className="h-9 border-black/20 bg-transparent text-black hover:bg-black/5 dark:border-white/20 dark:text-white dark:hover:bg-white/10"
+				>
+					<Trash2 className="h-4 w-4" />
+					Delete
+				</Button>
 			</div>
 		</div>
 	);
@@ -2633,11 +2700,6 @@ export default function ModelPlayground({
 							<Sparkles className="h-4 w-4" />
 							{imageIsGenerating ? "Generating..." : "Generate Image"}
 						</Button>
-						{imageError ? (
-							<p className="rounded-md border border-black/20 bg-black/5 px-3 py-2 text-sm text-black dark:border-white/20 dark:bg-white/10 dark:text-white">
-								{imageError}
-							</p>
-						) : null}
 					</div>
 
 					<div className="min-h-[440px] border-black/15 md:border-l md:pl-6 dark:border-white/20">
@@ -2663,6 +2725,15 @@ export default function ModelPlayground({
 							<div className="text-sm leading-6 text-black dark:text-white">
 								<Streamdown>{imageResponseText}</Streamdown>
 							</div>
+						) : showImageFailureState ? (
+							renderFailurePanel({
+								message: imageError ?? "Image request failed. Please try again.",
+								onRetry: () => {
+									void handleGenerateImage();
+								},
+								onDelete: clearImageGeneration,
+								isBusy: imageIsGenerating,
+							})
 						) : showImageThinkingState ? (
 							renderThinkingPanel()
 						) : showEmptyImageResponse ? (
@@ -2693,11 +2764,6 @@ export default function ModelPlayground({
 							<Sparkles className="h-4 w-4" />
 							{videoIsGenerating ? "Generating..." : "Generate Video"}
 						</Button>
-						{videoError ? (
-							<p className="rounded-md border border-black/20 bg-black/5 px-3 py-2 text-sm text-black dark:border-white/20 dark:bg-white/10 dark:text-white">
-								{videoError}
-							</p>
-						) : null}
 					</div>
 
 					<div className="min-h-[440px] border-black/15 md:border-l md:pl-6 dark:border-white/20">
@@ -2725,6 +2791,15 @@ export default function ModelPlayground({
 							<div className="text-sm leading-6 text-black dark:text-white">
 								<Streamdown>{videoResponseText}</Streamdown>
 							</div>
+						) : showVideoFailureState ? (
+							renderFailurePanel({
+								message: videoError ?? "Video request failed. Please try again.",
+								onRetry: () => {
+									void handleGenerateVideo();
+								},
+								onDelete: clearVideoGeneration,
+								isBusy: videoIsGenerating,
+							})
 						) : showVideoThinkingState ? (
 							renderThinkingPanel()
 						) : showEmptyVideoResponse ? (

--- a/apps/web/src/components/(data)/model/quickstart/Support.tsx
+++ b/apps/web/src/components/(data)/model/quickstart/Support.tsx
@@ -99,10 +99,10 @@ export default function Support() {
 		  )}.`
 		: "Live chat replies resume soon.";
 	useEffect(() => {
-		const { date, day, minutes } = getLondonInfo();
+		const { isoLike, day, minutes } = getLondonInfo();
 		console.log(
 			"[support] London",
-			date.toISOString(),
+			isoLike,
 			`day=${day}`,
 			`minuteOfDay=${minutes}`,
 			`open=${isOpen}`,

--- a/apps/web/src/components/contact/ContactClient.tsx
+++ b/apps/web/src/components/contact/ContactClient.tsx
@@ -278,8 +278,8 @@ export function ContactClient({
 
 	return (
 		<div className="container mx-auto space-y-8 px-4 py-10 sm:px-6 lg:px-8">
-			<div className="flex flex-wrap items-start justify-between gap-4">
-				<div className="space-y-2">
+			<div className="flex flex-col gap-5 lg:flex-row lg:items-start lg:justify-between">
+				<div className="max-w-2xl space-y-2">
 					<Badge variant="secondary" className="w-fit">
 						Talk to a human
 					</Badge>
@@ -290,13 +290,17 @@ export function ContactClient({
 						founder, for a human response.
 					</p>
 				</div>
-				<div className="flex flex-col items-end gap-1 text-xs text-muted-foreground">
+				<div className="w-full rounded-xl border border-border/60 bg-card/70 px-4 py-3 text-sm text-muted-foreground lg:ml-auto lg:max-w-sm">
 					<Badge variant="outline" className="gap-2 border-border/60">
 						<span className={cn("h-2 w-2 rounded-full", statusDotClass)} />
 						Support {resolvedStatusLabel}
 					</Badge>
-					<span>{resolvedWaitText}</span>
-					<span>London time: {resolvedLondonLabel}</span>
+					<div className="mt-3 space-y-1.5">
+						<p className="leading-6 text-foreground/80">{resolvedWaitText}</p>
+						<p className="text-xs text-muted-foreground">
+							London time: {resolvedLondonLabel}
+						</p>
+					</div>
 				</div>
 			</div>
 

--- a/apps/web/src/components/header/TeamSwitcher.tsx
+++ b/apps/web/src/components/header/TeamSwitcher.tsx
@@ -99,10 +99,10 @@ export default function TeamSwitcher({
 		: "bg-amber-500 ring-amber-400/60";
 
 	useEffect(() => {
-		const { date, day, minutes } = getLondonInfo();
+		const { isoLike, day, minutes } = getLondonInfo();
 		console.log(
 			"[workspace-switcher] London",
-			date.toISOString(),
+			isoLike,
 			`day=${day}`,
 			`minuteOfDay=${minutes}`,
 			`open=${supportIsOpen}`,

--- a/apps/web/src/lib/support/schedule.ts
+++ b/apps/web/src/lib/support/schedule.ts
@@ -72,23 +72,13 @@ function getLondonParts(date = new Date()): LondonParts {
 		second: Number(getPart("second") || 0),
 	};
 }
-export function getLondonInfo(date?: Date) {
-	const london = getLondonParts(date);
-	return {
-		label: londonLabelFormatter.format(date ?? new Date()),
-		isoLike: `${String(london.year).padStart(4, "0")}-${String(london.month).padStart(2, "0")}-${String(london.dayOfMonth).padStart(2, "0")}T${String(london.hour).padStart(2, "0")}:${String(london.minute).padStart(2, "0")}:${String(london.second).padStart(2, "0")} Europe/London`,
-		weekdayLabel: london.weekdayLabel,
-		day: WEEKDAY_INDEX[london.weekdayLabel] ?? 0,
-		minutes: london.hour * 60 + london.minute,
-	};
-}
 
 function getMinutesUntilNextWindow(day: number, minutes: number): number | null {
-	for (let offset = 0; offset < 7; offset++) {
+	for (let offset = 0; offset < 7; offset += 1) {
 		const currentDay = (day + offset) % 7;
-		const windows = (SCHEDULE[currentDay] ?? []).slice().sort(
-			(a, b) => a.start - b.start
-		);
+		const windows = (SCHEDULE[currentDay] ?? [])
+			.slice()
+			.sort((a, b) => a.start - b.start);
 
 		for (const window of windows) {
 			if (offset === 0 && window.start <= minutes) {
@@ -107,19 +97,30 @@ export interface SupportAvailability {
 	minutesUntilNextWindow: number | null;
 }
 
+export function getLondonInfo(date?: Date) {
+	const sourceDate = date ?? new Date();
+	const london = getLondonParts(date);
+	return {
+		date: sourceDate,
+		label: londonLabelFormatter.format(sourceDate),
+		isoLike: `${String(london.year).padStart(4, "0")}-${String(london.month).padStart(2, "0")}-${String(london.dayOfMonth).padStart(2, "0")}T${String(london.hour).padStart(2, "0")}:${String(london.minute).padStart(2, "0")}:${String(london.second).padStart(2, "0")} Europe/London`,
+		weekdayLabel: london.weekdayLabel,
+		day: WEEKDAY_INDEX[london.weekdayLabel] ?? 0,
+		minutes: london.hour * 60 + london.minute,
+	};
+}
+
 export function getSupportAvailability(date?: Date): SupportAvailability {
 	const london = getLondonInfo(date);
-	const day = london.day;
-	const minutes = london.minutes;
-	const windows = SCHEDULE[day] ?? [];
+	const windows = SCHEDULE[london.day] ?? [];
 
 	const isOpen = windows.some(
-		(window) => minutes >= window.start && minutes < window.end
+		(window) => london.minutes >= window.start && london.minutes < window.end,
 	);
 
 	const minutesUntilNextWindow = isOpen
 		? null
-		: getMinutesUntilNextWindow(day, minutes);
+		: getMinutesUntilNextWindow(london.day, london.minutes);
 
 	return { isOpen, minutesUntilNextWindow };
 }

--- a/apps/web/src/lib/support/schedule.ts
+++ b/apps/web/src/lib/support/schedule.ts
@@ -15,7 +15,8 @@ const SCHEDULE: Record<number, ScheduleWindow[]> = {
 
 const DAY_MINUTES = 24 * 60;
 
-const londonFormatter = new Intl.DateTimeFormat("en-GB", {
+const londonPartsFormatter = new Intl.DateTimeFormat("en-GB", {
+	weekday: "short",
 	day: "2-digit",
 	month: "2-digit",
 	year: "numeric",
@@ -26,34 +27,60 @@ const londonFormatter = new Intl.DateTimeFormat("en-GB", {
 	timeZone: "Europe/London",
 });
 
-function toLondonDate(date = new Date()) {
-	const parts = londonFormatter.formatToParts(date);
-	const getPart = (type: string) => {
-		const part = parts.find((p) => p.type === type);
-		return part ? Number(part.value) : 0;
+const londonLabelFormatter = new Intl.DateTimeFormat("en-GB", {
+	weekday: "short",
+	day: "2-digit",
+	month: "short",
+	hour: "2-digit",
+	minute: "2-digit",
+	hour12: false,
+	timeZone: "Europe/London",
+});
+
+const WEEKDAY_INDEX: Record<string, number> = {
+	Sun: 0,
+	Mon: 1,
+	Tue: 2,
+	Wed: 3,
+	Thu: 4,
+	Fri: 5,
+	Sat: 6,
+};
+
+type LondonParts = {
+	weekdayLabel: string;
+	year: number;
+	month: number;
+	dayOfMonth: number;
+	hour: number;
+	minute: number;
+	second: number;
+};
+
+function getLondonParts(date = new Date()): LondonParts {
+	const parts = londonPartsFormatter.formatToParts(date);
+	const getPart = (type: Intl.DateTimeFormatPartTypes) =>
+		parts.find((part) => part.type === type)?.value ?? "";
+
+	return {
+		weekdayLabel: getPart("weekday"),
+		year: Number(getPart("year") || 0),
+		month: Number(getPart("month") || 0),
+		dayOfMonth: Number(getPart("day") || 0),
+		hour: Number(getPart("hour") || 0),
+		minute: Number(getPart("minute") || 0),
+		second: Number(getPart("second") || 0),
 	};
-
-	const year = getPart("year");
-	const month = getPart("month");
-	const day = getPart("day");
-	const hour = getPart("hour");
-	const minute = getPart("minute");
-	const second = getPart("second");
-
-	const londonUtc = Date.UTC(year, month - 1, day, hour, minute, second);
-	return new Date(londonUtc);
 }
 export function getLondonInfo(date?: Date) {
-	const londonDate = toLondonDate(date);
+	const london = getLondonParts(date);
 	return {
-		date: londonDate,
-		day: londonDate.getDay(),
-		minutes: minutesOfDay(londonDate),
+		label: londonLabelFormatter.format(date ?? new Date()),
+		isoLike: `${String(london.year).padStart(4, "0")}-${String(london.month).padStart(2, "0")}-${String(london.dayOfMonth).padStart(2, "0")}T${String(london.hour).padStart(2, "0")}:${String(london.minute).padStart(2, "0")}:${String(london.second).padStart(2, "0")} Europe/London`,
+		weekdayLabel: london.weekdayLabel,
+		day: WEEKDAY_INDEX[london.weekdayLabel] ?? 0,
+		minutes: london.hour * 60 + london.minute,
 	};
-}
-
-function minutesOfDay(date: Date) {
-	return date.getHours() * 60 + date.getMinutes();
 }
 
 function getMinutesUntilNextWindow(day: number, minutes: number): number | null {
@@ -81,9 +108,9 @@ export interface SupportAvailability {
 }
 
 export function getSupportAvailability(date?: Date): SupportAvailability {
-	const london = toLondonDate(date);
-	const day = london.getDay();
-	const minutes = minutesOfDay(london);
+	const london = getLondonInfo(date);
+	const day = london.day;
+	const minutes = london.minutes;
 	const windows = SCHEDULE[day] ?? [];
 
 	const isOpen = windows.some(


### PR DESCRIPTION
## Summary
- add explicit retry/delete failed-state actions for image and video generations in the web playground
- fix the shared London support schedule helper so it no longer depends on the local runtime timezone
- update contact/support consumers to use the corrected London info output

## Details
- failed image and video generations now render a result-panel state with `Retry` and `Delete`
- retry reuses the current prompt and model selection without manual copy/paste
- delete clears the failed generation state from the panel
- `/contact`, quickstart support, and the team switcher now consume timezone-safe London schedule data

## Validation
- `pnpm --filter @ai-stats/web typecheck`
