### PR TITLE
feat(gateway): add replayable request diagnostics and observability detail

### DIFF
--- a/apps/api/src/core/error-handler.test.ts
+++ b/apps/api/src/core/error-handler.test.ts
@@ -132,6 +132,10 @@ describe("handleError", () => {
 			ctx: {
 				requestId: "G-TEST-1",
 				model: "xiaomi/mimo-v2-tts:free",
+				rawBody: {
+					model: "xiaomi/mimo-v2-tts:free",
+					input: [{ role: "user", content: "say hello" }],
+				},
 			} as any,
 			auditFailure: async (args) => {
 				capturedAuditArgs = args;
@@ -204,6 +208,10 @@ describe("handleError", () => {
 					upstream_error_code: "400",
 				}),
 			],
+		});
+		expect(capturedAuditArgs?.requestPayload).toEqual({
+			model: "xiaomi/mimo-v2-tts:free",
+			input: [{ role: "user", content: "say hello" }],
 		});
 	});
 

--- a/apps/api/src/core/error-handler.test.ts
+++ b/apps/api/src/core/error-handler.test.ts
@@ -86,11 +86,28 @@ describe("extractUpstreamUnsupportedParamSignal", () => {
 
 describe("handleError", () => {
 	it("preserves execute upstream diagnostics for client debugging", async () => {
+		let capturedAuditArgs: any = null;
 		const upstream = new Response(
 			JSON.stringify({
 				error: "upstream_error",
 				reason: "all_candidates_failed",
 				description: "Provider failed.",
+				provider_failure_diagnostics: {
+					category: "credentials_not_configured",
+					hint: "Provider credentials are not configured for this route. Verify gateway keys or the selected BYOK configuration before retrying.",
+					provider: "xiaomi",
+				},
+				routing_diagnostics: {
+					filterStages: [{
+						stage: "capability_status_gate",
+						beforeCount: 1,
+						afterCount: 0,
+						droppedProviders: [{
+							providerId: "xiaomi",
+							reason: "capability_status_internal_testing_requires_testing_mode",
+						}],
+					}],
+				},
 				attempt_count: 1,
 				failed_providers: ["xiaomi"],
 				failed_statuses: [400],
@@ -116,7 +133,9 @@ describe("handleError", () => {
 				requestId: "G-TEST-1",
 				model: "xiaomi/mimo-v2-tts:free",
 			} as any,
-			auditFailure: async () => { },
+			auditFailure: async (args) => {
+				capturedAuditArgs = args;
+			},
 		});
 			const payload = await res.json();
 			expect(payload.error).toBe("upstream_error");
@@ -125,6 +144,22 @@ describe("handleError", () => {
 			expect(payload.attempt_count).toBe(1);
 			expect(payload.failed_providers).toEqual(["xiaomi"]);
 			expect(payload.failed_statuses).toEqual([400]);
+		expect(payload.routing_diagnostics).toEqual({
+			filterStages: [{
+				stage: "capability_status_gate",
+				beforeCount: 1,
+				afterCount: 0,
+				droppedProviders: [{
+					providerId: "xiaomi",
+					reason: "capability_status_internal_testing_requires_testing_mode",
+				}],
+			}],
+		});
+		expect(payload.provider_failure_diagnostics).toEqual({
+			category: "credentials_not_configured",
+			hint: "Provider credentials are not configured for this route. Verify gateway keys or the selected BYOK configuration before retrying.",
+			provider: "xiaomi",
+		});
 		expect(payload.upstream_error).toEqual({
 			code: "400",
 			message: "Param Incorrect",
@@ -142,9 +177,38 @@ describe("handleError", () => {
 			upstream_payload_preview: "{\"error\":{\"message\":\"Param Incorrect\"}}",
 			retryable: false,
 		}]);
+		expect(capturedAuditArgs?.errorPayload).toMatchObject({
+			error: "upstream_error",
+			reason: "all_candidates_failed",
+			provider_failure_diagnostics: {
+				category: "credentials_not_configured",
+				provider: "xiaomi",
+			},
+			routing_diagnostics: {
+				filterStages: [
+					{
+						stage: "capability_status_gate",
+						beforeCount: 1,
+						afterCount: 0,
+					},
+				],
+			},
+			upstream_error: {
+				code: "400",
+				message: "Param Incorrect",
+				param: "voice",
+			},
+			failure_sample: [
+				expect.objectContaining({
+					provider: "xiaomi",
+					upstream_error_code: "400",
+				}),
+			],
+		});
 	});
 
 	it("surfaces unsupported model diagnostics from before-stage guards", async () => {
+		let capturedAuditArgs: any = null;
 		const upstream = new Response(
 			JSON.stringify({
 				error: "unsupported_model_or_endpoint",
@@ -154,6 +218,13 @@ describe("handleError", () => {
 					totalProviders: 1,
 					supportsEndpointCount: 1,
 					candidateCount: 1,
+					droppedUnsupportedEndpoint: ["anthropic"],
+					droppedMissingAdapter: [
+						{
+							providerId: "openai",
+							endpoint: "moderations",
+						},
+					],
 				},
 				provider_enablement: {
 					capability: "moderations",
@@ -174,7 +245,9 @@ describe("handleError", () => {
 				requestId: "G-TEST-2",
 				model: "openai/omni-moderation",
 			} as any,
-			auditFailure: async () => { },
+			auditFailure: async (args) => {
+				capturedAuditArgs = args;
+			},
 		});
 			const payload = await res.json();
 			expect(payload.error).toBe("unsupported_model_or_endpoint");
@@ -184,6 +257,13 @@ describe("handleError", () => {
 				totalProviders: 1,
 				supportsEndpointCount: 1,
 				candidateCount: 1,
+				droppedUnsupportedEndpoint: ["anthropic"],
+				droppedMissingAdapter: [
+					{
+						providerId: "openai",
+						endpoint: "moderations",
+					},
+				],
 			});
 		expect(payload.provider_enablement).toEqual({
 			capability: "moderations",
@@ -192,6 +272,21 @@ describe("handleError", () => {
 			dropped: [{ providerId: "openai", reason: "pricing_missing" }],
 		});
 		expect(payload.missing_pricing_providers).toEqual(["openai"]);
+		expect(capturedAuditArgs?.errorPayload).toMatchObject({
+			error: "unsupported_model_or_endpoint",
+			reason: "pricing_not_configured",
+			provider_candidate_diagnostics: {
+				totalProviders: 1,
+				supportsEndpointCount: 1,
+				candidateCount: 1,
+			},
+			provider_enablement: {
+				capability: "moderations",
+				providersBefore: ["openai"],
+				providersAfter: [],
+			},
+			missing_pricing_providers: ["openai"],
+		});
 	});
 
 	it("marks pipeline execution failures as gateway-origin errors", async () => {

--- a/apps/api/src/core/error-handler.test.ts
+++ b/apps/api/src/core/error-handler.test.ts
@@ -215,6 +215,49 @@ describe("handleError", () => {
 		});
 	});
 
+	it("stores the original request body for replay on execute-stage failures", async () => {
+		let capturedAuditArgs: any = null;
+		const upstream = new Response(
+			JSON.stringify({
+				error: "upstream_error",
+				description: "Provider failed.",
+				reason: "all_candidates_failed",
+			}),
+			{ status: 502, headers: { "content-type": "application/json" } },
+		);
+
+		await handleError({
+			stage: "execute",
+			res: upstream,
+			endpoint: "responses",
+			ctx: {
+				requestId: "G-TEST-REPLAY",
+				model: "openai/gpt-5.4-nano",
+				body: {
+					model: "openai/gpt-5.4-nano",
+					input: "retry me",
+				},
+			} as any,
+			auditFailure: async (args) => {
+				capturedAuditArgs = args;
+			},
+		});
+
+		expect(capturedAuditArgs?.requestPayload).toEqual({
+			model: "openai/gpt-5.4-nano",
+			input: "retry me",
+		});
+		expect(capturedAuditArgs?.providerResponse).toEqual({
+			error: "upstream_error",
+			description: "Provider failed.",
+			reason: "all_candidates_failed",
+		});
+		expect(capturedAuditArgs?.detailMetadata).toMatchObject({
+			replay_supported: true,
+			stage: "execute",
+		});
+	});
+
 	it("surfaces unsupported model diagnostics from before-stage guards", async () => {
 		let capturedAuditArgs: any = null;
 		const upstream = new Response(

--- a/apps/api/src/core/error-handler.ts
+++ b/apps/api/src/core/error-handler.ts
@@ -768,6 +768,7 @@ export async function handleError({
     }
     const gatewayErrorPayload = sanitizeForAxiom(errorPayload);
     const providerResponseHeaders = sanitizeForAxiom(headersToRecord(res.headers));
+    const replayRequestPayload = ctx?.rawBody ?? ctx?.body ?? null;
 
     // Audit failure
     const auditExtraJson = (() => {
@@ -910,14 +911,14 @@ export async function handleError({
         extraJson: auditExtraJson,
         errorDetailsJson,
         errorPayload: gatewayErrorPayload,
-        requestPayload: ctx?.rawBody ?? ctx?.body ?? body ?? null,
+        requestPayload: replayRequestPayload,
         gatewayResponse: errorPayload,
         providerResponse: body ?? null,
         detailMetadata: {
             stage,
             replay_supported: Boolean(
-                (ctx?.rawBody ?? ctx?.body ?? body) &&
-                    typeof (ctx?.rawBody ?? ctx?.body ?? body) === "object"
+                replayRequestPayload &&
+                    typeof replayRequestPayload === "object"
             ),
         },
     };

--- a/apps/api/src/core/error-handler.ts
+++ b/apps/api/src/core/error-handler.ts
@@ -193,6 +193,7 @@ export function extractErrorCode(body: any, fallback: string): string {
     if (typeof e === "number") return String(e);
     if (e && typeof e === "object") {
         if (typeof e.code === "string") return e.code;
+        if (typeof e.status === "string") return e.status;
         if (typeof e.type === "string") return e.type;
         if (typeof e.error === "string") return e.error;
         if (typeof e.message === "string") return e.message.slice(0, 120);
@@ -736,6 +737,12 @@ export async function handleError({
                 .slice(0, 16);
         }
     }
+    if (body?.routing_diagnostics && typeof body.routing_diagnostics === "object") {
+        errorPayload.routing_diagnostics = body.routing_diagnostics;
+    }
+    if (body?.provider_failure_diagnostics && typeof body.provider_failure_diagnostics === "object") {
+        errorPayload.provider_failure_diagnostics = body.provider_failure_diagnostics;
+    }
     if (debugEnabled) {
         const routingDebug = ctx
             ? {
@@ -902,6 +909,14 @@ export async function handleError({
         edgeAsn: requestMeta.edgeAsn,
         extraJson: auditExtraJson,
         errorDetailsJson,
+        errorPayload: gatewayErrorPayload,
+        requestPayload: body ?? null,
+        gatewayResponse: errorPayload,
+        providerResponse: body ?? null,
+        detailMetadata: {
+            stage,
+            replay_supported: Boolean(body && typeof body === "object"),
+        },
     };
     if (stage === "execute") {
         auditArgs.stream = ctx?.stream;

--- a/apps/api/src/core/error-handler.ts
+++ b/apps/api/src/core/error-handler.ts
@@ -910,12 +910,15 @@ export async function handleError({
         extraJson: auditExtraJson,
         errorDetailsJson,
         errorPayload: gatewayErrorPayload,
-        requestPayload: body ?? null,
+        requestPayload: ctx?.rawBody ?? ctx?.body ?? body ?? null,
         gatewayResponse: errorPayload,
         providerResponse: body ?? null,
         detailMetadata: {
             stage,
-            replay_supported: Boolean(body && typeof body === "object"),
+            replay_supported: Boolean(
+                (ctx?.rawBody ?? ctx?.body ?? body) &&
+                    typeof (ctx?.rawBody ?? ctx?.body ?? body) === "object"
+            ),
         },
     };
     if (stage === "execute") {

--- a/apps/api/src/observability/events.test.ts
+++ b/apps/api/src/observability/events.test.ts
@@ -1,113 +1,368 @@
-import { describe, expect, it } from "vitest";
-import { extractRoutingFailureSignals, extractUpstreamErrorSummary } from "./events";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { clearRuntime, configureRuntime } from "@/runtime/env";
+import { emitGatewayRequestEvent } from "./events";
+import type { PipelineContext } from "@pipeline/before/types";
+import type { RequestResult } from "@pipeline/execute";
 
-describe("extractRoutingFailureSignals", () => {
-	it("extracts provider_status_not_ready details from routing diagnostics", () => {
-		const signals = extractRoutingFailureSignals({
+const sendAxiomWideEventMock = vi.fn(async (_event: Record<string, unknown>) => {});
+
+vi.mock("./axiom", () => ({
+	sendAxiomWideEvent: (...args: unknown[]) => sendAxiomWideEventMock(...args),
+}));
+
+describe("emitGatewayRequestEvent", () => {
+	beforeEach(() => {
+		sendAxiomWideEventMock.mockReset();
+		configureRuntime({
+			SUPABASE_URL: "https://example.supabase.co",
+			SUPABASE_SERVICE_ROLE_KEY: "service-role-key",
+			GATEWAY_CACHE: {} as KVNamespace,
+			NODE_ENV: "test",
+			AXIOM_API_KEY: "axiom_test_key",
+			AXIOM_DATASET: "gateway-wide",
+			AXIOM_SUCCESS_SAMPLE_RATE: "1",
+			AXIOM_DETAIL_SAMPLE_RATE: "1",
+			AXIOM_SLOW_REQUEST_MS: "1",
+		} as any);
+	});
+
+	afterEach(() => {
+		clearRuntime();
+	});
+
+	it("emits provider attempt chains for successful video generation requests", async () => {
+		const ctx = {
+			endpoint: "video.generation",
+			capability: "video.generation",
+			requestId: "req_video_obs_123",
+			protocol: "openai",
+			meta: {
+				apiKeyId: "key_video_obs_123",
+				requestMethod: "POST",
+				requestPath: "/v1/videos",
+				requestUrl: "https://api.phaseo.app/v1/videos",
+				sessionId: "sess_video_obs_123",
+				appId: "app_video_obs_123",
+				before_ms: 5,
+				latency_ms: 120,
+				generation_ms: 95,
+				throughput_tps: 0,
+			},
+			rawBody: {
+				model: "google/veo-3.1-lite-generate-preview",
+				prompt: "A calm lake at sunrise",
+				duration: 5,
+			},
+			body: {
+				model: "google/veo-3.1-lite-generate-preview",
+				prompt: "A calm lake at sunrise",
+				duration: 5,
+			},
+			model: "google/veo-3.1-lite-generate-preview",
+			workspaceId: "ws_video_obs_123",
+			stream: false,
+			providers: [
+				{
+					providerId: "google-vertex",
+					pricingCard: { id: "price_google_vertex" },
+					providerStatus: "active",
+					capabilityStatus: "active",
+				},
+			],
+			pricing: {},
+			gating: {
+				key: { ok: true, reason: null },
+				keyLimit: { ok: true, reason: null },
+				credit: { ok: true, reason: null },
+			},
+			providerAttempts: [
+				{
+					attempt_number: 1,
+					provider: "google-vertex",
+					endpoint: "video.generation",
+					model: "google/veo-3.1-lite-generate-preview",
+					provider_model_slug: "veo-3.1-lite-generate-preview",
+					outcome: "success",
+					duration_ms: 95,
+					status: 200,
+					status_text: "OK",
+					key_source: "gateway",
+					response_kind: "completed",
+				},
+			],
+			attemptErrors: [],
+			teamSettings: {
+				routingMode: "balanced",
+			},
+			timing: {
+				before_start: 5,
+				internal_latency_ms: 120,
+				execute: {
+					total_ms: 95,
+					adapter_ms: 95,
+				},
+			},
+		} as unknown as PipelineContext;
+
+		const result = {
+			provider: "google-vertex",
+			upstream: new Response(JSON.stringify({ id: "upstream_video_job" }), {
+				status: 200,
+				headers: { "Content-Type": "application/json" },
+			}),
+			mappedRequest: JSON.stringify({ prompt: "A calm lake at sunrise" }),
+			rawResponse: {
+				id: "upstream_video_job",
+				status: "queued",
+			},
+			generationTimeMs: 95,
+		} as unknown as RequestResult;
+
+		await emitGatewayRequestEvent({
+			ctx,
+			result,
+			statusCode: 202,
+			success: true,
+			finishReason: null,
+			usage: {
+				requests: 1,
+				output_video_seconds: 5,
+			},
+			pricing: {
+				total_cents: 15,
+				total_nanos: 150_000_000,
+				currency: "USD",
+			},
+			gatewayResponse: {
+				id: "req_video_obs_123",
+				status: "queued",
+				model: "google/veo-3.1-lite-generate-preview",
+			},
+		});
+
+		expect(sendAxiomWideEventMock).toHaveBeenCalledTimes(1);
+		const event = sendAxiomWideEventMock.mock.calls[0]?.[0] as Record<string, unknown>;
+		expect(event).toMatchObject({
+			event_type: "gateway.request",
+			request_id: "req_video_obs_123",
+			generation_id: "req_video_obs_123",
+			workspace_id: "ws_video_obs_123",
+			endpoint: "video.generation",
+			model: "google/veo-3.1-lite-generate-preview",
+			provider: "google-vertex",
+			success: true,
+			status_code: 202,
+			attempt_count: 1,
+			attempted_providers_count: 1,
+			cost_total_nanos: 150000000,
+			cost_total_cents: 15,
+			cost_currency: "USD",
+			provider_status_code: 200,
+		});
+
+		const attemptedProviders = JSON.parse(String(event.attempted_providers_json ?? "[]"));
+		expect(attemptedProviders).toEqual(["google-vertex"]);
+
+		const providerAttempts = JSON.parse(String(event.provider_attempts_json ?? "[]"));
+		expect(providerAttempts).toEqual([
+			expect.objectContaining({
+				attempt_number: 1,
+				provider: "google-vertex",
+				endpoint: "video.generation",
+				outcome: "success",
+				duration_ms: 95,
+				status: 200,
+				response_kind: "completed",
+			}),
+		]);
+	});
+
+	it("emits routed failure diagnostics for execute-stage errors", async () => {
+		const ctx = {
+			endpoint: "responses",
+			capability: "responses",
+			requestId: "req_error_obs_123",
+			protocol: "openai",
+			meta: {
+				apiKeyId: "key_error_obs_123",
+				requestMethod: "POST",
+				requestPath: "/v1/responses",
+				requestUrl: "https://api.phaseo.app/v1/responses",
+				sessionId: "sess_error_obs_123",
+				appId: "app_error_obs_123",
+				before_ms: 9,
+				latency_ms: 140,
+				generation_ms: 88,
+			},
+			rawBody: {
+				model: "google/gemini-2.5-pro",
+				input: "hello",
+			},
+			body: {
+				model: "google/gemini-2.5-pro",
+				input: "hello",
+			},
+			model: "google/gemini-2.5-pro",
+			workspaceId: "ws_error_obs_123",
+			stream: false,
+			providers: [
+				{
+					providerId: "google-ai-studio",
+					pricingCard: { id: "price_google_ai_studio" },
+					providerStatus: "active",
+					capabilityStatus: "active",
+				},
+				{
+					providerId: "openai",
+					pricingCard: { id: "price_openai" },
+					providerStatus: "beta",
+					capabilityStatus: "active",
+				},
+			],
+			pricing: {},
+			gating: {
+				key: { ok: true, reason: null },
+				keyLimit: { ok: true, reason: null },
+				credit: { ok: true, reason: null },
+			},
+			providerEnablementDiagnostics: {
+				capability: "responses",
+				providersBefore: ["google-ai-studio", "openai"],
+				providersAfter: ["google-ai-studio"],
+				dropped: [{ providerId: "openai", reason: "pricing_missing" }],
+			},
+			providerCandidateBuildDiagnostics: {
+				totalProviders: 2,
+				supportsEndpointCount: 2,
+				candidateCount: 2,
+				droppedUnsupportedEndpoint: [],
+				droppedMissingAdapter: [],
+			},
+		} as unknown as PipelineContext;
+
+		await emitGatewayRequestEvent({
+			ctx,
+			statusCode: 502,
 			success: false,
+			errorCode: "upstream_error",
+			errorMessage: "All providers failed.",
+			errorType: "system",
+			errorStage: "execute",
 			errorDetails: {
+				error: "upstream_error",
+				reason: "all_candidates_failed",
+				status_code: 502,
+				provider_failure_diagnostics: {
+					category: "provider_access_missing",
+					hint: "The provider account appears not to have access to this model or feature yet.",
+					provider: "google-ai-studio",
+				},
+				upstream_error: {
+					code: "PERMISSION_DENIED",
+					message: "The caller does not have permission.",
+					param: "model",
+				},
 				routing_diagnostics: {
-					finalCandidateCount: 0,
 					filterStages: [
 						{
 							stage: "status_gate",
-							beforeCount: 1,
-							afterCount: 0,
+							beforeCount: 2,
+							afterCount: 1,
 							droppedProviders: [
-								{ providerId: "openai", reason: "provider_status_not_ready" },
+								{
+									providerId: "openai",
+									reason: "provider_status_not_ready",
+								},
 							],
 						},
-						{
-							stage: "capability_status_gate",
-							beforeCount: 0,
-							afterCount: 0,
-							droppedProviders: [],
-						},
 					],
+					finalCandidateCount: 1,
 				},
-			},
-		} as any);
-
-		expect(signals.finalCandidateCount).toBe(0);
-		expect(signals.statusGateBeforeCount).toBe(1);
-		expect(signals.statusGateAfterCount).toBe(0);
-		expect(signals.capabilityGateBeforeCount).toBe(0);
-		expect(signals.capabilityGateAfterCount).toBe(0);
-		expect(signals.dropReasons).toContain("provider_status_not_ready");
-		expect(signals.providerStatusNotReadyProviders).toEqual(["openai"]);
-	});
-});
-
-describe("extractUpstreamErrorSummary", () => {
-	it("extracts upstream details from providerResponse.error shape", () => {
-		const summary = extractUpstreamErrorSummary({
-			success: false,
-			providerResponse: {
-				error: {
-					code: "invalid_request_error",
-					type: "invalid_request_error",
-					param: "messages",
-					message: "messages is invalid",
-					status: 400,
-				},
-			},
-		} as any);
-
-		expect(summary).toEqual({
-			code: "invalid_request_error",
-			type: "invalid_request_error",
-			param: "messages",
-			message: "messages is invalid",
-			status: 400,
-			raw: {
-				error: {
-					code: "invalid_request_error",
-					type: "invalid_request_error",
-					param: "messages",
-					message: "messages is invalid",
-					status: 400,
-				},
+				failure_sample: [
+					{
+						provider: "google-ai-studio",
+						type: "upstream_non_2xx",
+						status: 403,
+						upstream_error_code: "PERMISSION_DENIED",
+						upstream_error_message: "The caller does not have permission.",
+						upstream_error_description: "Project is not allowed to access this model.",
+						retryable: false,
+					},
+					{
+						provider: "openai",
+						type: "blocked",
+						status: 503,
+						upstream_error_message: "Provider not ready.",
+						retryable: true,
+					},
+				],
 			},
 		});
-	});
 
-	it("extracts fallback fields from errorDetails root shape", () => {
-		const summary = extractUpstreamErrorSummary({
+		expect(sendAxiomWideEventMock).toHaveBeenCalledTimes(1);
+		const event = sendAxiomWideEventMock.mock.calls[0]?.[0] as Record<string, unknown>;
+		expect(event).toMatchObject({
+			event_type: "gateway.request",
+			request_id: "req_error_obs_123",
+			workspace_id: "ws_error_obs_123",
+			endpoint: "responses",
+			model: "google/gemini-2.5-pro",
 			success: false,
-			errorDetails: {
-				error_code: "quota_exceeded",
-				error_type: "rate_limit",
-				error_description: "Quota exceeded",
-				status: "429",
-			},
-		} as any);
+			status_code: 502,
+			error_code: "upstream_error",
+			error_stage: "execute",
+			error_type: "system",
+			attempt_count: 2,
+			attempted_providers_count: 2,
+			attempt_failure_count: 2,
+			routing_filter_stage_count: 1,
+			routing_drop_reason_count: 1,
+			routing_status_gate_before_count: 2,
+			routing_status_gate_after_count: 1,
+			error_is_provider_status_not_ready: true,
+			upstream_error_code: "PERMISSION_DENIED",
+			upstream_error_message: "The caller does not have permission.",
+			upstream_error_param: "model",
+			upstream_error_status: 502,
+			provider_failure_category: "provider_access_missing",
+			provider_failure_provider: "google-ai-studio",
+			failure_sample_first_provider: "google-ai-studio",
+			failure_sample_first_type: "upstream_non_2xx",
+			failure_sample_first_status: 403,
+			failure_sample_first_retryable: false,
+			failure_sample_first_upstream_error_code: "PERMISSION_DENIED",
+			failure_sample_first_upstream_error_message: "The caller does not have permission.",
+		});
 
-		expect(summary?.code).toBe("quota_exceeded");
-		expect(summary?.type).toBe("rate_limit");
-		expect(summary?.message).toBe("Quota exceeded");
-		expect(summary?.status).toBe(429);
-	});
+		const attemptedProviders = JSON.parse(String(event.attempted_providers_json ?? "[]"));
+		expect(attemptedProviders).toEqual(["google-ai-studio", "openai"]);
 
-	it("returns null when no upstream summary fields exist", () => {
-		const summary = extractUpstreamErrorSummary({
-			success: false,
-			errorDetails: { foo: "bar" },
-		} as any);
+		const providerAttempts = JSON.parse(String(event.provider_attempts_json ?? "[]"));
+		expect(providerAttempts).toEqual([
+			expect.objectContaining({
+				provider: "google-ai-studio",
+				type: "upstream_non_2xx",
+				status: 403,
+				upstream_error_code: "PERMISSION_DENIED",
+			}),
+			expect.objectContaining({
+				provider: "openai",
+				type: "blocked",
+				status: 503,
+			}),
+		]);
 
-		expect(summary).toBeNull();
-	});
+		const routingDropReasons = JSON.parse(String(event.routing_drop_reasons_json ?? "[]"));
+		expect(routingDropReasons).toEqual(["provider_status_not_ready"]);
 
-	it("falls back to errors array + statusCode when needed", () => {
-		const summary = extractUpstreamErrorSummary({
-			success: false,
-			statusCode: 503,
-			errorDetails: {
-				errors: [{ message: "temporary upstream outage" }],
-			},
-		} as any);
-
-		expect(summary?.message).toBe("temporary upstream outage");
-		expect(summary?.status).toBe(503);
+		const providerEnablement = JSON.parse(
+			String(event.provider_enablement_diagnostics_json ?? "null")
+		);
+		expect(providerEnablement).toEqual({
+			capability: "responses",
+			providersBefore: ["google-ai-studio", "openai"],
+			providersAfter: ["google-ai-studio"],
+			dropped: [{ providerId: "openai", reason: "pricing_missing" }],
+		});
 	});
 });
-

--- a/apps/api/src/observability/events.ts
+++ b/apps/api/src/observability/events.ts
@@ -387,6 +387,21 @@ type UpstreamErrorSummary = {
     raw: unknown;
 };
 
+type ProviderFailureSummary = {
+    category: string | null;
+    hint: string | null;
+    provider: string | null;
+};
+
+type FailureSampleSummary = {
+    provider: string | null;
+    type: string | null;
+    status: number | null;
+    retryable: boolean | null;
+    upstreamErrorCode: string | null;
+    upstreamErrorMessage: string | null;
+};
+
 function getRoutingDiagnosticsFromArgs(args: EventArgs): any {
     const fromCtx = (args.ctx as any)?.routingDiagnostics;
     if (fromCtx && typeof fromCtx === "object") return fromCtx;
@@ -548,7 +563,7 @@ export function extractUpstreamErrorSummary(args: EventArgs): UpstreamErrorSumma
         const root = asObject(source);
         if (!root) continue;
 
-        const errObj = asObject(root.error) ?? root;
+        const errObj = asObject((root as any).upstream_error) ?? asObject(root.error) ?? root;
         const code =
             asString(errObj.code) ??
             asString((root as any).error_code) ??
@@ -565,11 +580,12 @@ export function extractUpstreamErrorSummary(args: EventArgs): UpstreamErrorSumma
             null;
         const message =
             asString(errObj.message) ??
-            asString((root as any).error) ??
             asString((root as any).message) ??
             asString((root as any).error_description) ??
             asString((root as any)?.errors?.[0]?.message) ??
+            asString(errObj.description) ??
             asString((root as any).description) ??
+            asString((root as any).error) ??
             null;
         const status =
             asNumber(errObj.status) ??
@@ -589,6 +605,63 @@ export function extractUpstreamErrorSummary(args: EventArgs): UpstreamErrorSumma
                 raw: root,
             };
         }
+    }
+
+    return null;
+}
+
+function extractProviderFailureSummary(args: EventArgs): ProviderFailureSummary | null {
+    const sources = [args.errorDetails, args.providerResponse];
+
+    for (const source of sources) {
+        const root = asObject(source);
+        if (!root) continue;
+        const diagnostics = asObject((root as any).provider_failure_diagnostics);
+        if (!diagnostics) continue;
+
+        const category = asString(diagnostics.category);
+        const hint = asString(diagnostics.hint);
+        const provider = asString(diagnostics.provider);
+        if (category || hint || provider) {
+            return { category, hint, provider };
+        }
+    }
+
+    return null;
+}
+
+function extractFailureSampleSummary(args: EventArgs): FailureSampleSummary | null {
+    const root = asObject(args.errorDetails);
+    const sample = Array.isArray((root as any)?.failure_sample)
+        ? (root as any).failure_sample[0]
+        : null;
+    const entry = asObject(sample);
+    if (!entry) return null;
+
+    const provider = asString(entry.provider);
+    const type = asString(entry.type);
+    const status = asNumber(entry.status);
+    const retryable =
+        typeof entry.retryable === "boolean" ? entry.retryable : null;
+    const upstreamErrorCode = asString(entry.upstream_error_code);
+    const upstreamErrorMessage = asString(entry.upstream_error_message);
+
+    if (
+        provider ||
+        type ||
+        status !== null ||
+        retryable !== null ||
+        upstreamErrorCode ||
+        upstreamErrorMessage
+    ) {
+        return {
+            provider,
+            type,
+            status,
+            retryable,
+            upstreamErrorCode,
+            upstreamErrorMessage,
+        };
     }
 
     return null;
@@ -667,6 +740,8 @@ export async function emitGatewayRequestEvent(args: EventArgs) {
         const sanitizedProviderAttempts = includeDetailedPayloads
             ? sanitizeForAxiom(getProviderAttemptsFromArgs(args))
             : null;
+        const providerFailure = extractProviderFailureSummary(args);
+        const failureSample = extractFailureSampleSummary(args);
         const mappingSnapshot = includeDetailedPayloads
             ? sanitizeForAxiom({
                 protocol: args.protocolOverride ?? ctx?.protocol ?? null,
@@ -927,6 +1002,17 @@ export async function emitGatewayRequestEvent(args: EventArgs) {
             upstream_error_json: includeDetailedPayloads
                 ? stringifyForAxiom(sanitizeForAxiom(upstreamError?.raw ?? null))
                 : null,
+            provider_failure_category: providerFailure?.category ?? null,
+            provider_failure_provider: providerFailure?.provider ?? null,
+            provider_failure_hint: providerFailure?.hint ?? null,
+            failure_sample_first_provider: failureSample?.provider ?? null,
+            failure_sample_first_type: failureSample?.type ?? null,
+            failure_sample_first_status: failureSample?.status ?? null,
+            failure_sample_first_retryable: failureSample?.retryable ?? null,
+            failure_sample_first_upstream_error_code:
+                failureSample?.upstreamErrorCode ?? null,
+            failure_sample_first_upstream_error_message:
+                failureSample?.upstreamErrorMessage ?? null,
             gateway_response_redacted_json: includeDetailedPayloads
                 ? stringifyForAxiom(sanitizedGatewayResponse)
                 : null,

--- a/apps/api/src/pipeline/after/audit.ts
+++ b/apps/api/src/pipeline/after/audit.ts
@@ -236,7 +236,8 @@ export async function handleFailureAudit(
     attribution: string,
     errorCode: string,
     errorMessage: string,
-    errorDetails?: unknown
+    errorDetails?: unknown,
+    gatewayErrorPayload?: Record<string, unknown> | null,
 ) {
     const beforeMs = resolveBeforeLatencyMs(ctx);
     const execMs = resolveExecuteTotalLatencyMs(ctx) ?? 0;
@@ -331,7 +332,19 @@ export async function handleFailureAudit(
             edgeCountry: ctx.meta.edgeCountry ?? null,
             edgeContinent: ctx.meta.edgeContinent ?? null,
             edgeAsn: ctx.meta.edgeAsn ?? null,
+            errorPayload:
+                sanitizeForAxiom(gatewayErrorPayload ?? gatewayFailurePayload) as
+                    | Record<string, unknown>
+                    | null,
             extraJson,
+            requestPayload: ctx.rawBody ?? ctx.body ?? null,
+            gatewayResponse: gatewayErrorPayload ?? gatewayFailurePayload,
+            providerRequest: result.mappedRequest ?? null,
+            providerResponse: errorDetails ?? result.rawResponse ?? null,
+            detailMetadata: {
+                stage: "execute",
+                replay_supported: true,
+            },
         });
     } catch (auditErr) {
         console.error("auditFailure failed", auditErr);
@@ -349,7 +362,7 @@ export async function handleFailureAudit(
             mappedRequest: result.mappedRequest ?? null,
             errorDetails,
             providerResponse: errorDetails ?? result.rawResponse ?? null,
-            gatewayResponse: gatewayFailurePayload,
+            gatewayResponse: gatewayErrorPayload ?? gatewayFailurePayload,
         });
     } catch (eventErr) {
         console.error("emitGatewayRequestEvent (failure) failed", eventErr);
@@ -489,6 +502,15 @@ export async function handleSuccessAudit(
             throughput: ctx.meta.throughput_tps ?? null,
             keyId: ctx.meta.apiKeyId ?? ctx.keyId ?? null,
             extraJson,
+            requestPayload: ctx.rawBody ?? ctx.body ?? null,
+            gatewayResponse: gatewayResponse ?? null,
+            providerRequest: result.mappedRequest ?? null,
+            providerResponse: result.rawResponse ?? null,
+            detailMetadata: {
+                stage: "execute",
+                finish_reason: finishReason ?? null,
+                replay_supported: true,
+            },
             // Wide event enrichment
             teamEnrichment: ctx.teamEnrichment ?? null,
             keyEnrichment: ctx.keyEnrichment ?? null,

--- a/apps/api/src/pipeline/after/index.ts
+++ b/apps/api/src/pipeline/after/index.ts
@@ -225,6 +225,13 @@ export async function finalizeRequest(args: {
     const status = 502;
     const errorCode = "normalization_failed";
     const errorMessage = "Gateway could not normalize upstream response.";
+    const gatewayErrorPayload = {
+        generation_id: ctx.requestId,
+        status_code: status,
+        error: errorCode,
+        description: errorMessage,
+        upstream_status: result.upstream.status ?? null,
+    };
 
     await handleFailureAudit(
         ctx,
@@ -232,7 +239,9 @@ export async function finalizeRequest(args: {
         status,
         "gateway",
         errorCode,
-        errorMessage
+        errorMessage,
+        undefined,
+        gatewayErrorPayload,
     );
 
     const headers = makeHeaders(args.timingHeader);

--- a/apps/api/src/pipeline/audit/index.test.ts
+++ b/apps/api/src/pipeline/audit/index.test.ts
@@ -181,4 +181,69 @@ describe("audit request detail persistence", () => {
 			}),
 		);
 	});
+
+	it("syncs the request rollup before detail persistence failures surface", async () => {
+		getSupabaseAdminMock.mockReturnValue({
+			from: vi.fn((table: string) => {
+				if (table === "gateway_requests") {
+					return {
+						insert: vi.fn(() => ({
+							select: vi.fn(() => ({
+								single: vi.fn(async () => ({
+									data: {
+										id: "row_3",
+										created_at: "2026-05-05T12:10:00.000Z",
+										workspace_id: "ws_3",
+									},
+									error: null,
+								})),
+							})),
+						})),
+					};
+				}
+
+				if (table === "gateway_request_details") {
+					return {
+						insert: vi.fn(async () => ({
+							error: { message: "details insert failed" },
+						})),
+					};
+				}
+
+				throw new Error(`unexpected table ${table}`);
+			}),
+		});
+
+		await expect(
+			auditSuccess({
+				requestId: "req_success_2",
+				workspaceId: "ws_3",
+				provider: "openai",
+				model: "openai/gpt-5-nano",
+				endpoint: "chat.completions",
+				stream: false,
+				byok: false,
+				usagePriced: { prompt_tokens: 2, completion_tokens: 1, pricing: { lines: [] } },
+				totalCents: 0.001,
+				totalNanos: 1000000,
+				currency: "USD",
+				statusCode: 200,
+				requestPayload: {
+					model: "openai/gpt-5-nano",
+					messages: [{ role: "user", content: "hello" }],
+				},
+				gatewayResponse: { id: "resp_2", output_text: "hi" },
+				providerRequest: { model: "openai/gpt-5-nano" },
+				providerResponse: { id: "chatcmpl_2" },
+				detailMetadata: { replay_supported: true },
+			}),
+		).rejects.toThrow("details insert failed");
+
+		expect(syncWorkspaceUsageRollupForRequestMock).toHaveBeenCalledWith({
+			requestRowId: "row_3",
+			requestCreatedAt: "2026-05-05T12:10:00.000Z",
+			workspaceId: "ws_3",
+			context: "audit_success",
+		});
+	});
 });

--- a/apps/api/src/pipeline/audit/index.test.ts
+++ b/apps/api/src/pipeline/audit/index.test.ts
@@ -1,0 +1,184 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const getSupabaseAdminMock = vi.fn();
+const ensureRuntimeForBackgroundMock = vi.fn();
+const ensureAppIdMock = vi.fn();
+const syncWorkspaceUsageRollupForRequestMock = vi.fn();
+
+vi.mock("@/runtime/env", () => ({
+	getSupabaseAdmin: (...args: any[]) => getSupabaseAdminMock(...args),
+	ensureRuntimeForBackground: (...args: any[]) => ensureRuntimeForBackgroundMock(...args),
+}));
+
+vi.mock("../after/apps", () => ({
+	ensureAppId: (...args: any[]) => ensureAppIdMock(...args),
+}));
+
+vi.mock("@core/workspace-usage-rollups", () => ({
+	syncWorkspaceUsageRollupForRequest: (...args: any[]) =>
+		syncWorkspaceUsageRollupForRequestMock(...args),
+}));
+
+import { auditFailure, auditSuccess } from "./index";
+
+describe("audit request detail persistence", () => {
+	beforeEach(() => {
+		getSupabaseAdminMock.mockReset();
+		ensureRuntimeForBackgroundMock.mockReset();
+		ensureAppIdMock.mockReset();
+		syncWorkspaceUsageRollupForRequestMock.mockReset();
+		ensureRuntimeForBackgroundMock.mockReturnValue(() => {});
+		ensureAppIdMock.mockResolvedValue("app_resolved");
+		syncWorkspaceUsageRollupForRequestMock.mockResolvedValue(undefined);
+	});
+
+	it("stores replay-ready details for successful requests", async () => {
+		const gatewayRequestRows: any[] = [];
+		const detailRows: any[] = [];
+
+		getSupabaseAdminMock.mockReturnValue({
+			from: vi.fn((table: string) => {
+				if (table === "gateway_requests") {
+					return {
+						insert: vi.fn((row: any) => {
+							gatewayRequestRows.push(row);
+							return {
+								select: vi.fn(() => ({
+									single: vi.fn(async () => ({
+										data: {
+											id: "row_1",
+											created_at: "2026-05-05T12:00:00.000Z",
+											workspace_id: "ws_1",
+										},
+										error: null,
+									})),
+								})),
+							};
+						}),
+					};
+				}
+
+				if (table === "gateway_request_details") {
+					return {
+						insert: vi.fn(async (row: any) => {
+							detailRows.push(row);
+							return { error: null };
+						}),
+					};
+				}
+
+				throw new Error(`unexpected table ${table}`);
+			}),
+		});
+
+		await auditSuccess({
+			requestId: "req_success_1",
+			workspaceId: "ws_1",
+			provider: "openai",
+			model: "openai/gpt-5-nano",
+			endpoint: "chat.completions",
+			stream: false,
+			byok: false,
+			usagePriced: { prompt_tokens: 2, completion_tokens: 1, pricing: { lines: [] } },
+			totalCents: 0.001,
+			totalNanos: 1000000,
+			currency: "USD",
+			statusCode: 200,
+			requestPayload: {
+				model: "openai/gpt-5-nano",
+				messages: [{ role: "user", content: "hello" }],
+			},
+			gatewayResponse: { id: "resp_1", output_text: "hi" },
+			providerRequest: { model: "openai/gpt-5-nano", messages: [{ role: "user", content: "hello" }] },
+			providerResponse: { id: "chatcmpl_1" },
+			detailMetadata: { replay_supported: true },
+		});
+
+		expect(gatewayRequestRows).toHaveLength(1);
+		expect(detailRows).toHaveLength(1);
+		expect(detailRows[0]).toEqual(
+			expect.objectContaining({
+				request_id: "req_success_1",
+				workspace_id: "ws_1",
+				request_payload: {
+					model: "openai/gpt-5-nano",
+					messages: [{ role: "user", content: "hello" }],
+				},
+				request_content: [{ role: "user", content: "hello" }],
+				metadata: { replay_supported: true },
+			}),
+		);
+	});
+
+	it("stores replay-ready details for execute-stage failures", async () => {
+		const detailRows: any[] = [];
+
+		getSupabaseAdminMock.mockReturnValue({
+			from: vi.fn((table: string) => {
+				if (table === "gateway_requests") {
+					return {
+						insert: vi.fn(() => ({
+							select: vi.fn(() => ({
+								single: vi.fn(async () => ({
+									data: {
+										id: "row_2",
+										created_at: "2026-05-05T12:05:00.000Z",
+										workspace_id: "ws_2",
+									},
+									error: null,
+								})),
+							})),
+						})),
+					};
+				}
+
+				if (table === "gateway_request_details") {
+					return {
+						insert: vi.fn(async (row: any) => {
+							detailRows.push(row);
+							return { error: null };
+						}),
+					};
+				}
+
+				throw new Error(`unexpected table ${table}`);
+			}),
+		});
+
+		await auditFailure({
+			stage: "execute",
+			requestId: "req_failure_1",
+			workspaceId: "ws_2",
+			endpoint: "responses",
+			model: "openai/gpt-5.4-nano",
+			provider: "openai",
+			stream: false,
+			statusCode: 500,
+			errorCode: "gateway:upstream_error",
+			errorMessage: "provider failed",
+			requestPayload: {
+				model: "openai/gpt-5.4-nano",
+				input: [{ role: "user", content: "retry me" }],
+			},
+			gatewayResponse: { error: "upstream_error" },
+			providerRequest: { model: "openai/gpt-5.4-nano" },
+			providerResponse: { error: { message: "bad gateway" } },
+			detailMetadata: { replay_supported: true, stage: "execute" },
+		});
+
+		expect(detailRows).toHaveLength(1);
+		expect(detailRows[0]).toEqual(
+			expect.objectContaining({
+				request_id: "req_failure_1",
+				workspace_id: "ws_2",
+				success: false,
+				request_payload: {
+					model: "openai/gpt-5.4-nano",
+					input: [{ role: "user", content: "retry me" }],
+				},
+				request_content: [{ role: "user", content: "retry me" }],
+				metadata: { replay_supported: true, stage: "execute" },
+			}),
+		);
+	});
+});

--- a/apps/api/src/pipeline/audit/index.test.ts
+++ b/apps/api/src/pipeline/audit/index.test.ts
@@ -182,7 +182,7 @@ describe("audit request detail persistence", () => {
 		);
 	});
 
-	it("syncs the request rollup before detail persistence failures surface", async () => {
+	it("keeps rollup sync independent from detail persistence failures", async () => {
 		getSupabaseAdminMock.mockReturnValue({
 			from: vi.fn((table: string) => {
 				if (table === "gateway_requests") {
@@ -237,7 +237,7 @@ describe("audit request detail persistence", () => {
 				providerResponse: { id: "chatcmpl_2" },
 				detailMetadata: { replay_supported: true },
 			}),
-		).rejects.toThrow("details insert failed");
+		).resolves.toBeUndefined();
 
 		expect(syncWorkspaceUsageRollupForRequestMock).toHaveBeenCalledWith({
 			requestRowId: "row_3",

--- a/apps/api/src/pipeline/audit/index.ts
+++ b/apps/api/src/pipeline/audit/index.ts
@@ -51,6 +51,45 @@ async function insertGatewayRequest(row: any) {
     return data as { id: string; created_at: string; workspace_id: string };
 }
 
+function normalizeJsonValue(value: unknown): unknown {
+    if (value === undefined) return null;
+    if (value === null) return null;
+    if (
+        typeof value === "string" ||
+        typeof value === "number" ||
+        typeof value === "boolean"
+    ) {
+        return value;
+    }
+    try {
+        return JSON.parse(JSON.stringify(value));
+    } catch {
+        return null;
+    }
+}
+
+function extractReplayContent(value: unknown): unknown {
+    if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+    const payload = value as Record<string, unknown>;
+    if (Array.isArray(payload.messages)) return payload.messages;
+    if (Array.isArray(payload.input)) return payload.input;
+    if (Array.isArray(payload.input_items)) return payload.input_items;
+    if (Array.isArray(payload.contents)) return payload.contents;
+    return null;
+}
+
+async function insertGatewayRequestDetails(row: any) {
+    const client = supaAdmin();
+    const { error } = await client
+        .from("gateway_request_details")
+        .insert(row);
+    if (error) {
+        const err = new Error(`[audit] insert gateway_request_details error: ${error?.message ?? "unknown"}`);
+        (err as any).cause = error;
+        throw err;
+    }
+}
+
 async function syncInsertedRequestRollup(
     insertedRow: { id: string; created_at: string; workspace_id: string } | null | undefined,
     context: string,
@@ -89,6 +128,7 @@ function buildSupaRow(args: {
     providerAttempts?: Array<Record<string, unknown>> | null;
     statusCode?: number | null; success: boolean;
     errorCode?: string | null; errorMessage?: string | null;
+    errorPayload?: Record<string, unknown> | null;
     appId?: string | null; keyId?: string | null;
     latencyMs?: number | null; generationMs?: number | null;
     usage?: any | null; costNanos?: number | null; currency?: string | null;
@@ -122,6 +162,10 @@ function buildSupaRow(args: {
         success: !!args.success,
         error_code: args.errorCode ?? null,
         error_message: args.errorMessage ?? null,
+        error_payload:
+            args.errorPayload && typeof args.errorPayload === "object"
+                ? args.errorPayload
+                : null,
         latency_ms: args.latencyMs ?? null,
         generation_ms: args.generationMs ?? null,
         usage: args.usage ?? {},
@@ -174,6 +218,12 @@ export async function auditSuccess(args: {
     finishReason?: string | null;
     statusCode: number; throughput?: number | null; keyId?: string | null;
     extraJson?: string | null;
+    errorPayload?: Record<string, unknown> | null;
+    requestPayload?: unknown;
+    gatewayResponse?: unknown;
+    providerRequest?: unknown;
+    providerResponse?: unknown;
+    detailMetadata?: Record<string, unknown> | null;
     // Wide event enrichment
     teamEnrichment?: any | null;
     keyEnrichment?: any | null;
@@ -222,6 +272,7 @@ export async function auditSuccess(args: {
             success: true,
             errorCode: null,
             errorMessage: null,
+            errorPayload: null,
             appId,
             keyId: args.keyId ?? null,
             latencyMs: args.latencyMs ?? null,
@@ -244,6 +295,30 @@ export async function auditSuccess(args: {
             const insertedRow = await retryWithBackoff(
                 () => insertGatewayRequest(row),
                 "supabase_audit_success_insert",
+            );
+            await retryWithBackoff(
+                () =>
+                    insertGatewayRequestDetails({
+                        gateway_request_id: insertedRow.id,
+                        gateway_request_created_at: insertedRow.created_at,
+                        request_id: args.requestId,
+                        workspace_id: args.workspaceId,
+                        app_id: appId ?? null,
+                        key_id: args.keyId ?? null,
+                        endpoint: args.endpoint,
+                        model_id: args.model,
+                        provider: args.provider ?? null,
+                        status_code: args.statusCode,
+                        success: true,
+                        request_payload: normalizeJsonValue(args.requestPayload) ?? {},
+                        request_content: normalizeJsonValue(extractReplayContent(args.requestPayload)),
+                        gateway_response: normalizeJsonValue(args.gatewayResponse),
+                        response_content: normalizeJsonValue(extractReplayContent(args.gatewayResponse)),
+                        provider_request: normalizeJsonValue(args.providerRequest),
+                        provider_response: normalizeJsonValue(args.providerResponse),
+                        metadata: normalizeJsonValue(args.detailMetadata) ?? {},
+                    }),
+                "supabase_audit_success_details_insert",
             );
             await syncInsertedRequestRollup(insertedRow, "audit_success");
         } catch (err) {
@@ -283,6 +358,7 @@ type AuditFailureBefore = {
     sessionId?: string | null;
     traceData?: Record<string, unknown> | null;
     providerAttempts?: Array<Record<string, unknown>> | null;
+    errorPayload?: Record<string, unknown> | null;
     userAgent?: string | null;
     clientIp?: string | null;
     cfRay?: string | null;
@@ -292,6 +368,10 @@ type AuditFailureBefore = {
     edgeContinent?: string | null;
     edgeAsn?: number | null;
     extraJson?: string | null;
+    requestPayload?: unknown;
+    gatewayResponse?: unknown;
+    providerResponse?: unknown;
+    detailMetadata?: Record<string, unknown> | null;
 };
 type AuditFailureExecute = {
     stage: "execute";
@@ -323,6 +403,7 @@ type AuditFailureExecute = {
     sessionId?: string | null;
     traceData?: Record<string, unknown> | null;
     providerAttempts?: Array<Record<string, unknown>> | null;
+    errorPayload?: Record<string, unknown> | null;
     userAgent?: string | null;
     clientIp?: string | null;
     cfRay?: string | null;
@@ -332,6 +413,11 @@ type AuditFailureExecute = {
     edgeContinent?: string | null;
     edgeAsn?: number | null;
     extraJson?: string | null;
+    requestPayload?: unknown;
+    gatewayResponse?: unknown;
+    providerRequest?: unknown;
+    providerResponse?: unknown;
+    detailMetadata?: Record<string, unknown> | null;
 };
 
 export async function auditFailure(args: AuditFailureBefore | AuditFailureExecute) {
@@ -367,20 +453,21 @@ export async function auditFailure(args: AuditFailureBefore | AuditFailureExecut
                 statusCode: args.statusCode,
                 success: false,
                 errorCode: args.errorCode,
-            errorMessage: args.errorMessage ?? null,
-            appId: resolvedAppId,
-            latencyMs: args.latencyMs ?? null,
-            generationMs: null,
-            usage: {},
-            currency: null,
-            pricingLines: [],
-            keyId: args.keyId ?? null,
-            edgeColo: args.edgeColo ?? null,
-            edgeCity: args.edgeCity ?? null,
-            edgeCountry: args.edgeCountry ?? null,
-            edgeContinent: args.edgeContinent ?? null,
-            edgeAsn: args.edgeAsn ?? null,
-        });
+                errorMessage: args.errorMessage ?? null,
+                errorPayload: args.errorPayload ?? null,
+                appId: resolvedAppId,
+                latencyMs: args.latencyMs ?? null,
+                generationMs: null,
+                usage: {},
+                currency: null,
+                pricingLines: [],
+                keyId: args.keyId ?? null,
+                edgeColo: args.edgeColo ?? null,
+                edgeCity: args.edgeCity ?? null,
+                edgeCountry: args.edgeCountry ?? null,
+                edgeContinent: args.edgeContinent ?? null,
+                edgeAsn: args.edgeAsn ?? null,
+            });
 
             let supabaseError: Error | null = null;
             if (args.workspaceId) {
@@ -388,6 +475,30 @@ export async function auditFailure(args: AuditFailureBefore | AuditFailureExecut
                     const insertedRow = await retryWithBackoff(
                         () => insertGatewayRequest(row),
                         "supabase_audit_failure_before_insert",
+                    );
+                    await retryWithBackoff(
+                        () =>
+                            insertGatewayRequestDetails({
+                                gateway_request_id: insertedRow.id,
+                                gateway_request_created_at: insertedRow.created_at,
+                                request_id: args.requestId,
+                                workspace_id: args.workspaceId,
+                                app_id: resolvedAppId ?? null,
+                                key_id: args.keyId ?? null,
+                                endpoint: args.endpoint,
+                                model_id: args.model ?? "unknown",
+                                provider: null,
+                                status_code: args.statusCode,
+                                success: false,
+                                request_payload: normalizeJsonValue(args.requestPayload) ?? {},
+                                request_content: normalizeJsonValue(extractReplayContent(args.requestPayload)),
+                                gateway_response: normalizeJsonValue(args.gatewayResponse),
+                                response_content: normalizeJsonValue(extractReplayContent(args.gatewayResponse)),
+                                provider_request: null,
+                                provider_response: normalizeJsonValue(args.providerResponse),
+                                metadata: normalizeJsonValue(args.detailMetadata) ?? {},
+                            }),
+                        "supabase_audit_failure_before_details_insert",
                     );
                     await syncInsertedRequestRollup(insertedRow, "audit_failure_before");
                 } catch (err) {
@@ -428,6 +539,7 @@ export async function auditFailure(args: AuditFailureBefore | AuditFailureExecut
             success: false,
             errorCode: args.errorCode,
             errorMessage: args.errorMessage ?? null,
+            errorPayload: args.errorPayload ?? null,
             appId: resolvedAppId,
             latencyMs: args.latencyMs ?? null,
             generationMs: args.generationMs ?? null,
@@ -448,6 +560,30 @@ export async function auditFailure(args: AuditFailureBefore | AuditFailureExecut
                 const insertedRow = await retryWithBackoff(
                     () => insertGatewayRequest(row),
                     "supabase_audit_failure_execute_insert",
+                );
+                await retryWithBackoff(
+                    () =>
+                        insertGatewayRequestDetails({
+                            gateway_request_id: insertedRow.id,
+                            gateway_request_created_at: insertedRow.created_at,
+                            request_id: args.requestId,
+                            workspace_id: args.workspaceId,
+                            app_id: resolvedAppId ?? null,
+                            key_id: args.keyId ?? null,
+                            endpoint: args.endpoint,
+                            model_id: args.model,
+                            provider: args.provider ?? null,
+                            status_code: args.statusCode,
+                            success: false,
+                            request_payload: normalizeJsonValue(args.requestPayload) ?? {},
+                            request_content: normalizeJsonValue(extractReplayContent(args.requestPayload)),
+                            gateway_response: normalizeJsonValue(args.gatewayResponse),
+                            response_content: normalizeJsonValue(extractReplayContent(args.gatewayResponse)),
+                            provider_request: normalizeJsonValue(args.providerRequest),
+                            provider_response: normalizeJsonValue(args.providerResponse),
+                            metadata: normalizeJsonValue(args.detailMetadata) ?? {},
+                        }),
+                    "supabase_audit_failure_execute_details_insert",
                 );
                 await syncInsertedRequestRollup(insertedRow, "audit_failure_execute");
             } catch (err) {

--- a/apps/api/src/pipeline/audit/index.ts
+++ b/apps/api/src/pipeline/audit/index.ts
@@ -114,6 +114,23 @@ async function syncInsertedRequestRollup(
     }
 }
 
+async function insertGatewayRequestDetailsNonBlocking(
+    row: Record<string, unknown>,
+    context: string,
+) {
+    try {
+        await retryWithBackoff(
+            () => insertGatewayRequestDetails(row),
+            context,
+        );
+    } catch (error) {
+        console.error("[audit] failed to persist request details", {
+            context,
+            error: error instanceof Error ? error.message : String(error),
+        });
+    }
+}
+
 function buildSupaRow(args: {
     requestId: string; workspaceId?: string | null;
     endpoint: Endpoint; model?: string | null; canonicalModel?: string | null; provider?: string | null;
@@ -297,28 +314,27 @@ export async function auditSuccess(args: {
                 "supabase_audit_success_insert",
             );
             await syncInsertedRequestRollup(insertedRow, "audit_success");
-            await retryWithBackoff(
-                () =>
-                    insertGatewayRequestDetails({
-                        gateway_request_id: insertedRow.id,
-                        gateway_request_created_at: insertedRow.created_at,
-                        request_id: args.requestId,
-                        workspace_id: args.workspaceId,
-                        app_id: appId ?? null,
-                        key_id: args.keyId ?? null,
-                        endpoint: args.endpoint,
-                        model_id: args.model,
-                        provider: args.provider ?? null,
-                        status_code: args.statusCode,
-                        success: true,
-                        request_payload: normalizeJsonValue(args.requestPayload) ?? {},
-                        request_content: normalizeJsonValue(extractReplayContent(args.requestPayload)),
-                        gateway_response: normalizeJsonValue(args.gatewayResponse),
-                        response_content: normalizeJsonValue(extractReplayContent(args.gatewayResponse)),
-                        provider_request: normalizeJsonValue(args.providerRequest),
-                        provider_response: normalizeJsonValue(args.providerResponse),
-                        metadata: normalizeJsonValue(args.detailMetadata) ?? {},
-                    }),
+            await insertGatewayRequestDetailsNonBlocking(
+                {
+                    gateway_request_id: insertedRow.id,
+                    gateway_request_created_at: insertedRow.created_at,
+                    request_id: args.requestId,
+                    workspace_id: args.workspaceId,
+                    app_id: appId ?? null,
+                    key_id: args.keyId ?? null,
+                    endpoint: args.endpoint,
+                    model_id: args.model,
+                    provider: args.provider ?? null,
+                    status_code: args.statusCode,
+                    success: true,
+                    request_payload: normalizeJsonValue(args.requestPayload) ?? {},
+                    request_content: normalizeJsonValue(extractReplayContent(args.requestPayload)),
+                    gateway_response: normalizeJsonValue(args.gatewayResponse),
+                    response_content: normalizeJsonValue(extractReplayContent(args.gatewayResponse)),
+                    provider_request: normalizeJsonValue(args.providerRequest),
+                    provider_response: normalizeJsonValue(args.providerResponse),
+                    metadata: normalizeJsonValue(args.detailMetadata) ?? {},
+                },
                 "supabase_audit_success_details_insert",
             );
         } catch (err) {
@@ -477,28 +493,27 @@ export async function auditFailure(args: AuditFailureBefore | AuditFailureExecut
                         "supabase_audit_failure_before_insert",
                     );
                     await syncInsertedRequestRollup(insertedRow, "audit_failure_before");
-                    await retryWithBackoff(
-                        () =>
-                            insertGatewayRequestDetails({
-                                gateway_request_id: insertedRow.id,
-                                gateway_request_created_at: insertedRow.created_at,
-                                request_id: args.requestId,
-                                workspace_id: args.workspaceId,
-                                app_id: resolvedAppId ?? null,
-                                key_id: args.keyId ?? null,
-                                endpoint: args.endpoint,
-                                model_id: args.model ?? "unknown",
-                                provider: null,
-                                status_code: args.statusCode,
-                                success: false,
-                                request_payload: normalizeJsonValue(args.requestPayload) ?? {},
-                                request_content: normalizeJsonValue(extractReplayContent(args.requestPayload)),
-                                gateway_response: normalizeJsonValue(args.gatewayResponse),
-                                response_content: normalizeJsonValue(extractReplayContent(args.gatewayResponse)),
-                                provider_request: null,
-                                provider_response: normalizeJsonValue(args.providerResponse),
-                                metadata: normalizeJsonValue(args.detailMetadata) ?? {},
-                            }),
+                    await insertGatewayRequestDetailsNonBlocking(
+                        {
+                            gateway_request_id: insertedRow.id,
+                            gateway_request_created_at: insertedRow.created_at,
+                            request_id: args.requestId,
+                            workspace_id: args.workspaceId,
+                            app_id: resolvedAppId ?? null,
+                            key_id: args.keyId ?? null,
+                            endpoint: args.endpoint,
+                            model_id: args.model ?? "unknown",
+                            provider: null,
+                            status_code: args.statusCode,
+                            success: false,
+                            request_payload: normalizeJsonValue(args.requestPayload) ?? {},
+                            request_content: normalizeJsonValue(extractReplayContent(args.requestPayload)),
+                            gateway_response: normalizeJsonValue(args.gatewayResponse),
+                            response_content: normalizeJsonValue(extractReplayContent(args.gatewayResponse)),
+                            provider_request: null,
+                            provider_response: normalizeJsonValue(args.providerResponse),
+                            metadata: normalizeJsonValue(args.detailMetadata) ?? {},
+                        },
                         "supabase_audit_failure_before_details_insert",
                     );
                 } catch (err) {
@@ -562,28 +577,27 @@ export async function auditFailure(args: AuditFailureBefore | AuditFailureExecut
                     "supabase_audit_failure_execute_insert",
                 );
                 await syncInsertedRequestRollup(insertedRow, "audit_failure_execute");
-                await retryWithBackoff(
-                    () =>
-                        insertGatewayRequestDetails({
-                            gateway_request_id: insertedRow.id,
-                            gateway_request_created_at: insertedRow.created_at,
-                            request_id: args.requestId,
-                            workspace_id: args.workspaceId,
-                            app_id: resolvedAppId ?? null,
-                            key_id: args.keyId ?? null,
-                            endpoint: args.endpoint,
-                            model_id: args.model,
-                            provider: args.provider ?? null,
-                            status_code: args.statusCode,
-                            success: false,
-                            request_payload: normalizeJsonValue(args.requestPayload) ?? {},
-                            request_content: normalizeJsonValue(extractReplayContent(args.requestPayload)),
-                            gateway_response: normalizeJsonValue(args.gatewayResponse),
-                            response_content: normalizeJsonValue(extractReplayContent(args.gatewayResponse)),
-                            provider_request: normalizeJsonValue(args.providerRequest),
-                            provider_response: normalizeJsonValue(args.providerResponse),
-                            metadata: normalizeJsonValue(args.detailMetadata) ?? {},
-                        }),
+                await insertGatewayRequestDetailsNonBlocking(
+                    {
+                        gateway_request_id: insertedRow.id,
+                        gateway_request_created_at: insertedRow.created_at,
+                        request_id: args.requestId,
+                        workspace_id: args.workspaceId,
+                        app_id: resolvedAppId ?? null,
+                        key_id: args.keyId ?? null,
+                        endpoint: args.endpoint,
+                        model_id: args.model,
+                        provider: args.provider ?? null,
+                        status_code: args.statusCode,
+                        success: false,
+                        request_payload: normalizeJsonValue(args.requestPayload) ?? {},
+                        request_content: normalizeJsonValue(extractReplayContent(args.requestPayload)),
+                        gateway_response: normalizeJsonValue(args.gatewayResponse),
+                        response_content: normalizeJsonValue(extractReplayContent(args.gatewayResponse)),
+                        provider_request: normalizeJsonValue(args.providerRequest),
+                        provider_response: normalizeJsonValue(args.providerResponse),
+                        metadata: normalizeJsonValue(args.detailMetadata) ?? {},
+                    },
                     "supabase_audit_failure_execute_details_insert",
                 );
             } catch (err) {

--- a/apps/api/src/pipeline/audit/index.ts
+++ b/apps/api/src/pipeline/audit/index.ts
@@ -296,6 +296,7 @@ export async function auditSuccess(args: {
                 () => insertGatewayRequest(row),
                 "supabase_audit_success_insert",
             );
+            await syncInsertedRequestRollup(insertedRow, "audit_success");
             await retryWithBackoff(
                 () =>
                     insertGatewayRequestDetails({
@@ -320,7 +321,6 @@ export async function auditSuccess(args: {
                     }),
                 "supabase_audit_success_details_insert",
             );
-            await syncInsertedRequestRollup(insertedRow, "audit_success");
         } catch (err) {
             supabaseError = err instanceof Error ? err : new Error(String(err));
         }
@@ -476,6 +476,7 @@ export async function auditFailure(args: AuditFailureBefore | AuditFailureExecut
                         () => insertGatewayRequest(row),
                         "supabase_audit_failure_before_insert",
                     );
+                    await syncInsertedRequestRollup(insertedRow, "audit_failure_before");
                     await retryWithBackoff(
                         () =>
                             insertGatewayRequestDetails({
@@ -500,7 +501,6 @@ export async function auditFailure(args: AuditFailureBefore | AuditFailureExecut
                             }),
                         "supabase_audit_failure_before_details_insert",
                     );
-                    await syncInsertedRequestRollup(insertedRow, "audit_failure_before");
                 } catch (err) {
                     supabaseError = err instanceof Error ? err : new Error(String(err));
                 }
@@ -561,6 +561,7 @@ export async function auditFailure(args: AuditFailureBefore | AuditFailureExecut
                     () => insertGatewayRequest(row),
                     "supabase_audit_failure_execute_insert",
                 );
+                await syncInsertedRequestRollup(insertedRow, "audit_failure_execute");
                 await retryWithBackoff(
                     () =>
                         insertGatewayRequestDetails({
@@ -585,7 +586,6 @@ export async function auditFailure(args: AuditFailureBefore | AuditFailureExecut
                         }),
                     "supabase_audit_failure_execute_details_insert",
                 );
-                await syncInsertedRequestRollup(insertedRow, "audit_failure_execute");
             } catch (err) {
                 supabaseError = err instanceof Error ? err : new Error(String(err));
             }

--- a/apps/api/src/routes/v1/control/generations.test.ts
+++ b/apps/api/src/routes/v1/control/generations.test.ts
@@ -1,0 +1,165 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const authenticateMock = vi.fn();
+const getSupabaseAdminMock = vi.fn();
+
+vi.mock("@pipeline/before/auth", () => ({
+	authenticate: (...args: any[]) => authenticateMock(...args),
+}));
+
+vi.mock("@/runtime/env", () => ({
+	getSupabaseAdmin: (...args: any[]) => getSupabaseAdminMock(...args),
+}));
+
+vi.mock("../../utils", () => ({
+	withRuntime:
+		(handler: (req: Request) => Promise<Response>) =>
+		async (c: { req: { raw: Request } }) =>
+			handler(c.req.raw),
+	json: (data: unknown, status = 200, headers: Record<string, string> = {}) =>
+		new Response(JSON.stringify(data), {
+			status,
+			headers: {
+				"Content-Type": "application/json",
+				...headers,
+			},
+		}),
+}));
+
+import { generationsRoutes } from "./generations";
+
+function buildSupabaseMock(options: {
+	requestData?: Record<string, unknown> | null;
+	requestError?: { message: string } | null;
+	detailData?: Record<string, unknown> | null;
+	detailError?: { message: string } | null;
+}) {
+	return {
+		from: vi.fn((table: string) => {
+			if (table === "gateway_requests") {
+				return {
+					select: vi.fn(() => ({
+						eq: vi.fn(() => ({
+							eq: vi.fn(() => ({
+								maybeSingle: vi.fn(async () => ({
+									data: options.requestData ?? null,
+									error: options.requestError ?? null,
+								})),
+							})),
+						})),
+					})),
+				};
+			}
+
+			if (table === "gateway_request_details") {
+				return {
+					select: vi.fn(() => ({
+						eq: vi.fn(() => ({
+							eq: vi.fn(() => ({
+								order: vi.fn(() => ({
+									limit: vi.fn(() => ({
+										maybeSingle: vi.fn(async () => ({
+											data: options.detailData ?? null,
+											error: options.detailError ?? null,
+										})),
+									})),
+								})),
+							})),
+						})),
+					})),
+				};
+			}
+
+			throw new Error(`unexpected table: ${table}`);
+		}),
+	};
+}
+
+describe("generationsRoutes", () => {
+	beforeEach(() => {
+		authenticateMock.mockReset();
+		getSupabaseAdminMock.mockReset();
+		authenticateMock.mockResolvedValue({
+			ok: true,
+			workspaceId: "ws_test",
+		});
+	});
+
+	it("returns replay-ready payloads when request details exist", async () => {
+		getSupabaseAdminMock.mockReturnValue(
+			buildSupabaseMock({
+				requestData: {
+					request_id: "gen_123",
+					endpoint: "chat/completions",
+					model_id: "openai/gpt-5-nano",
+					success: true,
+					status_code: 200,
+				},
+				detailData: {
+					request_payload: {
+						model: "openai/gpt-5-nano",
+						messages: [{ role: "user", content: "hello" }],
+						temperature: 0.2,
+					},
+				},
+			}),
+		);
+
+		const response = await generationsRoutes.request("https://example.com/?id=gen_123");
+
+		expect(response.status).toBe(200);
+		await expect(response.json()).resolves.toEqual(
+			expect.objectContaining({
+				request_id: "gen_123",
+				replay_supported: true,
+				replay_request: {
+					model: "openai/gpt-5-nano",
+					messages: [{ role: "user", content: "hello" }],
+					temperature: 0.2,
+				},
+			}),
+		);
+	});
+
+	it("returns replay_supported=false for older rows without stored payloads", async () => {
+		getSupabaseAdminMock.mockReturnValue(
+			buildSupabaseMock({
+				requestData: {
+					request_id: "gen_legacy",
+					endpoint: "responses",
+					model_id: "openai/gpt-5.4-nano",
+					success: false,
+					status_code: 500,
+				},
+				detailData: null,
+			}),
+		);
+
+		const response = await generationsRoutes.request("https://example.com/?id=gen_legacy");
+
+		expect(response.status).toBe(200);
+		await expect(response.json()).resolves.toEqual(
+			expect.objectContaining({
+				request_id: "gen_legacy",
+				replay_supported: false,
+				replay_request: null,
+			}),
+		);
+	});
+
+	it("returns 401 when authentication fails", async () => {
+		authenticateMock.mockResolvedValue({
+			ok: false,
+			reason: "missing",
+		});
+
+		const response = await generationsRoutes.request("https://example.com/?id=gen_123");
+
+		expect(response.status).toBe(401);
+		await expect(response.json()).resolves.toEqual({
+			ok: false,
+			error: "unauthorised",
+			reason: "missing",
+		});
+	});
+});

--- a/apps/api/src/routes/v1/control/generations.ts
+++ b/apps/api/src/routes/v1/control/generations.ts
@@ -9,6 +9,15 @@ import type { AuthFailure } from "@pipeline/before/auth";
 import { getSupabaseAdmin } from "@/runtime/env";
 import { json, withRuntime } from "../../utils";
 
+function resolveReplayRequest(value: unknown): Record<string, unknown> | null {
+    if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+    const entries = Object.entries(value as Record<string, unknown>).filter(
+        ([, entry]) => entry !== undefined,
+    );
+    if (entries.length === 0) return null;
+    return Object.fromEntries(entries);
+}
+
 async function handleGeneration(req: Request) {
     const url = new URL(req.url);
     const id = url.searchParams.get("id");
@@ -39,7 +48,30 @@ async function handleGeneration(req: Request) {
         return json({ ok: false, error: "not_found" }, 404, { "Cache-Control": "no-store" });
     }
 
-    return json(data, 200, { "Cache-Control": "no-store" });
+    const { data: detailData, error: detailError } = await supabase
+        .from("gateway_request_details")
+        .select("request_payload")
+        .eq("workspace_id", auth.workspaceId)
+        .eq("request_id", id)
+        .order("created_at", { ascending: false })
+        .limit(1)
+        .maybeSingle();
+
+    if (detailError) {
+        return json({ ok: false, error: "db_error", message: detailError.message }, 500, { "Cache-Control": "no-store" });
+    }
+
+    const replayRequest = resolveReplayRequest(detailData?.request_payload);
+
+    return json(
+        {
+            ...data,
+            replay_supported: Boolean(replayRequest),
+            replay_request: replayRequest,
+        },
+        200,
+        { "Cache-Control": "no-store" },
+    );
 }
 
 export const generationsRoutes = new Hono<Env>();

--- a/apps/api/src/routes/v1/data/async-jobs.test.ts
+++ b/apps/api/src/routes/v1/data/async-jobs.test.ts
@@ -1,6 +1,58 @@
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { parseAsyncWebsocketOptions } from "./async-jobs";
+
+const state = vi.hoisted(() => ({
+	authResult: {
+		ok: true as const,
+		workspaceId: "ws_async_test",
+		apiKeyId: "key_async_test",
+		apiKeyRef: "kid_async_test",
+		apiKeyKid: "async_test_kid",
+		userId: null,
+		internal: false,
+	},
+	record: {
+		workspaceId: "ws_async_test",
+		kind: "video",
+		internalId: "job_123",
+		status: "queued",
+		updatedAt: "2026-05-05T00:00:00.000Z",
+		meta: {},
+	} as Record<string, unknown> | null,
+}));
+
+vi.mock("@pipeline/before/auth", () => ({
+	authenticate: vi.fn(async () => state.authResult),
+}));
+
+vi.mock("@core/async-operations", () => ({
+	getAsyncOperation: vi.fn(async () => state.record),
+}));
+
+vi.mock("@core/async-notifications", async () => {
+	const actual = await vi.importActual<typeof import("@core/async-notifications")>("@core/async-notifications");
+	return {
+		...actual,
+		buildAsyncNotificationData: vi.fn(async () => ({
+			id: "job_123",
+			kind: "video",
+			status: "queued",
+		})),
+	};
+});
+
+vi.mock("../../utils", () => ({
+	withRuntime: (handler: (req: Request) => Promise<Response>) => async (c: any) => handler(c.req.raw),
+	json: (body: unknown, status = 200, headers: Record<string, string> = {}) =>
+		new Response(JSON.stringify(body), {
+			status,
+			headers: {
+				"Content-Type": "application/json",
+				...headers,
+			},
+		}),
+}));
 
 describe("parseAsyncWebsocketOptions", () => {
 	it("uses safe defaults", () => {
@@ -31,6 +83,80 @@ describe("parseAsyncWebsocketOptions", () => {
 		).toEqual({
 			intervalMs: 10000,
 			closeOnTerminal: true,
+		});
+	});
+});
+
+describe("asyncJobsRoutes", () => {
+	beforeEach(() => {
+		state.authResult = {
+			ok: true,
+			workspaceId: "ws_async_test",
+			apiKeyId: "key_async_test",
+			apiKeyRef: "kid_async_test",
+			apiKeyKid: "async_test_kid",
+			userId: null,
+			internal: false,
+		};
+		state.record = {
+			workspaceId: "ws_async_test",
+			kind: "video",
+			internalId: "job_123",
+			status: "queued",
+			updatedAt: "2026-05-05T00:00:00.000Z",
+			meta: {},
+		};
+		vi.resetModules();
+	});
+
+	it("returns 426 for non-websocket HTTP requests", async () => {
+		const { asyncJobsRoutes } = await import("./async-jobs");
+
+		const response = await asyncJobsRoutes.request("https://example.com/video/job_123/ws", {
+			method: "GET",
+		});
+
+		expect(response.status).toBe(426);
+		expect(response.headers.get("upgrade")).toBe("websocket");
+		expect(await response.json()).toMatchObject({
+			error: {
+				code: "websocket_upgrade_required",
+			},
+		});
+	});
+
+	it("returns 400 when the async kind in the path is invalid", async () => {
+		const { asyncJobsRoutes } = await import("./async-jobs");
+
+		const response = await asyncJobsRoutes.request("https://example.com/unknown/job_123/ws", {
+			method: "GET",
+			headers: {
+				Upgrade: "websocket",
+			},
+		});
+
+		expect(response.status).toBe(400);
+		expect(await response.json()).toMatchObject({
+			error: "validation_error",
+			reason: "invalid_async_job_path",
+		});
+	});
+
+	it("returns 404 when the async job is not owned or does not exist", async () => {
+		state.record = null;
+		const { asyncJobsRoutes } = await import("./async-jobs");
+
+		const response = await asyncJobsRoutes.request("https://example.com/video/job_123/ws", {
+			method: "GET",
+			headers: {
+				Upgrade: "websocket",
+			},
+		});
+
+		expect(response.status).toBe(404);
+		expect(await response.json()).toMatchObject({
+			error: "not_found",
+			reason: "async_job_not_found_or_not_owned",
 		});
 	});
 });

--- a/apps/docs/v1/api-reference/endpoint/async-jobs-ws.mdx
+++ b/apps/docs/v1/api-reference/endpoint/async-jobs-ws.mdx
@@ -1,0 +1,133 @@
+---
+title: "Async Jobs WebSocket"
+description: "Subscribe to owned batch or video async job updates over WebSocket."
+---
+
+<Note type="warning">
+Experimental endpoint. This surface is WebSocket-only and is currently intended for async batch and video lifecycle updates.
+</Note>
+
+Successful connection is HTTP `101 Switching Protocols` (not `200`). If you call this path as a normal HTTP GET without WebSocket upgrade headers, the gateway returns `426 websocket_upgrade_required`.
+
+## Endpoint
+
+- URL: `wss://api.phaseo.app/v1/async/{kind}/{id}/ws`
+- Supported `kind` values: `batch`, `video`
+- Method semantics: WebSocket starts as an HTTP `GET` with `Upgrade: websocket`
+- Auth: `Authorization: Bearer YOUR_API_KEY`
+
+The gateway enforces workspace ownership before opening the socket. If the async job is missing or not owned by the caller, the HTTP handshake fails with `404 async_job_not_found_or_not_owned`.
+
+## Query parameters
+
+- `interval_ms` optional polling interval override
+  - default: `2500`
+  - minimum: `1000`
+  - maximum: `10000`
+- `close_on_terminal` optional boolean
+  - default: `true`
+  - when enabled, the gateway closes the socket after a terminal update
+
+## Server events
+
+The socket sends JSON envelopes with a `type` and `data` field.
+
+- `job.snapshot`
+  - initial current state emitted immediately after upgrade
+- `job.updated`
+  - emitted when the async job payload changes during polling
+- `job.deleted`
+  - emitted if the owned async job record disappears before completion
+- `pong`
+  - sent in reply to a client `ping` message
+
+The `data` payload follows the same owned async-job shape used by webhook/web UI notifications, including status, routing metadata, file/content links where available, and terminal billing fields for supported kinds.
+
+Batch payloads can also include:
+
+- `pricing_lines`
+  - the same batch pricing line metadata exposed by the normal batch API responses when settlement or priced-usage data is available
+- `webhook`
+  - sanitized webhook configuration with the public callback `url` and subscribed `events` when the batch was created with gateway-managed webhook settings
+
+Common identity fields include:
+
+- `id`
+  - gateway-owned async job id
+- `request_id`
+  - originating gateway request id when the async job was created from a tracked request
+- `session_id`
+  - gateway session id when the originating request was session-scoped
+- `app_id`
+  - owning app id when the originating request was associated with an app
+- `native_id`
+  - provider-native operation / batch id when the upstream returned one
+
+Failed batch and video payloads can also include the same normalized gateway failure diagnostics used by the request error contract when that metadata was captured during execution or reconciliation:
+
+- `upstream_error`
+  - normalized upstream provider error object with fields like `code`, `message`, `description`, `param`, and `status`
+- `provider_failure_diagnostics`
+  - compact gateway classification of the failure category, implicated provider, and optional operator hint
+- `failure_sample`
+  - per-attempt upstream failure summaries, including provider, status, retryability, and upstream error fields when available
+- `routing_diagnostics`
+  - provider-count and drop-stage details when routing filtered candidates before failure
+- `provider_enablement`
+  - capability/provider activation diagnostics when enablement gating was part of the failure path
+- `provider_candidate_diagnostics`
+  - candidate counts and dropped-provider summary data when the gateway computed a narrowed provider set
+
+For video jobs, timing fields use the same explicit semantics as the rest of the gateway where available:
+
+- `latency_ms`
+  - time to first byte / first meaningful provider response when tracked
+- `generation_ms`
+  - post-latency generation time when tracked
+- `total_duration_ms`
+  - end-to-end async job lifecycle duration
+- `duration_ms`
+  - legacy alias for `total_duration_ms`
+
+Video job payloads can also include lifecycle transition metadata that is useful for long-running investigations:
+
+- `last_polled_at`
+  - last provider poll timestamp recorded by the gateway
+- `polled_status`
+  - last raw/normalized provider status observed during polling
+- `last_reconciled_at`
+  - last scheduled reconciliation pass that touched the job
+
+Terminal batch and video payloads can also include:
+
+- `finalized_at`
+  - when terminal billing/finalization completed
+
+When the job was created with a gateway key versus BYOK credentials, batch and video payloads can also include:
+
+- `key_source`
+  - `gateway` or `byok`
+- `byok_key_id`
+  - gateway-side identifier for the BYOK credential when available
+
+Async job payloads can also include webhook dispatch state copied from the owned async operation record:
+
+- `next_webhook_retry_at`
+  - next scheduled retry timestamp, if a delivery is queued
+- `last_webhook_progress`
+  - most recent coarse progress bucket dispatched to webhook consumers
+- `last_webhook_progress_at`
+  - when that progress bucket was last emitted
+- `last_webhook_dispatched_at`
+  - last webhook dispatch attempt timestamp, regardless of outcome
+
+## Client messages
+
+- `ping`
+  - keepalive; server replies with `pong`
+- `refresh`
+  - force an immediate state refresh without waiting for the next poll interval
+
+## Terminal behavior
+
+When `close_on_terminal=true`, the gateway closes the socket after a terminal `completed`, `failed`, or `cancelled` update. Disable that flag if you want the client to keep the connection open and decide when to close it.

--- a/apps/docs/v1/api-reference/endpoint/generation.mdx
+++ b/apps/docs/v1/api-reference/endpoint/generation.mdx
@@ -8,3 +8,14 @@ Fetches the stored audit record for a given `request_id` that belongs to your te
 Use:
 - `GET /v1/generations?id=<request_id>`
 
+When the gateway captured full request details for that generation, the response also includes:
+
+- `replay_supported`: whether a replay-ready payload is available
+- `replay_request`: the stored request body you can send back to the original endpoint for a controlled rerun
+
+Typical replay flow:
+
+1. Read the generation record with `GET /v1/generations?id=<request_id>`.
+2. Check `replay_supported === true`.
+3. Re-submit `replay_request` to the original endpoint named by `endpoint` such as `/v1/chat/completions` or `/v1/responses`.
+

--- a/apps/docs/v1/api-reference/errors.mdx
+++ b/apps/docs/v1/api-reference/errors.mdx
@@ -9,10 +9,39 @@ Gateway errors use a consistent JSON shape:
 ```json
 {
   "generation_id": "G-abc123",
-  "status_code": 401,
-  "error": "validation_error",
-  "error_type": "user",
-  "description": "Input validation failed"
+  "status_code": 502,
+  "error": "upstream_error",
+  "error_type": "system",
+  "error_origin": "upstream",
+  "reason": "all_candidates_failed",
+  "description": "Provider \"google-ai-studio\" failed with HTTP 403 for endpoint \"responses\" on model \"google/gemini-2.5-pro\".",
+  "attempt_count": 1,
+  "failed_providers": ["google-ai-studio"],
+  "failed_statuses": [403],
+  "provider_failure_diagnostics": {
+    "category": "provider_access_missing",
+    "hint": "The provider account appears not to have access to this model or feature yet. Verify account entitlements and provider-side access.",
+    "provider": "google-ai-studio"
+  },
+  "upstream_error": {
+    "code": "PERMISSION_DENIED",
+    "message": "The caller does not have permission.",
+    "description": null,
+    "param": null
+  },
+  "failure_sample": [
+    {
+      "provider": "google-ai-studio",
+      "type": "upstream_non_2xx",
+      "status": 403,
+      "upstream_error_code": "PERMISSION_DENIED",
+      "upstream_error_message": "The caller does not have permission.",
+      "upstream_error_description": null,
+      "upstream_error_param": null,
+      "upstream_payload_preview": "{\"error\":{\"status\":\"PERMISSION_DENIED\"}}",
+      "retryable": false
+    }
+  ]
 }
 ```
 
@@ -22,8 +51,18 @@ Every response includes:
 - `status_code`: mirrors the HTTP status to make retries decisions easier.
 - `error`: a machine-readable error code (for example `validation_error`).
 - `error_type`: high-level classification (`user` or `system`).
+- `error_origin`: whether the failure is primarily attributed to the caller, the gateway, or an upstream provider.
 - `description`: a human-friendly explanation.
 - `details` (optional): structured validation errors when `error` is `validation_error`.
+
+Some responses also include richer diagnostics:
+
+- `reason`: a more specific machine-readable subreason such as `all_candidates_failed` or `pricing_not_configured`.
+- `provider_candidate_diagnostics` and `provider_enablement`: explain why a known model/provider is not currently routable for `unsupported_model_or_endpoint` style failures.
+- `routing_diagnostics`: filter-stage detail for capability, rollout, and routing-status gates.
+- `provider_failure_diagnostics`: normalized operator-facing hints for missing credentials, missing access, region restrictions, rate limits, and similar execute-stage failures.
+- `upstream_error` and `failure_sample`: best-effort summaries of the first upstream/provider failure when the request reached a provider.
+- `failed_providers`, `failed_statuses`, and `attempt_count`: aggregate retry/failover context for routed request failures.
 
 ## Status class guidance
 
@@ -44,6 +83,105 @@ Every response includes:
 | `validation_error`     | `400`       | Invalid parameters or request body.                  |
 | `provider_error`       | `502`       | Upstream model provider failed to respond correctly. |
 | `server_error`         | `500`       | Unexpected issue within the Gateway.                 |
+
+## Structured upstream diagnostics
+
+When a routed request reaches one or more providers and still fails, the Gateway may include:
+
+- `provider_failure_diagnostics.category`
+- `provider_failure_diagnostics.hint`
+- `provider_failure_diagnostics.provider`
+
+Current categories include:
+
+- `credentials_not_configured`
+- `credentials_invalid_or_forbidden`
+- `provider_access_missing`
+- `region_or_project_restriction`
+- `model_unavailable_for_endpoint`
+- `rate_limited`
+- `server_error`
+
+These fields are intended to make triage easier without enabling full debug mode.
+
+## Unsupported model diagnostics
+
+For `unsupported_model_or_endpoint` responses, the Gateway may include:
+
+- `provider_candidate_diagnostics`
+- `provider_enablement`
+- `missing_pricing_providers`
+- `routing_diagnostics`
+
+These help distinguish:
+
+- known but disabled
+- unsupported for endpoint
+- pricing missing
+- rollout-restricted or internal-testing-only mappings
+
+Representative fields:
+
+- `provider_candidate_diagnostics.totalProviders`: how many providers were known for the model before endpoint filtering.
+- `provider_candidate_diagnostics.supportsEndpointCount`: how many of those providers support the requested endpoint at all.
+- `provider_candidate_diagnostics.candidateCount`: how many providers remained as executable candidates after adapter checks.
+- `provider_candidate_diagnostics.droppedUnsupportedEndpoint`: provider ids dropped because the provider does not support the requested endpoint.
+- `provider_candidate_diagnostics.droppedMissingAdapter`: provider/endpoint pairs dropped because a mapping exists but the gateway does not yet have an adapter for that endpoint.
+- `provider_enablement.capability`: the capability gate being enforced, such as `video_generation`.
+- `provider_enablement.providersBefore` / `provider_enablement.providersAfter`: provider ids before and after capability or enablement filtering.
+- `provider_enablement.dropped[].reason`: machine-readable reasons such as `pricing_missing`.
+- `routing_diagnostics.filterStages[].stage`: the routing/filter stage, for example capability, rollout, or routing-status filtering.
+- `routing_diagnostics.filterStages[].beforeCount` / `routing_diagnostics.filterStages[].afterCount`: provider counts before and after each stage.
+- `routing_diagnostics.filterStages[].droppedProviders[].reason`: machine-readable reasons such as rollout or routing restrictions.
+
+Example:
+
+```json
+{
+  "generation_id": "G-unsupported123",
+  "status_code": 400,
+  "error": "unsupported_model_or_endpoint",
+  "description": "No provider is currently routable for endpoint \"responses\" on model \"example/model\".",
+  "provider_candidate_diagnostics": {
+    "totalProviders": 3,
+    "supportsEndpointCount": 2,
+    "candidateCount": 1,
+    "droppedUnsupportedEndpoint": ["provider-a"],
+    "droppedMissingAdapter": [
+      {
+        "providerId": "provider-b",
+        "endpoint": "responses"
+      }
+    ]
+  },
+  "provider_enablement": {
+    "capability": "responses",
+    "providersBefore": ["provider-b", "provider-c"],
+    "providersAfter": ["provider-c"],
+    "dropped": [
+      {
+        "providerId": "provider-b",
+        "reason": "pricing_missing"
+      }
+    ]
+  },
+  "routing_diagnostics": {
+    "filterStages": [
+      {
+        "stage": "provider_routing_status",
+        "beforeCount": 1,
+        "afterCount": 0,
+        "droppedProviders": [
+          {
+            "providerId": "provider-c",
+            "reason": "provider_status_not_ready"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
 
 ## Debug options
 

--- a/apps/docs/v1/api-reference/introduction.mdx
+++ b/apps/docs/v1/api-reference/introduction.mdx
@@ -48,20 +48,15 @@ The table below outlines the main endpoints available in the AI Stats Gateway ri
 | `POST /embeddings`, `POST /moderations` | Embeddings and moderation checks. |
 | `POST /audio/speech`, `POST /audio/transcriptions`, `POST /audio/translations` | TTS, STT, and audio translations. |
 | `POST /images/generations`, `POST /images/edits` | Image generation and editing. |
-| `POST /videos` | Create a video generation job (asynchronous). |
+| `POST /videos`, `GET /videos`, `GET /videos/models` | Create, list, and discover video generation capabilities. |
 | `GET /videos/{video_id}` | Poll the video job status until complete. |
-| `GET /videos/{video_id}/content`, `DELETE /videos/{video_id}` | Fetch completed video bytes or delete a job. |
+| `GET /videos/{video_id}/content`, `POST /videos/{video_id}/download_url`, `DELETE /videos/{video_id}` | Fetch completed video bytes, issue a signed download link, or delete a terminal job record. |
+| `POST /videos/{video_id}/cancel` | Reserved public cancel route. Currently returns a structured `501 not_implemented_yet` error while provider cancellation is standardized. |
 | `POST /music/generate`, `GET /music/generate/{music_id}` | Create and poll music generation jobs. |
-| `POST /ocr`, `POST /batches`, `GET /batches/{batch_id}`, `POST /files`, `GET /files`, `GET /files/{file_id}` | OCR is active; batch and file endpoints are currently placeholders returning `501 not_implemented`. |
-| `GET /gateway/models`, `GET /data/models`, `GET /providers`, `GET /generations?id=...`, `GET /key`, `GET /keys`, `GET /workspaces`, `GET /credits`, `GET /activity` | Platform API discovery endpoints plus elevated administration endpoints. |
+| `POST /ocr`, `POST /batches`, `GET /batches/{batch_id}`, `POST /batches/{batch_id}/cancel`, `POST /files`, `GET /files/{file_id}`, `GET /files/{file_id}/content` | OCR is active. Batch endpoints are available in beta. File upload, owned file retrieval, and file content download are active in beta; `GET /files` currently returns `file_list_not_supported_with_shared_gateway_key` on the shared gateway key. |
+| `GET /gateway/models`, `GET /gateway/models/me`, `GET /data/models`, `GET /providers`, `GET /endpoints`, `GET /organisations`, `GET /pricing/models`, `POST /pricing/calculate`, `GET /generations?id=...`, `GET /key`, `GET /keys`, `GET /workspaces`, `GET /credits`, `GET /activity` | Platform API discovery endpoints plus elevated administration endpoints. |
 
 Use the `endpoints` query parameter on `GET /gateway/models` to reproduce the per-surface catalogues (chat, moderations, embeddings, images, video, or audio) without bouncing between separate endpoints.
-
-The following endpoints are documented, but still under active work:
-
-| Endpoint | Description |
-| --- | --- |
-| `GET /endpoints` | Coming Soon placeholder endpoint. |
 
 Responses include an optional `usage` and `meta` object with your usage, in both tokens and pricing, broken down into clear lines to
 see what costs what, as well as detailed timing and performance metadata, such as throughput, latency, and generation time,

--- a/apps/docs/v1/guides/websocket-mode.mdx
+++ b/apps/docs/v1/guides/websocket-mode.mdx
@@ -21,6 +21,7 @@ This endpoint is still experimental on AI Stats Gateway and is currently not rec
 - Auth: `Authorization: Bearer YOUR_API_KEY`
 
 If you call this path as a normal HTTP GET without WebSocket upgrade headers, the gateway returns `426 websocket_upgrade_required`.
+If websocket mode is disabled for the current deployment, the handshake instead returns `501 responses_websocket_disabled` before upgrade or auth processing begins.
 
 ## How the gateway processes this endpoint
 

--- a/apps/web/src/app/(dashboard)/gateway/usage/server-actions.ts
+++ b/apps/web/src/app/(dashboard)/gateway/usage/server-actions.ts
@@ -1,5 +1,6 @@
 "use server";
 
+import { cache } from "react";
 import { createClient } from "@/utils/supabase/server";
 import { createAdminClient } from "@/utils/supabase/admin";
 import { getWorkspaceIdFromCookie } from "@/utils/workspaceCookie";
@@ -11,6 +12,12 @@ import {
 	requireAuthenticatedUser,
 	requireWorkspaceMembership,
 } from "@/utils/serverActionAuth";
+import {
+	parseAsyncJobFailureDiagnostics,
+	type AsyncJobFailureSampleRow,
+	type AsyncJobProviderFailureDiagnosticsRow,
+	type AsyncJobUpstreamErrorRow,
+} from "@/lib/gateway/usage/asyncJobFailureDiagnostics";
 
 // Raw fallback can pull large request windows; keep it opt-in to protect DB egress.
 const ENABLE_GATEWAY_USAGE_RAW_FALLBACK =
@@ -32,6 +39,20 @@ async function requireAuthedTeamContext(
 	return { user, workspaceId };
 }
 
+function normalizeLookupIds(ids: string[]): string[] {
+	return Array.from(
+		new Set(
+			ids
+				.map((id) => (typeof id === "string" ? id.trim() : ""))
+				.filter((id) => id.length > 0),
+		),
+	).sort((a, b) => a.localeCompare(b));
+}
+
+function toLookupCacheKey(ids: string[]): string {
+	return normalizeLookupIds(ids).join("\n");
+}
+
 export interface PaginatedRequestsParams {
 	timeRange: { from: string; to: string };
 	modelFilter?: string | null;
@@ -48,9 +69,11 @@ export interface PaginatedRequestsParams {
 export interface RequestRow {
 	request_id: string;
 	created_at: string;
+	endpoint: string | null;
 	model_id: string | null;
 	provider: string | null;
 	native_response_id: string | null;
+	upstream_request_id: string | null;
 	stream: boolean;
 	session_id: string | null;
 	app_id: string | null;
@@ -68,7 +91,9 @@ export interface RequestRow {
 	status_code: number | null;
 	error_code: string | null;
 	error_message: string | null;
+	error_payload: Record<string, unknown> | null;
 	key_id: string | null;
+	pricing_lines: AsyncJobRequestPricingLine[];
 	provider_attempts: Array<{
 		attempt_number: number | null;
 		provider: string | null;
@@ -82,12 +107,125 @@ export interface RequestRow {
 	}>;
 }
 
+export type SerializableModelMetadataEntry = {
+	organisationId: string;
+	organisationName: string;
+	modelName?: string;
+};
+
+export interface InvestigateGenerationResult {
+	request: RequestRow;
+	appName: string | null;
+	modelMetadata: Array<[string, SerializableModelMetadataEntry]>;
+	providerNames: Array<[string, string]>;
+	providerMetadata: Array<[string, ProviderMetadataEntry]>;
+}
+
 export interface PaginatedRequestsResult {
 	data: RequestRow[];
 	total: number;
 	page: number;
 	pageSize: number;
 	totalPages: number;
+}
+
+function normalizeProviderAttempts(
+	value: unknown,
+): RequestRow["provider_attempts"] {
+	if (!Array.isArray(value)) return [];
+	return value.map((attempt: any) => ({
+		attempt_number:
+			typeof attempt?.attempt_number === "number"
+				? attempt.attempt_number
+				: typeof attempt?.attempt_number === "string"
+					? Number(attempt.attempt_number)
+					: null,
+		provider:
+			typeof attempt?.provider === "string" ? attempt.provider : null,
+		outcome:
+			typeof attempt?.outcome === "string" ? attempt.outcome : null,
+		status:
+			typeof attempt?.status === "number"
+				? attempt.status
+				: typeof attempt?.status === "string"
+					? Number(attempt.status)
+					: null,
+		status_text:
+			typeof attempt?.status_text === "string"
+				? attempt.status_text
+				: null,
+		duration_ms:
+			typeof attempt?.duration_ms === "number"
+				? attempt.duration_ms
+				: typeof attempt?.duration_ms === "string"
+					? Number(attempt.duration_ms)
+					: null,
+		upstream_error_code:
+			typeof attempt?.upstream_error_code === "string"
+				? attempt.upstream_error_code
+				: null,
+		upstream_error_message:
+			typeof attempt?.upstream_error_message === "string"
+				? attempt.upstream_error_message
+				: null,
+		upstream_error_description:
+			typeof attempt?.upstream_error_description === "string"
+				? attempt.upstream_error_description
+				: null,
+	}));
+}
+
+function normalizePlainObject(
+	value: unknown,
+): Record<string, unknown> | null {
+	return value && typeof value === "object" && !Array.isArray(value)
+		? (value as Record<string, unknown>)
+		: null;
+}
+
+function toRequestRow(row: any): RequestRow {
+	const appRow = Array.isArray(row?.app) ? row.app[0] : row?.app;
+	const appTitle =
+		typeof appRow?.title === "string" && appRow.title.trim().length > 0
+			? appRow.title.trim()
+			: null;
+	const appKey =
+		typeof appRow?.app_key === "string" && appRow.app_key.trim().length > 0
+			? appRow.app_key.trim()
+			: null;
+	const appImageUrl =
+		typeof appRow?.image_url === "string" && appRow.image_url.trim().length > 0
+			? appRow.image_url.trim()
+			: null;
+
+	return {
+		...row,
+		endpoint:
+			typeof row?.endpoint === "string" && row.endpoint.trim().length > 0
+				? row.endpoint.trim()
+				: null,
+		native_response_id:
+			typeof row?.native_response_id === "string" &&
+			row.native_response_id.trim().length > 0
+				? row.native_response_id.trim()
+				: null,
+		upstream_request_id:
+			typeof row?.upstream_request_id === "string" &&
+			row.upstream_request_id.trim().length > 0
+				? row.upstream_request_id.trim()
+				: null,
+		stream: row?.stream === true,
+		session_id:
+			typeof row?.session_id === "string" && row.session_id.trim().length > 0
+				? row.session_id.trim()
+				: null,
+		app_title: appTitle,
+		app_key: appKey,
+		app_image_url: appImageUrl,
+		pricing_lines: normalizePricingLines(row?.pricing_lines),
+		error_payload: normalizePlainObject(row?.error_payload),
+		provider_attempts: normalizeProviderAttempts(row?.provider_attempts),
+	} as RequestRow;
 }
 
 /**
@@ -117,14 +255,14 @@ export async function fetchPaginatedRequests(
 		.from("gateway_requests")
 		.select(
 			`
-			request_id,
-			created_at,
-			model_id,
-			provider,
-			native_response_id,
-			stream,
-			session_id,
-			app_id,
+                        request_id,
+                        created_at,
+                        endpoint,
+                        model_id,
+                        provider,
+                        stream,
+                        session_id,
+                        app_id,
 			app:api_apps!gateway_requests_app_id_fkey (
 				id,
 				app_key,
@@ -136,14 +274,13 @@ export async function fetchPaginatedRequests(
 			generation_ms,
 			latency_ms,
 			finish_reason,
-			success,
-			status_code,
-			error_code,
-			error_message,
-			key_id,
-			throughput,
-			provider_attempts
-		`,
+                        success,
+                        status_code,
+                        error_code,
+                        error_message,
+                        key_id,
+                        throughput
+                `,
 			{ count: "exact" }
 		)
 		.eq("workspace_id", workspaceId)
@@ -190,27 +327,26 @@ export async function fetchPaginatedRequests(
 			.from("gateway_requests")
 			.select(
 				`
-				request_id,
-				created_at,
-				model_id,
-				provider,
-				native_response_id,
-				stream,
-				session_id,
-				app_id,
+                                request_id,
+                                created_at,
+                                endpoint,
+                                model_id,
+                                provider,
+                                stream,
+                                session_id,
+                                app_id,
 				usage,
 				cost_nanos,
 				generation_ms,
 				latency_ms,
 				finish_reason,
-				success,
-				status_code,
-				error_code,
-				error_message,
-				key_id,
-				throughput,
-				provider_attempts
-			`,
+                                success,
+                                status_code,
+                                error_code,
+                                error_message,
+                                key_id,
+                                throughput
+                        `,
 				{ count: "exact" },
 			)
 			.eq("workspace_id", workspaceId)
@@ -242,25 +378,25 @@ export async function fetchPaginatedRequests(
 				.select(
 					`
 					request_id,
-					created_at,
-					model_id,
-					provider,
-					native_response_id,
-					stream,
-					session_id,
-					app_id,
+                                        created_at,
+                                        endpoint,
+                                        model_id,
+                                        provider,
+                                        stream,
+                                        session_id,
+                                        app_id,
 					usage,
 					cost_nanos,
 					generation_ms,
 					latency_ms,
 					finish_reason,
-					success,
-					status_code,
-					error_code,
-					error_message,
-					key_id,
-					throughput
-				`,
+                                        success,
+                                        status_code,
+                                        error_code,
+                                        error_message,
+                                        key_id,
+                                        throughput
+                                `,
 					{ count: "exact" },
 				)
 				.eq("workspace_id", workspaceId)
@@ -300,81 +436,7 @@ export async function fetchPaginatedRequests(
 	}
 
 	return {
-		data:
-			(rows ?? []).map((row) => {
-				const appRow = Array.isArray(row?.app) ? row.app[0] : row?.app;
-				const appTitle =
-					typeof appRow?.title === "string" && appRow.title.trim().length > 0
-						? appRow.title.trim()
-						: null;
-				const appKey =
-					typeof appRow?.app_key === "string" && appRow.app_key.trim().length > 0
-						? appRow.app_key.trim()
-						: null;
-				const appImageUrl =
-					typeof appRow?.image_url === "string" && appRow.image_url.trim().length > 0
-						? appRow.image_url.trim()
-						: null;
-				return {
-					...row,
-					native_response_id:
-						typeof row?.native_response_id === "string" &&
-						row.native_response_id.trim().length > 0
-							? row.native_response_id.trim()
-							: null,
-					stream: row?.stream === true,
-					session_id:
-						typeof row?.session_id === "string" &&
-						row.session_id.trim().length > 0
-							? row.session_id.trim()
-							: null,
-					app_title: appTitle,
-					app_key: appKey,
-					app_image_url: appImageUrl,
-					provider_attempts: Array.isArray(row?.provider_attempts)
-						? row.provider_attempts.map((attempt: any) => ({
-								attempt_number:
-									typeof attempt?.attempt_number === "number"
-										? attempt.attempt_number
-										: typeof attempt?.attempt_number === "string"
-											? Number(attempt.attempt_number)
-											: null,
-								provider:
-									typeof attempt?.provider === "string" ? attempt.provider : null,
-								outcome:
-									typeof attempt?.outcome === "string" ? attempt.outcome : null,
-								status:
-									typeof attempt?.status === "number"
-										? attempt.status
-										: typeof attempt?.status === "string"
-											? Number(attempt.status)
-											: null,
-								status_text:
-									typeof attempt?.status_text === "string"
-										? attempt.status_text
-										: null,
-								duration_ms:
-									typeof attempt?.duration_ms === "number"
-										? attempt.duration_ms
-										: typeof attempt?.duration_ms === "string"
-											? Number(attempt.duration_ms)
-											: null,
-								upstream_error_code:
-									typeof attempt?.upstream_error_code === "string"
-										? attempt.upstream_error_code
-										: null,
-								upstream_error_message:
-									typeof attempt?.upstream_error_message === "string"
-										? attempt.upstream_error_message
-										: null,
-								upstream_error_description:
-									typeof attempt?.upstream_error_description === "string"
-										? attempt.upstream_error_description
-										: null,
-						  }))
-						: [],
-				} as RequestRow;
-			}) ?? [],
+		data: (rows ?? []).map((row) => toRequestRow(row)) ?? [],
 		total: totalCount,
 		page: params.page,
 		pageSize,
@@ -389,13 +451,20 @@ export async function fetchPaginatedRequests(
 export async function fetchOrganizationColors(
 	modelIds: string[]
 ): Promise<Map<string, string>> {
+	return fetchOrganizationColorsCached(toLookupCacheKey(modelIds));
+}
+
+const fetchOrganizationColorsCached = cache(async (
+	modelIdsKey: string
+): Promise<Map<string, string>> => {
 	const { supabase } = await requireAuthenticatedUser();
+	const modelIds = modelIdsKey ? modelIdsKey.split("\n") : [];
 
 	if (modelIds.length === 0) {
 		return new Map();
 	}
 
-	const uniqueModelIds = Array.from(new Set(modelIds));
+	const uniqueModelIds = normalizeLookupIds(modelIds);
 	const colorMap = new Map<string, string>();
 	const normalizeApiId = (id: string) => {
 		const base = id.split(":")[0];
@@ -529,7 +598,7 @@ export async function fetchOrganizationColors(
 	void providerApiIds;
 
 	return colorMap;
-}
+});
 
 /**
  * Fetch model metadata for filters
@@ -547,6 +616,21 @@ export async function fetchModelMetadata(
 		}
 	>
 > {
+	return fetchModelMetadataCached(toLookupCacheKey(modelIds));
+}
+
+const fetchModelMetadataCached = cache(async (
+	modelIdsKey: string
+): Promise<
+	Map<
+		string,
+		{
+			organisationId: string;
+			organisationName: string;
+			modelName?: string;
+		}
+	>
+> => {
 	const { supabase } = await requireAuthenticatedUser();
 	const metadataDebugEnabled =
 		process.env.USAGE_MODEL_METADATA_DEBUG === "1" ||
@@ -559,11 +643,13 @@ export async function fetchModelMetadata(
 		}
 	};
 
+	const modelIds = modelIdsKey ? modelIdsKey.split("\n") : [];
+
 	if (modelIds.length === 0) {
 		return new Map();
 	}
 
-	const uniqueModelIds = Array.from(new Set(modelIds));
+	const uniqueModelIds = normalizeLookupIds(modelIds);
 	const metadataMap = new Map<
 		string,
 		{
@@ -1047,7 +1133,7 @@ export async function fetchModelMetadata(
 	}
 
 	return metadataMap;
-}
+});
 /**
  * Fetch provider names for display labels
  * Returns a map of provider_id -> provider name
@@ -1055,13 +1141,20 @@ export async function fetchModelMetadata(
 export async function fetchProviderNames(
 	providerIds: string[]
 ): Promise<Map<string, string>> {
+	return fetchProviderNamesCached(toLookupCacheKey(providerIds));
+}
+
+const fetchProviderNamesCached = cache(async (
+	providerIdsKey: string
+): Promise<Map<string, string>> => {
 	const { supabase } = await requireAuthenticatedUser();
+	const providerIds = providerIdsKey ? providerIdsKey.split("\n") : [];
 
 	if (providerIds.length === 0) {
 		return new Map();
 	}
 
-	const uniqueProviderIds = Array.from(new Set(providerIds.filter(Boolean)));
+	const uniqueProviderIds = normalizeLookupIds(providerIds);
 	const { data: providers } = await supabase
 		.from("data_api_providers")
 		.select("api_provider_id, api_provider_name")
@@ -1080,7 +1173,7 @@ export async function fetchProviderNames(
 	}
 
 	return providerNameMap;
-}
+});
 
 export type ProviderMetadataEntry = {
 	name: string;
@@ -1090,13 +1183,20 @@ export type ProviderMetadataEntry = {
 export async function fetchProviderMetadata(
 	providerIds: string[]
 ): Promise<Map<string, ProviderMetadataEntry>> {
+	return fetchProviderMetadataCached(toLookupCacheKey(providerIds));
+}
+
+const fetchProviderMetadataCached = cache(async (
+	providerIdsKey: string
+): Promise<Map<string, ProviderMetadataEntry>> => {
 	const { supabase } = await requireAuthenticatedUser();
+	const providerIds = providerIdsKey ? providerIdsKey.split("\n") : [];
 
 	if (providerIds.length === 0) {
 		return new Map();
 	}
 
-	const uniqueProviderIds = Array.from(new Set(providerIds.filter(Boolean)));
+	const uniqueProviderIds = normalizeLookupIds(providerIds);
 	const { data: providers } = await supabase
 		.from("data_api_providers")
 		.select("api_provider_id, api_provider_name, prompt_training_policy")
@@ -1118,7 +1218,7 @@ export async function fetchProviderMetadata(
 	}
 
 	return providerMetadataMap;
-}
+});
 
 /**
  * Fetch fun stats and insights
@@ -1235,18 +1335,26 @@ export async function fetchFunStats(
  * Returns a map of app_id -> app title
  */
 export async function fetchAppNames(appIds: string[]): Promise<Map<string, string>> {
+	return fetchAppNamesCached(toLookupCacheKey(appIds));
+}
+
+const fetchAppNamesCached = cache(async (
+	appIdsKey: string
+): Promise<Map<string, string>> => {
 	const supabase = await createClient();
 	const { workspaceId } = await requireAuthedTeamContext(supabase);
+	const appIds = appIdsKey ? appIdsKey.split("\n") : [];
 
 	if (!workspaceId || appIds.length === 0) {
 		return new Map();
 	}
 
+	const uniqueAppIds = normalizeLookupIds(appIds);
 	const { data: apps } = await supabase
 		.from("api_apps")
 		.select("id, title")
 		.eq("workspace_id", workspaceId)
-		.in("id", appIds);
+		.in("id", uniqueAppIds);
 
 	const appMap = new Map<string, string>();
 
@@ -1257,7 +1365,7 @@ export async function fetchAppNames(appIds: string[]): Promise<Map<string, strin
 	}
 
 	return appMap;
-}
+});
 
 /**
  * Investigate a generation by request_id
@@ -1265,7 +1373,11 @@ export async function fetchAppNames(appIds: string[]): Promise<Map<string, strin
  */
 export async function investigateGeneration(
 	requestId: string
-): Promise<{ success: boolean; data?: any; error?: string }> {
+): Promise<{
+	success: boolean;
+	data?: InvestigateGenerationResult;
+	error?: string;
+}> {
 	const supabase = await createClient();
 	const { workspaceId } = await requireAuthedTeamContext(supabase);
 
@@ -1283,29 +1395,190 @@ export async function investigateGeneration(
 		};
 	}
 
+	const trimmedRequestId = requestId.trim();
+	const requestSelect = `
+		request_id,
+		created_at,
+		endpoint,
+		model_id,
+		provider,
+		native_response_id,
+		upstream_request_id,
+		stream,
+		session_id,
+		app_id,
+		app:api_apps!gateway_requests_app_id_fkey (
+			id,
+			app_key,
+			title,
+			image_url
+		),
+		usage,
+		cost_nanos,
+		generation_ms,
+		latency_ms,
+		finish_reason,
+		success,
+		status_code,
+		error_code,
+		error_message,
+		error_payload,
+		key_id,
+		pricing_lines,
+		throughput,
+		provider_attempts
+	`;
+
 	const { data, error } = await supabase
 		.from("gateway_requests")
-		.select("*")
+		.select(requestSelect)
 		.eq("workspace_id", workspaceId)
-		.eq("request_id", requestId.trim())
-		.single();
+		.eq("request_id", trimmedRequestId)
+		.maybeSingle();
 
 	if (error) {
-		if (error.code === "PGRST116") {
+		console.error("Error fetching investigated request (with app join):", error);
+		const { data: fallbackData, error: fallbackError } = await supabase
+			.from("gateway_requests")
+			.select(
+				`
+				request_id,
+				created_at,
+				endpoint,
+				model_id,
+				provider,
+				native_response_id,
+				upstream_request_id,
+				stream,
+				session_id,
+				app_id,
+				usage,
+				cost_nanos,
+				generation_ms,
+				latency_ms,
+				finish_reason,
+				success,
+				status_code,
+				error_code,
+				error_message,
+				error_payload,
+				key_id,
+				pricing_lines,
+				throughput,
+				provider_attempts
+			`,
+			)
+			.eq("workspace_id", workspaceId)
+			.eq("request_id", trimmedRequestId)
+			.maybeSingle();
+
+		if (fallbackError) {
+			if (fallbackError.code === "PGRST116") {
+				return {
+					success: false,
+					error: "Request not found or not authorized",
+				};
+			}
+			return {
+				success: false,
+				error: fallbackError.message || "Failed to fetch request",
+			};
+		}
+
+		if (!fallbackData) {
 			return {
 				success: false,
 				error: "Request not found or not authorized",
 			};
 		}
+
+		const request = toRequestRow(fallbackData);
+		const providerIds = Array.from(
+			new Set(
+				[
+					request.provider,
+					...request.provider_attempts.map((attempt) => attempt.provider),
+				].filter(
+					(value): value is string =>
+					typeof value === "string" && value.trim().length > 0,
+				),
+			),
+		);
+		const [appMetadata, modelMetadata, providerNames, providerMetadata] =
+			await Promise.all([
+				request.app_id
+					? fetchAppMetadata([request.app_id])
+					: Promise.resolve(new Map<string, { title: string }>()),
+				request.model_id
+					? fetchModelMetadata([request.model_id])
+					: Promise.resolve(new Map<string, SerializableModelMetadataEntry>()),
+				fetchProviderNames(providerIds),
+				fetchProviderMetadata(providerIds),
+			]);
+		const appName = request.app_id
+			? appMetadata.get(request.app_id)?.title ?? null
+			: null;
+
 		return {
-			success: false,
-			error: error.message || "Failed to fetch request",
+			success: true,
+			data: {
+				request,
+				appName,
+				modelMetadata: Array.from(modelMetadata.entries()),
+				providerNames: Array.from(providerNames.entries()),
+				providerMetadata: Array.from(providerMetadata.entries()),
+			},
 		};
 	}
 
+	if (!data) {
+		return {
+			success: false,
+			error: "Request not found or not authorized",
+		};
+	}
+
+	const request = toRequestRow(data);
+	const providerIds = Array.from(
+		new Set(
+			[
+				request.provider,
+				...request.provider_attempts.map((attempt) => attempt.provider),
+			].filter(
+				(value): value is string =>
+				typeof value === "string" && value.trim().length > 0,
+			),
+		),
+	);
+	const [appMetadata, modelMetadata, providerNames, providerMetadata] =
+		await Promise.all([
+			typeof request.app_title === "string" && request.app_title.trim().length > 0
+				? Promise.resolve(new Map<string, { title: string }>())
+				: request.app_id
+					? fetchAppMetadata([request.app_id])
+					: Promise.resolve(new Map<string, { title: string }>()),
+			request.model_id
+				? fetchModelMetadata([request.model_id])
+				: Promise.resolve(new Map<string, SerializableModelMetadataEntry>()),
+			fetchProviderNames(providerIds),
+			fetchProviderMetadata(providerIds),
+		]);
+	const resolvedAppName =
+		typeof request.app_title === "string" && request.app_title.trim().length > 0
+			? request.app_title.trim()
+			: request.app_id
+				? appMetadata.get(request.app_id)?.title ?? null
+				: null;
+
 	return {
 		success: true,
-		data,
+		data: {
+			request,
+			appName: resolvedAppName,
+			modelMetadata: Array.from(modelMetadata.entries()),
+			providerNames: Array.from(providerNames.entries()),
+			providerMetadata: Array.from(providerMetadata.entries()),
+		},
 	};
 }
 
@@ -2082,18 +2355,26 @@ export interface AppMetadata {
 export async function fetchAppMetadata(
 	appIds: string[],
 ): Promise<Map<string, AppMetadata>> {
+	return fetchAppMetadataCached(toLookupCacheKey(appIds));
+}
+
+const fetchAppMetadataCached = cache(async (
+	appIdsKey: string,
+): Promise<Map<string, AppMetadata>> => {
 	const supabase = await createClient();
 	const { workspaceId } = await requireAuthedTeamContext(supabase);
+	const appIds = appIdsKey ? appIdsKey.split("\n") : [];
 
 	if (!workspaceId || appIds.length === 0) {
 		return new Map();
 	}
 
+	const uniqueAppIds = normalizeLookupIds(appIds);
 	const { data: apps } = await supabase
 		.from("api_apps")
 		.select("id, title, image_url")
 		.eq("workspace_id", workspaceId)
-		.in("id", appIds);
+		.in("id", uniqueAppIds);
 
 	const appMap = new Map<string, AppMetadata>();
 
@@ -2111,7 +2392,7 @@ export async function fetchAppMetadata(
 	}
 
 	return appMap;
-}
+});
 
 export interface SessionRequestRow extends RequestRow {
 	session_id: string | null;
@@ -2140,6 +2421,7 @@ export async function fetchSessionRequests(params: {
 			model_id,
 			provider,
 			native_response_id,
+			upstream_request_id,
 			stream,
 			session_id,
 			app_id,
@@ -2158,8 +2440,11 @@ export async function fetchSessionRequests(params: {
 			status_code,
 			error_code,
 			error_message,
+			error_payload,
 			key_id,
+			pricing_lines,
 			throughput,
+			provider_attempts,
 			session_id,
 			endpoint,
 			end_user_id
@@ -2185,24 +2470,8 @@ export async function fetchSessionRequests(params: {
 
 	return (
 		(data as any[] | null)?.map((row) => {
-			const appRow = Array.isArray(row?.app) ? row.app[0] : row?.app;
-			const appTitle =
-				typeof appRow?.title === "string" && appRow.title.trim().length > 0
-					? appRow.title.trim()
-					: null;
-			const appKey =
-				typeof appRow?.app_key === "string" && appRow.app_key.trim().length > 0
-					? appRow.app_key.trim()
-					: null;
-			const appImageUrl =
-				typeof appRow?.image_url === "string" && appRow.image_url.trim().length > 0
-					? appRow.image_url.trim()
-					: null;
 			return {
-				...row,
-				app_title: appTitle,
-				app_key: appKey,
-				app_image_url: appImageUrl,
+				...toRequestRow(row),
 			} as SessionRequestRow;
 		}) ?? []
 	);
@@ -2283,6 +2552,11 @@ function normalizeFiniteNumber(value: unknown): number | null {
 	return null;
 }
 
+function normalizeRecord(value: unknown): Record<string, unknown> | null {
+	if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+	return value as Record<string, unknown>;
+}
+
 type AsyncWebhookAttemptStatus =
 	| "delivered"
 	| "scheduled_retry"
@@ -2306,6 +2580,7 @@ export interface AsyncJobWebhookAttemptRow {
 export interface AsyncJobWebhookSummaryRow {
 	configured: boolean;
 	url: string | null;
+	events: string[];
 	delivered_events: number;
 	attempt_count: number;
 	pending_retries: number;
@@ -2315,10 +2590,34 @@ export interface AsyncJobWebhookSummaryRow {
 	last_error_message: string | null;
 }
 
+export interface AsyncJobRequestCounts {
+	total: number | null;
+	completed: number | null;
+	failed: number | null;
+}
+
+export interface AsyncJobPricingBreakdown {
+	total_nanos: number | null;
+	total_usd_str: string | null;
+	total_cents: number | null;
+	completed_requests: number | null;
+	failed_requests: number | null;
+	total_requests: number | null;
+}
+
+export type AsyncJobRequestPricingLine =
+	| Record<string, unknown>
+	| string
+	| number
+	| boolean
+	| null;
+
 export interface AsyncJobRow {
 	kind: "video" | "batch";
 	internal_id: string;
 	request_id: string | null;
+	session_id: string | null;
+	app_id: string | null;
 	provider: string | null;
 	model: string | null;
 	status: string | null;
@@ -2327,21 +2626,138 @@ export interface AsyncJobRow {
 	updated_at: string;
 	request_created_at: string | null;
 	request_cost_nanos: number | null;
+	settled_cost_nanos: number | null;
+	settled_cost_usd: number | null;
+	charged: boolean | null;
+	billing_reason: string | null;
+	job_failure_category: string | null;
+	job_failure_provider: string | null;
+	job_failure_hint: string | null;
+	request_counts: AsyncJobRequestCounts | null;
 	webhook: AsyncJobWebhookSummaryRow;
 }
 
 export interface AsyncJobDetailRow extends AsyncJobRow {
+	native_id: string | null;
 	endpoint: string | null;
 	completion_window: string | null;
 	resolution: string | null;
 	duration_seconds: number | null;
+	output_access: string | null;
+	key_source: string | null;
+	byok_key_id: string | null;
+	reservation_id: string | null;
+	reservation_status: string | null;
+	next_webhook_retry_at: string | null;
+	last_webhook_progress: number | null;
+	last_webhook_progress_at: string | null;
+	last_webhook_dispatched_at: string | null;
+	finalized_at: string | null;
+	last_polled_at: string | null;
+	polled_status: string | null;
+	last_reconciled_at: string | null;
+	total_duration_ms: number | null;
+	latency_ms: number | null;
+	generation_ms: number | null;
+	request_native_response_id: string | null;
+	request_upstream_request_id: string | null;
+	request_endpoint: string | null;
+	request_model_id: string | null;
+	request_success: boolean | null;
+	request_status_code: number | null;
+	request_error_code: string | null;
+	request_error_message: string | null;
+	request_error_payload: Record<string, unknown> | null;
+	request_finish_reason: string | null;
+	request_latency_ms: number | null;
+	request_generation_ms: number | null;
+	request_provider_attempts: RequestRow["provider_attempts"];
+	request_pricing_lines: AsyncJobRequestPricingLine[];
+	job_upstream_error: AsyncJobUpstreamErrorRow | null;
+	job_provider_failure_diagnostics: AsyncJobProviderFailureDiagnosticsRow | null;
+	job_failure_sample: AsyncJobFailureSampleRow[];
+	job_routing_diagnostics: Record<string, unknown> | null;
+	job_provider_enablement: Record<string, unknown> | null;
+	job_provider_candidate_diagnostics: Record<string, unknown> | null;
 	content_url: string | null;
 	cancel_url: string | null;
 	output_file_id: string | null;
 	error_file_id: string | null;
 	request_created_at: string | null;
 	request_cost_nanos: number | null;
+	batch_pricing_lines: AsyncJobRequestPricingLine[];
+	pricing_breakdown: AsyncJobPricingBreakdown | null;
 	webhook_attempts: AsyncJobWebhookAttemptRow[];
+}
+
+function parseAsyncJobRequestCounts(meta: Record<string, unknown> | null | undefined): AsyncJobRequestCounts | null {
+	const counts =
+		meta?.requestCounts && typeof meta.requestCounts === "object" && !Array.isArray(meta.requestCounts)
+			? (meta.requestCounts as Record<string, unknown>)
+			: meta?.request_counts && typeof meta.request_counts === "object" && !Array.isArray(meta.request_counts)
+				? (meta.request_counts as Record<string, unknown>)
+				: null;
+	if (!counts) return null;
+	return {
+		total: normalizeFiniteNumber(counts.total),
+		completed: normalizeFiniteNumber(counts.completed),
+		failed: normalizeFiniteNumber(counts.failed),
+	};
+}
+
+function parseAsyncJobPricingBreakdown(meta: Record<string, unknown> | null | undefined): AsyncJobPricingBreakdown | null {
+	const pricing =
+		meta?.pricingBreakdown && typeof meta.pricingBreakdown === "object" && !Array.isArray(meta.pricingBreakdown)
+			? (meta.pricingBreakdown as Record<string, unknown>)
+			: meta?.pricing_breakdown && typeof meta.pricing_breakdown === "object" && !Array.isArray(meta.pricing_breakdown)
+				? (meta.pricing_breakdown as Record<string, unknown>)
+				: null;
+	if (!pricing) return null;
+	return {
+		total_nanos: normalizeFiniteNumber(pricing.total_nanos),
+		total_usd_str: normalizeText(pricing.total_usd_str),
+		total_cents: normalizeFiniteNumber(pricing.total_cents),
+		completed_requests: normalizeFiniteNumber(pricing.completed_requests),
+		failed_requests: normalizeFiniteNumber(pricing.failed_requests),
+		total_requests: normalizeFiniteNumber(pricing.total_requests),
+	};
+}
+
+function parseAsyncJobBatchPricingLines(
+	meta: Record<string, unknown> | null | undefined,
+): AsyncJobRequestPricingLine[] {
+	if (!meta) return [];
+	const directLines = normalizePricingLines(meta.pricingLines ?? meta.pricing_lines);
+	if (directLines.length > 0) return directLines;
+
+	const pricedUsage =
+		meta.pricedUsage && typeof meta.pricedUsage === "object" && !Array.isArray(meta.pricedUsage)
+			? (meta.pricedUsage as Record<string, unknown>)
+			: meta.priced_usage && typeof meta.priced_usage === "object" && !Array.isArray(meta.priced_usage)
+				? (meta.priced_usage as Record<string, unknown>)
+				: null;
+	const pricedUsagePricing =
+		pricedUsage?.pricing && typeof pricedUsage.pricing === "object" && !Array.isArray(pricedUsage.pricing)
+			? (pricedUsage.pricing as Record<string, unknown>)
+			: null;
+	const pricedUsageLines = normalizePricingLines(pricedUsagePricing?.lines);
+	if (pricedUsageLines.length > 0) return pricedUsageLines;
+
+	const totalNanos = normalizeFiniteNumber(meta.costNanos ?? meta.cost_nanos);
+	if (totalNanos == null) return [];
+	const counts = parseAsyncJobRequestCounts(meta);
+	const pricingBreakdown = parseAsyncJobPricingBreakdown(meta);
+	return [
+		{
+			dimension: "batch_requests",
+			pricing_plan: "batch",
+			service_tier: "batch",
+			endpoint: normalizeText(meta.endpoint),
+			units: counts?.completed ?? counts?.total ?? null,
+			total_nanos: totalNanos,
+			total_usd_str: pricingBreakdown?.total_usd_str ?? null,
+		},
+	];
 }
 
 function parseWebhookAttempts(value: unknown): AsyncJobWebhookAttemptRow[] {
@@ -2408,9 +2824,15 @@ function buildWebhookSummary(meta: Record<string, unknown> | null | undefined): 
 		.map((entry) => entry.next_retry_at)
 		.filter((entry): entry is string => Boolean(entry))
 		.sort((a, b) => a.localeCompare(b))[0] ?? null;
+	const events = Array.isArray(webhook?.events)
+		? webhook.events
+				.map((event) => normalizeText(event))
+				.filter((event): event is string => Boolean(event))
+		: [];
 	return {
 		configured: Boolean(webhook),
 		url: normalizeText(webhook?.url),
+		events,
 		delivered_events: deliveredEvents,
 		attempt_count: attempts.length,
 		pending_retries: retryQueue.length,
@@ -2434,6 +2856,7 @@ function toAsyncJobRow(
 		row.meta && typeof row.meta === "object" && !Array.isArray(row.meta)
 			? (row.meta as Record<string, unknown>)
 			: null;
+	const failureDiagnostics = parseAsyncJobFailureDiagnostics(meta);
 	const webhook = buildWebhookSummary(meta);
 	if (
 		!options?.includeWithoutWebhook &&
@@ -2447,6 +2870,8 @@ function toAsyncJobRow(
 		kind,
 		internal_id: internalId,
 		request_id: normalizeText(row.request_id),
+		session_id: normalizeText(row.session_id),
+		app_id: normalizeText(row.app_id),
 		provider: normalizeText(row.provider),
 		model: normalizeText(row.model),
 		status: normalizeText(row.status),
@@ -2455,8 +2880,42 @@ function toAsyncJobRow(
 		updated_at: updatedAt,
 		request_created_at: null,
 		request_cost_nanos: null,
+		settled_cost_nanos: normalizeFiniteNumber(meta?.costNanos ?? meta?.cost_nanos),
+		settled_cost_usd: normalizeFiniteNumber(meta?.costUsd ?? meta?.cost_usd),
+		charged:
+			typeof meta?.charged === "boolean"
+				? meta.charged
+				: typeof meta?.charged === "string"
+					? ["1", "true", "yes", "on"].includes(meta.charged.toLowerCase())
+					: null,
+		billing_reason: normalizeText(meta?.billingReason ?? meta?.billing_reason),
+		job_failure_category:
+			failureDiagnostics.job_provider_failure_diagnostics?.category ?? null,
+		job_failure_provider:
+			failureDiagnostics.job_provider_failure_diagnostics?.provider ?? null,
+		job_failure_hint:
+			failureDiagnostics.job_provider_failure_diagnostics?.hint ?? null,
+		request_counts: parseAsyncJobRequestCounts(meta),
 		webhook,
 	};
+}
+
+function normalizePricingLines(value: unknown): AsyncJobRequestPricingLine[] {
+	if (!Array.isArray(value)) return [];
+	return value.map((entry) => {
+		if (
+			entry == null ||
+			typeof entry === "string" ||
+			typeof entry === "number" ||
+			typeof entry === "boolean"
+		) {
+			return entry;
+		}
+		if (typeof entry === "object" && !Array.isArray(entry)) {
+			return entry as Record<string, unknown>;
+		}
+		return JSON.stringify(entry);
+	});
 }
 
 export async function fetchRecentAsyncJobs(params?: {
@@ -2476,7 +2935,7 @@ export async function fetchRecentAsyncJobs(params?: {
 
 	let query = admin
 		.from("gateway_async_operations")
-		.select("kind,internal_id,request_id,provider,model,status,billed_at,created_at,updated_at,meta")
+		.select("kind,internal_id,request_id,session_id,app_id,provider,model,status,billed_at,created_at,updated_at,meta")
 		.eq("workspace_id", workspaceId)
 		.in("kind", ["video", "batch"]);
 
@@ -2574,7 +3033,7 @@ export async function fetchAsyncJobDetail(input: {
 
 	const { data, error } = await admin
 		.from("gateway_async_operations")
-		.select("kind,internal_id,request_id,provider,model,status,billed_at,created_at,updated_at,meta")
+		.select("kind,internal_id,request_id,session_id,app_id,provider,native_id,model,status,billed_at,created_at,updated_at,meta")
 		.eq("workspace_id", workspaceId)
 		.eq("kind", input.kind)
 		.eq("internal_id", input.internalId)
@@ -2595,13 +3054,28 @@ export async function fetchAsyncJobDetail(input: {
 			? (data.meta as Record<string, unknown>)
 			: null;
 	const webhookAttempts = parseWebhookAttempts(meta?.webhookAttempts ?? meta?.webhook_attempts);
+	const failureDiagnostics = parseAsyncJobFailureDiagnostics(meta);
 
 	let requestCreatedAt: string | null = null;
 	let requestCostNanos: number | null = null;
+	let requestNativeResponseId: string | null = null;
+	let requestUpstreamRequestId: string | null = null;
+	let requestEndpoint: string | null = null;
+	let requestModelId: string | null = null;
+	let requestSuccess: boolean | null = null;
+	let requestStatusCode: number | null = null;
+	let requestErrorCode: string | null = null;
+	let requestErrorMessage: string | null = null;
+	let requestErrorPayload: Record<string, unknown> | null = null;
+	let requestFinishReason: string | null = null;
+	let requestLatencyMs: number | null = null;
+	let requestGenerationMs: number | null = null;
+	let requestProviderAttempts: RequestRow["provider_attempts"] = [];
+	let requestPricingLines: AsyncJobRequestPricingLine[] = [];
 	if (base.request_id) {
 		const { data: requestData } = await admin
 			.from("gateway_requests")
-			.select("created_at,cost_nanos")
+			.select("created_at,cost_nanos,native_response_id,upstream_request_id,endpoint,model_id,success,status_code,error_code,error_message,error_payload,finish_reason,latency_ms,generation_ms,provider_attempts,pricing_lines")
 			.eq("workspace_id", workspaceId)
 			.eq("request_id", base.request_id)
 			.order("created_at", { ascending: false })
@@ -2609,14 +3083,45 @@ export async function fetchAsyncJobDetail(input: {
 			.maybeSingle();
 		requestCreatedAt = normalizeIsoDate(requestData?.created_at);
 		requestCostNanos = normalizeFiniteNumber(requestData?.cost_nanos);
+		requestNativeResponseId = normalizeText(requestData?.native_response_id);
+		requestUpstreamRequestId = normalizeText(requestData?.upstream_request_id);
+		requestEndpoint = normalizeText(requestData?.endpoint);
+		requestModelId = normalizeText(requestData?.model_id);
+		requestSuccess = typeof requestData?.success === "boolean" ? requestData.success : null;
+		requestStatusCode = normalizeFiniteNumber(requestData?.status_code);
+		requestErrorCode = normalizeText(requestData?.error_code);
+		requestErrorMessage = normalizeText(requestData?.error_message);
+		requestErrorPayload = normalizePlainObject(requestData?.error_payload);
+		requestFinishReason = normalizeText(requestData?.finish_reason);
+		requestLatencyMs = normalizeFiniteNumber(requestData?.latency_ms);
+		requestGenerationMs = normalizeFiniteNumber(requestData?.generation_ms);
+		requestProviderAttempts = normalizeProviderAttempts(requestData?.provider_attempts);
+		requestPricingLines = normalizePricingLines(requestData?.pricing_lines);
 	}
 
 	return {
 		...base,
+		native_id: normalizeText((data as Record<string, unknown>).native_id),
 		endpoint: normalizeText(meta?.endpoint),
 		completion_window: normalizeText(meta?.completionWindow ?? meta?.completion_window),
 		resolution: normalizeText(meta?.resolution),
 		duration_seconds: normalizeFiniteNumber(meta?.seconds),
+		output_access: normalizeText(meta?.outputAccess ?? meta?.output_access),
+		key_source: normalizeText(meta?.keySource ?? meta?.key_source),
+		byok_key_id: normalizeText(meta?.byokKeyId ?? meta?.byok_key_id),
+		reservation_id: normalizeText(meta?.reservationId ?? meta?.reservation_id),
+		reservation_status: normalizeText(meta?.reservationStatus ?? meta?.reservation_status),
+		next_webhook_retry_at: normalizeIsoDate(meta?.nextWebhookRetryAt ?? meta?.next_webhook_retry_at),
+		last_webhook_progress: normalizeFiniteNumber(meta?.lastWebhookProgress ?? meta?.last_webhook_progress),
+		last_webhook_progress_at: normalizeIsoDate(meta?.lastWebhookProgressAt ?? meta?.last_webhook_progress_at),
+		last_webhook_dispatched_at: normalizeIsoDate(meta?.lastWebhookDispatchedAt ?? meta?.last_webhook_dispatched_at),
+		finalized_at: normalizeIsoDate(meta?.finalizedAt ?? meta?.finalized_at),
+		last_polled_at: normalizeIsoDate(meta?.lastPolledAt ?? meta?.last_polled_at),
+		polled_status: normalizeText(meta?.polledStatus ?? meta?.polled_status),
+		last_reconciled_at: normalizeIsoDate(meta?.lastReconciledAt ?? meta?.last_reconciled_at),
+		total_duration_ms: normalizeFiniteNumber(meta?.totalDurationMs ?? meta?.total_duration_ms ?? meta?.durationMs ?? meta?.duration_ms),
+		latency_ms: normalizeFiniteNumber(meta?.latencyMs ?? meta?.latency_ms),
+		generation_ms: normalizeFiniteNumber(meta?.generationMs ?? meta?.generation_ms),
 		content_url: normalizeText(meta?.googleVideoUri ?? meta?.google_video_uri ?? meta?.downloadUrl ?? meta?.download_url),
 		cancel_url: input.kind === "batch" && ["pending", "in_progress"].includes((base.status ?? "").toLowerCase())
 			? `/v1/batches/${encodeURIComponent(base.internal_id)}/cancel`
@@ -2625,6 +3130,30 @@ export async function fetchAsyncJobDetail(input: {
 		error_file_id: normalizeText(meta?.errorFileId ?? meta?.error_file_id),
 		request_created_at: requestCreatedAt,
 		request_cost_nanos: requestCostNanos,
+		batch_pricing_lines: parseAsyncJobBatchPricingLines(meta),
+		request_native_response_id: requestNativeResponseId,
+		request_upstream_request_id: requestUpstreamRequestId,
+		request_endpoint: requestEndpoint,
+		request_model_id: requestModelId,
+		request_success: requestSuccess,
+		request_status_code: requestStatusCode,
+		request_error_code: requestErrorCode,
+		request_error_message: requestErrorMessage,
+		request_error_payload: requestErrorPayload,
+		request_finish_reason: requestFinishReason,
+		request_latency_ms: requestLatencyMs,
+		request_generation_ms: requestGenerationMs,
+		request_provider_attempts: requestProviderAttempts,
+		request_pricing_lines: requestPricingLines,
+		job_upstream_error: failureDiagnostics.job_upstream_error,
+		job_provider_failure_diagnostics:
+			failureDiagnostics.job_provider_failure_diagnostics,
+		job_failure_sample: failureDiagnostics.job_failure_sample,
+		job_routing_diagnostics: failureDiagnostics.job_routing_diagnostics,
+		job_provider_enablement: failureDiagnostics.job_provider_enablement,
+		job_provider_candidate_diagnostics:
+			failureDiagnostics.job_provider_candidate_diagnostics,
+		pricing_breakdown: parseAsyncJobPricingBreakdown(meta),
 		webhook_attempts: webhookAttempts,
 	};
 }

--- a/apps/web/src/app/(dashboard)/settings/usage/logs/page.tsx
+++ b/apps/web/src/app/(dashboard)/settings/usage/logs/page.tsx
@@ -34,6 +34,7 @@ import {
 	fetchModelMetadata,
 	fetchProviderMetadata,
 	fetchProviderNames,
+	fetchPaginatedRequests,
 	fetchSessionRollups,
 } from "@/app/(dashboard)/gateway/usage/server-actions";
 
@@ -127,6 +128,15 @@ async function UsageLogsContent({
 	const customFrom = parseUsageDateInput(firstSearchParam(sp?.[rangeKeys.from]));
 	const customTo = parseUsageDateInput(firstSearchParam(sp?.[rangeKeys.to]));
 	const sessionFilter = firstSearchParam(sp?.session)?.trim() || null;
+	const logModelFilter = firstSearchParam(sp?.model)?.trim() || null;
+	const logProviderFilter = firstSearchParam(sp?.provider)?.trim() || null;
+	const logKeyFilter = firstSearchParam(sp?.key)?.trim() || null;
+	const rawLogStatusFilter = firstSearchParam(sp?.status)?.trim().toLowerCase() || null;
+	const logStatusFilter =
+		rawLogStatusFilter === "success" || rawLogStatusFilter === "error"
+			? rawLogStatusFilter
+			: "all";
+	const logRequestFilter = firstSearchParam(sp?.req)?.trim() || null;
 	const jobKindFilter = firstSearchParam(sp?.job_kind)?.trim() || null;
 	const jobStatusFilter = firstSearchParam(sp?.job_status)?.trim() || null;
 	const jobProviderFilter = firstSearchParam(sp?.job_provider)?.trim() || null;
@@ -242,10 +252,11 @@ async function UsageLogsContent({
 		const sessionProviderIds = Array.from(
 			new Set(sessions.flatMap((session) => session.provider_ids ?? []).filter(Boolean)),
 		);
-		const [appMetadata, modelMetadata, providerNames] = await Promise.all([
+		const [appMetadata, modelMetadata, providerNames, providerMetadata] = await Promise.all([
 			fetchAppMetadata(sessionAppIds),
 			fetchModelMetadata(sessionModelIds),
 			fetchProviderNames(sessionProviderIds),
+			fetchProviderMetadata(sessionProviderIds),
 		]);
 		filters = (
 			<UsageViewFilters
@@ -264,6 +275,7 @@ async function UsageLogsContent({
 				initialSessions={sessions}
 				initialAppMetadata={appMetadata}
 				initialModelMetadata={modelMetadata}
+				initialProviderMetadata={providerMetadata}
 				initialProviderNames={providerNames}
 				timeRange={timeRange}
 				showRefreshButton={false}
@@ -349,6 +361,22 @@ async function UsageLogsContent({
 			fetchProviderMetadata(dedupedProviders),
 			fetchModelMetadata(dedupedModels),
 		]);
+		const initialPage = Math.max(1, Number.parseInt(firstSearchParam(sp?.page) ?? "1", 10) || 1);
+		const initialSortField = firstSearchParam(sp?.sort)?.trim() || "created_at";
+		const initialSortDirection =
+			firstSearchParam(sp?.dir)?.trim().toLowerCase() === "asc" ? "asc" : "desc";
+		const initialRequests = await fetchPaginatedRequests({
+			timeRange,
+			modelFilter: logModelFilter,
+			providerFilter: logProviderFilter,
+			keyFilter: logKeyFilter,
+			statusFilter: logStatusFilter,
+			requestFilter: logRequestFilter,
+			sessionFilter,
+			page: initialPage,
+			sortField: initialSortField,
+			sortDirection: initialSortDirection,
+		});
 
 		// Keys list for key label rendering inside the logs table.
 		const { data: keyRows } = await supabase
@@ -383,6 +411,10 @@ async function UsageLogsContent({
 				providerNames={providerNames}
 				providerMetadata={providerMetadata}
 				modelMetadata={modelMetadata}
+				initialPage={initialRequests.page}
+				initialRows={initialRequests.data}
+				initialTotal={initialRequests.total}
+				initialTotalPages={initialRequests.totalPages}
 			/>
 		);
 	}

--- a/apps/web/src/components/(gateway)/usage/AsyncJobsPanel.tsx
+++ b/apps/web/src/components/(gateway)/usage/AsyncJobsPanel.tsx
@@ -1,13 +1,21 @@
 "use client";
 
 import * as React from "react";
+import dynamic from "next/dynamic";
 import {
+        fetchAppMetadata,
 	fetchAsyncJobDetail,
 	fetchModelMetadata,
 	fetchProviderNames,
 	fetchRecentAsyncJobs,
+	type AppMetadata,
+	investigateGeneration,
 	type AsyncJobDetailRow,
+	type AsyncJobRequestPricingLine,
 	type AsyncJobRow,
+	type InvestigateGenerationResult,
+	type ProviderMetadataEntry,
+	type RequestRow,
 } from "@/app/(dashboard)/gateway/usage/server-actions";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -40,6 +48,7 @@ import {
 	TableRow,
 } from "@/components/ui/table";
 import {
+	AppWindow,
 	AlertTriangle,
 	Clock3,
 	Layers3,
@@ -55,13 +64,17 @@ import {
 	formatDateTime,
 	formatWordyDateTime,
 } from "@/lib/gateway/usage/timeFormatting";
+import { formatAsyncJobFailureSummary } from "@/lib/gateway/usage/asyncJobFailureSummary";
+import { formatRoomError } from "@/lib/chat/formatRoomError";
 import { getModelDisplayName, type ModelMetadataMap } from "./model-display";
 import Link from "next/link";
 import {
-	DetailKeyValueGrid,
-	DetailMetricTile,
-	DetailSection,
+        DetailKeyValueGrid,
+        DetailMetricTile,
+        DetailSection,
 } from "./DetailDialogPrimitives";
+
+const RequestDetailDialog = dynamic(() => import("./RequestDetailDialog"));
 
 function AsyncJobHeader({
 	job,
@@ -153,9 +166,148 @@ function getModelLogoId(
 	return null;
 }
 
+function collectJobProviderIds(jobs: AsyncJobRow[]): string[] {
+	return Array.from(
+		new Set(
+			jobs
+				.map((job) => job.provider)
+				.filter(
+					(providerId): providerId is string =>
+						typeof providerId === "string" && providerId.trim().length > 0,
+				),
+		),
+	);
+}
+
+function collectJobAppIds(jobs: AsyncJobRow[]): string[] {
+	return Array.from(
+		new Set(
+			jobs
+				.map((job) => job.app_id)
+				.filter(
+					(appId): appId is string =>
+						typeof appId === "string" && appId.trim().length > 0,
+				),
+		),
+	);
+}
+
+function collectJobModelIds(jobs: AsyncJobRow[]): string[] {
+	return Array.from(
+		new Set(
+			jobs
+				.map((job) => job.model)
+				.filter(
+					(modelId): modelId is string =>
+						typeof modelId === "string" && modelId.trim().length > 0,
+				),
+		),
+	);
+}
+
+function buildUsageLogsFilterHref(args: {
+	view: "logs" | "sessions";
+	requestId?: string | null;
+	sessionId?: string | null;
+}): string {
+	const next = new URLSearchParams();
+	next.set("view", args.view);
+	if (args.requestId) next.set("req", args.requestId);
+	if (args.sessionId) next.set("session", args.sessionId);
+	return `/settings/usage/logs?${next.toString()}`;
+}
+
 function formatMoneyFromNanos(value: number | null | undefined): string {
 	if (value == null || !Number.isFinite(value)) return "-";
 	return `$${(value / 1e9).toFixed(5)}`;
+}
+
+function formatMoneyFromUsd(value: number | null | undefined): string {
+	if (value == null || !Number.isFinite(value)) return "-";
+	return `$${value.toFixed(5)}`;
+}
+
+function formatMilliseconds(value: number | null | undefined): string {
+	if (value == null || !Number.isFinite(value)) return "-";
+	if (value < 1000) return `${Math.round(value)} ms`;
+	return `${(value / 1000).toFixed(2)} s`;
+}
+
+function formatSettledCost(job: AsyncJobRow | AsyncJobDetailRow): string {
+	if (job.settled_cost_nanos != null) return formatMoneyFromNanos(job.settled_cost_nanos);
+	if (job.settled_cost_usd != null) return formatMoneyFromUsd(job.settled_cost_usd);
+	return "-";
+}
+
+function formatRequestCountSummary(job: AsyncJobDetailRow): string {
+	const counts = job.request_counts;
+	if (!counts) return "-";
+	const total = counts.total ?? 0;
+	const completed = counts.completed ?? 0;
+	const failed = counts.failed ?? 0;
+	return `${completed}/${total} completed, ${failed} failed`;
+}
+
+function formatRequestPricingLine(line: AsyncJobRequestPricingLine): string {
+	if (line == null) return "null";
+	if (
+		typeof line === "string" ||
+		typeof line === "number" ||
+		typeof line === "boolean"
+	) {
+		return String(line);
+	}
+	const provider =
+		typeof line.provider === "string" && line.provider.trim().length > 0
+			? line.provider.trim()
+			: null;
+	const endpoint =
+		typeof line.endpoint === "string" && line.endpoint.trim().length > 0
+			? line.endpoint.trim()
+			: null;
+	const dimension =
+		typeof line.dimension === "string" && line.dimension.trim().length > 0
+			? line.dimension.trim()
+			: null;
+	const units =
+		typeof line.units === "number"
+			? line.units
+			: typeof line.units === "string" && line.units.trim().length > 0
+				? line.units.trim()
+				: null;
+	const costUsd =
+		typeof line.cost_usd === "number"
+			? line.cost_usd.toFixed(6)
+			: typeof line.cost_usd === "string" && line.cost_usd.trim().length > 0
+				? line.cost_usd.trim()
+				: null;
+	const costNanos =
+		typeof line.cost_nanos === "number"
+			? line.cost_nanos.toLocaleString()
+			: typeof line.cost_nanos === "string" && line.cost_nanos.trim().length > 0
+				? line.cost_nanos.trim()
+				: null;
+
+	const parts = [
+		provider,
+		endpoint,
+		dimension ? `${dimension}${units != null ? `=${units}` : ""}` : null,
+		costUsd ? `$${costUsd}` : null,
+		costNanos ? `${costNanos} nanos` : null,
+	].filter(Boolean);
+
+	return parts.length > 0 ? parts.join(" · ") : JSON.stringify(line);
+}
+
+function formatStructuredDiagnostic(
+	value: Record<string, unknown> | null | undefined,
+): string {
+	if (!value) return "{}";
+	try {
+		return JSON.stringify(value, null, 2);
+	} catch {
+		return String(value);
+	}
 }
 
 function webhookStatusBadgeClass(status: string | null | undefined): string {
@@ -248,19 +400,123 @@ function JobStatusBadge({ status }: { status: string | null | undefined }) {
 	);
 }
 
+function buildFileContentPath(fileId: string | null | undefined): string | null {
+	if (!fileId) return null;
+	const trimmed = fileId.trim();
+	if (!trimmed) return null;
+	return `/v1/files/${encodeURIComponent(trimmed)}/content`;
+}
+
+function CopyableCodeValue({
+	value,
+	copyLabel,
+}: {
+	value: string | null | undefined;
+	copyLabel: string;
+}) {
+	if (!value) return <>-</>;
+
+	return (
+		<div className="flex items-center gap-2">
+			<code className="min-w-0 truncate font-mono text-xs">{value}</code>
+			<CopyButton
+				size="sm"
+				variant="ghost"
+				className="text-muted-foreground hover:text-foreground"
+				content={value}
+				aria-label={copyLabel}
+			/>
+		</div>
+	);
+}
+
+function AsyncJobAppBadge({
+	appId,
+	appLabel,
+	href,
+}: {
+	appId: string | null;
+	appLabel: string | null;
+	href: string | null;
+}) {
+	if (!appId || !appLabel) return null;
+
+	const badge = (
+		<Badge
+			variant="outline"
+			className="inline-flex max-w-[220px] items-center gap-2"
+		>
+			<AppWindow className="h-3.5 w-3.5 text-muted-foreground" />
+			<span className="truncate">{appLabel}</span>
+		</Badge>
+	);
+
+	if (!href) return badge;
+
+	return (
+		<Link
+			href={href}
+			className="underline decoration-transparent transition-colors duration-200 hover:text-primary hover:decoration-current"
+			onClick={stopRowClick}
+		>
+			{badge}
+		</Link>
+	);
+}
+
 function AsyncJobDetailDialog({
 	job,
 	modelMetadata,
 	providerNames,
+	appMetadata,
 	open,
 	onOpenChange,
+	onInspectRequest,
+	isInspectingRequest,
 }: {
 	job: AsyncJobDetailRow | null;
 	modelMetadata: ModelMetadataMap;
 	providerNames: Map<string, string>;
+	appMetadata: Map<string, AppMetadata>;
 	open: boolean;
 	onOpenChange: (open: boolean) => void;
+	onInspectRequest: ((requestId: string) => void) | null;
+	isInspectingRequest: boolean;
 }) {
+	const requestFilterHref = job?.request_id
+		? buildUsageLogsFilterHref({
+				view: "logs",
+				requestId: job.request_id,
+		  })
+		: null;
+	const sessionFilterHref = job?.session_id
+		? buildUsageLogsFilterHref({
+				view: "sessions",
+				sessionId: job.session_id,
+		  })
+		: null;
+	const appHref = job?.app_id ? `/apps/${encodeURIComponent(job.app_id)}` : null;
+	const appTitle =
+		job?.app_id
+			? appMetadata.get(job.app_id)?.title?.trim() || job.app_id
+			: null;
+	const formattedRequestError = job?.request_error_payload
+		? formatRoomError(JSON.stringify(job.request_error_payload))
+		: job?.request_error_message?.trim()
+			? formatRoomError(job.request_error_message)
+			: null;
+	const failedRequestProviders = formattedRequestError?.failedProviders ?? [];
+	const failedRequestStatuses = formattedRequestError?.failedStatuses ?? [];
+	const hasJobFailureDiagnostics = Boolean(
+		job &&
+			(job.job_upstream_error ||
+				job.job_provider_failure_diagnostics ||
+				job.job_failure_sample.length > 0 ||
+				job.job_routing_diagnostics ||
+				job.job_provider_enablement ||
+				job.job_provider_candidate_diagnostics),
+	);
+
 	return (
 		<Dialog open={open} onOpenChange={onOpenChange}>
 			<DialogContent className="max-h-[90vh] max-w-6xl overflow-hidden p-0">
@@ -283,6 +539,13 @@ function AsyncJobDetailDialog({
 									label="Request cost"
 									value={<span className="font-mono">{formatMoneyFromNanos(job.request_cost_nanos)}</span>}
 									tone="amber"
+									compact
+								/>
+								<DetailMetricTile
+									icon={Layers3}
+									label="Settled cost"
+									value={<span className="font-mono">{formatSettledCost(job)}</span>}
+									tone={job.charged ? "emerald" : "slate"}
 									compact
 								/>
 								<DetailMetricTile
@@ -315,7 +578,7 @@ function AsyncJobDetailDialog({
 								/>
 								<DetailMetricTile
 									icon={Video}
-									label={job.kind === "video" ? "Duration" : "Completion window"}
+									label={job.kind === "video" ? "Output duration" : "Completion window"}
 									value={
 										job.kind === "video"
 											? job.duration_seconds != null
@@ -326,6 +589,69 @@ function AsyncJobDetailDialog({
 									tone="sky"
 									compact
 								/>
+								{job.kind === "video" ? (
+									<DetailMetricTile
+										icon={Clock3}
+										label="Total duration"
+										value={formatMilliseconds(job.total_duration_ms)}
+										tone="slate"
+										compact
+									/>
+								) : null}
+								{job.kind === "video" ? (
+									<DetailMetricTile
+										icon={Clock3}
+										label="Latency"
+										value={formatMilliseconds(job.latency_ms)}
+										tone="amber"
+										compact
+									/>
+								) : null}
+								{job.kind === "video" ? (
+									<DetailMetricTile
+										icon={Clock3}
+										label="Generation"
+										value={formatMilliseconds(job.generation_ms)}
+										tone="violet"
+										compact
+									/>
+								) : null}
+								{job.kind === "video" ? (
+									<DetailMetricTile
+										icon={Layers3}
+										label="Reservation"
+										value={job.reservation_status ?? "-"}
+										tone={job.charged ? "emerald" : "slate"}
+										compact
+									/>
+								) : null}
+								{job.key_source ? (
+									<DetailMetricTile
+										icon={Layers3}
+										label="Key source"
+										value={job.key_source ?? "-"}
+										tone={job.key_source === "byok" ? "amber" : "slate"}
+										compact
+									/>
+								) : null}
+								{job.kind === "video" ? (
+									<DetailMetricTile
+										icon={Clock3}
+										label="Polled status"
+										value={job.polled_status ?? "-"}
+										tone="slate"
+										compact
+									/>
+								) : null}
+								{job.kind === "batch" ? (
+									<DetailMetricTile
+										icon={Send}
+										label="Request counts"
+										value={formatRequestCountSummary(job)}
+										tone="slate"
+										compact
+									/>
+								) : null}
 							</div>
 
 							<DetailSection title="Job details" className="border-none bg-transparent p-0">
@@ -352,7 +678,104 @@ function AsyncJobDetailDialog({
 										{
 											label: "Request ID",
 											value: job.request_id ? (
-												<code className="font-mono text-xs">{job.request_id}</code>
+												<div className="flex items-center gap-2">
+													{requestFilterHref ? (
+														<Link
+															href={requestFilterHref}
+															className="min-w-0 truncate font-mono text-xs underline decoration-transparent transition-colors duration-200 hover:text-primary hover:decoration-current"
+														>
+															{job.request_id}
+														</Link>
+													) : (
+														<code className="min-w-0 truncate font-mono text-xs">
+															{job.request_id}
+														</code>
+													)}
+													<CopyButton
+														size="sm"
+														variant="ghost"
+														className="text-muted-foreground hover:text-foreground"
+														content={job.request_id}
+														aria-label="Copy request id"
+													/>
+													{onInspectRequest ? (
+														<Button
+															type="button"
+															variant="ghost"
+															size="sm"
+															className="h-7 px-2 text-xs"
+															onClick={() => onInspectRequest(job.request_id!)}
+															disabled={isInspectingRequest}
+														>
+															{isInspectingRequest ? "Loading..." : "Inspect"}
+														</Button>
+													) : null}
+												</div>
+											) : (
+												"-"
+											),
+										},
+										{
+											label: "Native ID",
+											value: (
+												<CopyableCodeValue
+													value={job.native_id}
+													copyLabel="Copy native id"
+												/>
+											),
+										},
+										{
+											label: "Session ID",
+											value: job.session_id ? (
+												<div className="flex items-center gap-2">
+													{sessionFilterHref ? (
+														<Link
+															href={sessionFilterHref}
+															className="min-w-0 truncate font-mono text-xs underline decoration-transparent transition-colors duration-200 hover:text-primary hover:decoration-current"
+														>
+															{job.session_id}
+														</Link>
+													) : (
+														<code className="min-w-0 truncate font-mono text-xs">
+															{job.session_id}
+														</code>
+													)}
+													<CopyButton
+														size="sm"
+														variant="ghost"
+														className="text-muted-foreground hover:text-foreground"
+														content={job.session_id}
+														aria-label="Copy session id"
+													/>
+												</div>
+											) : (
+												"-"
+											),
+										},
+										{
+											label: "App",
+											value: job.app_id ? (
+												<div className="flex items-center gap-2">
+													{appHref ? (
+														<Link
+															href={appHref}
+															className="min-w-0 truncate font-mono text-xs underline decoration-transparent transition-colors duration-200 hover:text-primary hover:decoration-current"
+														>
+															{appTitle}
+														</Link>
+													) : (
+														<code className="min-w-0 truncate font-mono text-xs">
+															{appTitle}
+														</code>
+													)}
+													<CopyButton
+														size="sm"
+														variant="ghost"
+														className="text-muted-foreground hover:text-foreground"
+														content={job.app_id}
+														aria-label="Copy app id"
+													/>
+												</div>
 											) : (
 												"-"
 											),
@@ -404,13 +827,107 @@ function AsyncJobDetailDialog({
 											value: job.kind === "video" ? (job.resolution ?? "-") : (job.endpoint ?? "-"),
 										},
 										{
-											label: job.kind === "video" ? "Duration" : "Completion window",
+											label: job.kind === "video" ? "Output duration" : "Completion window",
 											value:
 												job.kind === "video"
 													? job.duration_seconds != null
 														? `${job.duration_seconds}s`
 														: "-"
 													: job.completion_window ?? "-",
+										},
+										{
+											label: "Total duration",
+											value:
+												job.kind === "video"
+													? formatMilliseconds(job.total_duration_ms)
+													: "-",
+										},
+										{
+											label: "Latency",
+											value:
+												job.kind === "video"
+													? formatMilliseconds(job.latency_ms)
+													: "-",
+										},
+										{
+											label: "Generation",
+											value:
+												job.kind === "video"
+													? formatMilliseconds(job.generation_ms)
+													: "-",
+										},
+										{
+											label: "Output access",
+											value:
+												job.kind === "video"
+													? job.output_access ?? "-"
+													: "-",
+										},
+										{
+											label: "Key source",
+											value:
+												job.kind === "video" || job.kind === "batch"
+													? job.key_source ?? "-"
+													: "-",
+										},
+										{
+											label: "BYOK key ID",
+											value:
+												job.kind === "video" || job.kind === "batch" ? (
+													<CopyableCodeValue
+														value={job.byok_key_id}
+														copyLabel="Copy BYOK key id"
+													/>
+												) : (
+													"-"
+												),
+										},
+										{
+											label: "Reservation ID",
+											value:
+												job.kind === "video" ? (
+													<CopyableCodeValue
+														value={job.reservation_id}
+														copyLabel="Copy reservation id"
+													/>
+												) : (
+													"-"
+												),
+										},
+										{
+											label: "Reservation status",
+											value:
+												job.kind === "video"
+													? job.reservation_status ?? "-"
+													: "-",
+										},
+										{
+											label: "Finalized",
+											value:
+												job.kind === "video" || job.kind === "batch"
+													? formatTimestamp(job.finalized_at)
+													: "-",
+										},
+										{
+											label: "Last polled",
+											value:
+												job.kind === "video"
+													? formatTimestamp(job.last_polled_at)
+													: "-",
+										},
+										{
+											label: "Polled status",
+											value:
+												job.kind === "video"
+													? job.polled_status ?? "-"
+													: "-",
+										},
+										{
+											label: "Last reconciled",
+											value:
+												job.kind === "video"
+													? formatTimestamp(job.last_reconciled_at)
+													: "-",
 										},
 										{ label: "Created", value: formatTimestamp(job.created_at) },
 										{ label: "Updated", value: formatTimestamp(job.updated_at) },
@@ -419,12 +936,604 @@ function AsyncJobDetailDialog({
 											value: job.billed_at ? formatTimestamp(job.billed_at) : "Not billed",
 										},
 										{
+											label: "Billing reason",
+											value: job.billing_reason ?? "-",
+										},
+										{
+											label: "Charged",
+											value:
+												job.charged == null ? "-" : job.charged ? "Yes" : "No",
+										},
+										{
+											label: "Settled cost",
+											value: <span className="font-mono">{formatSettledCost(job)}</span>,
+										},
+										{
 											label: "Request created",
 											value: formatTimestamp(job.request_created_at),
+										},
+										{
+											label: "Batch request counts",
+											value: job.kind === "batch" ? formatRequestCountSummary(job) : "-",
 										},
 									]}
 								/>
 							</DetailSection>
+
+							{job.kind === "batch" ? (
+								<DetailSection title="Batch settlement">
+									<DetailKeyValueGrid
+										columns={2}
+										items={[
+											{
+												label: "Settled cost",
+												value: <span className="font-mono">{formatSettledCost(job)}</span>,
+											},
+											{
+												label: "Pricing total nanos",
+												value: job.pricing_breakdown?.total_nanos != null ? (
+													<code className="font-mono text-xs">
+														{job.pricing_breakdown.total_nanos.toLocaleString()}
+													</code>
+												) : (
+													"-"
+												),
+											},
+											{
+												label: "Completed requests",
+												value:
+													job.request_counts?.completed ??
+													job.pricing_breakdown?.completed_requests ??
+													"-",
+											},
+											{
+												label: "Failed requests",
+												value:
+													job.request_counts?.failed ??
+													job.pricing_breakdown?.failed_requests ??
+													"-",
+											},
+											{
+												label: "Total requests",
+												value:
+													job.request_counts?.total ??
+													job.pricing_breakdown?.total_requests ??
+													"-",
+											},
+											{
+												label: "Pricing total USD",
+												value: job.pricing_breakdown?.total_usd_str ? (
+													<code className="font-mono text-xs">
+														${job.pricing_breakdown.total_usd_str}
+													</code>
+												) : (
+													"-"
+												),
+											},
+											{
+												label: "Pricing lines",
+												value: job.batch_pricing_lines.length.toLocaleString(),
+											},
+										]}
+									/>
+
+									{job.batch_pricing_lines.length > 0 ? (
+										<div className="mt-4 space-y-2 rounded-xl border border-border/60 p-4">
+											<div className="text-sm font-medium">Batch pricing lines</div>
+											<div className="space-y-2">
+												{job.batch_pricing_lines.map((line, index) => (
+													<div
+														key={`batch-pricing-line-${index}`}
+														className="rounded-lg border border-border/60 bg-muted/30 px-3 py-2"
+													>
+														<code className="whitespace-pre-wrap break-words font-mono text-xs">
+															{formatRequestPricingLine(line)}
+														</code>
+													</div>
+												))}
+											</div>
+										</div>
+									) : null}
+								</DetailSection>
+							) : null}
+
+							{job.request_native_response_id ||
+							job.request_upstream_request_id ||
+							job.request_endpoint ||
+							job.request_model_id ||
+							job.request_success != null ||
+							job.request_status_code != null ||
+							job.request_error_code ||
+							job.request_error_message ||
+							job.request_finish_reason ||
+							job.request_latency_ms != null ||
+							job.request_generation_ms != null ||
+							job.request_pricing_lines.length > 0 ||
+							job.request_provider_attempts.length > 0 ? (
+								<DetailSection title="Create request execution">
+									<DetailKeyValueGrid
+										columns={2}
+										items={[
+											{
+												label: "Native response ID",
+												value: (
+													<CopyableCodeValue
+														value={job.request_native_response_id}
+														copyLabel="Copy native response id"
+													/>
+												),
+											},
+											{
+												label: "Upstream request ID",
+												value: (
+													<CopyableCodeValue
+														value={job.request_upstream_request_id}
+														copyLabel="Copy upstream request id"
+													/>
+												),
+											},
+											{
+												label: "Request endpoint",
+												value: job.request_endpoint ?? "-",
+											},
+											{
+												label: "Request model ID",
+												value: (
+													<CopyableCodeValue
+														value={job.request_model_id}
+														copyLabel="Copy request model id"
+													/>
+												),
+											},
+											{
+												label: "Request success",
+												value:
+													job.request_success == null
+														? "-"
+														: job.request_success
+															? "true"
+															: "false",
+											},
+											{
+												label: "Status code",
+												value:
+													job.request_status_code != null
+														? String(job.request_status_code)
+														: "-",
+											},
+											{
+												label: "Error code",
+												value: job.request_error_code ?? "-",
+											},
+											{
+												label: "Finish reason",
+												value: job.request_finish_reason ?? "-",
+											},
+											{
+												label: "Request latency",
+												value: formatMilliseconds(job.request_latency_ms),
+											},
+											{
+												label: "Request generation",
+												value: formatMilliseconds(job.request_generation_ms),
+											},
+											{
+												label: "Provider attempts",
+												value: job.request_provider_attempts.length.toLocaleString(),
+											},
+											{
+												label: "Pricing lines",
+												value: job.request_pricing_lines.length.toLocaleString(),
+											},
+										]}
+									/>
+
+									{job.request_pricing_lines.length > 0 ? (
+										<div className="mt-4 space-y-2 rounded-xl border border-border/60 p-4">
+											<div className="text-sm font-medium">Request pricing lines</div>
+											<div className="space-y-2">
+												{job.request_pricing_lines.map((line, index) => (
+													<div
+														key={`pricing-line-${index}`}
+														className="rounded-lg border border-border/60 bg-muted/30 px-3 py-2"
+													>
+														<code className="whitespace-pre-wrap break-words font-mono text-xs">
+															{formatRequestPricingLine(line)}
+														</code>
+													</div>
+												))}
+											</div>
+										</div>
+									) : null}
+
+									{job.request_error_message ? (
+										<div className="mt-4 space-y-2 rounded-xl border border-border/60 p-4">
+											<div className="text-sm font-medium">
+												{formattedRequestError?.title?.trim()
+													? formattedRequestError.title
+													: "Request error message"}
+											</div>
+											<div className="text-sm text-muted-foreground whitespace-pre-wrap break-words">
+												{formattedRequestError?.message ?? job.request_error_message}
+											</div>
+											{formattedRequestError?.hint ? (
+												<div className="rounded-lg border border-amber-200 bg-amber-50 px-3 py-2 text-sm text-amber-950">
+													<div className="mb-1 font-medium text-amber-900">Hint</div>
+													<div className="whitespace-pre-wrap break-words">
+														{formattedRequestError.hint}
+													</div>
+												</div>
+											) : null}
+											{formattedRequestError?.generationId ? (
+												<div className="flex items-center gap-2 text-xs text-muted-foreground">
+													<span>Generation ID:</span>
+													<code className="font-mono">
+														{formattedRequestError.generationId}
+													</code>
+													<CopyButton
+														size="sm"
+														content={formattedRequestError.generationId}
+														aria-label="Copy generation id"
+													/>
+												</div>
+											) : null}
+											{formattedRequestError?.upstreamError ? (
+												<div className="rounded-lg border border-slate-200 bg-slate-50 px-3 py-2 text-sm text-slate-900">
+													<div className="mb-1 font-medium">Upstream error</div>
+													<div className="space-y-1 text-slate-800">
+														{formattedRequestError.upstreamError.code ? (
+															<div>
+																<span className="font-medium">Code:</span>{" "}
+																<code className="rounded bg-slate-200 px-1.5 py-0.5 text-xs">
+																	{formattedRequestError.upstreamError.code}
+																</code>
+															</div>
+														) : null}
+														{formattedRequestError.upstreamError.message ? (
+															<div>
+																<span className="font-medium">Message:</span>{" "}
+																{formattedRequestError.upstreamError.message}
+															</div>
+														) : null}
+														{formattedRequestError.upstreamError.description ? (
+															<div>
+																<span className="font-medium">Detail:</span>{" "}
+																{formattedRequestError.upstreamError.description}
+															</div>
+														) : null}
+														{formattedRequestError.upstreamError.param ? (
+															<div>
+																<span className="font-medium">Param:</span>{" "}
+																<code className="rounded bg-slate-200 px-1.5 py-0.5 text-xs">
+																	{formattedRequestError.upstreamError.param}
+																</code>
+															</div>
+														) : null}
+													</div>
+												</div>
+											) : null}
+											{formattedRequestError?.reason ||
+											formattedRequestError?.attemptCount != null ||
+											failedRequestProviders.length > 0 ||
+											failedRequestStatuses.length > 0 ? (
+												<div className="rounded-lg border border-slate-200 bg-slate-50 px-3 py-2 text-sm text-slate-900">
+													<div className="mb-1 font-medium">Routing failure summary</div>
+													<div className="space-y-1 text-slate-800">
+														{formattedRequestError?.reason ? (
+															<div>
+																<span className="font-medium">Reason:</span>{" "}
+																<code className="rounded bg-slate-200 px-1.5 py-0.5 text-xs">
+																	{formattedRequestError.reason}
+																</code>
+															</div>
+														) : null}
+														{formattedRequestError?.attemptCount != null ? (
+															<div>
+																<span className="font-medium">Attempts:</span>{" "}
+																{formattedRequestError.attemptCount}
+															</div>
+														) : null}
+														{failedRequestProviders.length > 0 ? (
+															<div>
+																<span className="font-medium">Failed providers:</span>{" "}
+																{failedRequestProviders.join(", ")}
+															</div>
+														) : null}
+														{failedRequestStatuses.length > 0 ? (
+															<div>
+																<span className="font-medium">Failed statuses:</span>{" "}
+																{failedRequestStatuses.join(", ")}
+															</div>
+														) : null}
+													</div>
+												</div>
+											) : null}
+										</div>
+									) : null}
+
+									{job.request_provider_attempts.length > 0 ? (
+										<div className="mt-4 overflow-x-auto rounded-xl border border-border/60">
+											<Table>
+												<TableHeader>
+													<TableRow>
+														<TableHead>Attempt</TableHead>
+														<TableHead>Provider</TableHead>
+														<TableHead>Status</TableHead>
+														<TableHead>Outcome</TableHead>
+														<TableHead>Duration</TableHead>
+														<TableHead>Upstream error</TableHead>
+													</TableRow>
+												</TableHeader>
+												<TableBody>
+													{job.request_provider_attempts.map((attempt, index) => (
+														<TableRow key={`${attempt.provider ?? "provider"}:${attempt.attempt_number ?? index}`}>
+															<TableCell>{attempt.attempt_number ?? index + 1}</TableCell>
+															<TableCell>{attempt.provider ?? "-"}</TableCell>
+															<TableCell>
+																{attempt.status != null
+																	? `${attempt.status}${attempt.status_text ? ` ${attempt.status_text}` : ""}`
+																	: "-"}
+															</TableCell>
+															<TableCell>{attempt.outcome ?? "-"}</TableCell>
+															<TableCell>{formatMilliseconds(attempt.duration_ms)}</TableCell>
+															<TableCell>
+																<div className="space-y-1">
+																	<div>{attempt.upstream_error_code ?? "-"}</div>
+																	{attempt.upstream_error_message ? (
+																		<div className="text-xs text-muted-foreground">
+																			{attempt.upstream_error_message}
+																		</div>
+																	) : null}
+																	{attempt.upstream_error_description &&
+																	attempt.upstream_error_description !== attempt.upstream_error_message ? (
+																		<div className="text-xs text-muted-foreground">
+																			{attempt.upstream_error_description}
+																		</div>
+																	) : null}
+																</div>
+															</TableCell>
+														</TableRow>
+													))}
+												</TableBody>
+											</Table>
+										</div>
+									) : null}
+								</DetailSection>
+							) : null}
+
+							{hasJobFailureDiagnostics ? (
+								<DetailSection title="Job failure diagnostics">
+									<DetailKeyValueGrid
+										columns={2}
+										items={[
+											{
+												label: "Failure category",
+												value: job.job_provider_failure_diagnostics?.category ?? "-",
+											},
+											{
+												label: "Failure provider",
+												value: job.job_provider_failure_diagnostics?.provider ?? "-",
+											},
+											{
+												label: "Failure hint",
+												value: job.job_provider_failure_diagnostics?.hint ?? "-",
+											},
+											{
+												label: "Failure samples",
+												value: job.job_failure_sample.length.toLocaleString(),
+											},
+										]}
+									/>
+
+									{job.job_upstream_error ? (
+										<div className="mt-4 rounded-lg border border-slate-200 bg-slate-50 px-3 py-2 text-sm text-slate-900">
+											<div className="mb-1 font-medium">Upstream error</div>
+											<div className="space-y-1 text-slate-800">
+												{job.job_upstream_error.code ? (
+													<div>
+														<span className="font-medium">Code:</span>{" "}
+														<code className="rounded bg-slate-200 px-1.5 py-0.5 text-xs">
+															{job.job_upstream_error.code}
+														</code>
+													</div>
+												) : null}
+												{job.job_upstream_error.type ? (
+													<div>
+														<span className="font-medium">Type:</span>{" "}
+														<code className="rounded bg-slate-200 px-1.5 py-0.5 text-xs">
+															{job.job_upstream_error.type}
+														</code>
+													</div>
+												) : null}
+												{job.job_upstream_error.status != null ? (
+													<div>
+														<span className="font-medium">Status:</span>{" "}
+														{job.job_upstream_error.status}
+													</div>
+												) : null}
+												{job.job_upstream_error.message ? (
+													<div>
+														<span className="font-medium">Message:</span>{" "}
+														{job.job_upstream_error.message}
+													</div>
+												) : null}
+												{job.job_upstream_error.description ? (
+													<div>
+														<span className="font-medium">Detail:</span>{" "}
+														{job.job_upstream_error.description}
+													</div>
+												) : null}
+												{job.job_upstream_error.param ? (
+													<div>
+														<span className="font-medium">Param:</span>{" "}
+														<code className="rounded bg-slate-200 px-1.5 py-0.5 text-xs">
+															{job.job_upstream_error.param}
+														</code>
+													</div>
+												) : null}
+											</div>
+										</div>
+									) : null}
+
+									{job.job_failure_sample.length > 0 ? (
+										<div className="mt-4 space-y-2 rounded-xl border border-border/60 p-4">
+											<div className="text-sm font-medium">Failure samples</div>
+											<div className="space-y-2">
+												{job.job_failure_sample.map((sample, index) => (
+													<div
+														key={`job-failure-sample-${index}`}
+														className="rounded-lg border border-border/60 bg-muted/30 px-3 py-2 text-sm"
+													>
+														<div className="font-medium">
+															{sample.provider ?? "Unknown provider"}
+															{sample.type ? ` · ${sample.type}` : ""}
+															{sample.status != null ? ` · ${sample.status}` : ""}
+														</div>
+														<div className="mt-1 space-y-1 text-muted-foreground">
+															{sample.retryable != null ? (
+																<div>Retryable: {sample.retryable ? "true" : "false"}</div>
+															) : null}
+															{sample.upstream_error_code ? (
+																<div>
+																	Code:{" "}
+																	<code className="font-mono text-xs">
+																		{sample.upstream_error_code}
+																	</code>
+																</div>
+															) : null}
+															{sample.upstream_error_message ? (
+																<div>{sample.upstream_error_message}</div>
+															) : null}
+															{sample.upstream_error_description &&
+															sample.upstream_error_description !== sample.upstream_error_message ? (
+																<div>{sample.upstream_error_description}</div>
+															) : null}
+															{sample.upstream_error_param ? (
+																<div>
+																	Param:{" "}
+																	<code className="font-mono text-xs">
+																		{sample.upstream_error_param}
+																	</code>
+																</div>
+															) : null}
+														</div>
+													</div>
+												))}
+											</div>
+										</div>
+									) : null}
+
+									{job.job_routing_diagnostics ||
+									job.job_provider_enablement ||
+									job.job_provider_candidate_diagnostics ? (
+										<div className="mt-4 grid gap-4 xl:grid-cols-3">
+											{job.job_routing_diagnostics ? (
+												<div className="rounded-xl border border-border/60 p-4">
+													<div className="mb-2 text-sm font-medium">Routing diagnostics</div>
+													<code className="whitespace-pre-wrap break-words font-mono text-xs">
+														{formatStructuredDiagnostic(job.job_routing_diagnostics)}
+													</code>
+												</div>
+											) : null}
+											{job.job_provider_enablement ? (
+												<div className="rounded-xl border border-border/60 p-4">
+													<div className="mb-2 text-sm font-medium">Provider enablement</div>
+													<code className="whitespace-pre-wrap break-words font-mono text-xs">
+														{formatStructuredDiagnostic(job.job_provider_enablement)}
+													</code>
+												</div>
+											) : null}
+											{job.job_provider_candidate_diagnostics ? (
+												<div className="rounded-xl border border-border/60 p-4">
+													<div className="mb-2 text-sm font-medium">Candidate diagnostics</div>
+													<code className="whitespace-pre-wrap break-words font-mono text-xs">
+														{formatStructuredDiagnostic(job.job_provider_candidate_diagnostics)}
+													</code>
+												</div>
+											) : null}
+										</div>
+									) : null}
+								</DetailSection>
+							) : null}
+
+							{job.kind === "batch" || job.content_url ? (
+								<DetailSection title="Artifacts and actions">
+									<DetailKeyValueGrid
+										columns={2}
+										items={[
+											{
+												label: "Output file ID",
+												value: (
+													<CopyableCodeValue
+														value={job.output_file_id}
+														copyLabel="Copy output file id"
+													/>
+												),
+											},
+											{
+												label: "Output content endpoint",
+												value: (
+													<CopyableCodeValue
+														value={buildFileContentPath(job.output_file_id)}
+														copyLabel="Copy output file content endpoint"
+													/>
+												),
+											},
+											{
+												label: "Error file ID",
+												value: (
+													<CopyableCodeValue
+														value={job.error_file_id}
+														copyLabel="Copy error file id"
+													/>
+												),
+											},
+											{
+												label: "Error content endpoint",
+												value: (
+													<CopyableCodeValue
+														value={buildFileContentPath(job.error_file_id)}
+														copyLabel="Copy error file content endpoint"
+													/>
+												),
+											},
+											{
+												label: "Content URL",
+												value: job.content_url ? (
+													<div className="flex flex-wrap items-center gap-2">
+														<Link
+															href={job.content_url}
+															target="_blank"
+															rel="noreferrer"
+															className="min-w-0 truncate underline decoration-transparent transition-colors duration-200 hover:text-primary hover:decoration-current"
+														>
+															{job.content_url}
+														</Link>
+														<CopyButton
+															size="sm"
+															variant="ghost"
+															className="text-muted-foreground hover:text-foreground"
+															content={job.content_url}
+															aria-label="Copy content url"
+														/>
+													</div>
+												) : (
+													"-"
+												),
+											},
+											{
+												label: "Cancel endpoint",
+												value: (
+													<CopyableCodeValue
+														value={job.cancel_url}
+														copyLabel="Copy cancel endpoint"
+													/>
+												),
+											},
+										]}
+									/>
+								</DetailSection>
+							) : null}
 
 							<div className="grid grid-cols-1 gap-6 xl:grid-cols-[1.05fr_0.95fr]">
 								<DetailSection title="Webhook configuration">
@@ -434,6 +1543,13 @@ function AsyncJobDetailDialog({
 											{
 												label: "Webhook URL",
 												value: job.webhook.url ?? "No webhook configured",
+											},
+											{
+												label: "Subscribed events",
+												value:
+													job.webhook.events.length > 0
+														? job.webhook.events.join(", ")
+														: "-",
 											},
 											{
 												label: "Last attempt",
@@ -448,6 +1564,21 @@ function AsyncJobDetailDialog({
 												) : (
 													"-"
 												),
+											},
+											{
+												label: "Last dispatched",
+												value: formatTimestamp(job.last_webhook_dispatched_at),
+											},
+											{
+												label: "Last progress",
+												value:
+													job.last_webhook_progress != null
+														? `${job.last_webhook_progress}%`
+														: "-",
+											},
+											{
+												label: "Last progress update",
+												value: formatTimestamp(job.last_webhook_progress_at),
 											},
 										]}
 									/>
@@ -467,6 +1598,12 @@ function AsyncJobDetailDialog({
 											{
 												label: "Attempts recorded",
 												value: job.webhook_attempts.length.toLocaleString(),
+											},
+											{
+												label: "Next retry",
+												value: formatTimestamp(
+													job.next_webhook_retry_at ?? job.webhook.next_retry_at,
+												),
 											},
 										]}
 									/>
@@ -529,6 +1666,7 @@ export default function AsyncJobsPanel({
 	variant = "card",
 	providerNames,
 	modelMetadata,
+	appMetadata,
 	timeRange,
 	showRefreshButton = true,
 	kindFilter = null,
@@ -544,6 +1682,7 @@ export default function AsyncJobsPanel({
 	variant?: "card" | "logs";
 	providerNames?: Map<string, string>;
 	modelMetadata?: ModelMetadataMap;
+	appMetadata?: Map<string, AppMetadata>;
 	timeRange?: { from: string; to: string };
 	showRefreshButton?: boolean;
 	kindFilter?: "video" | "batch" | null;
@@ -560,11 +1699,32 @@ export default function AsyncJobsPanel({
 	);
 	const [resolvedModelMetadata, setResolvedModelMetadata] =
 		React.useState<ModelMetadataMap>(() => new Map(modelMetadata ?? []));
+	const [resolvedAppMetadata, setResolvedAppMetadata] = React.useState(
+		() => new Map(appMetadata ?? []),
+	);
 	const [open, setOpen] = React.useState(false);
 	const [selectedJob, setSelectedJob] = React.useState<AsyncJobDetailRow | null>(null);
+	const [requestDetailOpen, setRequestDetailOpen] = React.useState(false);
+	const [selectedRequest, setSelectedRequest] = React.useState<RequestRow | null>(null);
+	const [requestDetailAppName, setRequestDetailAppName] = React.useState<string | null>(null);
+	const [requestDetailProviderNames, setRequestDetailProviderNames] = React.useState(
+		() => new Map<string, string>(),
+	);
+	const [requestDetailProviderMetadata, setRequestDetailProviderMetadata] = React.useState(
+		() => new Map<string, ProviderMetadataEntry>(),
+	);
+	const [requestDetailModelMetadata, setRequestDetailModelMetadata] =
+		React.useState<ModelMetadataMap>(() => new Map());
 	const [isRefreshing, setIsRefreshing] = React.useState(false);
 	const [isLoadingDetail, startLoadingDetail] = React.useTransition();
+	const [isLoadingRequestDetail, startLoadingRequestDetail] = React.useTransition();
 	const [relativeNowMs, setRelativeNowMs] = React.useState<number | null>(null);
+	const detailCacheRef = React.useRef(
+		new Map<string, AsyncJobDetailRow>(),
+	);
+	const requestDetailCacheRef = React.useRef(
+		new Map<string, InvestigateGenerationResult>(),
+	);
 
 	React.useEffect(() => {
 		setJobs(initialJobs);
@@ -579,6 +1739,10 @@ export default function AsyncJobsPanel({
 	}, [modelMetadata]);
 
 	React.useEffect(() => {
+		setResolvedAppMetadata(new Map(appMetadata ?? []));
+	}, [appMetadata]);
+
+	React.useEffect(() => {
 		const updateNow = () => setRelativeNowMs(Date.now());
 		updateNow();
 		const interval = setInterval(updateNow, 60_000);
@@ -589,57 +1753,128 @@ export default function AsyncJobsPanel({
 		return (async () => {
 			setIsRefreshing(true);
 			try {
-			const next = await fetchRecentAsyncJobs({
-				limit: refreshLimit,
-				includeWithoutWebhook,
-				timeRange,
-				kind: kindFilter,
-				status: statusFilter,
-				provider: providerFilter,
-			});
-			setJobs(next);
-			const providerIds = Array.from(
-				new Set(
-					next
-						.map((job) => job.provider)
-						.filter(
-							(providerId): providerId is string =>
-								typeof providerId === "string" && providerId.trim().length > 0,
-						),
-				),
-			);
-			const modelIds = Array.from(
-				new Set(
-					next
-						.map((job) => job.model)
-						.filter(
-							(modelId): modelId is string =>
-								typeof modelId === "string" && modelId.trim().length > 0,
-						),
-				),
-			);
-			const [nextProviderNames, nextModelMetadata] = await Promise.all([
-				fetchProviderNames(providerIds),
-				fetchModelMetadata(modelIds),
-			]);
-			setResolvedProviderNames(nextProviderNames);
-			setResolvedModelMetadata(nextModelMetadata);
+				const next = await fetchRecentAsyncJobs({
+					limit: refreshLimit,
+					includeWithoutWebhook,
+					timeRange,
+					kind: kindFilter,
+					status: statusFilter,
+					provider: providerFilter,
+				});
+				setJobs(next);
+
+				const missingProviderIds = collectJobProviderIds(next).filter(
+					(providerId) => !resolvedProviderNames.has(providerId),
+				);
+				const missingModelIds = collectJobModelIds(next).filter(
+					(modelId) => !resolvedModelMetadata.has(modelId),
+				);
+				const missingAppIds = collectJobAppIds(next).filter(
+					(appId) => !resolvedAppMetadata.has(appId),
+				);
+				const [nextProviderNames, nextModelMetadata, nextAppMetadata] = await Promise.all([
+					missingProviderIds.length > 0
+						? fetchProviderNames(missingProviderIds)
+						: Promise.resolve(new Map<string, string>()),
+					missingModelIds.length > 0
+						? fetchModelMetadata(missingModelIds)
+						: Promise.resolve(new Map<string, { organisationId: string; organisationName: string; modelName?: string }>()),
+					missingAppIds.length > 0
+						? fetchAppMetadata(missingAppIds)
+						: Promise.resolve(new Map<string, AppMetadata>()),
+				]);
+				if (nextProviderNames.size > 0) {
+					setResolvedProviderNames(
+						(prev) => new Map([...prev, ...nextProviderNames]),
+					);
+				}
+				if (nextModelMetadata.size > 0) {
+					setResolvedModelMetadata(
+						(prev) => new Map([...prev, ...nextModelMetadata]),
+					);
+				}
+				if (nextAppMetadata.size > 0) {
+					setResolvedAppMetadata((prev) => new Map([...prev, ...nextAppMetadata]));
+				}
 			} finally {
 				setIsRefreshing(false);
 			}
 		})();
-	}, [includeWithoutWebhook, kindFilter, providerFilter, refreshLimit, statusFilter, timeRange]);
+	}, [
+		includeWithoutWebhook,
+		kindFilter,
+		providerFilter,
+		refreshLimit,
+		resolvedAppMetadata,
+		resolvedModelMetadata,
+		resolvedProviderNames,
+		statusFilter,
+		timeRange,
+	]);
 
 	React.useEffect(() => registerUsageViewRefresher("jobs", refresh), [refresh]);
 
 	const openDetail = React.useCallback((job: AsyncJobRow) => {
 		setOpen(true);
+		const cacheKey = `${job.kind}:${job.internal_id}`;
+		const cached = detailCacheRef.current.get(cacheKey);
+		if (cached) {
+			setSelectedJob(cached);
+			return;
+		}
+		setSelectedJob(null);
 		startLoadingDetail(async () => {
 			const detail = await fetchAsyncJobDetail({
 				kind: job.kind,
 				internalId: job.internal_id,
 			});
+			if (detail) {
+				detailCacheRef.current.set(cacheKey, detail);
+			}
 			setSelectedJob(detail);
+		});
+	}, []);
+
+	const openRequestDetail = React.useCallback((requestId: string) => {
+		const trimmedRequestId = requestId.trim();
+		if (!trimmedRequestId) return;
+		setOpen(false);
+		setRequestDetailOpen(true);
+		const cached = requestDetailCacheRef.current.get(trimmedRequestId);
+		if (cached) {
+			setSelectedRequest(cached.request as RequestRow);
+			setRequestDetailAppName(cached.appName ?? null);
+			setRequestDetailModelMetadata(new Map(cached.modelMetadata ?? []));
+			setRequestDetailProviderNames(new Map(cached.providerNames ?? []));
+			setRequestDetailProviderMetadata(new Map(cached.providerMetadata ?? []));
+			return;
+		}
+		setSelectedRequest(null);
+		setRequestDetailAppName(null);
+		setRequestDetailModelMetadata(new Map());
+		setRequestDetailProviderNames(new Map());
+		setRequestDetailProviderMetadata(new Map());
+		startLoadingRequestDetail(async () => {
+			const response = await investigateGeneration(trimmedRequestId);
+			if (!response.success || !response.data) {
+				setRequestDetailOpen(false);
+				return;
+			}
+			requestDetailCacheRef.current.set(trimmedRequestId, response.data);
+			setSelectedRequest(response.data.request as RequestRow);
+			setRequestDetailAppName(response.data.appName ?? null);
+			const nextModelMetadata = new Map(response.data.modelMetadata ?? []);
+			const nextProviderNames = new Map(response.data.providerNames ?? []);
+			const nextProviderMetadata = new Map(response.data.providerMetadata ?? []);
+			setRequestDetailModelMetadata(nextModelMetadata);
+			setRequestDetailProviderNames(nextProviderNames);
+			setRequestDetailProviderMetadata(nextProviderMetadata);
+			if (nextModelMetadata.size > 0) {
+				setResolvedModelMetadata((prev) => new Map([...prev, ...nextModelMetadata]));
+			}
+			if (nextProviderNames.size > 0) {
+				setResolvedProviderNames((prev) => new Map([...prev, ...nextProviderNames]));
+			}
 		});
 	}, []);
 
@@ -656,6 +1891,11 @@ export default function AsyncJobsPanel({
 					const providerLabel = job.provider
 						? resolvedProviderNames.get(job.provider) ?? job.provider
 						: null;
+					const failureSummary = formatAsyncJobFailureSummary(job);
+					const appLabel = job.app_id
+						? resolvedAppMetadata.get(job.app_id)?.title?.trim() || job.app_id
+						: null;
+					const appHref = job.app_id ? `/apps/${encodeURIComponent(job.app_id)}` : null;
 					const modelLabel = getModelDisplayName(
 						job.model,
 						resolvedModelMetadata,
@@ -703,12 +1943,14 @@ export default function AsyncJobsPanel({
 										</div>
 									</div>
 								</div>
-								<div className="shrink-0 text-right">
-									<div className="font-mono text-sm text-foreground">
-										{formatMoneyFromNanos(job.request_cost_nanos)}
-									</div>
-									<div className="mt-1">
-										<JobStatusBadge status={job.status} />
+									<div className="shrink-0 text-right">
+										<div className="font-mono text-sm text-foreground">
+											{job.kind === "batch" && (job.settled_cost_nanos != null || job.settled_cost_usd != null)
+												? formatSettledCost(job)
+												: formatMoneyFromNanos(job.request_cost_nanos)}
+										</div>
+										<div className="mt-1">
+											<JobStatusBadge status={job.status} />
 									</div>
 								</div>
 							</div>
@@ -728,6 +1970,11 @@ export default function AsyncJobsPanel({
 										<span className="truncate">{providerLabel}</span>
 									</Badge>
 								) : null}
+								<AsyncJobAppBadge
+									appId={job.app_id}
+									appLabel={appLabel}
+									href={appHref}
+								/>
 								<Badge
 									variant="outline"
 									className="inline-flex items-center gap-2 capitalize"
@@ -736,6 +1983,11 @@ export default function AsyncJobsPanel({
 									{job.kind}
 								</Badge>
 							</div>
+							{failureSummary ? (
+								<div className="mt-2 text-xs text-rose-700 line-clamp-2">
+									{failureSummary}
+								</div>
+							) : null}
 						</button>
 					);
 				})}
@@ -761,9 +2013,14 @@ export default function AsyncJobsPanel({
 					{jobs.map((job) => {
 						const Icon = kindIcon(job.kind);
 						const timestamp = job.request_created_at ?? job.created_at;
+						const failureSummary = formatAsyncJobFailureSummary(job);
 						const providerLabel = job.provider
 							? resolvedProviderNames.get(job.provider) ?? job.provider
 							: null;
+						const appLabel = job.app_id
+							? resolvedAppMetadata.get(job.app_id)?.title?.trim() || job.app_id
+							: null;
+						const appHref = job.app_id ? `/apps/${encodeURIComponent(job.app_id)}` : null;
 						const modelLabel = getModelDisplayName(
 							job.model,
 							resolvedModelMetadata,
@@ -887,6 +2144,16 @@ export default function AsyncJobsPanel({
 												{job.provider ?? "Unknown provider"}
 												{job.model ? ` · ${job.model}` : ""}
 											</div>
+											{failureSummary ? (
+												<div className="text-xs text-rose-700 line-clamp-2">
+													{failureSummary}
+												</div>
+											) : null}
+											<AsyncJobAppBadge
+												appId={job.app_id}
+												appLabel={appLabel}
+												href={appHref}
+											/>
 										</div>
 									</TableCell>
 								)}
@@ -912,24 +2179,40 @@ export default function AsyncJobsPanel({
 								) : null}
 								{variant === "logs" ? (
 									<TableCell className="py-2">
-										<div className="flex items-center gap-2">
-											<Badge
-												variant="outline"
-												className="inline-flex items-center gap-2 capitalize"
-											>
-												<Icon className="h-3.5 w-3.5 text-muted-foreground" />
-												{job.kind}
-											</Badge>
+										<div className="space-y-1">
+											<div className="flex items-center gap-2">
+												<Badge
+													variant="outline"
+													className="inline-flex items-center gap-2 capitalize"
+												>
+													<Icon className="h-3.5 w-3.5 text-muted-foreground" />
+													{job.kind}
+												</Badge>
+											</div>
+											<AsyncJobAppBadge
+												appId={job.app_id}
+												appLabel={appLabel}
+												href={appHref}
+											/>
 										</div>
 									</TableCell>
 								) : null}
 								{variant === "logs" ? (
 									<TableCell className="py-2 text-right font-mono text-xs">
-										{formatMoneyFromNanos(job.request_cost_nanos)}
+										{job.kind === "batch" && (job.settled_cost_nanos != null || job.settled_cost_usd != null)
+											? formatSettledCost(job)
+											: formatMoneyFromNanos(job.request_cost_nanos)}
 									</TableCell>
 								) : null}
 								<TableCell>
-									<JobStatusBadge status={job.status} />
+									<div className="space-y-1">
+										<JobStatusBadge status={job.status} />
+										{failureSummary ? (
+											<div className="max-w-[220px] text-xs text-rose-700 line-clamp-2">
+												{failureSummary}
+											</div>
+										) : null}
+									</div>
 								</TableCell>
 								{variant === "logs" ? null : (
 									<TableCell>
@@ -1020,7 +2303,10 @@ export default function AsyncJobsPanel({
 				job={selectedJob}
 				modelMetadata={resolvedModelMetadata}
 				providerNames={resolvedProviderNames}
+				appMetadata={resolvedAppMetadata}
 				open={open}
+				onInspectRequest={openRequestDetail}
+				isInspectingRequest={isLoadingRequestDetail}
 				onOpenChange={(nextOpen) => {
 					setOpen(nextOpen);
 					if (!nextOpen) {
@@ -1029,8 +2315,33 @@ export default function AsyncJobsPanel({
 				}}
 			/>
 
-			{isLoadingDetail ? (
-				<div className="sr-only">Loading async job details...</div>
+			<RequestDetailDialog
+				open={requestDetailOpen}
+				onOpenChange={(nextOpen) => {
+					setRequestDetailOpen(nextOpen);
+					if (!nextOpen) {
+						setSelectedRequest(null);
+					}
+				}}
+				request={selectedRequest}
+				appName={requestDetailAppName}
+				modelMetadata={requestDetailModelMetadata}
+				providerName={
+					selectedRequest?.provider
+						? requestDetailProviderNames.get(selectedRequest.provider) ??
+							selectedRequest.provider
+						: null
+				}
+				providerNames={requestDetailProviderNames}
+				providerMetadata={requestDetailProviderMetadata}
+			/>
+
+			{isLoadingDetail || isLoadingRequestDetail ? (
+				<div className="sr-only">
+					{isLoadingDetail
+						? "Loading async job details..."
+						: "Loading request details..."}
+				</div>
 			) : null}
 		</>
 	);

--- a/apps/web/src/components/(gateway)/usage/ErroredRequests/ErrorRequestDialog.tsx
+++ b/apps/web/src/components/(gateway)/usage/ErroredRequests/ErrorRequestDialog.tsx
@@ -23,6 +23,7 @@ import {
 	Hash,
 } from "lucide-react";
 import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
+import { formatRoomError } from "@/lib/chat/formatRoomError";
 
 export type ErrorDialogRow = {
 	request_id?: string | null;
@@ -32,6 +33,7 @@ export type ErrorDialogRow = {
 	status_code?: number | null;
 	error_code?: string | null;
 	error_message?: string | null;
+	error_payload?: Record<string, unknown> | null;
 	usage?: any;
 	cost_nanos?: number | null;
 };
@@ -96,6 +98,15 @@ function getFriendlyErrorCode(code: string | null | undefined): string {
 		bad_request: "Bad request",
 	};
 	return mapping[cleanCode] || cleanCode.replace(/_/g, " ");
+}
+
+function formatDiagnosticLabel(value: string | null | undefined): string {
+	if (!value) return "-";
+	return value
+		.split("_")
+		.filter(Boolean)
+		.map((part) => part[0].toUpperCase() + part.slice(1))
+		.join(" ");
 }
 
 function statusBadge(status?: number | null) {
@@ -200,6 +211,20 @@ export default function ErrorRequestDialog({
 	onOpenChange: (open: boolean) => void;
 }) {
 	const selected = row;
+	const formattedGatewayError = React.useMemo(() => {
+		const raw = selected?.error_payload
+			? JSON.stringify(selected.error_payload)
+			: selected?.error_message?.trim();
+		if (!raw) return null;
+		return formatRoomError(raw);
+	}, [selected?.error_message, selected?.error_payload]);
+	const formattedFailureSample = formattedGatewayError?.failureSample ?? [];
+	const providerCandidateDiagnostics =
+		formattedGatewayError?.providerCandidateDiagnostics;
+	const providerEnablement = formattedGatewayError?.providerEnablement;
+	const routingDiagnostics = formattedGatewayError?.routingDiagnostics;
+	const failedProviders = formattedGatewayError?.failedProviders ?? [];
+	const failedStatuses = formattedGatewayError?.failedStatuses ?? [];
 	return (
 		<Dialog open={open} onOpenChange={onOpenChange}>
 			<DialogContent className="sm:max-w-[900px] overflow-hidden p-0">
@@ -305,11 +330,330 @@ export default function ErrorRequestDialog({
 							{selected?.error_message ? (
 								<div className="rounded-2xl border bg-card p-4">
 									<div className="mb-2 text-sm font-medium">
-										Message
+										{formattedGatewayError?.title?.trim()
+											? formattedGatewayError.title
+											: "Message"}
 									</div>
 									<div className="whitespace-pre-wrap wrap-break-word text-sm">
-										{selected.error_message}
+										{formattedGatewayError?.message ?? selected.error_message}
 									</div>
+									{formattedGatewayError?.hint ? (
+										<div className="mt-4 rounded-xl border border-amber-200 bg-amber-50 p-3 text-sm text-amber-950">
+											<div className="mb-1 font-medium text-amber-900">
+												Hint
+											</div>
+											<div className="whitespace-pre-wrap wrap-break-word">
+												{formattedGatewayError.hint}
+											</div>
+										</div>
+									) : null}
+									{formattedGatewayError?.generationId ? (
+										<div className="mt-4 flex items-center gap-2 text-xs text-muted-foreground">
+											<span>Generation ID:</span>
+											<span className="font-mono break-all">
+												{formattedGatewayError.generationId}
+											</span>
+											<CopyButton
+												size="sm"
+												content={formattedGatewayError.generationId}
+												aria-label="Copy generation id"
+											/>
+										</div>
+									) : null}
+									{formattedGatewayError?.reason ||
+									formattedGatewayError?.attemptCount != null ||
+									failedProviders.length > 0 ||
+									failedStatuses.length > 0 ? (
+										<div className="mt-4 rounded-xl border border-slate-200 bg-slate-50 p-3 text-sm">
+											<div className="mb-1 font-medium text-slate-900">
+												Routing failure summary
+											</div>
+											<div className="space-y-1 text-slate-800">
+												{formattedGatewayError?.reason ? (
+													<div>
+														<span className="font-medium">Reason:</span>{" "}
+														<code className="rounded bg-slate-200 px-1.5 py-0.5 text-xs">
+															{formattedGatewayError.reason}
+														</code>
+														<span className="ml-2 text-slate-700">
+															{formatDiagnosticLabel(formattedGatewayError.reason)}
+														</span>
+													</div>
+												) : null}
+												{formattedGatewayError?.attemptCount != null ? (
+													<div>
+														<span className="font-medium">Attempts:</span>{" "}
+														{formattedGatewayError.attemptCount}
+													</div>
+												) : null}
+												{failedProviders.length > 0 ? (
+													<div>
+														<span className="font-medium">Failed providers:</span>{" "}
+														{failedProviders.join(", ")}
+													</div>
+												) : null}
+												{failedStatuses.length > 0 ? (
+													<div>
+														<span className="font-medium">Failed statuses:</span>{" "}
+														{failedStatuses.join(", ")}
+													</div>
+												) : null}
+											</div>
+										</div>
+									) : null}
+									{formattedGatewayError?.providerFailureCategory ||
+									formattedGatewayError?.providerFailureProvider ? (
+										<div className="mt-4 rounded-xl border border-slate-200 bg-slate-50 p-3 text-sm">
+											<div className="mb-1 font-medium text-slate-900">
+												Provider diagnostics
+											</div>
+											<div className="space-y-1 text-slate-800">
+												{formattedGatewayError.providerFailureCategory ? (
+													<div>
+														<span className="font-medium">Category:</span>{" "}
+														<code className="rounded bg-slate-200 px-1.5 py-0.5 text-xs">
+															{formattedGatewayError.providerFailureCategory}
+														</code>
+														<span className="ml-2 text-slate-700">
+															{formatDiagnosticLabel(
+																formattedGatewayError.providerFailureCategory
+															)}
+														</span>
+													</div>
+												) : null}
+												{formattedGatewayError.providerFailureProvider ? (
+													<div>
+														<span className="font-medium">Provider:</span>{" "}
+														{formattedGatewayError.providerFailureProvider}
+													</div>
+												) : null}
+											</div>
+										</div>
+									) : null}
+									{formattedGatewayError?.upstreamError ? (
+										<div className="mt-4 rounded-xl border border-slate-200 bg-slate-50 p-3 text-sm">
+											<div className="mb-1 font-medium text-slate-900">
+												Upstream error
+											</div>
+											<div className="space-y-1 text-slate-800">
+												{formattedGatewayError.upstreamError.code ? (
+													<div>
+														<span className="font-medium">Code:</span>{" "}
+														<code className="rounded bg-slate-200 px-1.5 py-0.5 text-xs">
+															{formattedGatewayError.upstreamError.code}
+														</code>
+													</div>
+												) : null}
+												{formattedGatewayError.upstreamError.message ? (
+													<div>
+														<span className="font-medium">Message:</span>{" "}
+														{formattedGatewayError.upstreamError.message}
+													</div>
+												) : null}
+												{formattedGatewayError.upstreamError.description ? (
+													<div>
+														<span className="font-medium">Detail:</span>{" "}
+														{formattedGatewayError.upstreamError.description}
+													</div>
+												) : null}
+												{formattedGatewayError.upstreamError.param ? (
+													<div>
+														<span className="font-medium">Param:</span>{" "}
+														<code className="rounded bg-slate-200 px-1.5 py-0.5 text-xs">
+															{formattedGatewayError.upstreamError.param}
+														</code>
+													</div>
+												) : null}
+											</div>
+										</div>
+									) : null}
+									{formattedFailureSample.length > 0 ? (
+										<div className="mt-4 rounded-xl border border-slate-200 bg-slate-50 p-3 text-sm">
+											<div className="mb-2 font-medium text-slate-900">
+												Failure sample
+											</div>
+											<div className="space-y-2">
+												{formattedFailureSample.map((sample, index) => (
+													<div
+														key={`${sample.provider ?? "unknown"}-${sample.status ?? "na"}-${index}`}
+														className="rounded-lg border border-slate-200 bg-white p-3"
+													>
+														<div className="flex flex-wrap items-center gap-2">
+															<span className="font-medium">
+																{sample.provider ?? "Unknown provider"}
+															</span>
+															{sample.status != null ? (
+																<code className="rounded bg-slate-100 px-1.5 py-0.5 text-xs">
+																	HTTP {sample.status}
+																</code>
+															) : null}
+															{sample.upstreamErrorCode ? (
+																<code className="rounded bg-slate-100 px-1.5 py-0.5 text-xs">
+																	{sample.upstreamErrorCode}
+																</code>
+															) : null}
+														</div>
+														{sample.upstreamErrorMessage ? (
+															<div className="mt-2">
+																<span className="font-medium">Message:</span>{" "}
+																{sample.upstreamErrorMessage}
+															</div>
+														) : null}
+														{sample.upstreamErrorDescription &&
+														sample.upstreamErrorDescription !==
+															sample.upstreamErrorMessage ? (
+															<div className="mt-1 text-slate-700">
+																<span className="font-medium">Detail:</span>{" "}
+																{sample.upstreamErrorDescription}
+															</div>
+														) : null}
+													</div>
+												))}
+											</div>
+										</div>
+									) : null}
+									{providerCandidateDiagnostics ? (
+										<div className="mt-4 rounded-xl border border-slate-200 bg-slate-50 p-3 text-sm">
+											<div className="mb-2 font-medium text-slate-900">
+												Provider candidates
+											</div>
+											<div className="grid gap-2 sm:grid-cols-3">
+												<div>
+													<div className="text-xs font-medium uppercase tracking-wide text-slate-700">
+														Known
+													</div>
+													<div className="font-mono text-sm">
+														{providerCandidateDiagnostics.totalProviders ?? "-"}
+													</div>
+												</div>
+												<div>
+													<div className="text-xs font-medium uppercase tracking-wide text-slate-700">
+														Supports endpoint
+													</div>
+													<div className="font-mono text-sm">
+														{providerCandidateDiagnostics.supportsEndpointCount ?? "-"}
+													</div>
+												</div>
+												<div>
+													<div className="text-xs font-medium uppercase tracking-wide text-slate-700">
+														Candidates
+													</div>
+													<div className="font-mono text-sm">
+														{providerCandidateDiagnostics.candidateCount ?? "-"}
+													</div>
+												</div>
+											</div>
+											{providerCandidateDiagnostics.droppedUnsupportedEndpoint.length >
+											0 ? (
+												<div className="mt-3">
+													<div className="mb-1 text-xs font-medium uppercase tracking-wide text-slate-700">
+														Unsupported endpoints
+													</div>
+													<div className="flex flex-wrap gap-2">
+														{providerCandidateDiagnostics.droppedUnsupportedEndpoint.map(
+															(endpoint) => (
+																<code
+																	key={endpoint}
+																	className="rounded bg-slate-200 px-1.5 py-0.5 text-xs"
+																>
+																	{endpoint}
+																</code>
+															)
+														)}
+													</div>
+												</div>
+											) : null}
+										</div>
+									) : null}
+									{providerEnablement ? (
+										<div className="mt-4 rounded-xl border border-slate-200 bg-slate-50 p-3 text-sm">
+											<div className="mb-2 font-medium text-slate-900">
+												Provider enablement
+											</div>
+											{providerEnablement.capability ? (
+												<div className="mb-2">
+													<span className="font-medium">Capability:</span>{" "}
+													<code className="rounded bg-slate-200 px-1.5 py-0.5 text-xs">
+														{providerEnablement.capability}
+													</code>
+												</div>
+											) : null}
+											<div className="grid gap-3 sm:grid-cols-2">
+												<div>
+													<div className="mb-1 text-xs font-medium uppercase tracking-wide text-slate-700">
+														Before
+													</div>
+													<div className="flex flex-wrap gap-2">
+														{providerEnablement.providersBefore.length > 0 ? (
+															providerEnablement.providersBefore.map((providerId) => (
+																<code
+																	key={providerId}
+																	className="rounded bg-slate-200 px-1.5 py-0.5 text-xs"
+																>
+																	{providerId}
+																</code>
+															))
+														) : (
+															<span className="text-slate-700">-</span>
+														)}
+													</div>
+												</div>
+												<div>
+													<div className="mb-1 text-xs font-medium uppercase tracking-wide text-slate-700">
+														After
+													</div>
+													<div className="flex flex-wrap gap-2">
+														{providerEnablement.providersAfter.length > 0 ? (
+															providerEnablement.providersAfter.map((providerId) => (
+																<code
+																	key={providerId}
+																	className="rounded bg-slate-200 px-1.5 py-0.5 text-xs"
+																>
+																	{providerId}
+																</code>
+															))
+														) : (
+															<span className="text-slate-700">-</span>
+														)}
+													</div>
+												</div>
+											</div>
+										</div>
+									) : null}
+									{routingDiagnostics &&
+									routingDiagnostics.filterStages.length > 0 ? (
+										<div className="mt-4 rounded-xl border border-slate-200 bg-slate-50 p-3 text-sm">
+											<div className="mb-2 font-medium text-slate-900">
+												Routing diagnostics
+											</div>
+											<div className="space-y-2">
+												{routingDiagnostics.filterStages.map((stage, index) => (
+													<div
+														key={`${stage.stage ?? "stage"}-${index}`}
+														className="rounded-lg border border-slate-200 bg-white p-3"
+													>
+														<div className="flex flex-wrap items-center gap-2">
+															<span className="font-medium">
+																{stage.stage
+																	? formatDiagnosticLabel(stage.stage)
+																	: `Stage ${index + 1}`}
+															</span>
+															{stage.beforeCount != null ? (
+																<code className="rounded bg-slate-100 px-1.5 py-0.5 text-xs">
+																	before {stage.beforeCount}
+																</code>
+															) : null}
+															{stage.afterCount != null ? (
+																<code className="rounded bg-slate-100 px-1.5 py-0.5 text-xs">
+																	after {stage.afterCount}
+																</code>
+															) : null}
+														</div>
+													</div>
+												))}
+											</div>
+										</div>
+									) : null}
 								</div>
 							) : (
 								<div className="text-sm text-muted-foreground">

--- a/apps/web/src/components/(gateway)/usage/ErroredRequests/ErrorsPanel.tsx
+++ b/apps/web/src/components/(gateway)/usage/ErroredRequests/ErrorsPanel.tsx
@@ -1,10 +1,21 @@
 "use client";
 
 import React from "react";
+import dynamic from "next/dynamic";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
+import { toast } from "sonner";
+import {
+	investigateGeneration,
+	type InvestigateGenerationResult,
+	type ProviderMetadataEntry,
+	type RequestRow,
+} from "@/app/(dashboard)/gateway/usage/server-actions";
+import type { ModelMetadataMap } from "../model-display";
 import ErrorsTable, { type ErrorRow } from "./ErrorsTable";
 import ErrorRequestDialog, { type ErrorDialogRow } from "./ErrorRequestDialog";
+
+const RequestDetailDialog = dynamic(() => import("../RequestDetailDialog"));
 
 export default function ErrorsPanel(props: {
 	totalErrors: number;
@@ -12,12 +23,67 @@ export default function ErrorsPanel(props: {
 	topCodes: Array<{ code: string; count: number }>;
 	recent: ErrorRow[];
 }) {
-	const [open, setOpen] = React.useState(false);
+	const [fallbackOpen, setFallbackOpen] = React.useState(false);
 	const [selected, setSelected] = React.useState<null | ErrorRow>(null);
+	const [detailOpen, setDetailOpen] = React.useState(false);
+	const [request, setRequest] = React.useState<RequestRow | null>(null);
+	const [appName, setAppName] = React.useState<string | null>(null);
+	const [modelMetadata, setModelMetadata] = React.useState<ModelMetadataMap>(
+		new Map(),
+	);
+	const [providerNames, setProviderNames] = React.useState<Map<string, string>>(
+		new Map(),
+	);
+	const [providerMetadata, setProviderMetadata] = React.useState<
+		Map<string, ProviderMetadataEntry>
+	>(new Map());
+	const lookupCacheRef = React.useRef(
+		new Map<string, InvestigateGenerationResult>(),
+	);
 
-	function openRow(r: ErrorRow) {
+	async function openRow(r: ErrorRow) {
 		setSelected(r);
-		setOpen(true);
+		const requestId =
+			typeof r.request_id === "string" ? r.request_id.trim() : "";
+		if (!requestId) {
+			setFallbackOpen(true);
+			return;
+		}
+
+		try {
+			const cached = lookupCacheRef.current.get(requestId);
+			if (cached) {
+				setRequest(cached.request);
+				setAppName(cached.appName ?? null);
+				setModelMetadata(new Map(cached.modelMetadata ?? []));
+				setProviderNames(new Map(cached.providerNames ?? []));
+				setProviderMetadata(new Map(cached.providerMetadata ?? []));
+				setDetailOpen(true);
+				return;
+			}
+
+			const response = await investigateGeneration(requestId);
+			if (!response.success || !response.data) {
+				setFallbackOpen(true);
+				if (response.error) {
+					toast.error(response.error);
+				}
+				return;
+			}
+
+			const result = response.data as InvestigateGenerationResult;
+			lookupCacheRef.current.set(requestId, result);
+			setRequest(result.request);
+			setAppName(result.appName ?? null);
+			setModelMetadata(new Map(result.modelMetadata ?? []));
+			setProviderNames(new Map(result.providerNames ?? []));
+			setProviderMetadata(new Map(result.providerMetadata ?? []));
+			setDetailOpen(true);
+		} catch (error) {
+			console.error("Error loading errored request detail:", error);
+			setFallbackOpen(true);
+			toast.error("Failed to load request details");
+		}
 	}
 
 	// Precompute badge text so the JSX stays clean
@@ -39,10 +105,24 @@ export default function ErrorsPanel(props: {
 			</CardHeader>
 			<CardContent className="space-y-4">
 				<ErrorsTable rows={props.recent} onSelect={openRow} />
+				<RequestDetailDialog
+					open={detailOpen}
+					onOpenChange={setDetailOpen}
+					request={request}
+					appName={appName}
+					modelMetadata={modelMetadata}
+					providerNames={providerNames}
+					providerMetadata={providerMetadata}
+					providerName={
+						request?.provider
+							? providerNames.get(request.provider) || request.provider
+							: null
+					}
+				/>
 				<ErrorRequestDialog
 					row={selected as ErrorDialogRow | null}
-					open={open}
-					onOpenChange={setOpen}
+					open={fallbackOpen}
+					onOpenChange={setFallbackOpen}
 				/>
 			</CardContent>
 		</Card>

--- a/apps/web/src/components/(gateway)/usage/ErroredRequests/ErrorsTable.tsx
+++ b/apps/web/src/components/(gateway)/usage/ErroredRequests/ErrorsTable.tsx
@@ -11,6 +11,7 @@ import {
 } from "@/components/ui/table";
 import { Button } from "@/components/ui/button";
 import { ChevronRight } from "lucide-react";
+import { formatErrorListSummary } from "@/lib/gateway/usage/errorListSummary";
 
 export type ErrorRow = {
 	request_id?: string | null;
@@ -20,6 +21,7 @@ export type ErrorRow = {
 	status_code?: number | null;
 	error_code?: string | null;
 	error_message?: string | null;
+	error_payload?: Record<string, unknown> | null;
 	usage?: any;
 	cost_nanos?: number | null;
 };
@@ -51,13 +53,22 @@ export default function ErrorsTable({
 					</TableRow>
 				</TableHeader>
 				<TableBody>
-					{rows.map((r, idx) => (
+					{rows.map((r, idx) => {
+						const summary = formatErrorListSummary(r);
+						return (
 						<TableRow key={idx} className="h-8">
 							<TableCell className="py-1 align-middle">
 								{niceDate(r.created_at)}
 							</TableCell>
 							<TableCell className="py-1 align-middle">
-								{r.model_id ?? "-"}
+								<div className="space-y-1">
+									<div>{r.model_id ?? "-"}</div>
+									{summary ? (
+										<div className="text-xs text-rose-700 line-clamp-2">
+											{summary}
+										</div>
+									) : null}
+								</div>
 							</TableCell>
 							<TableCell className="py-1 align-middle">
 								<span className="font-mono text-xs">
@@ -76,7 +87,8 @@ export default function ErrorsTable({
 								</Button>
 							</TableCell>
 						</TableRow>
-					))}
+						);
+					})}
 				</TableBody>
 			</Table>
 		</div>

--- a/apps/web/src/components/(gateway)/usage/MetricsOverview.tsx
+++ b/apps/web/src/components/(gateway)/usage/MetricsOverview.tsx
@@ -19,6 +19,7 @@ interface MetricsOverviewProps {
 	colorMap: Record<string, string>;
 	modelMetadata: ModelMetadataMap;
 	validKeyIds?: string[];
+	initialChartData?: ChartDataResult | null;
 }
 
 type MetricType = "requests" | "tokens" | "cost" | null;
@@ -34,6 +35,7 @@ export default function MetricsOverview({
 	colorMap,
 	modelMetadata,
 	validKeyIds = [],
+	initialChartData = null,
 }: MetricsOverviewProps) {
 	const [keyFilter] = useQueryState("key");
 	const [groupBy] = useQueryState<GroupBy>("group", {
@@ -41,50 +43,66 @@ export default function MetricsOverview({
 		parse: parseGroup,
 		serialize: (value) => value,
 	});
-	const [chartData, setChartData] = useState<ChartDataResult | null>(null);
+	const [chartData, setChartData] = useState<ChartDataResult | null>(initialChartData);
 	const [resolvedColorMap, setResolvedColorMap] = useState<Record<string, string>>(colorMap);
 	const [resolvedModelMetadata, setResolvedModelMetadata] =
 		useState<ModelMetadataMap>(new Map(modelMetadata));
-	const [loading, setLoading] = useState(true);
+	const resolvedColorMapRef = React.useRef<Record<string, string>>(colorMap);
+	const resolvedModelMetadataRef = React.useRef<ModelMetadataMap>(
+		new Map(modelMetadata),
+	);
+	const [loading, setLoading] = useState(initialChartData == null);
 	const [dialogOpen, setDialogOpen] = useState(false);
 	const [selectedMetric, setSelectedMetric] = useState<MetricType>(null);
 	const normalizedKeyFilter =
 		groupBy === "key" && keyFilter && validKeyIds.includes(keyFilter)
 			? keyFilter
 			: null;
+	const chartCacheRef = React.useRef(new Map<string, ChartDataResult>());
+	const chartCacheKey = `${timeRange.from}:${timeRange.to}:${range}:${normalizedKeyFilter ?? ""}`;
 
 	useEffect(() => {
-		const fetchData = async () => {
-			setLoading(true);
-			try {
-				const data = await fetchChartData({
-					timeRange,
-					range,
-					keyFilter: normalizedKeyFilter,
-				});
-				setChartData(data);
+		if (initialChartData) {
+			chartCacheRef.current.set(chartCacheKey, initialChartData);
+		}
+	}, [chartCacheKey, initialChartData]);
 
-				const modelIds = Array.from(
-					new Set(
-						[
-							...data.requestsChart,
-							...data.tokensChart,
-							...data.costChart,
-						].flatMap((row) =>
-							Object.keys(row).filter((key) => key !== "bucket"),
-						),
+	useEffect(() => {
+		const hydrateChartMetadata = async (data: ChartDataResult) => {
+			const modelIds = Array.from(
+				new Set(
+					[
+						...data.requestsChart,
+						...data.tokensChart,
+						...data.costChart,
+					].flatMap((row) =>
+						Object.keys(row).filter((key) => key !== "bucket"),
 					),
-				);
+				),
+			);
 
-				if (modelIds.length > 0) {
-					const [liveColors, liveMetadata] = await Promise.all([
-						fetchOrganizationColors(modelIds),
-						fetchModelMetadata(modelIds),
-					]);
+			if (modelIds.length > 0) {
+				const missingColorModelIds = modelIds.filter(
+					(modelId) => !(modelId in resolvedColorMapRef.current),
+				);
+				const missingMetadataModelIds = modelIds.filter(
+					(modelId) => !resolvedModelMetadataRef.current.has(modelId),
+				);
+				const [liveColors, liveMetadata] = await Promise.all([
+					missingColorModelIds.length > 0
+						? fetchOrganizationColors(missingColorModelIds)
+						: Promise.resolve(new Map<string, string>()),
+					missingMetadataModelIds.length > 0
+						? fetchModelMetadata(missingMetadataModelIds)
+						: Promise.resolve(new Map()),
+				]);
+				if (liveColors.size > 0) {
 					setResolvedColorMap((prev) => ({
 						...prev,
 						...Object.fromEntries(liveColors),
 					}));
+				}
+				if (liveMetadata.size > 0) {
 					setResolvedModelMetadata((prev) => {
 						const merged = new Map(prev);
 						for (const [key, value] of liveMetadata.entries()) {
@@ -93,6 +111,28 @@ export default function MetricsOverview({
 						return merged;
 					});
 				}
+			}
+		};
+
+		const fetchData = async () => {
+			const cached = chartCacheRef.current.get(chartCacheKey);
+			if (cached) {
+				setChartData(cached);
+				setLoading(false);
+				void hydrateChartMetadata(cached);
+				return;
+			}
+
+			setLoading(true);
+			try {
+				const data = await fetchChartData({
+					timeRange,
+					range,
+					keyFilter: normalizedKeyFilter,
+				});
+				chartCacheRef.current.set(chartCacheKey, data);
+				setChartData(data);
+				await hydrateChartMetadata(data);
 			} catch (error) {
 				console.error("Error fetching chart data:", error);
 				setChartData(null);
@@ -102,15 +142,28 @@ export default function MetricsOverview({
 		};
 
 		fetchData();
-	}, [timeRange, range, normalizedKeyFilter]);
+	}, [
+		chartCacheKey,
+		timeRange,
+		range,
+		normalizedKeyFilter,
+	]);
 
 	useEffect(() => {
 		setResolvedColorMap(colorMap);
 	}, [colorMap]);
 
 	useEffect(() => {
+		resolvedColorMapRef.current = resolvedColorMap;
+	}, [resolvedColorMap]);
+
+	useEffect(() => {
 		setResolvedModelMetadata(new Map(modelMetadata));
 	}, [modelMetadata]);
+
+	useEffect(() => {
+		resolvedModelMetadataRef.current = resolvedModelMetadata;
+	}, [resolvedModelMetadata]);
 
 	const handleCardClick = (metric: MetricType) => {
 		setSelectedMetric(metric);

--- a/apps/web/src/components/(gateway)/usage/RequestDetailDialog.tsx
+++ b/apps/web/src/components/(gateway)/usage/RequestDetailDialog.tsx
@@ -26,6 +26,14 @@ import {
 	TooltipContent,
 	TooltipTrigger,
 } from "@/components/ui/tooltip";
+import {
+	Table,
+	TableBody,
+	TableCell,
+	TableHead,
+	TableHeader,
+	TableRow,
+} from "@/components/ui/table";
 import { Logo } from "@/components/Logo";
 import {
 	RequestRow,
@@ -45,6 +53,7 @@ import {
 	PROVIDER_PROMPT_TRAINING_POLICY_LABELS,
 	normalizeProviderPromptTrainingPolicy,
 } from "@/lib/providers/promptTrainingPolicy";
+import { formatRoomError } from "@/lib/chat/formatRoomError";
 
 interface RequestDetailDialogProps {
 	open: boolean;
@@ -58,6 +67,65 @@ interface RequestDetailDialogProps {
 }
 
 type ProviderAttemptRow = RequestRow["provider_attempts"][number];
+
+function formatRequestPricingLine(line: RequestRow["pricing_lines"][number]): string {
+	if (line == null) return "null";
+	if (
+		typeof line === "string" ||
+		typeof line === "number" ||
+		typeof line === "boolean"
+	) {
+		return String(line);
+	}
+	const provider =
+		typeof line.provider === "string" && line.provider.trim().length > 0
+			? line.provider.trim()
+			: null;
+	const endpoint =
+		typeof line.endpoint === "string" && line.endpoint.trim().length > 0
+			? line.endpoint.trim()
+			: null;
+	const dimension =
+		typeof line.dimension === "string" && line.dimension.trim().length > 0
+			? line.dimension.trim()
+			: null;
+	const units =
+		typeof line.units === "number"
+			? line.units
+			: typeof line.units === "string" && line.units.trim().length > 0
+				? line.units.trim()
+				: null;
+	const costUsd =
+		typeof line.cost_usd === "number"
+			? line.cost_usd.toFixed(6)
+			: typeof line.cost_usd === "string" && line.cost_usd.trim().length > 0
+				? line.cost_usd.trim()
+				: null;
+	const costNanos =
+		typeof line.cost_nanos === "number"
+			? line.cost_nanos.toLocaleString()
+			: typeof line.cost_nanos === "string" && line.cost_nanos.trim().length > 0
+				? line.cost_nanos.trim()
+				: null;
+
+	const parts = [
+		provider,
+		endpoint,
+		dimension ? `${dimension}${units != null ? `=${units}` : ""}` : null,
+		costUsd ? `$${costUsd}` : null,
+		costNanos ? `${costNanos} nanos` : null,
+	].filter(Boolean);
+
+	return parts.length > 0 ? parts.join(" | ") : JSON.stringify(line);
+}
+
+function formatDiagnosticLabel(value: string): string {
+	return value
+		.split("_")
+		.filter(Boolean)
+		.map((part) => part[0].toUpperCase() + part.slice(1))
+		.join(" ");
+}
 
 function formatCost(nanos: number | null | undefined): string {
 	const dollars = Number(nanos ?? 0) / 1e9;
@@ -438,6 +506,18 @@ export default function RequestDetailDialog({
 				sessionId: request.session_id,
 		  })
 		: null;
+	const formattedGatewayError = request.error_payload
+		? formatRoomError(JSON.stringify(request.error_payload))
+		: request.error_message?.trim()
+			? formatRoomError(request.error_message)
+			: null;
+	const formattedFailureSample = formattedGatewayError?.failureSample ?? [];
+	const providerCandidateDiagnostics =
+		formattedGatewayError?.providerCandidateDiagnostics;
+	const providerEnablement = formattedGatewayError?.providerEnablement;
+	const routingDiagnostics = formattedGatewayError?.routingDiagnostics;
+	const failedProviders = formattedGatewayError?.failedProviders ?? [];
+	const failedStatuses = formattedGatewayError?.failedStatuses ?? [];
 	const requestDetailItems = [
 		{
 			label: "Model",
@@ -503,6 +583,44 @@ export default function RequestDetailDialog({
 			),
 		},
 		{
+			label: "Native response ID",
+			value: request.native_response_id ? (
+				<div className="flex items-center gap-2">
+					<code className="min-w-0 truncate font-mono text-xs">
+						{request.native_response_id}
+					</code>
+					<CopyButton
+						size="sm"
+						variant="ghost"
+						className="text-muted-foreground hover:text-foreground"
+						content={request.native_response_id}
+						aria-label="Copy native response id"
+					/>
+				</div>
+			) : (
+				"-"
+			),
+		},
+		{
+			label: "Upstream request ID",
+			value: request.upstream_request_id ? (
+				<div className="flex items-center gap-2">
+					<code className="min-w-0 truncate font-mono text-xs">
+						{request.upstream_request_id}
+					</code>
+					<CopyButton
+						size="sm"
+						variant="ghost"
+						className="text-muted-foreground hover:text-foreground"
+						content={request.upstream_request_id}
+						aria-label="Copy upstream request id"
+					/>
+				</div>
+			) : (
+				"-"
+			),
+		},
+		{
 			label: "Provider",
 			value: request.provider ? (
 				<Link
@@ -525,6 +643,14 @@ export default function RequestDetailDialog({
 			label: "Model ID",
 			value: request.model_id ? (
 				<code className="font-mono text-xs">{request.model_id}</code>
+			) : (
+				"-"
+			),
+		},
+		{
+			label: "Endpoint",
+			value: request.endpoint ? (
+				<code className="font-mono text-xs">{request.endpoint}</code>
 			) : (
 				"-"
 			),
@@ -599,7 +725,7 @@ export default function RequestDetailDialog({
 			? [
 					{
 						label: "Error message",
-						value: request.error_message,
+						value: formattedGatewayError?.message ?? request.error_message,
 						className: "sm:col-span-2",
 					},
 			  ]
@@ -640,10 +766,413 @@ export default function RequestDetailDialog({
 									{request.error_message ? (
 										<div>
 											<span className="font-medium">Message:</span>{" "}
-											{request.error_message}
+											{formattedGatewayError?.message ?? request.error_message}
 										</div>
 									) : null}
 								</div>
+								{formattedGatewayError?.hint ? (
+									<div className="mt-3 rounded-xl border border-rose-300/60 bg-white/50 p-3 text-rose-950">
+										<div className="mb-1 font-medium">Hint:</div>
+										<div>{formattedGatewayError.hint}</div>
+									</div>
+								) : null}
+								{formattedGatewayError?.generationId ? (
+									<div className="mt-3 flex items-center gap-2 text-rose-950/90">
+										<span className="font-medium">Generation ID:</span>
+										<code className="rounded bg-rose-100 px-1.5 py-0.5 text-xs">
+											{formattedGatewayError.generationId}
+										</code>
+										<CopyButton
+											size="sm"
+											variant="ghost"
+											className="text-rose-900/80 hover:text-rose-950"
+											content={formattedGatewayError.generationId}
+											aria-label="Copy generation id"
+										/>
+									</div>
+								) : null}
+								{formattedGatewayError?.reason ||
+								formattedGatewayError?.attemptCount != null ||
+								failedProviders.length > 0 ||
+								failedStatuses.length > 0 ? (
+									<div className="mt-3 rounded-xl border border-rose-300/60 bg-white/50 p-3 text-rose-950">
+										<div className="mb-2 font-medium">Routing failure summary</div>
+										<div className="space-y-1 text-sm">
+											{formattedGatewayError?.reason ? (
+												<div>
+													<span className="font-medium">Reason:</span>{" "}
+													<code className="rounded bg-rose-100 px-1.5 py-0.5 text-xs">
+														{formattedGatewayError.reason}
+													</code>
+													<span className="ml-2 text-rose-950/80">
+														{formatDiagnosticLabel(formattedGatewayError.reason)}
+													</span>
+												</div>
+											) : null}
+											{formattedGatewayError?.attemptCount != null ? (
+												<div>
+													<span className="font-medium">Attempts:</span>{" "}
+													{formattedGatewayError.attemptCount}
+												</div>
+											) : null}
+											{failedProviders.length > 0 ? (
+												<div>
+													<span className="font-medium">Failed providers:</span>{" "}
+													{failedProviders.join(", ")}
+												</div>
+											) : null}
+											{failedStatuses.length > 0 ? (
+												<div>
+													<span className="font-medium">Failed statuses:</span>{" "}
+													{failedStatuses.join(", ")}
+												</div>
+											) : null}
+										</div>
+									</div>
+								) : null}
+								{formattedGatewayError?.providerFailureCategory ||
+								formattedGatewayError?.providerFailureProvider ? (
+									<div className="mt-3 rounded-xl border border-rose-300/60 bg-white/50 p-3 text-rose-950">
+										<div className="mb-2 font-medium">Provider diagnostics</div>
+										<div className="space-y-1 text-sm">
+											{formattedGatewayError.providerFailureCategory ? (
+												<div>
+													<span className="font-medium">Category:</span>{" "}
+													<code className="rounded bg-rose-100 px-1.5 py-0.5 text-xs">
+														{formattedGatewayError.providerFailureCategory}
+													</code>
+													<span className="ml-2 text-rose-950/80">
+														{formatDiagnosticLabel(
+															formattedGatewayError.providerFailureCategory
+														)}
+													</span>
+												</div>
+											) : null}
+											{formattedGatewayError.providerFailureProvider ? (
+												<div className="flex items-center gap-2">
+													<span className="font-medium">Provider:</span>
+													<Logo
+														id={formattedGatewayError.providerFailureProvider}
+														width={14}
+														height={14}
+														className="flex-shrink-0"
+													/>
+													<span>
+														{providerNames?.get(
+															formattedGatewayError.providerFailureProvider
+														) ??
+															formattedGatewayError.providerFailureProvider}
+													</span>
+												</div>
+											) : null}
+										</div>
+									</div>
+								) : null}
+								{formattedGatewayError?.upstreamError ? (
+									<div className="mt-3 rounded-xl border border-rose-300/60 bg-white/50 p-3 text-rose-950">
+										<div className="mb-2 font-medium">Upstream error</div>
+										<div className="space-y-1 text-sm">
+											{formattedGatewayError.upstreamError.code ? (
+												<div>
+													<span className="font-medium">Code:</span>{" "}
+													<code className="rounded bg-rose-100 px-1.5 py-0.5 text-xs">
+														{formattedGatewayError.upstreamError.code}
+													</code>
+												</div>
+											) : null}
+											{formattedGatewayError.upstreamError.message ? (
+												<div>
+													<span className="font-medium">Message:</span>{" "}
+													{formattedGatewayError.upstreamError.message}
+												</div>
+											) : null}
+											{formattedGatewayError.upstreamError.description ? (
+												<div>
+													<span className="font-medium">Detail:</span>{" "}
+													{formattedGatewayError.upstreamError.description}
+												</div>
+											) : null}
+											{formattedGatewayError.upstreamError.param ? (
+												<div>
+													<span className="font-medium">Param:</span>{" "}
+													<code className="rounded bg-rose-100 px-1.5 py-0.5 text-xs">
+														{formattedGatewayError.upstreamError.param}
+													</code>
+												</div>
+											) : null}
+										</div>
+									</div>
+								) : null}
+								{formattedFailureSample.length > 0 ? (
+									<div className="mt-3 rounded-xl border border-rose-300/60 bg-white/50 p-3 text-rose-950">
+										<div className="mb-2 font-medium">Failure sample</div>
+										<div className="space-y-2">
+											{formattedFailureSample.map((sample, index) => (
+												<div
+													key={`${sample.provider ?? "unknown"}-${sample.status ?? "na"}-${index}`}
+													className="rounded-lg border border-rose-200/70 bg-white/70 p-3 text-sm"
+												>
+													<div className="flex flex-wrap items-center gap-2">
+														<span className="font-medium">
+															{sample.provider
+																? providerNames?.get(sample.provider) ??
+																	sample.provider
+																: "Unknown provider"}
+														</span>
+														{sample.status != null ? (
+															<code className="rounded bg-rose-100 px-1.5 py-0.5 text-xs">
+																HTTP {sample.status}
+															</code>
+														) : null}
+														{sample.upstreamErrorCode ? (
+															<code className="rounded bg-rose-100 px-1.5 py-0.5 text-xs">
+																{sample.upstreamErrorCode}
+															</code>
+														) : null}
+													</div>
+													{sample.upstreamErrorMessage ? (
+														<div className="mt-2">
+															<span className="font-medium">Message:</span>{" "}
+															{sample.upstreamErrorMessage}
+														</div>
+													) : null}
+													{sample.upstreamErrorDescription &&
+													sample.upstreamErrorDescription !==
+														sample.upstreamErrorMessage ? (
+														<div className="mt-1 text-rose-950/80">
+															<span className="font-medium">Detail:</span>{" "}
+															{sample.upstreamErrorDescription}
+														</div>
+													) : null}
+												</div>
+											))}
+										</div>
+									</div>
+								) : null}
+								{providerCandidateDiagnostics ? (
+									<div className="mt-3 rounded-xl border border-rose-300/60 bg-white/50 p-3 text-rose-950">
+										<div className="mb-2 font-medium">Provider candidates</div>
+										<div className="grid gap-2 sm:grid-cols-3">
+											<div>
+												<div className="text-xs font-medium uppercase tracking-wide text-rose-950/70">
+													Known
+												</div>
+												<div className="font-mono text-sm">
+													{providerCandidateDiagnostics.totalProviders ?? "-"}
+												</div>
+											</div>
+											<div>
+												<div className="text-xs font-medium uppercase tracking-wide text-rose-950/70">
+													Supports endpoint
+												</div>
+												<div className="font-mono text-sm">
+													{providerCandidateDiagnostics.supportsEndpointCount ?? "-"}
+												</div>
+											</div>
+											<div>
+												<div className="text-xs font-medium uppercase tracking-wide text-rose-950/70">
+													Candidates
+												</div>
+												<div className="font-mono text-sm">
+													{providerCandidateDiagnostics.candidateCount ?? "-"}
+												</div>
+											</div>
+										</div>
+										{providerCandidateDiagnostics.droppedUnsupportedEndpoint.length >
+										0 ? (
+											<div className="mt-3">
+												<div className="mb-1 text-xs font-medium uppercase tracking-wide text-rose-950/70">
+													Unsupported endpoints
+												</div>
+												<div className="flex flex-wrap gap-2">
+													{providerCandidateDiagnostics.droppedUnsupportedEndpoint.map(
+														(endpoint) => (
+															<code
+																key={endpoint}
+																className="rounded bg-rose-100 px-1.5 py-0.5 text-xs"
+															>
+																{endpoint}
+															</code>
+														)
+													)}
+												</div>
+											</div>
+										) : null}
+										{providerCandidateDiagnostics.droppedMissingAdapter.length > 0 ? (
+											<div className="mt-3 space-y-2">
+												<div className="text-xs font-medium uppercase tracking-wide text-rose-950/70">
+													Missing adapters
+												</div>
+												{providerCandidateDiagnostics.droppedMissingAdapter.map(
+													(entry, index) => (
+														<div
+															key={`${entry.providerId ?? "unknown"}-${entry.endpoint ?? "unknown"}-${index}`}
+															className="rounded-lg border border-rose-200/70 bg-white/70 p-2 text-sm"
+														>
+															<span className="font-medium">
+																{entry.providerId
+																	? providerNames?.get(entry.providerId) ??
+																		entry.providerId
+																	: "Unknown provider"}
+															</span>
+															{entry.endpoint ? (
+																<>
+																	{" "}
+																	for{" "}
+																	<code className="rounded bg-rose-100 px-1.5 py-0.5 text-xs">
+																		{entry.endpoint}
+																	</code>
+																</>
+															) : null}
+														</div>
+													)
+												)}
+											</div>
+										) : null}
+									</div>
+								) : null}
+								{providerEnablement ? (
+									<div className="mt-3 rounded-xl border border-rose-300/60 bg-white/50 p-3 text-rose-950">
+										<div className="mb-2 font-medium">Provider enablement</div>
+										{providerEnablement.capability ? (
+											<div className="mb-2">
+												<span className="font-medium">Capability:</span>{" "}
+												<code className="rounded bg-rose-100 px-1.5 py-0.5 text-xs">
+													{providerEnablement.capability}
+												</code>
+											</div>
+										) : null}
+										<div className="grid gap-3 sm:grid-cols-2">
+											<div>
+												<div className="mb-1 text-xs font-medium uppercase tracking-wide text-rose-950/70">
+													Before
+												</div>
+												<div className="flex flex-wrap gap-2">
+													{providerEnablement.providersBefore.length > 0 ? (
+														providerEnablement.providersBefore.map((providerId) => (
+															<code
+																key={providerId}
+																className="rounded bg-rose-100 px-1.5 py-0.5 text-xs"
+															>
+																{providerNames?.get(providerId) ?? providerId}
+															</code>
+														))
+													) : (
+														<span className="text-sm text-rose-950/70">-</span>
+													)}
+												</div>
+											</div>
+											<div>
+												<div className="mb-1 text-xs font-medium uppercase tracking-wide text-rose-950/70">
+													After
+												</div>
+												<div className="flex flex-wrap gap-2">
+													{providerEnablement.providersAfter.length > 0 ? (
+														providerEnablement.providersAfter.map((providerId) => (
+															<code
+																key={providerId}
+																className="rounded bg-rose-100 px-1.5 py-0.5 text-xs"
+															>
+																{providerNames?.get(providerId) ?? providerId}
+															</code>
+														))
+													) : (
+														<span className="text-sm text-rose-950/70">-</span>
+													)}
+												</div>
+											</div>
+										</div>
+										{providerEnablement.dropped.length > 0 ? (
+											<div className="mt-3 space-y-2">
+												<div className="text-xs font-medium uppercase tracking-wide text-rose-950/70">
+													Dropped providers
+												</div>
+												{providerEnablement.dropped.map((entry, index) => (
+													<div
+														key={`${entry.providerId ?? "unknown"}-${entry.reason ?? "unknown"}-${index}`}
+														className="rounded-lg border border-rose-200/70 bg-white/70 p-2 text-sm"
+													>
+														<div className="font-medium">
+															{entry.providerId
+																? providerNames?.get(entry.providerId) ??
+																	entry.providerId
+																: "Unknown provider"}
+														</div>
+														{entry.reason ? (
+															<div className="mt-1 text-rose-950/80">
+																<code className="rounded bg-rose-100 px-1.5 py-0.5 text-xs">
+																	{entry.reason}
+																</code>
+																<span className="ml-2">
+																	{formatDiagnosticLabel(entry.reason)}
+																</span>
+															</div>
+														) : null}
+													</div>
+												))}
+											</div>
+										) : null}
+									</div>
+								) : null}
+								{routingDiagnostics &&
+								routingDiagnostics.filterStages.length > 0 ? (
+									<div className="mt-3 rounded-xl border border-rose-300/60 bg-white/50 p-3 text-rose-950">
+										<div className="mb-2 font-medium">Routing diagnostics</div>
+										<div className="space-y-3">
+											{routingDiagnostics.filterStages.map((stage, index) => (
+												<div
+													key={`${stage.stage ?? "stage"}-${index}`}
+													className="rounded-lg border border-rose-200/70 bg-white/70 p-3 text-sm"
+												>
+													<div className="flex flex-wrap items-center gap-2">
+														<span className="font-medium">
+															{stage.stage
+																? formatDiagnosticLabel(stage.stage)
+																: `Stage ${index + 1}`}
+														</span>
+														{stage.beforeCount != null ? (
+															<code className="rounded bg-rose-100 px-1.5 py-0.5 text-xs">
+																before {stage.beforeCount}
+															</code>
+														) : null}
+														{stage.afterCount != null ? (
+															<code className="rounded bg-rose-100 px-1.5 py-0.5 text-xs">
+																after {stage.afterCount}
+															</code>
+														) : null}
+													</div>
+													{stage.droppedProviders.length > 0 ? (
+														<div className="mt-2 space-y-2">
+															{stage.droppedProviders.map((entry, entryIndex) => (
+																<div
+																	key={`${entry.providerId ?? "unknown"}-${entry.reason ?? "unknown"}-${entryIndex}`}
+																	className="rounded border border-rose-200/70 bg-white/80 p-2"
+																>
+																	<div className="font-medium">
+																		{entry.providerId
+																			? providerNames?.get(entry.providerId) ??
+																				entry.providerId
+																			: "Unknown provider"}
+																	</div>
+																	{entry.reason ? (
+																		<div className="mt-1 text-rose-950/80">
+																			<code className="rounded bg-rose-100 px-1.5 py-0.5 text-xs">
+																				{entry.reason}
+																			</code>
+																			<span className="ml-2">
+																				{formatDiagnosticLabel(entry.reason)}
+																			</span>
+																		</div>
+																	) : null}
+																</div>
+															))}
+														</div>
+													) : null}
+												</div>
+											))}
+										</div>
+									</div>
+								) : null}
 							</div>
 						) : null}
 
@@ -658,7 +1187,7 @@ export default function RequestDetailDialog({
 										"-"
 									)
 								}
-								sub="Time to first frame"
+								sub="Time to first token or output byte"
 								tone="emerald"
 								compact
 							/>
@@ -672,7 +1201,7 @@ export default function RequestDetailDialog({
 										"-"
 									)
 								}
-								sub="First frame to completion"
+								sub="Post-latency generation time"
 								tone="sky"
 								compact
 							/>
@@ -744,9 +1273,76 @@ export default function RequestDetailDialog({
 							)}
 						</DetailSection>
 
+						{request.pricing_lines.length > 0 ? (
+							<DetailSection title="Pricing lines">
+								<div className="space-y-2">
+									{request.pricing_lines.map((line, index) => (
+										<div
+											key={`request-pricing-line-${index}`}
+											className="rounded-lg border border-border/60 bg-muted/30 px-3 py-2"
+										>
+											<code className="whitespace-pre-wrap break-words font-mono text-xs">
+												{formatRequestPricingLine(line)}
+											</code>
+										</div>
+									))}
+								</div>
+							</DetailSection>
+						) : null}
+
 						<DetailSection title="Provider response">
 							<div className="space-y-4">
 								<DetailTimingBar items={responseTimelineItems} />
+
+								{attempts.length > 0 ? (
+									<div className="overflow-x-auto rounded-xl border border-border/60">
+										<Table>
+											<TableHeader>
+												<TableRow>
+													<TableHead>Attempt</TableHead>
+													<TableHead>Provider</TableHead>
+													<TableHead>Status</TableHead>
+													<TableHead>Outcome</TableHead>
+													<TableHead>Duration</TableHead>
+													<TableHead>Upstream error</TableHead>
+												</TableRow>
+											</TableHeader>
+											<TableBody>
+												{attempts.map((attempt, index) => (
+													<TableRow
+														key={`${attempt.provider ?? "provider"}:${attempt.attempt_number ?? index}`}
+													>
+														<TableCell>{attempt.attempt_number ?? index + 1}</TableCell>
+														<TableCell>{attempt.provider ?? "-"}</TableCell>
+														<TableCell>
+															{attempt.status != null
+																? `${attempt.status}${attempt.status_text ? ` ${attempt.status_text}` : ""}`
+																: "-"}
+														</TableCell>
+														<TableCell>{attempt.outcome ?? "-"}</TableCell>
+														<TableCell>{formatDuration(attempt.duration_ms)}</TableCell>
+														<TableCell>
+															<div className="space-y-1">
+																<div>{attempt.upstream_error_code ?? "-"}</div>
+																{attempt.upstream_error_message ? (
+																	<div className="text-xs text-muted-foreground">
+																		{attempt.upstream_error_message}
+																	</div>
+																) : null}
+																{attempt.upstream_error_description &&
+																attempt.upstream_error_description !== attempt.upstream_error_message ? (
+																	<div className="text-xs text-muted-foreground">
+																		{attempt.upstream_error_description}
+																	</div>
+																) : null}
+															</div>
+														</TableCell>
+													</TableRow>
+												))}
+											</TableBody>
+										</Table>
+									</div>
+								) : null}
 							</div>
 						</DetailSection>
 					</div>

--- a/apps/web/src/components/(gateway)/usage/RequestsSection.tsx
+++ b/apps/web/src/components/(gateway)/usage/RequestsSection.tsx
@@ -14,6 +14,7 @@ import {
 	type ModelMetadataMap,
 } from "./model-display";
 import type { ProviderMetadataEntry } from "@/app/(dashboard)/gateway/usage/server-actions";
+import type { RequestRow } from "@/app/(dashboard)/gateway/usage/server-actions";
 
 interface RequestsSectionProps {
 	title?: string;
@@ -22,6 +23,10 @@ interface RequestsSectionProps {
 	providerNames: Map<string, string>;
 	providerMetadata: Map<string, ProviderMetadataEntry>;
 	modelMetadata: ModelMetadataMap;
+	initialPage: number;
+	initialRows: RequestRow[];
+	initialTotal: number;
+	initialTotalPages: number;
 }
 
 export default function RequestsSection({
@@ -31,6 +36,10 @@ export default function RequestsSection({
 	providerNames,
 	providerMetadata,
 	modelMetadata,
+	initialPage,
+	initialRows,
+	initialTotal,
+	initialTotalPages,
 }: RequestsSectionProps) {
 	const router = useRouter();
 	const exportRef = useRef<((format: "csv" | "pdf") => void) | null>(null);
@@ -95,6 +104,10 @@ export default function RequestsSection({
 				modelMetadata={modelMetadata}
 				providerNames={providerNames}
 				providerMetadata={providerMetadata}
+				initialPage={initialPage}
+				initialRows={initialRows}
+				initialTotal={initialTotal}
+				initialTotalPages={initialTotalPages}
 				onExportRef={exportRef}
 			/>
 		</div>

--- a/apps/web/src/components/(gateway)/usage/SessionsPanel.tsx
+++ b/apps/web/src/components/(gateway)/usage/SessionsPanel.tsx
@@ -1,13 +1,16 @@
 "use client";
 
 import * as React from "react";
+import dynamic from "next/dynamic";
 import Link from "next/link";
 import {
 	fetchAppMetadata,
 	fetchModelMetadata,
+	fetchProviderMetadata,
 	fetchProviderNames,
 	fetchSessionRequests,
 	type AppMetadata,
+	type ProviderMetadataEntry,
 	fetchSessionRollups,
 	type SessionRequestRow,
 	type SessionRollupRow,
@@ -38,6 +41,7 @@ import {
 } from "@/components/ui/table";
 import { formatRelativeToNow } from "@/lib/formatRelative";
 import { registerUsageViewRefresher } from "@/lib/gateway/usage/refreshBus";
+import { formatErrorListSummary } from "@/lib/gateway/usage/errorListSummary";
 import { cn } from "@/lib/utils";
 import {
 	AppWindow,
@@ -57,10 +61,12 @@ import {
 import { getModelDisplayName, type ModelMetadataMap } from "./model-display";
 import { extractUsageMeters, formatUsageNumber } from "./usageMeters";
 import {
-	DetailKeyValueGrid,
-	DetailMetricTile,
-	DetailSection,
+        DetailKeyValueGrid,
+        DetailMetricTile,
+        DetailSection,
 } from "./DetailDialogPrimitives";
+
+const RequestDetailDialog = dynamic(() => import("./RequestDetailDialog"));
 
 function formatMoneyFromNanos(value: number | null | undefined): string {
 	if (value == null || !Number.isFinite(value)) return "-";
@@ -107,6 +113,24 @@ function buildAppLabel(app: AppMetadata | null | undefined, fallbackId?: string 
 
 function stopRowClick(event: React.MouseEvent<HTMLElement>) {
 	event.stopPropagation();
+}
+
+function collectSessionAppIds(sessions: SessionRollupRow[]): string[] {
+	return Array.from(
+		new Set(sessions.flatMap((session) => session.app_ids ?? []).filter(Boolean)),
+	);
+}
+
+function collectSessionModelIds(sessions: SessionRollupRow[]): string[] {
+	return Array.from(
+		new Set(sessions.flatMap((session) => session.model_ids ?? []).filter(Boolean)),
+	);
+}
+
+function collectSessionProviderIds(sessions: SessionRollupRow[]): string[] {
+	return Array.from(
+		new Set(sessions.flatMap((session) => session.provider_ids ?? []).filter(Boolean)),
+	);
 }
 
 function AppBadge({
@@ -418,6 +442,7 @@ function SessionDetailDialog({
 	appMetadata,
 	modelMetadata,
 	providerNames,
+	providerMetadata,
 	open,
 	onOpenChange,
 }: {
@@ -426,6 +451,7 @@ function SessionDetailDialog({
 	appMetadata: Map<string, AppMetadata>;
 	modelMetadata: ModelMetadataMap;
 	providerNames: Map<string, string>;
+	providerMetadata: Map<string, ProviderMetadataEntry>;
 	open: boolean;
 	onOpenChange: (open: boolean) => void;
 }) {
@@ -434,6 +460,9 @@ function SessionDetailDialog({
 			? Intl.DateTimeFormat().resolvedOptions().timeZone || "UTC"
 			: "UTC";
 	const [relativeNowMs, setRelativeNowMs] = React.useState<number | null>(null);
+	const [requestDetailOpen, setRequestDetailOpen] = React.useState(false);
+	const [selectedRequest, setSelectedRequest] =
+		React.useState<SessionRequestRow | null>(null);
 
 	React.useEffect(() => {
 		const updateNow = () => setRelativeNowMs(Date.now());
@@ -504,109 +533,118 @@ function SessionDetailDialog({
 		},
 	];
 
+	const selectedRequestAppName =
+		selectedRequest?.app_id
+			? buildAppLabel(
+					appMetadata.get(selectedRequest.app_id),
+					selectedRequest.app_title ?? selectedRequest.app_id,
+				)
+			: selectedRequest?.app_title ?? null;
+
 	return (
-		<Dialog open={open} onOpenChange={onOpenChange}>
-			<DialogContent className="max-h-[90vh] max-w-7xl overflow-hidden p-0">
-				<DialogHeader className="sr-only">
-					<DialogTitle>Session details</DialogTitle>
-				</DialogHeader>
+		<>
+			<Dialog open={open} onOpenChange={onOpenChange}>
+				<DialogContent className="max-h-[90vh] max-w-7xl overflow-hidden p-0">
+					<DialogHeader className="sr-only">
+						<DialogTitle>Session details</DialogTitle>
+					</DialogHeader>
 
-				<div>
-					<div className="px-5 py-4 sm:px-6 sm:py-5">
-						<div className="pr-10">
-							<DialogTitle className="min-w-0 truncate text-lg font-semibold">
-								Session {shortenIdentifier(session.session_id, 6)}
-							</DialogTitle>
-							<div className="mt-2 text-sm text-muted-foreground">{subtitle}</div>
-						</div>
-					</div>
-					<div className="border-t" />
-
-					<div className="max-h-[calc(90vh-110px)] space-y-6 overflow-y-auto p-5 sm:p-6">
-						<div className="grid grid-cols-2 gap-2 md:grid-cols-3">
-							<DetailMetricTile
-								icon={Coins}
-								label="Total cost"
-								value={<span className="font-mono">{formatMoneyFromNanos(session.total_cost_nanos)}</span>}
-								tone="amber"
-								compact
-							/>
-							<DetailMetricTile
-								icon={Layers3}
-								label="Total requests"
-								value={session.request_count.toLocaleString()}
-								tone="sky"
-								compact
-							/>
-							<DetailMetricTile
-								icon={AppWindow}
-								label="Apps"
-								value={appCounts.length}
-								tone="violet"
-								compact
-							/>
-							<DetailMetricTile
-								icon={Layers3}
-								label="Models"
-								value={modelCounts.length}
-								tone="slate"
-								compact
-							/>
-							<DetailMetricTile
-								icon={Clock3}
-								label="First request"
-								value={formatWordyDateTime(session.first_request_at, { includeTime: true })}
-								tone="slate"
-								compact
-							/>
-							<DetailMetricTile
-								icon={Clock3}
-								label="Last request"
-								value={formatWordyDateTime(session.last_request_at, { includeTime: true })}
-								tone="slate"
-								compact
-							/>
-						</div>
-
-						<DetailSection title="Session details" className="border-none bg-transparent p-0">
-							<DetailKeyValueGrid columns={2} items={sessionDetailItems} />
-						</DetailSection>
-
-						<DetailSection title="Apps in session">
-							<div className="flex flex-wrap gap-1.5">
-								{appCounts.length > 0 ? (
-									appCounts.map((appCount) => (
-										<AppBadge
-											key={appCount.app_id}
-											appId={appCount.app_id}
-											app={appMetadata.get(appCount.app_id)}
-											compact
-										/>
-									))
-								) : (
-									<div className="text-sm text-muted-foreground">
-										No app metadata recorded.
-									</div>
-								)}
+					<div>
+						<div className="px-5 py-4 sm:px-6 sm:py-5">
+							<div className="pr-10">
+								<DialogTitle className="min-w-0 truncate text-lg font-semibold">
+									Session {shortenIdentifier(session.session_id, 6)}
+								</DialogTitle>
+								<div className="mt-2 text-sm text-muted-foreground">{subtitle}</div>
 							</div>
-						</DetailSection>
+						</div>
+						<div className="border-t" />
 
-						<DetailSection title="Models in session">
-							<SessionModelsCell
-								modelCounts={modelCounts}
-								modelMetadata={modelMetadata}
-								maxVisible={6}
-							/>
-						</DetailSection>
+						<div className="max-h-[calc(90vh-110px)] space-y-6 overflow-y-auto p-5 sm:p-6">
+							<div className="grid grid-cols-2 gap-2 md:grid-cols-3">
+								<DetailMetricTile
+									icon={Coins}
+									label="Total cost"
+									value={<span className="font-mono">{formatMoneyFromNanos(session.total_cost_nanos)}</span>}
+									tone="amber"
+									compact
+								/>
+								<DetailMetricTile
+									icon={Layers3}
+									label="Total requests"
+									value={session.request_count.toLocaleString()}
+									tone="sky"
+									compact
+								/>
+								<DetailMetricTile
+									icon={AppWindow}
+									label="Apps"
+									value={appCounts.length}
+									tone="violet"
+									compact
+								/>
+								<DetailMetricTile
+									icon={Layers3}
+									label="Models"
+									value={modelCounts.length}
+									tone="slate"
+									compact
+								/>
+								<DetailMetricTile
+									icon={Clock3}
+									label="First request"
+									value={formatWordyDateTime(session.first_request_at, { includeTime: true })}
+									tone="slate"
+									compact
+								/>
+								<DetailMetricTile
+									icon={Clock3}
+									label="Last request"
+									value={formatWordyDateTime(session.last_request_at, { includeTime: true })}
+									tone="slate"
+									compact
+								/>
+							</div>
 
-						<DetailSection title="Request timeline">
-							{requests.length === 0 ? (
-								<div className="rounded-lg border border-dashed px-4 py-8 text-sm text-muted-foreground">
-									No requests found for this session in the selected period.
+							<DetailSection title="Session details" className="border-none bg-transparent p-0">
+								<DetailKeyValueGrid columns={2} items={sessionDetailItems} />
+							</DetailSection>
+
+							<DetailSection title="Apps in session">
+								<div className="flex flex-wrap gap-1.5">
+									{appCounts.length > 0 ? (
+										appCounts.map((appCount) => (
+											<AppBadge
+												key={appCount.app_id}
+												appId={appCount.app_id}
+												app={appMetadata.get(appCount.app_id)}
+												compact
+											/>
+										))
+									) : (
+										<div className="text-sm text-muted-foreground">
+											No app metadata recorded.
+										</div>
+									)}
 								</div>
-							) : (
-								<div className="overflow-x-auto rounded-lg border">
-									<Table className="text-xs">
+							</DetailSection>
+
+							<DetailSection title="Models in session">
+								<SessionModelsCell
+									modelCounts={modelCounts}
+									modelMetadata={modelMetadata}
+									maxVisible={6}
+								/>
+							</DetailSection>
+
+							<DetailSection title="Request timeline">
+								{requests.length === 0 ? (
+									<div className="rounded-lg border border-dashed px-4 py-8 text-sm text-muted-foreground">
+										No requests found for this session in the selected period.
+									</div>
+								) : (
+									<div className="overflow-x-auto rounded-lg border">
+										<Table className="text-xs">
 									<TableHeader>
 										<TableRow className="h-9">
 											<TableHead>Time</TableHead>
@@ -617,6 +655,7 @@ function SessionDetailDialog({
 											<TableHead className="text-right">Out</TableHead>
 											<TableHead className="text-right">Cost</TableHead>
 											<TableHead>Status</TableHead>
+											<TableHead className="text-right">Inspect</TableHead>
 										</TableRow>
 									</TableHeader>
 									<TableBody>
@@ -640,6 +679,9 @@ function SessionDetailDialog({
 												? buildAppLabel(appInfo, request.app_title ?? request.app_id)
 												: request.app_title ?? "-";
 											const tokens = getUsageTokenCounts(request.usage);
+											const errorSummary = request.success
+												? null
+												: formatErrorListSummary(request);
 
 											return (
 												<TableRow
@@ -731,23 +773,65 @@ function SessionDetailDialog({
 														{formatMoneyFromNanos(request.cost_nanos)}
 													</TableCell>
 													<TableCell className="py-2">
-														<RequestStatusBadge
-															success={request.success}
-															statusCode={request.status_code}
-														/>
+														<div className="space-y-1">
+															<RequestStatusBadge
+																success={request.success}
+																statusCode={request.status_code}
+															/>
+															{errorSummary ? (
+																<div className="max-w-[220px] text-xs text-rose-700 line-clamp-2">
+																	{errorSummary}
+																</div>
+															) : null}
+														</div>
+													</TableCell>
+													<TableCell className="py-2 text-right">
+														<Button
+															type="button"
+															variant="ghost"
+															size="sm"
+															className="h-7 px-2 text-xs"
+															onClick={() => {
+																setSelectedRequest(request);
+																setRequestDetailOpen(true);
+															}}
+														>
+															Inspect
+														</Button>
 													</TableCell>
 												</TableRow>
 											);
 										})}
 									</TableBody>
-									</Table>
-								</div>
-							)}
-						</DetailSection>
+										</Table>
+									</div>
+								)}
+							</DetailSection>
+						</div>
 					</div>
-				</div>
-			</DialogContent>
-		</Dialog>
+				</DialogContent>
+			</Dialog>
+
+			<RequestDetailDialog
+				open={requestDetailOpen}
+				onOpenChange={(nextOpen) => {
+					setRequestDetailOpen(nextOpen);
+					if (!nextOpen) {
+						setSelectedRequest(null);
+					}
+				}}
+				request={selectedRequest}
+				appName={selectedRequestAppName}
+				modelMetadata={modelMetadata}
+				providerName={
+					selectedRequest?.provider
+						? providerNames.get(selectedRequest.provider) ?? selectedRequest.provider
+						: null
+				}
+				providerNames={providerNames}
+				providerMetadata={providerMetadata}
+			/>
+		</>
 	);
 }
 
@@ -756,6 +840,7 @@ export default function SessionsPanel({
 	initialAppMetadata,
 	initialModelMetadata,
 	initialProviderNames,
+	initialProviderMetadata,
 	timeRange,
 	emptyMessage = "No sessions found in this workspace yet.",
 	refreshLimit = 100,
@@ -769,6 +854,7 @@ export default function SessionsPanel({
 	initialAppMetadata: Map<string, AppMetadata>;
 	initialModelMetadata: ModelMetadataMap;
 	initialProviderNames: Map<string, string>;
+	initialProviderMetadata: Map<string, ProviderMetadataEntry>;
 	timeRange: { from: string; to: string };
 	emptyMessage?: string;
 	refreshLimit?: number;
@@ -792,6 +878,9 @@ export default function SessionsPanel({
 	const [providerNames, setProviderNames] = React.useState(
 		() => new Map(initialProviderNames),
 	);
+	const [providerMetadata, setProviderMetadata] = React.useState(
+		() => new Map(initialProviderMetadata),
+	);
 	const [selectedSession, setSelectedSession] =
 		React.useState<SessionRollupRow | null>(null);
 	const [selectedRequests, setSelectedRequests] = React.useState<SessionRequestRow[]>([]);
@@ -800,6 +889,7 @@ export default function SessionsPanel({
 	const [isLoadingDetail, startLoadingDetail] = React.useTransition();
 	const [relativeNowMs, setRelativeNowMs] = React.useState<number | null>(null);
 	const [copiedSessionId, setCopiedSessionId] = React.useState<string | null>(null);
+	const detailCacheRef = React.useRef(new Map<string, SessionRequestRow[]>());
 
 	React.useEffect(() => {
 		setSessions(initialSessions);
@@ -816,6 +906,10 @@ export default function SessionsPanel({
 	React.useEffect(() => {
 		setProviderNames(new Map(initialProviderNames));
 	}, [initialProviderNames]);
+
+	React.useEffect(() => {
+		setProviderMetadata(new Map(initialProviderMetadata));
+	}, [initialProviderMetadata]);
 
 	React.useEffect(() => {
 		const updateNow = () => setRelativeNowMs(Date.now());
@@ -836,43 +930,73 @@ export default function SessionsPanel({
 		return (async () => {
 			setIsRefreshing(true);
 			try {
-			const nextSessions = await fetchSessionRollups({
-				timeRange,
-				limit: refreshLimit,
-				appId: appFilter,
-				modelId: modelFilter,
-				provider: providerFilter,
-				sessionId: sessionFilter,
-			});
-			setSessions(nextSessions);
+				const nextSessions = await fetchSessionRollups({
+					timeRange,
+					limit: refreshLimit,
+					appId: appFilter,
+					modelId: modelFilter,
+					provider: providerFilter,
+					sessionId: sessionFilter,
+				});
+				setSessions(nextSessions);
 
-			const appIds = Array.from(
-				new Set(nextSessions.flatMap((session) => session.app_ids ?? []).filter(Boolean)),
-			);
-			const modelIds = Array.from(
-				new Set(nextSessions.flatMap((session) => session.model_ids ?? []).filter(Boolean)),
-			);
-			const providerIds = Array.from(
-				new Set(
-					nextSessions.flatMap((session) => session.provider_ids ?? []).filter(Boolean),
-				),
-			);
+				const missingAppIds = collectSessionAppIds(nextSessions).filter(
+					(appId) => !appMetadata.has(appId),
+				);
+				const missingModelIds = collectSessionModelIds(nextSessions).filter(
+					(modelId) => !modelMetadata.has(modelId),
+				);
+				const missingProviderIds = collectSessionProviderIds(nextSessions).filter(
+					(providerId) => !providerNames.has(providerId),
+				);
+				const missingProviderMetadataIds = collectSessionProviderIds(nextSessions).filter(
+					(providerId) => !providerMetadata.has(providerId),
+				);
 
-			const [nextAppMetadata, nextModelMetadata, nextProviderNames] =
-				await Promise.all([
-					fetchAppMetadata(appIds),
-					fetchModelMetadata(modelIds),
-					fetchProviderNames(providerIds),
-				]);
+				const [nextAppMetadata, nextModelMetadata, nextProviderNames, nextProviderMetadata] =
+					await Promise.all([
+						missingAppIds.length > 0
+							? fetchAppMetadata(missingAppIds)
+							: Promise.resolve(new Map()),
+						missingModelIds.length > 0
+							? fetchModelMetadata(missingModelIds)
+							: Promise.resolve(new Map()),
+						missingProviderIds.length > 0
+							? fetchProviderNames(missingProviderIds)
+							: Promise.resolve(new Map()),
+						missingProviderMetadataIds.length > 0
+							? fetchProviderMetadata(missingProviderMetadataIds)
+							: Promise.resolve(new Map()),
+					]);
 
-			setAppMetadata(nextAppMetadata);
-			setModelMetadata(nextModelMetadata);
-			setProviderNames(nextProviderNames);
+				if (nextAppMetadata.size > 0) {
+					setAppMetadata((prev) => new Map([...prev, ...nextAppMetadata]));
+				}
+				if (nextModelMetadata.size > 0) {
+					setModelMetadata((prev) => new Map([...prev, ...nextModelMetadata]));
+				}
+				if (nextProviderNames.size > 0) {
+					setProviderNames((prev) => new Map([...prev, ...nextProviderNames]));
+				}
+				if (nextProviderMetadata.size > 0) {
+					setProviderMetadata((prev) => new Map([...prev, ...nextProviderMetadata]));
+				}
 			} finally {
 				setIsRefreshing(false);
 			}
 		})();
-	}, [appFilter, modelFilter, providerFilter, refreshLimit, sessionFilter, timeRange]);
+	}, [
+		appFilter,
+		appMetadata,
+		modelFilter,
+		modelMetadata,
+		providerFilter,
+		providerMetadata,
+		providerNames,
+		refreshLimit,
+		sessionFilter,
+		timeRange,
+	]);
 
 	React.useEffect(() => registerUsageViewRefresher("sessions", refresh), [refresh]);
 
@@ -880,11 +1004,19 @@ export default function SessionsPanel({
 		(session: SessionRollupRow) => {
 			setSelectedSession(session);
 			setOpen(true);
+			const cacheKey = `${session.session_id}:${timeRange.from}:${timeRange.to}`;
+			const cached = detailCacheRef.current.get(cacheKey);
+			if (cached) {
+				setSelectedRequests(cached);
+				return;
+			}
+			setSelectedRequests([]);
 			startLoadingDetail(async () => {
 				const requests = await fetchSessionRequests({
 					sessionId: session.session_id,
 					timeRange,
 				});
+				detailCacheRef.current.set(cacheKey, requests);
 				setSelectedRequests(requests);
 
 				const requestAppIds = Array.from(
@@ -918,19 +1050,33 @@ export default function SessionsPanel({
 					),
 				);
 
-				const [nextAppMetadata, nextModelMetadata, nextProviderNames] =
+				const [nextAppMetadata, nextModelMetadata, nextProviderNames, nextProviderMetadata] =
 					await Promise.all([
-						fetchAppMetadata(requestAppIds),
-						fetchModelMetadata(requestModelIds),
-						fetchProviderNames(requestProviderIds),
+						fetchAppMetadata(
+							requestAppIds.filter((appId) => !appMetadata.has(appId)),
+						),
+						fetchModelMetadata(
+							requestModelIds.filter((modelId) => !modelMetadata.has(modelId)),
+						),
+						fetchProviderNames(
+							requestProviderIds.filter(
+								(providerId) => !providerNames.has(providerId),
+							),
+						),
+						fetchProviderMetadata(
+							requestProviderIds.filter(
+								(providerId) => !providerMetadata.has(providerId),
+							),
+						),
 					]);
 
 				setAppMetadata((prev) => new Map([...prev, ...nextAppMetadata]));
 				setModelMetadata((prev) => new Map([...prev, ...nextModelMetadata]));
 				setProviderNames((prev) => new Map([...prev, ...nextProviderNames]));
+				setProviderMetadata((prev) => new Map([...prev, ...nextProviderMetadata]));
 			});
 		},
-		[timeRange],
+		[appMetadata, modelMetadata, providerMetadata, providerNames, timeRange],
 	);
 
 	const table = sessions.length === 0 ? (
@@ -1122,6 +1268,7 @@ export default function SessionsPanel({
 				appMetadata={appMetadata}
 				modelMetadata={modelMetadata}
 				providerNames={providerNames}
+				providerMetadata={providerMetadata}
 				open={open}
 				onOpenChange={(nextOpen) => {
 					setOpen(nextOpen);

--- a/apps/web/src/components/(gateway)/usage/SuccessfulRequests/SuccessfulRequestDialog.tsx
+++ b/apps/web/src/components/(gateway)/usage/SuccessfulRequests/SuccessfulRequestDialog.tsx
@@ -649,8 +649,7 @@ export default function SuccessfulRequestDialog({
 						/>
 						<MetricTile
 							icon={<Activity className="h-4 w-4" />}
-							// label="Latency (to first token)"
-							label="Latency"
+							label="Latency (first token/byte)"
 							value={
 								<span className="font-mono">
 									{Number(

--- a/apps/web/src/components/(gateway)/usage/UnifiedRequestsTable.tsx
+++ b/apps/web/src/components/(gateway)/usage/UnifiedRequestsTable.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import React, { useState, useEffect, useCallback } from "react";
+import dynamic from "next/dynamic";
 import { useQueryState } from "nuqs";
 import Link from "next/link";
 import {
@@ -37,13 +38,14 @@ import {
 	AppWindow,
 } from "lucide-react";
 import {
-	fetchPaginatedRequests,
-	fetchModelMetadata,
-	PaginatedRequestsParams,
-	type ProviderMetadataEntry,
-	RequestRow,
+        fetchPaginatedRequests,
+        investigateGeneration,
+        fetchModelMetadata,
+        PaginatedRequestsParams,
+        type InvestigateGenerationResult,
+        type ProviderMetadataEntry,
+        RequestRow,
 } from "@/app/(dashboard)/gateway/usage/server-actions";
-import RequestDetailDialog from "./RequestDetailDialog";
 import { exportToCSV, exportToPDF } from "./export-utils";
 import ExportDropdown from "./ExportDropdown";
 import { cn } from "@/lib/utils";
@@ -53,9 +55,13 @@ import {
 	formatDateTime,
 	formatWordyDateTime,
 } from "@/lib/gateway/usage/timeFormatting";
+import { formatErrorListSummary } from "@/lib/gateway/usage/errorListSummary";
 import { registerUsageViewRefresher } from "@/lib/gateway/usage/refreshBus";
 import { buildUsageDisplay, extractUsageMeters, formatUsageNumber } from "./usageMeters";
 import { getModelDisplayName, type ModelMetadataMap } from "./model-display";
+import { toast } from "sonner";
+
+const RequestDetailDialog = dynamic(() => import("./RequestDetailDialog"));
 
 interface UnifiedRequestsTableProps {
 	timeRange: { from: string; to: string };
@@ -63,6 +69,10 @@ interface UnifiedRequestsTableProps {
 	modelMetadata: ModelMetadataMap;
 	providerNames: Map<string, string>;
 	providerMetadata: Map<string, ProviderMetadataEntry>;
+	initialPage: number;
+	initialRows: RequestRow[];
+	initialTotal: number;
+	initialTotalPages: number;
 	onExportRef?: React.MutableRefObject<
 		((format: "csv" | "pdf") => void) | null
 	>;
@@ -106,6 +116,10 @@ export default function UnifiedRequestsTable({
 	modelMetadata,
 	providerNames,
 	providerMetadata,
+	initialPage,
+	initialRows,
+	initialTotal,
+	initialTotalPages,
 	onExportRef,
 }: UnifiedRequestsTableProps) {
 	const userTimeZone =
@@ -146,18 +160,30 @@ export default function UnifiedRequestsTable({
 
 	// Local state
 	const [pageCache, setPageCache] = useState<Map<number, RequestRow[]>>(
-		new Map(),
+		() => new Map([[initialPage, initialRows]]),
 	);
-	const [total, setTotal] = useState(0);
-	const [totalPages, setTotalPages] = useState(0);
-	const [loading, setLoading] = useState(true);
+	const [total, setTotal] = useState(initialTotal);
+	const [totalPages, setTotalPages] = useState(initialTotalPages);
+	const [loading, setLoading] = useState(false);
 	const [isBackgroundLoading, setIsBackgroundLoading] = useState(false);
-	const [selectedRequest, setSelectedRequest] = useState<RequestRow | null>(
-		null,
-	);
-	const [resolvedModelMetadata, setResolvedModelMetadata] =
-		useState<ModelMetadataMap>(new Map(modelMetadata));
-	const [dialogOpen, setDialogOpen] = useState(false);
+        const [selectedRequest, setSelectedRequest] = useState<RequestRow | null>(
+                null,
+        );
+        const [selectedAppName, setSelectedAppName] = useState<string | null>(
+                null,
+        );
+        const [resolvedModelMetadata, setResolvedModelMetadata] =
+                useState<ModelMetadataMap>(new Map(modelMetadata));
+        const [resolvedProviderNames, setResolvedProviderNames] = useState<
+                Map<string, string>
+        >(new Map(providerNames));
+        const [resolvedProviderMetadata, setResolvedProviderMetadata] = useState<
+                Map<string, ProviderMetadataEntry>
+        >(new Map(providerMetadata));
+        const [dialogOpen, setDialogOpen] = useState(false);
+        const detailCacheRef = React.useRef(
+                new Map<string, InvestigateGenerationResult>(),
+        );
 
 	// Build cache key from filters
 	const getCacheKey = useCallback(() => {
@@ -210,8 +236,11 @@ export default function UnifiedRequestsTable({
 							),
 					),
 				);
-				if (pageModelIds.length > 0) {
-					const liveMetadata = await fetchModelMetadata(pageModelIds);
+				const missingModelIds = pageModelIds.filter(
+					(modelId) => !resolvedModelMetadata.has(modelId),
+				);
+				if (missingModelIds.length > 0) {
+					const liveMetadata = await fetchModelMetadata(missingModelIds);
 					setResolvedModelMetadata((prev) => {
 						const merged = new Map(prev);
 						for (const [key, value] of liveMetadata.entries()) {
@@ -259,6 +288,7 @@ export default function UnifiedRequestsTable({
 			sessionFilter,
 			sortField,
 			sortDir,
+			resolvedModelMetadata,
 		],
 	);
 
@@ -277,9 +307,24 @@ export default function UnifiedRequestsTable({
 		}
 	}, [getCacheKey, currentCacheKey, setPage]);
 
+        useEffect(() => {
+                setResolvedModelMetadata(new Map(modelMetadata));
+        }, [modelMetadata]);
+
+        useEffect(() => {
+                setResolvedProviderNames(new Map(providerNames));
+        }, [providerNames]);
+
+        useEffect(() => {
+                setResolvedProviderMetadata(new Map(providerMetadata));
+        }, [providerMetadata]);
+
 	useEffect(() => {
-		setResolvedModelMetadata(new Map(modelMetadata));
-	}, [modelMetadata]);
+		setPageCache(new Map([[initialPage, initialRows]]));
+		setTotal(initialTotal);
+		setTotalPages(initialTotalPages);
+		setLoading(false);
+	}, [initialPage, initialRows, initialTotal, initialTotalPages]);
 
 	useEffect(() => registerUsageViewRefresher("logs", refreshCurrentView), [refreshCurrentView]);
 
@@ -321,10 +366,70 @@ export default function UnifiedRequestsTable({
 		setPage(1);
 	};
 
-	const handleRowClick = (request: RequestRow) => {
-		setSelectedRequest(request);
-		setDialogOpen(true);
-	};
+        const applyInvestigatedResult = useCallback(
+                (result: InvestigateGenerationResult) => {
+                        setSelectedRequest(result.request);
+                        setSelectedAppName(result.appName ?? null);
+                        setResolvedModelMetadata((prev) => {
+                                const merged = new Map(prev);
+                                for (const [key, value] of result.modelMetadata ?? []) {
+                                        merged.set(key, value);
+                                }
+                                return merged;
+                        });
+                        setResolvedProviderNames((prev) => {
+                                const merged = new Map(prev);
+                                for (const [key, value] of result.providerNames ?? []) {
+                                        merged.set(key, value);
+                                }
+                                return merged;
+                        });
+                        setResolvedProviderMetadata((prev) => {
+                                const merged = new Map(prev);
+                                for (const [key, value] of result.providerMetadata ?? []) {
+                                        merged.set(key, value);
+                                }
+                                return merged;
+                        });
+                        setDialogOpen(true);
+                },
+                [],
+        );
+
+        const handleRowClick = useCallback(
+                async (request: RequestRow) => {
+                        const requestId =
+                                typeof request.request_id === "string"
+                                        ? request.request_id.trim()
+                                        : "";
+                        if (!requestId) {
+                                setSelectedRequest(request);
+                                setSelectedAppName(request.app_title ?? null);
+                                setDialogOpen(true);
+                                return;
+                        }
+
+                        const cached = detailCacheRef.current.get(requestId);
+                        if (cached) {
+                                applyInvestigatedResult(cached);
+                                return;
+                        }
+
+                        const response = await investigateGeneration(requestId);
+                        if (!response.success || !response.data) {
+                                setSelectedRequest(request);
+                                setSelectedAppName(request.app_title ?? null);
+                                setDialogOpen(true);
+                                if (response.error) toast.error(response.error);
+                                return;
+                        }
+
+                        const result = response.data as InvestigateGenerationResult;
+                        detailCacheRef.current.set(requestId, result);
+                        applyInvestigatedResult(result);
+                },
+                [applyInvestigatedResult],
+        );
 
 	const handleExport = React.useCallback(
 		(format: "csv" | "pdf") => {
@@ -353,7 +458,7 @@ export default function UnifiedRequestsTable({
 					"Input Tokens": formatUsageNumber(inputTokens),
 					"Output Tokens": formatUsageNumber(outputTokens),
 					Cost: formatCost(row.cost_nanos),
-					"Speed (ms)": row.generation_ms || row.latency_ms || "-",
+					"Generation (ms)": row.generation_ms || row.latency_ms || "-",
 					"Finish Reason": row.finish_reason || "-",
 					Status: row.success ? "Success" : "Error",
 				};
@@ -420,6 +525,7 @@ export default function UnifiedRequestsTable({
 				<div className="space-y-3 md:hidden">
 					{data.map((row, index) => {
 						const usageDisplay = buildUsageDisplay(row.usage);
+						const errorSummary = row.success ? null : formatErrorListSummary(row);
 						const rowKey = `mobile-${row.request_id}-${row.created_at}-${row.model_id ?? "no-model"}-${row.provider ?? "no-provider"}-${index}`;
 						const modelHref = getModelDetailsHref(row.model_id);
 						const modelMeta = row.model_id
@@ -451,7 +557,7 @@ export default function UnifiedRequestsTable({
 									"w-full rounded-lg border bg-card px-4 py-3 text-left transition-colors hover:bg-muted/40",
 									loading && "opacity-50",
 								)}
-								onClick={() => handleRowClick(row)}
+                                                                onClick={() => void handleRowClick(row)}
 							>
 								<div className="flex items-start justify-between gap-3">
 									<div className="min-w-0">
@@ -509,6 +615,11 @@ export default function UnifiedRequestsTable({
 										</div>
 									</div>
 								</div>
+								{errorSummary ? (
+									<div className="mt-2 text-xs text-rose-700 line-clamp-2">
+										{errorSummary}
+									</div>
+								) : null}
 
 								<div className="mt-3 flex flex-wrap items-center gap-2">
 									{row.provider ? (
@@ -709,6 +820,7 @@ export default function UnifiedRequestsTable({
 								{/* Show cached data with optional loading overlay */}
 								{data.map((row, index) => {
 									const usageDisplay = buildUsageDisplay(row.usage);
+									const errorSummary = row.success ? null : formatErrorListSummary(row);
 									const rowKey = `${row.request_id}-${row.created_at}-${row.model_id ?? "no-model"}-${row.provider ?? "no-provider"}-${index}`;
 									const modelHref = getModelDetailsHref(row.model_id);
 									const modelMeta = row.model_id
@@ -739,7 +851,7 @@ export default function UnifiedRequestsTable({
 												loading && "opacity-50",
 												"cursor-pointer hover:bg-muted/40",
 											)}
-											onClick={() => handleRowClick(row)}
+                                                                                onClick={() => void handleRowClick(row)}
 										>
 											<TableCell className="py-2 font-mono text-xs">
 												<HoverCard>
@@ -936,23 +1048,30 @@ export default function UnifiedRequestsTable({
 												{row.finish_reason || "-"}
 											</TableCell>
 											<TableCell className="py-2">
-												{row.success ? (
-													<Badge
-														variant="outline"
-														className="bg-green-50 text-green-700 border-green-200"
-													>
-														<CheckCircle2 className="mr-1 h-3 w-3" />
-														Success
-													</Badge>
-												) : (
-													<Badge
-														variant="outline"
-														className="bg-red-50 text-red-700 border-red-200"
-													>
-														<XCircle className="mr-1 h-3 w-3" />
-														Error
-													</Badge>
-												)}
+												<div className="space-y-1">
+													{row.success ? (
+														<Badge
+															variant="outline"
+															className="bg-green-50 text-green-700 border-green-200"
+														>
+															<CheckCircle2 className="mr-1 h-3 w-3" />
+															Success
+														</Badge>
+													) : (
+														<Badge
+															variant="outline"
+															className="bg-red-50 text-red-700 border-red-200"
+														>
+															<XCircle className="mr-1 h-3 w-3" />
+															Error
+														</Badge>
+													)}
+													{errorSummary ? (
+														<div className="max-w-[220px] text-xs text-rose-700 line-clamp-2">
+															{errorSummary}
+														</div>
+													) : null}
+												</div>
 											</TableCell>
 										</TableRow>
 									);
@@ -1019,26 +1138,22 @@ export default function UnifiedRequestsTable({
 			</div>
 
 			{/* Detail Dialog */}
-			<RequestDetailDialog
-				open={dialogOpen}
-				onOpenChange={setDialogOpen}
-				request={selectedRequest}
-				modelMetadata={resolvedModelMetadata}
-				providerNames={providerNames}
-				providerMetadata={providerMetadata}
-				providerName={
-					selectedRequest?.provider
-						? providerNames.get(selectedRequest.provider) || selectedRequest.provider
-						: null
-				}
-				appName={
-					selectedRequest?.app_id
-						? normalizeNonEmpty(selectedRequest.app_title) ??
-							normalizeNonEmpty(appNames.get(selectedRequest.app_id)) ??
-							"Unknown app"
-						: null
-				}
-			/>
+                        <RequestDetailDialog
+                                open={dialogOpen}
+                                onOpenChange={setDialogOpen}
+                                request={selectedRequest}
+                                modelMetadata={resolvedModelMetadata}
+                                providerNames={resolvedProviderNames}
+                                providerMetadata={resolvedProviderMetadata}
+                                providerName={
+                                        selectedRequest?.provider
+                                                ? resolvedProviderNames.get(
+                                                          selectedRequest.provider,
+                                                  ) || selectedRequest.provider
+                                                : null
+                                }
+                                appName={selectedAppName}
+                        />
 		</div>
 	);
 }

--- a/apps/web/src/components/(gateway)/usage/UsageHeader/InvestigateGeneration.tsx
+++ b/apps/web/src/components/(gateway)/usage/UsageHeader/InvestigateGeneration.tsx
@@ -14,7 +14,12 @@ import { toast } from "sonner";
 import { Search } from "lucide-react";
 import { investigateGeneration } from "@/app/(dashboard)/gateway/usage/server-actions";
 import RequestDetailDialog from "../RequestDetailDialog";
-import type { RequestRow } from "@/app/(dashboard)/gateway/usage/server-actions";
+import type {
+	InvestigateGenerationResult,
+	ProviderMetadataEntry,
+	RequestRow,
+} from "@/app/(dashboard)/gateway/usage/server-actions";
+import type { ModelMetadataMap } from "../model-display";
 
 interface InvestigateGenerationProps {
 	iconOnly?: boolean;
@@ -27,27 +32,63 @@ export default function InvestigateGeneration({
 	const [id, setId] = React.useState("");
 	const [loading, setLoading] = React.useState(false);
 	const [request, setRequest] = React.useState<RequestRow | null>(null);
+	const [appName, setAppName] = React.useState<string | null>(null);
+	const [modelMetadata, setModelMetadata] = React.useState<ModelMetadataMap>(
+		new Map(),
+	);
+	const [providerNames, setProviderNames] = React.useState<Map<string, string>>(
+		new Map(),
+	);
+	const [providerMetadata, setProviderMetadata] = React.useState<
+		Map<string, ProviderMetadataEntry>
+	>(new Map());
 	const [detailOpen, setDetailOpen] = React.useState(false);
+	const lookupCacheRef = React.useRef(
+		new Map<string, InvestigateGenerationResult>(),
+	);
 
 	async function onSubmit(e: React.FormEvent) {
 		e.preventDefault();
-		if (!id.trim()) {
+		const trimmedId = id.trim();
+		if (!trimmedId) {
 			toast.error("Please enter a request ID");
 			return;
 		}
 
 		try {
+			const cached = lookupCacheRef.current.get(trimmedId);
+			if (cached) {
+				setRequest(cached.request);
+				setAppName(cached.appName ?? null);
+				setModelMetadata(new Map(cached.modelMetadata ?? []));
+				setProviderNames(new Map(cached.providerNames ?? []));
+				setProviderMetadata(new Map(cached.providerMetadata ?? []));
+				setOpen(false);
+				setDetailOpen(true);
+				return;
+			}
+
 			setLoading(true);
 			setRequest(null);
+			setAppName(null);
+			setModelMetadata(new Map());
+			setProviderNames(new Map());
+			setProviderMetadata(new Map());
 
-			const response = await investigateGeneration(id.trim());
+			const response = await investigateGeneration(trimmedId);
 
 			if (!response.success) {
 				toast.error(response.error || "Failed to fetch request");
 				return;
 			}
 
-			setRequest(response.data as RequestRow);
+			const result = response.data as InvestigateGenerationResult;
+			lookupCacheRef.current.set(trimmedId, result);
+			setRequest(result.request as RequestRow);
+			setAppName(result.appName ?? null);
+			setModelMetadata(new Map(result.modelMetadata ?? []));
+			setProviderNames(new Map(result.providerNames ?? []));
+			setProviderMetadata(new Map(result.providerMetadata ?? []));
 			setOpen(false);
 			setDetailOpen(true);
 		} catch (error) {
@@ -95,7 +136,15 @@ export default function InvestigateGeneration({
 				open={detailOpen}
 				onOpenChange={setDetailOpen}
 				request={request}
-				appName={null}
+				appName={appName}
+				modelMetadata={modelMetadata}
+				providerNames={providerNames}
+				providerMetadata={providerMetadata}
+				providerName={
+					request?.provider
+						? providerNames.get(request.provider) || request.provider
+						: null
+				}
 			/>
 		</>
 	);

--- a/apps/web/src/components/(gateway)/usage/usageMeters.ts
+++ b/apps/web/src/components/(gateway)/usage/usageMeters.ts
@@ -32,6 +32,8 @@ const LABEL_OVERRIDES: Record<string, { long: string; short: string }> = {
 	video_pixels: { long: "Video pixels", short: "vid px" },
 	output_video_seconds: { long: "Video seconds", short: "video sec" },
 	output_audio_seconds: { long: "Audio seconds", short: "audio sec" },
+	output_reasoning_tokens: { long: "Output reasoning tokens", short: "reasoning out" },
+	output_video: { long: "Output videos", short: "out video" },
 	bfl_credits: { long: "BFL credits", short: "bfl credits" },
 };
 

--- a/apps/web/src/lib/chat/formatRoomError.test.ts
+++ b/apps/web/src/lib/chat/formatRoomError.test.ts
@@ -1,0 +1,276 @@
+import { formatRoomError } from "./formatRoomError";
+
+describe("formatRoomError", () => {
+	test("explains unsupported endpoint when the model exists but no provider supports the room", () => {
+		const formatted = formatRoomError(
+			JSON.stringify({
+				error: "unsupported_model_or_endpoint",
+				description: "Unsupported model or endpoint.",
+				provider_candidate_diagnostics: {
+					totalProviders: 3,
+					supportsEndpointCount: 0,
+					candidateCount: 0,
+				},
+			})
+		);
+
+		expect(formatted.hint).toBe(
+			"This model is known in the gateway, but no provider currently supports this room endpoint. Try a model that matches the room type."
+		);
+	});
+
+	test("explains missing pricing for unsupported model diagnostics", () => {
+		const formatted = formatRoomError(
+			JSON.stringify({
+				error: "unsupported_model_or_endpoint",
+				description: "Unsupported model or endpoint.",
+				provider_candidate_diagnostics: {
+					totalProviders: 1,
+					supportsEndpointCount: 1,
+					candidateCount: 1,
+				},
+				provider_enablement: {
+					capability: "moderations",
+					providersBefore: ["openai"],
+					providersAfter: [],
+					dropped: [{ providerId: "openai", reason: "pricing_missing" }],
+				},
+			})
+		);
+
+		expect(formatted.hint).toBe(
+			"A provider mapping exists for this endpoint, but pricing is not configured yet. Try another provider or model until pricing is enabled."
+		);
+	});
+
+	test("explains internal-testing-only routing failures", () => {
+		const formatted = formatRoomError(
+			JSON.stringify({
+				error: "upstream_error",
+				description: "All providers failed.",
+				routing_diagnostics: {
+					filterStages: [{
+						stage: "capability_status_gate",
+						beforeCount: 1,
+						afterCount: 0,
+						droppedProviders: [{
+							providerId: "google-ai-studio",
+							reason: "capability_status_internal_testing_requires_testing_mode",
+						}],
+					}],
+				},
+			})
+		);
+
+		expect(formatted.hint).toBe(
+			"This model/provider mapping exists, but the endpoint is internal-testing only right now and is not publicly routable in this room."
+		);
+	});
+
+	test("explains routing-disabled failures", () => {
+		const formatted = formatRoomError(
+			JSON.stringify({
+				error: "upstream_error",
+				description: "All providers failed.",
+				routing_diagnostics: {
+					filterStages: [{
+						stage: "model_routing_status_gate",
+						beforeCount: 2,
+						afterCount: 0,
+						droppedProviders: [{
+							providerId: "openai",
+							reason: "model_routing_status_disabled",
+						}],
+					}],
+				},
+			})
+		);
+
+		expect(formatted.hint).toBe(
+			"This model/provider mapping is known in the gateway, but routing is currently disabled for this endpoint."
+		);
+	});
+
+	test("prefers structured provider failure diagnostics when present", () => {
+		const formatted = formatRoomError(
+			JSON.stringify({
+				error: "upstream_error",
+				description: "All providers failed.",
+				provider_failure_diagnostics: {
+					category: "credentials_not_configured",
+					hint: "Provider credentials are not configured for this route. Verify gateway keys or the selected BYOK configuration before retrying.",
+					provider: "google-vertex",
+				},
+			})
+		);
+
+		expect(formatted.hint).toBe(
+			"Provider credentials are not configured for this route. Verify gateway keys or the selected BYOK configuration before retrying."
+		);
+	});
+
+	test("preserves provider failure category and failure sample details", () => {
+		const formatted = formatRoomError(
+			JSON.stringify({
+				error: "upstream_error",
+				description: "All providers failed.",
+				provider_failure_diagnostics: {
+					category: "region_or_project_restriction",
+					hint: "The provider appears to be restricted by region, location, or project configuration. Verify the provider region and project access for this model.",
+					provider: "google-vertex",
+				},
+				failure_sample: [
+					{
+						provider: "google-vertex",
+						status: 403,
+						upstream_error_code: "permission_denied",
+						upstream_error_message: "Project is not allowed in this region.",
+						upstream_error_description:
+							"Model access is limited to specific project locations.",
+					},
+				],
+			})
+		);
+
+		expect(formatted.providerFailureCategory).toBe(
+			"region_or_project_restriction"
+		);
+		expect(formatted.providerFailureProvider).toBe("google-vertex");
+		expect(formatted.failureSample).toEqual([
+			{
+				provider: "google-vertex",
+				status: 403,
+				upstreamErrorCode: "permission_denied",
+				upstreamErrorMessage: "Project is not allowed in this region.",
+				upstreamErrorDescription:
+					"Model access is limited to specific project locations.",
+			},
+		]);
+	});
+
+	test("preserves structured upstream error diagnostics", () => {
+		const formatted = formatRoomError(
+			JSON.stringify({
+				error: "upstream_error",
+				description: "Provider rejected the request.",
+				upstream_error: {
+					code: "PERMISSION_DENIED",
+					message: "The caller does not have permission.",
+					description: "Project is not allowed to access this model.",
+					param: "model",
+				},
+			})
+		);
+
+		expect(formatted.upstreamError).toEqual({
+			code: "PERMISSION_DENIED",
+			message: "The caller does not have permission.",
+			description: "Project is not allowed to access this model.",
+			param: "model",
+		});
+	});
+
+	test("preserves candidate, enablement, and routing diagnostics details", () => {
+		const formatted = formatRoomError(
+			JSON.stringify({
+				error: "unsupported_model_or_endpoint",
+				description: "Unsupported model or endpoint.",
+				provider_candidate_diagnostics: {
+					totalProviders: 3,
+					supportsEndpointCount: 2,
+					candidateCount: 1,
+					droppedUnsupportedEndpoint: ["moderations"],
+					droppedMissingAdapter: [
+						{
+							providerId: "anthropic",
+							endpoint: "responses",
+						},
+					],
+				},
+				provider_enablement: {
+					capability: "responses",
+					providersBefore: ["openai", "anthropic"],
+					providersAfter: ["openai"],
+					dropped: [
+						{
+							providerId: "anthropic",
+							reason: "pricing_missing",
+						},
+					],
+				},
+				routing_diagnostics: {
+					filterStages: [
+						{
+							stage: "provider_status_gate",
+							beforeCount: 2,
+							afterCount: 1,
+							droppedProviders: [
+								{
+									providerId: "anthropic",
+									reason: "beta_requires_team_beta_channel",
+								},
+							],
+						},
+					],
+				},
+			})
+		);
+
+		expect(formatted.providerCandidateDiagnostics).toEqual({
+			totalProviders: 3,
+			supportsEndpointCount: 2,
+			candidateCount: 1,
+			droppedUnsupportedEndpoint: ["moderations"],
+			droppedMissingAdapter: [
+				{
+					providerId: "anthropic",
+					endpoint: "responses",
+				},
+			],
+		});
+		expect(formatted.providerEnablement).toEqual({
+			capability: "responses",
+			providersBefore: ["openai", "anthropic"],
+			providersAfter: ["openai"],
+			dropped: [
+				{
+					providerId: "anthropic",
+					reason: "pricing_missing",
+				},
+			],
+		});
+		expect(formatted.routingDiagnostics).toEqual({
+			filterStages: [
+				{
+					stage: "provider_status_gate",
+					beforeCount: 2,
+					afterCount: 1,
+					droppedProviders: [
+						{
+							providerId: "anthropic",
+							reason: "beta_requires_team_beta_channel",
+						},
+					],
+				},
+			],
+		});
+	});
+
+	test("preserves routed failure aggregates from gateway error payloads", () => {
+		const formatted = formatRoomError(
+			JSON.stringify({
+				error: "upstream_error",
+				reason: "all_candidates_failed",
+				description: "All providers failed.",
+				attempt_count: 3,
+				failed_providers: ["openai", "anthropic"],
+				failed_statuses: [429, "503"],
+			})
+		);
+
+		expect(formatted.reason).toBe("all_candidates_failed");
+		expect(formatted.attemptCount).toBe(3);
+		expect(formatted.failedProviders).toEqual(["openai", "anthropic"]);
+		expect(formatted.failedStatuses).toEqual([429, 503]);
+	});
+});

--- a/apps/web/src/lib/chat/formatRoomError.ts
+++ b/apps/web/src/lib/chat/formatRoomError.ts
@@ -2,15 +2,71 @@ type ProviderCandidateDiagnostics = {
 	totalProviders?: number;
 	supportsEndpointCount?: number;
 	candidateCount?: number;
+	droppedUnsupportedEndpoint?: string[];
+	droppedMissingAdapter?: Array<{
+		providerId?: string | null;
+		endpoint?: string | null;
+	}>;
+};
+
+type ProviderEnablementDiagnostics = {
+	capability?: string;
+	providersBefore?: string[];
+	providersAfter?: string[];
+	dropped?: Array<{
+		providerId?: string | null;
+		reason?: string | null;
+	}>;
+};
+
+type RoutingDiagnostics = {
+	filterStages?: Array<{
+		stage?: string;
+		beforeCount?: number;
+		afterCount?: number;
+		droppedProviders?: Array<{
+			providerId?: string | null;
+			reason?: string | null;
+		}>;
+	}>;
+};
+
+type ProviderFailureDiagnostics = {
+	category?: string;
+	hint?: string;
+	provider?: string | null;
+};
+
+type UpstreamErrorDiagnostics = {
+	code?: string | null;
+	message?: string | null;
+	description?: string | null;
+	param?: string | null;
+};
+
+type FailureSampleEntry = {
+	provider?: string | null;
+	status?: number | null;
+	upstream_error_code?: string | null;
+	upstream_error_message?: string | null;
+	upstream_error_description?: string | null;
 };
 
 type ParsedGatewayError = {
 	error?: string;
 	description?: string;
 	message?: string;
+	reason?: string;
 	status_code?: number;
+	attempt_count?: number;
+	failed_providers?: string[];
+	failed_statuses?: number[];
 	generation_id?: string;
+	upstream_error?: UpstreamErrorDiagnostics;
 	provider_candidate_diagnostics?: ProviderCandidateDiagnostics;
+	provider_enablement?: ProviderEnablementDiagnostics;
+	routing_diagnostics?: RoutingDiagnostics;
+	provider_failure_diagnostics?: ProviderFailureDiagnostics;
 	failure_sample?: Array<{
 		provider?: string | null;
 		status?: number | null;
@@ -24,8 +80,57 @@ export type FormattedRoomError = {
 	title: string;
 	message: string;
 	hint?: string;
+	reason?: string;
 	statusCode?: number;
+	attemptCount?: number;
+	failedProviders?: string[];
+	failedStatuses?: number[];
 	generationId?: string;
+	upstreamError?: {
+		code: string | null;
+		message: string | null;
+		description: string | null;
+		param: string | null;
+	};
+	providerCandidateDiagnostics?: {
+		totalProviders: number | null;
+		supportsEndpointCount: number | null;
+		candidateCount: number | null;
+		droppedUnsupportedEndpoint: string[];
+		droppedMissingAdapter: Array<{
+			providerId: string | null;
+			endpoint: string | null;
+		}>;
+	};
+	providerEnablement?: {
+		capability: string | null;
+		providersBefore: string[];
+		providersAfter: string[];
+		dropped: Array<{
+			providerId: string | null;
+			reason: string | null;
+		}>;
+	};
+	routingDiagnostics?: {
+		filterStages: Array<{
+			stage: string | null;
+			beforeCount: number | null;
+			afterCount: number | null;
+			droppedProviders: Array<{
+				providerId: string | null;
+				reason: string | null;
+			}>;
+		}>;
+	};
+	providerFailureCategory?: string;
+	providerFailureProvider?: string;
+	failureSample?: Array<{
+		provider: string | null;
+		status: number | null;
+		upstreamErrorCode: string | null;
+		upstreamErrorMessage: string | null;
+		upstreamErrorDescription: string | null;
+	}>;
 };
 
 function parseJsonLike(raw: string): ParsedGatewayError | null {
@@ -65,15 +170,103 @@ function titleFromCode(code: string): string {
 		.join(" ");
 }
 
+function hintFromUnsupportedDiagnostics(payload: ParsedGatewayError): string | undefined {
+	const diagnostics = payload.provider_candidate_diagnostics;
+	const providerEnablement = payload.provider_enablement;
+
+	if (
+		Array.isArray(providerEnablement?.dropped) &&
+		providerEnablement.dropped.length > 0 &&
+		providerEnablement.dropped.every((entry) => entry?.reason === "pricing_missing")
+	) {
+		return "A provider mapping exists for this endpoint, but pricing is not configured yet. Try another provider or model until pricing is enabled.";
+	}
+
+	if ((diagnostics?.totalProviders ?? 0) === 0) {
+		return "No provider is currently routable for this model in this room. Try provider Auto or choose a model that supports this endpoint.";
+	}
+
+	if ((diagnostics?.supportsEndpointCount ?? 0) === 0) {
+		return "This model is known in the gateway, but no provider currently supports this room endpoint. Try a model that matches the room type.";
+	}
+
+	if (
+		(diagnostics?.candidateCount ?? 0) === 0 &&
+		Array.isArray(diagnostics?.droppedMissingAdapter) &&
+		diagnostics.droppedMissingAdapter.length > 0
+	) {
+		return "A provider mapping exists, but the gateway does not have an adapter for this endpoint yet.";
+	}
+
+	return "Try provider Auto, then retry with a model that supports this room endpoint.";
+}
+
+function hintFromRoutingDiagnostics(payload: ParsedGatewayError): string | undefined {
+	const stages = Array.isArray(payload.routing_diagnostics?.filterStages)
+		? payload.routing_diagnostics?.filterStages ?? []
+		: [];
+	if (!stages.length) return undefined;
+
+	const terminalStage = stages.find(
+		(stage) =>
+			typeof stage?.afterCount === "number" &&
+			stage.afterCount === 0 &&
+			Array.isArray(stage.droppedProviders) &&
+			stage.droppedProviders.length > 0
+	);
+	if (!terminalStage) return undefined;
+
+	const reasons = (terminalStage.droppedProviders ?? [])
+		.map((entry) => String(entry?.reason ?? "").trim())
+		.filter(Boolean);
+	if (!reasons.length) return undefined;
+
+	if (
+		reasons.every(
+			(reason) => reason === "capability_status_internal_testing_requires_testing_mode"
+		)
+	) {
+		return "This model/provider mapping exists, but the endpoint is internal-testing only right now and is not publicly routable in this room.";
+	}
+
+	if (
+		reasons.every(
+			(reason) =>
+				reason === "provider_routing_status_disabled" ||
+				reason === "model_routing_status_disabled" ||
+				reason === "capability_status_disabled"
+		)
+	) {
+		return "This model/provider mapping is known in the gateway, but routing is currently disabled for this endpoint.";
+	}
+
+	if (
+		reasons.every(
+			(reason) =>
+				reason === "beta_requires_team_beta_channel" ||
+				reason === "alpha_requires_beta_and_alpha_channels" ||
+				reason === "provider_status_not_ready"
+		)
+	) {
+		return "This provider exists for the model, but it is currently rollout-restricted for your workspace or channel.";
+	}
+
+	if (reasons.every((reason) => reason === "breaker_open")) {
+		return "All matching providers are temporarily unhealthy or rate-protected right now. Retrying later may succeed.";
+	}
+
+	return undefined;
+}
+
 function hintForGatewayError(payload: ParsedGatewayError): string | undefined {
+	const structuredFailureHint = payload.provider_failure_diagnostics?.hint?.trim();
+	if (structuredFailureHint) return structuredFailureHint;
 	const code = String(payload.error ?? "").trim().toLowerCase();
 	if (code === "unsupported_model_or_endpoint") {
-		const diagnostics = payload.provider_candidate_diagnostics;
-		if ((diagnostics?.totalProviders ?? 0) === 0) {
-			return "No provider is currently routable for this model in this room. Try provider Auto or choose a model that supports this endpoint.";
-		}
-		return "Try provider Auto, then retry with a model that supports this room endpoint.";
+		return hintFromUnsupportedDiagnostics(payload);
 	}
+	const routingHint = hintFromRoutingDiagnostics(payload);
+	if (routingHint) return routingHint;
 	const statusCode =
 		typeof payload.status_code === "number" ? payload.status_code : null;
 	const message = `${payload.description ?? ""} ${payload.message ?? ""}`.toLowerCase();
@@ -95,6 +288,175 @@ function hintForGatewayError(payload: ParsedGatewayError): string | undefined {
 	return undefined;
 }
 
+function normalizeFailureSampleEntry(entry: FailureSampleEntry): {
+	provider: string | null;
+	status: number | null;
+	upstreamErrorCode: string | null;
+	upstreamErrorMessage: string | null;
+	upstreamErrorDescription: string | null;
+} {
+	return {
+		provider:
+			typeof entry?.provider === "string" && entry.provider.trim()
+				? entry.provider.trim()
+				: null,
+		status: typeof entry?.status === "number" ? entry.status : null,
+		upstreamErrorCode:
+			typeof entry?.upstream_error_code === "string" &&
+			entry.upstream_error_code.trim()
+				? entry.upstream_error_code.trim()
+				: null,
+		upstreamErrorMessage:
+			typeof entry?.upstream_error_message === "string" &&
+			entry.upstream_error_message.trim()
+				? entry.upstream_error_message.trim()
+				: null,
+		upstreamErrorDescription:
+			typeof entry?.upstream_error_description === "string" &&
+			entry.upstream_error_description.trim()
+				? entry.upstream_error_description.trim()
+				: null,
+	};
+}
+
+function normalizeCount(value: unknown): number | null {
+	return typeof value === "number" && Number.isFinite(value) ? value : null;
+}
+
+function normalizeStringList(value: unknown): string[] {
+	if (!Array.isArray(value)) return [];
+	return value
+		.map((item) => (typeof item === "string" ? item.trim() : ""))
+		.filter((item) => item.length > 0);
+}
+
+function normalizeNumberList(value: unknown): number[] {
+	if (!Array.isArray(value)) return [];
+	return value
+		.map((item) => {
+			if (typeof item === "number" && Number.isFinite(item)) return item;
+			if (typeof item === "string" && item.trim()) {
+				const parsed = Number(item);
+				return Number.isFinite(parsed) ? parsed : null;
+			}
+			return null;
+		})
+		.filter((item): item is number => item != null);
+}
+
+function normalizeUpstreamError(
+	value: UpstreamErrorDiagnostics | undefined
+): FormattedRoomError["upstreamError"] | undefined {
+	if (!value) return undefined;
+	const normalized = {
+		code:
+			typeof value.code === "string" && value.code.trim()
+				? value.code.trim()
+				: null,
+		message:
+			typeof value.message === "string" && value.message.trim()
+				? value.message.trim()
+				: null,
+		description:
+			typeof value.description === "string" && value.description.trim()
+				? value.description.trim()
+				: null,
+		param:
+			typeof value.param === "string" && value.param.trim()
+				? value.param.trim()
+				: null,
+	};
+	return normalized.code ||
+		normalized.message ||
+		normalized.description ||
+		normalized.param
+		? normalized
+		: undefined;
+}
+
+function normalizeProviderCandidateDiagnostics(
+	value: ProviderCandidateDiagnostics | undefined
+): FormattedRoomError["providerCandidateDiagnostics"] | undefined {
+	if (!value) return undefined;
+	return {
+		totalProviders: normalizeCount(value.totalProviders),
+		supportsEndpointCount: normalizeCount(value.supportsEndpointCount),
+		candidateCount: normalizeCount(value.candidateCount),
+		droppedUnsupportedEndpoint: normalizeStringList(
+			value.droppedUnsupportedEndpoint
+		),
+		droppedMissingAdapter: Array.isArray(value.droppedMissingAdapter)
+			? value.droppedMissingAdapter.map((entry) => ({
+					providerId:
+						typeof entry?.providerId === "string" && entry.providerId.trim()
+							? entry.providerId.trim()
+							: null,
+					endpoint:
+						typeof entry?.endpoint === "string" && entry.endpoint.trim()
+							? entry.endpoint.trim()
+							: null,
+			  }))
+			: [],
+	};
+}
+
+function normalizeProviderEnablement(
+	value: ProviderEnablementDiagnostics | undefined
+): FormattedRoomError["providerEnablement"] | undefined {
+	if (!value) return undefined;
+	return {
+		capability:
+			typeof value.capability === "string" && value.capability.trim()
+				? value.capability.trim()
+				: null,
+		providersBefore: normalizeStringList(value.providersBefore),
+		providersAfter: normalizeStringList(value.providersAfter),
+		dropped: Array.isArray(value.dropped)
+			? value.dropped.map((entry) => ({
+					providerId:
+						typeof entry?.providerId === "string" && entry.providerId.trim()
+							? entry.providerId.trim()
+							: null,
+					reason:
+						typeof entry?.reason === "string" && entry.reason.trim()
+							? entry.reason.trim()
+							: null,
+			  }))
+			: [],
+	};
+}
+
+function normalizeRoutingDiagnostics(
+	value: RoutingDiagnostics | undefined
+): FormattedRoomError["routingDiagnostics"] | undefined {
+	if (!value) return undefined;
+	return {
+		filterStages: Array.isArray(value.filterStages)
+			? value.filterStages.map((stage) => ({
+					stage:
+						typeof stage?.stage === "string" && stage.stage.trim()
+							? stage.stage.trim()
+							: null,
+					beforeCount: normalizeCount(stage?.beforeCount),
+					afterCount: normalizeCount(stage?.afterCount),
+					droppedProviders: Array.isArray(stage?.droppedProviders)
+						? stage.droppedProviders.map((entry) => ({
+								providerId:
+									typeof entry?.providerId === "string" &&
+									entry.providerId.trim()
+										? entry.providerId.trim()
+										: null,
+								reason:
+									typeof entry?.reason === "string" && entry.reason.trim()
+										? entry.reason.trim()
+										: null,
+						  }))
+						: [],
+			  }))
+			: [],
+	};
+}
+
 export function formatRoomError(rawError: string): FormattedRoomError {
 	const fallbackMessage = rawError.trim() || "The request failed.";
 	const parsed = parseJsonLike(fallbackMessage);
@@ -113,11 +475,45 @@ export function formatRoomError(rawError: string): FormattedRoomError {
 		title,
 		message,
 		hint: hintForGatewayError(parsed),
+		reason:
+			typeof parsed.reason === "string" && parsed.reason.trim()
+				? parsed.reason.trim()
+				: undefined,
 		statusCode:
 			typeof parsed.status_code === "number" ? parsed.status_code : undefined,
+		attemptCount:
+			typeof parsed.attempt_count === "number" &&
+			Number.isFinite(parsed.attempt_count)
+				? parsed.attempt_count
+				: undefined,
+		failedProviders: normalizeStringList(parsed.failed_providers),
+		failedStatuses: normalizeNumberList(parsed.failed_statuses),
 		generationId:
 			typeof parsed.generation_id === "string" && parsed.generation_id.trim()
 				? parsed.generation_id.trim()
 				: undefined,
+		upstreamError: normalizeUpstreamError(parsed.upstream_error),
+		providerCandidateDiagnostics: normalizeProviderCandidateDiagnostics(
+			parsed.provider_candidate_diagnostics
+		),
+		providerEnablement: normalizeProviderEnablement(
+			parsed.provider_enablement
+		),
+		routingDiagnostics: normalizeRoutingDiagnostics(
+			parsed.routing_diagnostics
+		),
+		providerFailureCategory:
+			typeof parsed.provider_failure_diagnostics?.category === "string" &&
+			parsed.provider_failure_diagnostics.category.trim()
+				? parsed.provider_failure_diagnostics.category.trim()
+				: undefined,
+		providerFailureProvider:
+			typeof parsed.provider_failure_diagnostics?.provider === "string" &&
+			parsed.provider_failure_diagnostics.provider.trim()
+				? parsed.provider_failure_diagnostics.provider.trim()
+				: undefined,
+		failureSample: Array.isArray(parsed.failure_sample)
+			? parsed.failure_sample.map(normalizeFailureSampleEntry)
+			: undefined,
 	};
 }

--- a/apps/web/src/lib/gateway/usage/asyncJobFailureDiagnostics.test.ts
+++ b/apps/web/src/lib/gateway/usage/asyncJobFailureDiagnostics.test.ts
@@ -1,0 +1,178 @@
+import { parseAsyncJobFailureDiagnostics } from "./asyncJobFailureDiagnostics";
+
+describe("parseAsyncJobFailureDiagnostics", () => {
+	test("parses direct async job failure diagnostics fields", () => {
+		const parsed = parseAsyncJobFailureDiagnostics({
+			upstreamError: {
+				code: "PERMISSION_DENIED",
+				message: "The caller does not have permission.",
+				description: "Project is not allowed to access this model.",
+				param: "model",
+				status: 403,
+			},
+			providerFailureDiagnostics: {
+				category: "provider_access_missing",
+				provider: "x-ai",
+				hint: "Enable the model for this project.",
+			},
+			failureSample: [
+				{
+					provider: "x-ai",
+					type: "upstream_non_2xx",
+					status: 403,
+					retryable: false,
+					upstream_error_code: "PERMISSION_DENIED",
+					upstream_error_message: "The caller does not have permission.",
+					upstream_error_description:
+						"Project is not allowed to access this model.",
+					upstream_error_param: "model",
+				},
+			],
+			routingDiagnostics: {
+				providerCountBefore: 3,
+				providerCountAfter: 1,
+			},
+			providerEnablement: {
+				capability: "video.generation",
+				providersBefore: 3,
+				providersAfter: 1,
+			},
+			providerCandidateDiagnostics: {
+				totalProviders: 3,
+				candidateCount: 1,
+			},
+		});
+
+		expect(parsed).toEqual({
+			job_upstream_error: {
+				code: "PERMISSION_DENIED",
+				type: null,
+				message: "The caller does not have permission.",
+				description: "Project is not allowed to access this model.",
+				param: "model",
+				status: 403,
+			},
+			job_provider_failure_diagnostics: {
+				category: "provider_access_missing",
+				provider: "x-ai",
+				hint: "Enable the model for this project.",
+			},
+			job_failure_sample: [
+				{
+					provider: "x-ai",
+					type: "upstream_non_2xx",
+					status: 403,
+					retryable: false,
+					upstream_error_code: "PERMISSION_DENIED",
+					upstream_error_message: "The caller does not have permission.",
+					upstream_error_description:
+						"Project is not allowed to access this model.",
+					upstream_error_param: "model",
+				},
+			],
+			job_routing_diagnostics: {
+				providerCountBefore: 3,
+				providerCountAfter: 1,
+			},
+			job_provider_enablement: {
+				capability: "video.generation",
+				providersBefore: 3,
+				providersAfter: 1,
+			},
+			job_provider_candidate_diagnostics: {
+				totalProviders: 3,
+				candidateCount: 1,
+			},
+		});
+	});
+
+	test("falls back to nested meta.error diagnostics when direct fields are absent", () => {
+		const parsed = parseAsyncJobFailureDiagnostics({
+			error: {
+				upstream_error: {
+					code: "rate_limit_exceeded",
+					message: "Rate limit exceeded.",
+					description: "Reduce request volume and retry later.",
+					status: "429",
+				},
+				provider_failure_diagnostics: {
+					category: "provider_rate_limited",
+					provider: "openai",
+					hint: "Retry later or reduce concurrency.",
+				},
+				failure_sample: [
+					{
+						provider: "openai",
+						type: "upstream_non_2xx",
+						status: 429,
+						retryable: "true",
+						upstream_error_code: "rate_limit_exceeded",
+						upstream_error_message: "Rate limit exceeded.",
+					},
+				],
+				routing_diagnostics: {
+					filterStages: [
+						{
+							stage: "provider_status_gate",
+							beforeCount: 2,
+							afterCount: 1,
+						},
+					],
+				},
+				provider_enablement: {
+					capability: "responses.create",
+					providersBefore: 2,
+					providersAfter: 1,
+				},
+				provider_candidate_diagnostics: {
+					totalProviders: 2,
+					candidateCount: 1,
+				},
+			},
+		});
+
+		expect(parsed.job_upstream_error).toEqual({
+			code: "rate_limit_exceeded",
+			type: null,
+			message: "Rate limit exceeded.",
+			description: "Reduce request volume and retry later.",
+			param: null,
+			status: 429,
+		});
+		expect(parsed.job_provider_failure_diagnostics).toEqual({
+			category: "provider_rate_limited",
+			provider: "openai",
+			hint: "Retry later or reduce concurrency.",
+		});
+		expect(parsed.job_failure_sample).toEqual([
+			{
+				provider: "openai",
+				type: "upstream_non_2xx",
+				status: 429,
+				retryable: true,
+				upstream_error_code: "rate_limit_exceeded",
+				upstream_error_message: "Rate limit exceeded.",
+				upstream_error_description: null,
+				upstream_error_param: null,
+			},
+		]);
+		expect(parsed.job_routing_diagnostics).toEqual({
+			filterStages: [
+				{
+					stage: "provider_status_gate",
+					beforeCount: 2,
+					afterCount: 1,
+				},
+			],
+		});
+		expect(parsed.job_provider_enablement).toEqual({
+			capability: "responses.create",
+			providersBefore: 2,
+			providersAfter: 1,
+		});
+		expect(parsed.job_provider_candidate_diagnostics).toEqual({
+			totalProviders: 2,
+			candidateCount: 1,
+		});
+	});
+});

--- a/apps/web/src/lib/gateway/usage/asyncJobFailureDiagnostics.ts
+++ b/apps/web/src/lib/gateway/usage/asyncJobFailureDiagnostics.ts
@@ -1,0 +1,152 @@
+type AsyncJobFailureDiagnosticsRoot = Record<string, unknown> | null | undefined;
+
+export interface AsyncJobUpstreamErrorRow {
+	code: string | null;
+	type: string | null;
+	message: string | null;
+	description: string | null;
+	param: string | null;
+	status: number | null;
+}
+
+export interface AsyncJobProviderFailureDiagnosticsRow {
+	category: string | null;
+	provider: string | null;
+	hint: string | null;
+}
+
+export interface AsyncJobFailureSampleRow {
+	provider: string | null;
+	type: string | null;
+	status: number | null;
+	retryable: boolean | null;
+	upstream_error_code: string | null;
+	upstream_error_message: string | null;
+	upstream_error_description: string | null;
+	upstream_error_param: string | null;
+}
+
+export interface AsyncJobFailureDiagnostics {
+	job_upstream_error: AsyncJobUpstreamErrorRow | null;
+	job_provider_failure_diagnostics: AsyncJobProviderFailureDiagnosticsRow | null;
+	job_failure_sample: AsyncJobFailureSampleRow[];
+	job_routing_diagnostics: Record<string, unknown> | null;
+	job_provider_enablement: Record<string, unknown> | null;
+	job_provider_candidate_diagnostics: Record<string, unknown> | null;
+}
+
+function normalizeText(value: unknown): string | null {
+	if (typeof value !== "string") return null;
+	const trimmed = value.trim();
+	return trimmed.length > 0 ? trimmed : null;
+}
+
+function normalizeFiniteNumber(value: unknown): number | null {
+	if (typeof value === "number" && Number.isFinite(value)) return value;
+	if (typeof value === "string" && value.trim()) {
+		const parsed = Number(value.trim());
+		if (Number.isFinite(parsed)) return parsed;
+	}
+	return null;
+}
+
+function normalizeBoolean(value: unknown): boolean | null {
+	if (typeof value === "boolean") return value;
+	if (typeof value === "string") {
+		const normalized = value.trim().toLowerCase();
+		if (["1", "true", "yes", "on"].includes(normalized)) return true;
+		if (["0", "false", "no", "off"].includes(normalized)) return false;
+	}
+	if (typeof value === "number") {
+		if (value === 1) return true;
+		if (value === 0) return false;
+	}
+	return null;
+}
+
+function normalizeRecord(value: unknown): Record<string, unknown> | null {
+	if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+	return value as Record<string, unknown>;
+}
+
+function parseAsyncJobUpstreamError(value: unknown): AsyncJobUpstreamErrorRow | null {
+	const record = normalizeRecord(value);
+	if (!record) return null;
+	const normalized: AsyncJobUpstreamErrorRow = {
+		code: normalizeText(record.code),
+		type: normalizeText(record.type),
+		message: normalizeText(record.message),
+		description: normalizeText(record.description),
+		param: normalizeText(record.param),
+		status: normalizeFiniteNumber(record.status),
+	};
+	return Object.values(normalized).every((entry) => entry == null) ? null : normalized;
+}
+
+function parseAsyncJobProviderFailureDiagnostics(
+	value: unknown,
+): AsyncJobProviderFailureDiagnosticsRow | null {
+	const record = normalizeRecord(value);
+	if (!record) return null;
+	const normalized: AsyncJobProviderFailureDiagnosticsRow = {
+		category: normalizeText(record.category),
+		provider: normalizeText(record.provider),
+		hint: normalizeText(record.hint),
+	};
+	return Object.values(normalized).every((entry) => entry == null) ? null : normalized;
+}
+
+function parseAsyncJobFailureSample(value: unknown): AsyncJobFailureSampleRow[] {
+	if (!Array.isArray(value)) return [];
+	return value
+		.map((entry) => {
+			const record = normalizeRecord(entry);
+			if (!record) return null;
+			const normalized: AsyncJobFailureSampleRow = {
+				provider: normalizeText(record.provider),
+				type: normalizeText(record.type),
+				status: normalizeFiniteNumber(record.status),
+				retryable: normalizeBoolean(record.retryable),
+				upstream_error_code: normalizeText(record.upstream_error_code),
+				upstream_error_message: normalizeText(record.upstream_error_message),
+				upstream_error_description: normalizeText(record.upstream_error_description),
+				upstream_error_param: normalizeText(record.upstream_error_param),
+			};
+			return Object.values(normalized).every((field) => field == null) ? null : normalized;
+		})
+		.filter((entry): entry is AsyncJobFailureSampleRow => Boolean(entry));
+}
+
+export function parseAsyncJobFailureDiagnostics(
+	meta: AsyncJobFailureDiagnosticsRoot,
+): AsyncJobFailureDiagnostics {
+	const errorMeta = normalizeRecord(meta?.error);
+	const directFailureSample = parseAsyncJobFailureSample(
+		meta?.failureSample ?? meta?.failure_sample,
+	);
+	return {
+		job_upstream_error:
+			parseAsyncJobUpstreamError(meta?.upstreamError ?? meta?.upstream_error) ??
+			parseAsyncJobUpstreamError(errorMeta?.upstream_error) ??
+			parseAsyncJobUpstreamError(errorMeta),
+		job_provider_failure_diagnostics:
+			parseAsyncJobProviderFailureDiagnostics(
+				meta?.providerFailureDiagnostics ?? meta?.provider_failure_diagnostics,
+			) ??
+			parseAsyncJobProviderFailureDiagnostics(errorMeta?.provider_failure_diagnostics),
+		job_failure_sample:
+			directFailureSample.length > 0
+				? directFailureSample
+				: parseAsyncJobFailureSample(errorMeta?.failure_sample),
+		job_routing_diagnostics:
+			normalizeRecord(meta?.routingDiagnostics ?? meta?.routing_diagnostics) ??
+			normalizeRecord(errorMeta?.routing_diagnostics),
+		job_provider_enablement:
+			normalizeRecord(meta?.providerEnablement ?? meta?.provider_enablement) ??
+			normalizeRecord(errorMeta?.provider_enablement),
+		job_provider_candidate_diagnostics:
+			normalizeRecord(
+				meta?.providerCandidateDiagnostics ?? meta?.provider_candidate_diagnostics,
+			) ?? normalizeRecord(errorMeta?.provider_candidate_diagnostics),
+	};
+}

--- a/apps/web/src/lib/gateway/usage/asyncJobFailureSummary.test.ts
+++ b/apps/web/src/lib/gateway/usage/asyncJobFailureSummary.test.ts
@@ -1,0 +1,33 @@
+import { formatAsyncJobFailureSummary } from "./asyncJobFailureSummary";
+
+describe("formatAsyncJobFailureSummary", () => {
+	test("prefers category and provider when present", () => {
+		expect(
+			formatAsyncJobFailureSummary({
+				job_failure_category: "provider_access_missing",
+				job_failure_provider: "x-ai",
+				job_failure_hint: "Enable the model for this project.",
+			}),
+		).toBe("provider_access_missing · x-ai");
+	});
+
+	test("falls back to the hint when structured category/provider are absent", () => {
+		expect(
+			formatAsyncJobFailureSummary({
+				job_failure_category: null,
+				job_failure_provider: null,
+				job_failure_hint: "Retry later or reduce concurrency.",
+			}),
+		).toBe("Retry later or reduce concurrency.");
+	});
+
+	test("returns null when no compact summary fields are present", () => {
+		expect(
+			formatAsyncJobFailureSummary({
+				job_failure_category: null,
+				job_failure_provider: null,
+				job_failure_hint: null,
+			}),
+		).toBeNull();
+	});
+});

--- a/apps/web/src/lib/gateway/usage/asyncJobFailureSummary.ts
+++ b/apps/web/src/lib/gateway/usage/asyncJobFailureSummary.ts
@@ -1,0 +1,16 @@
+export interface AsyncJobFailureSummarySource {
+	job_failure_category: string | null;
+	job_failure_provider: string | null;
+	job_failure_hint: string | null;
+}
+
+export function formatAsyncJobFailureSummary(
+	job: AsyncJobFailureSummarySource,
+): string | null {
+	const parts = [
+		job.job_failure_category?.trim() || null,
+		job.job_failure_provider?.trim() || null,
+	].filter(Boolean);
+	if (parts.length > 0) return parts.join(" · ");
+	return job.job_failure_hint?.trim() || null;
+}

--- a/apps/web/src/lib/gateway/usage/errorListSummary.test.ts
+++ b/apps/web/src/lib/gateway/usage/errorListSummary.test.ts
@@ -1,0 +1,79 @@
+import { formatErrorListSummary } from "./errorListSummary";
+
+describe("formatErrorListSummary", () => {
+	test("prefers structured provider failure diagnostics", () => {
+		expect(
+			formatErrorListSummary({
+				provider: "x-ai",
+				error_code: "upstream_error",
+				error_message: JSON.stringify({
+					error: "upstream_error",
+					provider_failure_diagnostics: {
+						category: "provider_access_missing",
+						provider: "x-ai",
+						hint: "Enable the model for this project.",
+					},
+				}),
+			}),
+		).toBe("provider_access_missing · x-ai");
+	});
+
+	test("falls back to structured reason when provider failure diagnostics are absent", () => {
+		expect(
+			formatErrorListSummary({
+				provider: "openai",
+				error_code: "upstream_error",
+				error_message: JSON.stringify({
+					error: "upstream_error",
+					reason: "all_candidates_failed",
+				}),
+			}),
+		).toBe("all_candidates_failed");
+	});
+
+	test("prefers structured error_payload over plain error_message text", () => {
+		expect(
+			formatErrorListSummary({
+				provider: "openai",
+				error_code: "upstream_error",
+				error_message: "plain text error",
+				error_payload: {
+					error: "upstream_error",
+					provider_failure_diagnostics: {
+						category: "provider_access_missing",
+						provider: "openai",
+					},
+				},
+			}),
+		).toBe("provider_access_missing · openai");
+	});
+
+	test("falls back to provider attempt diagnostics when error_message is plain text", () => {
+		expect(
+			formatErrorListSummary({
+				provider: "google-ai-studio",
+				error_code: "upstream_error",
+				error_message: "plain text error",
+				provider_attempts: [
+					{
+						provider: "google-ai-studio",
+						outcome: "error",
+						status: 403,
+						upstream_error_code: "PERMISSION_DENIED",
+						upstream_error_message: "The caller does not have permission.",
+					},
+				],
+			}),
+		).toBe("PERMISSION_DENIED · google-ai-studio");
+	});
+
+	test("falls back to error_code and provider when no structured data is available", () => {
+		expect(
+			formatErrorListSummary({
+				provider: "anthropic",
+				error_code: "rate_limit_exceeded",
+				error_message: "plain text error",
+			}),
+		).toBe("rate_limit_exceeded · anthropic");
+	});
+});

--- a/apps/web/src/lib/gateway/usage/errorListSummary.ts
+++ b/apps/web/src/lib/gateway/usage/errorListSummary.ts
@@ -1,0 +1,88 @@
+import { formatRoomError } from "@/lib/chat/formatRoomError";
+
+export interface ErrorListSummarySource {
+	provider?: string | null;
+	error_code?: string | null;
+	error_message?: string | null;
+	error_payload?: Record<string, unknown> | null;
+	provider_attempts?: Array<{
+		provider?: string | null;
+		outcome?: string | null;
+		status?: number | null;
+		status_text?: string | null;
+		upstream_error_code?: string | null;
+		upstream_error_message?: string | null;
+	}>;
+}
+
+function normalizeNonEmptyString(value: unknown): string | null {
+	if (typeof value !== "string") return null;
+	const trimmed = value.trim();
+	return trimmed.length > 0 ? trimmed : null;
+}
+
+function summarizeProviderAttempts(
+	row: ErrorListSummarySource,
+): string | null {
+	if (!Array.isArray(row.provider_attempts) || row.provider_attempts.length === 0) {
+		return null;
+	}
+
+	const failedAttempt = row.provider_attempts.find((attempt) => {
+		if (!attempt || typeof attempt !== "object") return false;
+		if (normalizeNonEmptyString(attempt.upstream_error_code)) return true;
+		if (typeof attempt.status === "number" && attempt.status >= 400) return true;
+		if (normalizeNonEmptyString(attempt.upstream_error_message)) return true;
+		const outcome = normalizeNonEmptyString(attempt.outcome);
+		return outcome != null && outcome !== "success";
+	});
+
+	if (!failedAttempt) return null;
+
+	const summaryCode =
+		normalizeNonEmptyString(failedAttempt.upstream_error_code) ??
+		(typeof failedAttempt.status === "number" && failedAttempt.status >= 400
+			? `HTTP ${failedAttempt.status}`
+			: null) ??
+		normalizeNonEmptyString(failedAttempt.status_text) ??
+		normalizeNonEmptyString(failedAttempt.outcome) ??
+		normalizeNonEmptyString(failedAttempt.upstream_error_message);
+	const provider =
+		normalizeNonEmptyString(failedAttempt.provider) ??
+		normalizeNonEmptyString(row.provider);
+	const parts = [summaryCode, provider].filter(Boolean);
+	return parts.length > 0 ? parts.join(" · ") : null;
+}
+
+export function formatErrorListSummary(
+	row: ErrorListSummarySource,
+): string | null {
+	const raw = row.error_payload
+		? JSON.stringify(row.error_payload)
+		: row.error_message?.trim();
+	if (raw) {
+		const formatted = formatRoomError(raw);
+		const structuredParts = [
+			formatted.providerFailureCategory?.trim() || null,
+			formatted.providerFailureProvider?.trim() || null,
+		].filter(Boolean);
+		if (structuredParts.length > 0) return structuredParts.join(" · ");
+		if (formatted.reason?.trim()) return formatted.reason.trim();
+		if (formatted.upstreamError?.code?.trim()) {
+			const upstreamParts = [
+				formatted.upstreamError.code.trim(),
+				row.provider?.trim() || null,
+			].filter(Boolean);
+			if (upstreamParts.length > 0) return upstreamParts.join(" · ");
+		}
+	}
+
+	const attemptSummary = summarizeProviderAttempts(row);
+	if (attemptSummary) return attemptSummary;
+
+	const fallbackParts = [
+		row.error_code?.trim() || null,
+		row.provider?.trim() || null,
+	].filter(Boolean);
+	return fallbackParts.length > 0 ? fallbackParts.join(" · ") : null;
+}

--- a/supabase/migrations/20260505000001_add_gateway_requests_error_payload.sql
+++ b/supabase/migrations/20260505000001_add_gateway_requests_error_payload.sql
@@ -1,0 +1,7 @@
+-- Persist structured gateway error payloads for request investigation surfaces.
+
+alter table public.gateway_requests
+  add column if not exists error_payload jsonb;
+
+comment on column public.gateway_requests.error_payload is
+  'Sanitized structured gateway error payload captured for failed requests, used by request/session/job investigation surfaces.';

--- a/supabase/sql.sql
+++ b/supabase/sql.sql
@@ -281,6 +281,7 @@ CREATE TABLE public.gateway_requests (
   success boolean NOT NULL DEFAULT false,
   error_code text,
   error_message text,
+  error_payload jsonb,
   latency_ms integer,
   generation_ms integer,
   usage jsonb NOT NULL DEFAULT '{}'::jsonb,


### PR DESCRIPTION
## Summary

System.Object[]

## Stack Context

- Base branch: `feat/provider-catalog-activation-20260506`
- Head branch: `feat/replay-observability-20260506`
- This PR is part of a stacked review sequence split from a preserved local safety snapshot.
- Local safety snapshot retained separately and not pushed: `backup/20260506-backlog-snapshot` at `ae0631c54`.

## Notes

- Review this PR against its configured base branch, not as an independent branch from `main` unless it targets `main` directly.
- Backlog/status scratch artifacts such as `tasks.md`, `BACKLOG_CHANGELOG.md`, and `INNOVATION_REVIEW_2026-05-05.md` were intentionally excluded from the pushed stack.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added request replay functionality allowing you to re-submit failed requests with captured details.
  * Enhanced error responses with structured diagnostics including provider failure details and routing diagnostics.
  * Introduced experimental Async Jobs WebSocket endpoint for streaming job updates.
  * Improved usage logs with pagination and filtering by model, provider, key, and status.

* **Documentation**
  * Updated API reference with request replay flow guidance.
  * Enhanced error documentation with structured diagnostics schema.
  * Added Async Jobs WebSocket endpoint documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->