### PR TITLE
Improve models page pricing summaries and hover cards

### DIFF
--- a/apps/web/src/app/(dashboard)/models/page.tsx
+++ b/apps/web/src/app/(dashboard)/models/page.tsx
@@ -355,6 +355,10 @@ type GatewaySignals = {
 	lowestFromPrice: number | null;
 	lowestFromPriceUnit: string | null;
 	fromPriceByUnit: Map<string, number>;
+	pricingDetailRows: Array<{
+		label: string;
+		value: string;
+	}>;
 };
 
 function createEmptyGatewaySignals(): GatewaySignals {
@@ -388,6 +392,7 @@ function createEmptyGatewaySignals(): GatewaySignals {
 		lowestFromPrice: null,
 		lowestFromPriceUnit: null,
 		fromPriceByUnit: new Map<string, number>(),
+		pricingDetailRows: [],
 	};
 }
 
@@ -520,6 +525,19 @@ function aggregateGatewaySignals(
 			} else {
 				existing.lowestFromPrice = null;
 				existing.lowestFromPriceUnit = null;
+			}
+		}
+		for (const detailRow of row.provider.pricingDetailRows ?? []) {
+			if (!detailRow?.label || !detailRow?.value) continue;
+			const exists = existing.pricingDetailRows.some(
+				(candidate) =>
+					candidate.label === detailRow.label && candidate.value === detailRow.value,
+			);
+			if (!exists) {
+				existing.pricingDetailRows.push({
+					label: detailRow.label,
+					value: detailRow.value,
+				});
 			}
 		}
 		const apiDateCandidate = String(row.effectiveFrom ?? "").trim();
@@ -804,6 +822,7 @@ function withGatewayMetadata(
 				signals?.lowestStandardOutputPriceUnit ?? null,
 			lowest_from_price: signals?.lowestFromPrice ?? null,
 			lowest_from_price_unit: signals?.lowestFromPriceUnit ?? null,
+			pricing_detail_rows: (signals?.pricingDetailRows ?? []).slice(0, 6),
 			popularity_tokens_week: weeklyMetrics.tokensWeek,
 			throughput_week: weeklyMetrics.throughputWeek,
 			latency_week: weeklyMetrics.latencyWeek,

--- a/apps/web/src/components/(data)/models/Models/ModelCard.tsx
+++ b/apps/web/src/components/(data)/models/Models/ModelCard.tsx
@@ -327,6 +327,36 @@ function formatPriceWithUnit(
 	return `${amount} / ${normalizedUnit}`;
 }
 
+function inferPriceUnitFromModality(modalityKey: string): string | null {
+	if (modalityKey === "image") return "image";
+	if (modalityKey === "video") return "video";
+	if (modalityKey === "audio" || modalityKey === "audio_tts") return "minute";
+	return null;
+}
+
+function summarizePricingValues(values: string[]): string | null {
+	const parsed = values
+		.map((value) => {
+			const match = value.match(/^\$([\d.,]+)(?:-\$?([\d.,]+))?\s+\/\s+(.+)$/);
+			if (!match) return null;
+			const min = Number(match[1]?.replace(/,/g, ""));
+			const max = Number((match[2] ?? match[1])?.replace(/,/g, ""));
+			const unit = match[3]?.trim();
+			if (!Number.isFinite(min) || !Number.isFinite(max) || !unit) return null;
+			return { min, max, unit };
+		})
+		.filter((entry): entry is { min: number; max: number; unit: string } => Boolean(entry));
+	if (parsed.length === 0) return null;
+	const unit = parsed[0]?.unit ?? null;
+	if (!unit || parsed.some((entry) => entry.unit !== unit)) return null;
+	const min = Math.min(...parsed.map((entry) => entry.min));
+	const max = Math.max(...parsed.map((entry) => entry.max));
+	const minText = formatPrice(min, { allowZero: true });
+	const maxText = formatPrice(max, { allowZero: true });
+	if (!minText || !maxText) return null;
+	return min === max ? `${minText} / ${unit}` : `${minText}-${maxText} / ${unit}`;
+}
+
 function getModalityIcon(value: string): LucideIcon {
 	const normalized = value.toLowerCase().replace(/[._/-]+/g, " ");
 	if (normalized.includes("embed")) return Binary;
@@ -475,23 +505,34 @@ function ModelCardImpl({
 	const standardOutputPrice = formatPrice(model.lowest_standard_output_price, {
 		allowZero: true,
 	});
-	const ioPriceSummary =
-		inputPrice && outputPrice
-			? `${inputPrice} / ${outputPrice}`
-			: inputPrice
-				? inputPrice
-				: outputPrice
-					? outputPrice
+	const primaryInputKey = inputModalities[0]
+		? normalizeModalityOrderKey(String(inputModalities[0]))
+		: "";
+	const primaryOutputKey = outputModalities[0]
+		? normalizeModalityOrderKey(String(outputModalities[0]))
+		: "";
+	const outputUsesCheapestTierPrefix =
+		primaryOutputKey === "image" || primaryOutputKey === "video";
+	const formatStructuredPriceSummary = (
+		input: string | null,
+		output: string | null,
+	) => {
+		const formattedOutput =
+			output && outputUsesCheapestTierPrefix ? `${output}+` : output;
+		return input && formattedOutput
+			? `${input} / ${formattedOutput}`
+			: input
+				? input
+				: formattedOutput
+					? formattedOutput
 					: null;
-	const standardIoPriceSummary =
-		standardInputPrice && standardOutputPrice
-			? `${standardInputPrice} / ${standardOutputPrice}`
-			: standardInputPrice
-				? standardInputPrice
-				: standardOutputPrice
-					? standardOutputPrice
-					: null;
-	const textPriceSummary = standardIoPriceSummary ?? ioPriceSummary;
+	};
+	const ioPriceSummary = formatStructuredPriceSummary(inputPrice, outputPrice);
+	const standardIoPriceSummary = formatStructuredPriceSummary(
+		standardInputPrice,
+		standardOutputPrice,
+	);
+	const structuredPriceSummary = standardIoPriceSummary ?? ioPriceSummary;
 	const explicitFromPrice = formatFromPrice(
 		model.lowest_from_price,
 		model.lowest_from_price_unit,
@@ -541,33 +582,153 @@ function ModelCardImpl({
 	const priceSummary =
 		isFreeDisplayModel
 			? "Free"
-			: isTextModel && textPriceSummary
-				? textPriceSummary
+			: structuredPriceSummary
+				? structuredPriceSummary
 				: fromPriceSummary;
-	const priceLabel = isTextModel ? "Pricing" : "From:";
-	const pricingDetailRows = isTextModel
-		? [
+	const priceLabel = structuredPriceSummary || isTextModel ? "Pricing" : "From:";
+	const fallbackInputLabel =
+		primaryInputKey === "image"
+			? "Image Inputs"
+			: primaryInputKey === "audio"
+				? "Audio Input"
+				: primaryInputKey === "video"
+					? "Video Input"
+					: "Input";
+	const fallbackOutputLabel =
+		primaryOutputKey === "image"
+			? "Output Images (from)"
+			: primaryOutputKey === "audio"
+				? "Audio Output"
+				: primaryOutputKey === "video"
+					? "Video Output (from)"
+					: "Output";
+	const fallbackInputUnit =
+		normalizeFromPriceUnit(model.lowest_from_price_unit) ??
+		inferPriceUnitFromModality(primaryInputKey);
+	const fallbackOutputUnit =
+		(primaryOutputKey === primaryInputKey
+			? normalizeFromPriceUnit(model.lowest_from_price_unit)
+			: null) ?? inferPriceUnitFromModality(primaryOutputKey);
+	const explicitPricingDetailRows = (model.pricing_detail_rows ?? []).filter(
+		(row) =>
+			Boolean(String(row?.label ?? "").trim()) &&
+			Boolean(String(row?.value ?? "").trim()),
+	);
+	const standardPricingRows = [
+		{
+			id: "input",
+			label: String(model.lowest_standard_input_price_label ?? "").trim() || "Input",
+			value: formatPriceWithUnit(
+				model.lowest_standard_input_price,
+				model.lowest_standard_input_price_unit,
+			),
+		},
+		{
+			id: "output",
+			label:
+				String(model.lowest_standard_output_price_label ?? "").trim() || "Output",
+			value: formatPriceWithUnit(
+				model.lowest_standard_output_price,
+				model.lowest_standard_output_price_unit,
+			),
+		},
+	].filter((row) => Boolean(row.value));
+	const fallbackPricingRows = [
+		{
+			id: "input",
+			label: fallbackInputLabel,
+			value: formatFromPrice(
+				model.lowest_input_price,
+				fallbackInputUnit,
+				{ allowZero: true },
+			),
+		},
+		{
+			id: "output",
+			label: fallbackOutputLabel,
+			value: formatPriceWithUnit(
+				model.lowest_output_price,
+				fallbackOutputUnit,
+			),
+		},
+	].filter((row) => Boolean(row.value));
+	const pricingRowById = new Map<
+		string,
+		{ id: string; label: string; value: string | null }
+	>();
+	for (const row of fallbackPricingRows) pricingRowById.set(row.id, row);
+	for (const row of standardPricingRows) pricingRowById.set(row.id, row);
+	let pricingDetailRows =
+		explicitPricingDetailRows.length > 0
+			? explicitPricingDetailRows.map((row, index) => ({
+					id: `explicit-${index}`,
+					label: row.label,
+					value: row.value,
+				}))
+			: ["input", "output"]
+					.map((id) => pricingRowById.get(id))
+					.filter((row): row is { id: string; label: string; value: string } =>
+						Boolean(row?.value),
+					);
+	if (pricingDetailRows.length === 0 && priceSummary) {
+		pricingDetailRows = [
+			{
+				id: "summary",
+				label: "Pricing",
+				value: priceSummary,
+			},
+		];
+	}
+	const pricingDetailGroups = pricingDetailRows.reduce<
+		Array<{
+			id: string;
+			baseLabel: string;
+			items: Array<{ id: string; label: string; value: string; variant: string | null }>;
+		}>
+	>((groups, row) => {
+		const match = row.label.match(/^(.*?)(?: \((.+)\))?$/);
+		const baseLabel = match?.[1]?.trim() || row.label;
+		const variant = match?.[2]?.trim() || null;
+		const existingGroup = groups.find((group) => group.baseLabel === baseLabel);
+		if (existingGroup) {
+			existingGroup.items.push({
+				id: row.id,
+				label: row.label,
+				value: row.value,
+				variant,
+			});
+			return groups;
+		}
+		groups.push({
+			id: row.id,
+			baseLabel,
+			items: [
 				{
-					id: "input",
-					label:
-						String(model.lowest_standard_input_price_label ?? "").trim() || "Input",
-					value: formatPriceWithUnit(
-						model.lowest_standard_input_price,
-						model.lowest_standard_input_price_unit,
-					),
+					id: row.id,
+					label: row.label,
+					value: row.value,
+					variant,
 				},
-				{
-					id: "output",
-					label:
-						String(model.lowest_standard_output_price_label ?? "").trim() ||
-						"Output",
-					value: formatPriceWithUnit(
-						model.lowest_standard_output_price,
-						model.lowest_standard_output_price_unit,
-					),
-				},
-			].filter((row) => Boolean(row.value))
-		: [];
+			],
+		});
+		return groups;
+	}, []);
+	const getVideoAudioGroup = (variant: string | null) => {
+		if (!variant) return { heading: null, detail: null as string | null };
+		if (variant.endsWith(", with audio")) {
+			return {
+				heading: "With audio",
+				detail: variant.slice(0, -", with audio".length) || null,
+			};
+		}
+		if (variant.endsWith(", no audio")) {
+			return {
+				heading: "No audio",
+				detail: variant.slice(0, -", no audio".length) || null,
+			};
+		}
+		return { heading: null, detail: variant };
+	};
 	const formatModalities = (values: string[]) => {
 		const unique = sortModalitiesForDisplay(Array.from(
 			new Set(values.map((value) => String(value ?? "").trim()).filter(Boolean)),
@@ -797,7 +958,7 @@ function ModelCardImpl({
 							</div>
 						) : null}
 						{priceSummary ? (
-							isTextModel && pricingDetailRows.length > 0 ? (
+							pricingDetailRows.length > 0 ? (
 								<HoverCard openDelay={120} closeDelay={100}>
 									<HoverCardTrigger asChild>
 										<button
@@ -811,16 +972,133 @@ function ModelCardImpl({
 											</span>
 										</button>
 									</HoverCardTrigger>
-									<HoverCardContent align="start" className="w-52 p-3">
+									<HoverCardContent
+										align="start"
+										className="w-fit min-w-[13rem] max-w-[22rem] p-3"
+									>
 										<div className="space-y-2">
-											{pricingDetailRows.map((row) => (
-												<div key={row.id} className="space-y-0.5 text-xs">
-													<div className="font-semibold text-foreground">
-														{row.label}
+											{pricingDetailGroups.map((group) => {
+												const shouldGroupVariants =
+													group.items.length > 1 &&
+													group.items.every((item) => Boolean(item.variant));
+												if (!shouldGroupVariants) {
+													return group.items.map((item) => (
+														<div key={item.id} className="space-y-0.5 text-xs">
+															<div className="font-semibold text-foreground">
+																{item.label}
+															</div>
+															<div className="text-muted-foreground">{item.value}</div>
+														</div>
+													));
+												}
+												if (group.baseLabel === "Image Output" && group.items.length >= 3) {
+													const summarizedValue = summarizePricingValues(
+														group.items.map((item) => item.value),
+													);
+													if (summarizedValue) {
+														return (
+															<div key={group.id} className="space-y-0.5 text-xs">
+																<div className="font-semibold text-foreground">
+																	{group.baseLabel}
+																</div>
+																<div className="text-muted-foreground">
+																	{summarizedValue}
+																</div>
+															</div>
+														);
+													}
+												}
+												if (group.baseLabel === "Video Output") {
+													const audioGroups = group.items.reduce<
+														Array<{
+															id: string;
+															heading: string | null;
+															items: Array<{ id: string; detail: string | null; value: string }>;
+														}>
+													>((acc, item) => {
+														const parsed = getVideoAudioGroup(item.variant);
+														const key = parsed.heading ?? "__default__";
+														const existing = acc.find(
+															(candidate) => (candidate.heading ?? "__default__") === key,
+														);
+														if (existing) {
+															existing.items.push({
+																id: item.id,
+																detail: parsed.detail,
+																value: item.value,
+															});
+															return acc;
+														}
+														acc.push({
+															id: item.id,
+															heading: parsed.heading,
+															items: [
+																{
+																	id: item.id,
+																	detail: parsed.detail,
+																	value: item.value,
+																},
+															],
+														});
+														return acc;
+													}, []);
+													return (
+														<div key={group.id} className="space-y-1.5 text-xs">
+															<div className="font-semibold text-foreground">
+																{group.baseLabel}
+															</div>
+															<div className="space-y-1.5">
+																{audioGroups.map((audioGroup) => (
+																	<div key={audioGroup.id} className="space-y-1">
+																		{audioGroup.heading ? (
+																			<div className="text-[11px] font-medium text-foreground/80">
+																				{audioGroup.heading}
+																			</div>
+																		) : null}
+																		<div className="space-y-1">
+																			{audioGroup.items.map((item) => (
+																				<div
+																					key={item.id}
+																					className="flex items-baseline justify-between gap-3"
+																				>
+																					<div className="text-muted-foreground">
+																						{item.detail ?? "Standard"}
+																					</div>
+																					<div className="shrink-0 text-muted-foreground">
+																						{item.value}
+																					</div>
+																				</div>
+																			))}
+																		</div>
+																	</div>
+																))}
+															</div>
+														</div>
+													);
+												}
+												return (
+													<div key={group.id} className="space-y-1 text-xs">
+														<div className="font-semibold text-foreground">
+															{group.baseLabel}
+														</div>
+														<div className="space-y-1">
+															{group.items.map((item) => (
+																<div
+																	key={item.id}
+																	className="flex items-baseline justify-between gap-3"
+																>
+																	<div className="text-muted-foreground">
+																		{item.variant}
+																	</div>
+																	<div className="shrink-0 text-muted-foreground">
+																		{item.value}
+																	</div>
+																</div>
+															))}
+														</div>
 													</div>
-													<div className="text-muted-foreground">{row.value}</div>
-												</div>
-											))}
+												);
+											})}
 										</div>
 									</HoverCardContent>
 								</HoverCard>

--- a/apps/web/src/components/(data)/models/Models/ModelCard.tsx
+++ b/apps/web/src/components/(data)/models/Models/ModelCard.tsx
@@ -637,10 +637,9 @@ function ModelCardImpl({
 		{
 			id: "input",
 			label: fallbackInputLabel,
-			value: formatFromPrice(
+			value: formatPriceWithUnit(
 				model.lowest_input_price,
 				fallbackInputUnit,
-				{ allowZero: true },
 			),
 		},
 		{

--- a/apps/web/src/components/(data)/models/Models/modelsDisplay.types.ts
+++ b/apps/web/src/components/(data)/models/Models/modelsDisplay.types.ts
@@ -53,6 +53,7 @@ export type ModelsPageModel = Omit<
 	| "lowest_standard_output_price_unit"
 	| "lowest_from_price"
 	| "lowest_from_price_unit"
+	| "pricing_detail_rows"
 	| "popularity_tokens_week"
 	| "throughput_week"
 	| "latency_week"

--- a/apps/web/src/lib/fetchers/models/getAllModels.ts
+++ b/apps/web/src/lib/fetchers/models/getAllModels.ts
@@ -52,6 +52,10 @@ export interface ModelCard {
     lowest_standard_output_price_unit?: string | null;
     lowest_from_price?: number | null;
     lowest_from_price_unit?: string | null;
+    pricing_detail_rows?: Array<{
+        label: string;
+        value: string;
+    }>;
     popularity_tokens_week?: number | null;
     throughput_week?: number | null;
     latency_week?: number | null;

--- a/apps/web/src/lib/fetchers/models/table-view/getMonitorModels.ts
+++ b/apps/web/src/lib/fetchers/models/table-view/getMonitorModels.ts
@@ -73,6 +73,7 @@ type MonitorModelRpcRow = {
 };
 
 const MONITOR_RPC_PAGE_SIZE = 1000;
+const PRICING_RULE_PAGE_SIZE = 1000;
 
 type PricingRuleSupplementRow = {
 	model_key: string | null;
@@ -220,7 +221,7 @@ function formatPriceAmount(value: number): string {
 	if (!Number.isFinite(value) || value < 0) return "$0";
 	if (value === 0) return "$0";
 	if (value < 0.001) return `$${value.toFixed(4)}`;
-	if (value < 0.1) return `$${value.toFixed(3)}`;
+	if (value < 0.01) return `$${value.toFixed(3)}`;
 	if (value < 1) return `$${value.toFixed(2)}`;
 	return `$${value.toLocaleString(undefined, { maximumFractionDigits: 2 })}`;
 }
@@ -380,14 +381,22 @@ async function fetchPricingSupplements(
 	const pricingRows: PricingRuleSupplementRow[] = [];
 	for (let index = 0; index < modelKeys.length; index += 200) {
 		const chunk = modelKeys.slice(index, index + 200);
-		const { data, error } = await supabase
-			.from("data_api_pricing_rules")
-			.select(
-				"model_key, pricing_plan, meter, unit, unit_size, price_per_unit, effective_from, effective_to, match",
-			)
-			.in("model_key", chunk);
-		if (error) throw error;
-		pricingRows.push(...((data ?? []) as PricingRuleSupplementRow[]));
+		for (let from = 0; ; from += PRICING_RULE_PAGE_SIZE) {
+			const to = from + PRICING_RULE_PAGE_SIZE - 1;
+			const { data, error } = await supabase
+				.from("data_api_pricing_rules")
+				.select(
+					"model_key, pricing_plan, meter, unit, unit_size, price_per_unit, effective_from, effective_to, match",
+				)
+				.in("model_key", chunk)
+				.range(from, to);
+			if (error) throw error;
+			const page = (data ?? []) as PricingRuleSupplementRow[];
+			pricingRows.push(...page);
+			if (page.length < PRICING_RULE_PAGE_SIZE) {
+				break;
+			}
+		}
 	}
 
 	const nowMs = Date.now();
@@ -592,6 +601,18 @@ export async function getMonitorModels(
 	allFeatures: string[];
 	allStatuses: string[];
 }> {
+	"use cache";
+
+	cacheLife("minutes");
+	cacheTag("models:monitor");
+	cacheTag("monitor-models");
+	cacheTag("data:data_api_model_aliases");
+	cacheTag("data:data_api_provider_model_capabilities");
+	cacheTag("data:data_api_provider_models");
+	cacheTag("data:data_api_pricing_rules");
+	cacheTag("data:models");
+	cacheTag("data:api_providers");
+
 	const rpcRows = await fetchAllMonitorModelRows(includeHidden);
 	const pricingSupplements = await fetchPricingSupplements(rpcRows);
 

--- a/apps/web/src/lib/fetchers/models/table-view/getMonitorModels.ts
+++ b/apps/web/src/lib/fetchers/models/table-view/getMonitorModels.ts
@@ -590,7 +590,7 @@ async function fetchPricingSupplements(
 	return result;
 }
 
-export async function getMonitorModels(
+async function getMonitorModelsCached(
 	filters: MonitorModelFilters = {},
 	includeHidden: boolean
 ): Promise<{
@@ -999,5 +999,19 @@ export async function getMonitorModels(
 		allFeatures,
 		allStatuses,
 	};
+}
+
+export async function getMonitorModels(
+	filters: MonitorModelFilters = {},
+	includeHidden: boolean,
+): Promise<{
+	models: MonitorModelData[];
+	allTiers: string[];
+	allEndpoints: string[];
+	allModalities: string[];
+	allFeatures: string[];
+	allStatuses: string[];
+}> {
+	return getMonitorModelsCached(filters, includeHidden);
 }
 

--- a/apps/web/src/lib/fetchers/models/table-view/getMonitorModels.ts
+++ b/apps/web/src/lib/fetchers/models/table-view/getMonitorModels.ts
@@ -74,6 +74,33 @@ type MonitorModelRpcRow = {
 
 const MONITOR_RPC_PAGE_SIZE = 1000;
 
+type PricingRuleSupplementRow = {
+	model_key: string | null;
+	pricing_plan: string | null;
+	meter: string | null;
+	unit: string | null;
+	unit_size: number | null;
+	price_per_unit: number | null;
+	effective_from: string | null;
+	effective_to: string | null;
+	match: unknown;
+};
+
+type PricingSupplement = {
+	standardInputPrice: number | null;
+	standardOutputPrice: number | null;
+	standardInputPriceLabel: string | null;
+	standardInputPriceUnit: string | null;
+	standardOutputPriceLabel: string | null;
+	standardOutputPriceUnit: string | null;
+	fromPrice: number | null;
+	fromPriceUnit: string | null;
+	pricingDetailRows: Array<{
+		label: string;
+		value: string;
+	}>;
+};
+
 async function fetchAllMonitorModelRows(
 	includeHidden: boolean,
 ): Promise<MonitorModelRpcRow[]> {
@@ -103,6 +130,457 @@ async function fetchAllMonitorModelRows(
 	return rows;
 }
 
+function isRuleActive(
+	effectiveFrom: string | null | undefined,
+	effectiveTo: string | null | undefined,
+	nowMs: number,
+): boolean {
+	const fromMs = effectiveFrom ? new Date(effectiveFrom).getTime() : null;
+	const toMs = effectiveTo ? new Date(effectiveTo).getTime() : null;
+	if (fromMs !== null && Number.isFinite(fromMs) && fromMs > nowMs) return false;
+	if (toMs !== null && Number.isFinite(toMs) && nowMs >= toMs) return false;
+	return true;
+}
+
+function normalizeDisplayUnit(unit: string | null | undefined): string | null {
+	const normalized = String(unit ?? "")
+		.trim()
+		.toLowerCase();
+	if (!normalized) return null;
+	if (["token", "tokens"].includes(normalized)) return "1M tokens";
+	if (["minute", "minutes", "min", "mins", "m"].includes(normalized)) return "second";
+	if (["hour", "hours", "hr", "hrs", "h"].includes(normalized)) return "second";
+	if (["second", "seconds", "sec", "secs", "s"].includes(normalized)) return "second";
+	if (["image", "images"].includes(normalized)) return "image";
+	if (["video", "videos"].includes(normalized)) return "video";
+	if (["character", "characters", "char", "chars"].includes(normalized)) {
+		return "character";
+	}
+	return normalized;
+}
+
+function getStandardSideAndLabel(
+	meter: string | null | undefined,
+): { side: "input" | "output" | null; label: string | null } {
+	const normalized = String(meter ?? "")
+		.trim()
+		.toLowerCase();
+	if (["input_text_tokens", "input_tokens"].includes(normalized)) {
+		return { side: "input", label: "Text Input" };
+	}
+	if (["output_text_tokens", "output_tokens"].includes(normalized)) {
+		return { side: "output", label: "Text Output" };
+	}
+	if (["input_audio_tokens", "input_audio"].includes(normalized)) {
+		return { side: "input", label: "Audio Input" };
+	}
+	if (["output_audio_tokens", "output_audio", "output_audio_seconds"].includes(normalized)) {
+		return { side: "output", label: "Audio Output" };
+	}
+	if (["input_image_tokens", "input_image"].includes(normalized)) {
+		return { side: "input", label: "Image Input" };
+	}
+	if (["output_image_tokens", "output_image"].includes(normalized)) {
+		return { side: "output", label: "Image Output" };
+	}
+	if (["input_video_tokens", "input_video"].includes(normalized)) {
+		return { side: "input", label: "Video Input" };
+	}
+	if (["output_video_tokens", "output_video", "output_video_seconds"].includes(normalized)) {
+		return { side: "output", label: "Video Output" };
+	}
+	return { side: null, label: null };
+}
+
+function computeDisplayPrice(rule: PricingRuleSupplementRow): number | null {
+	const unitSize = Number(rule.unit_size ?? 0);
+	const pricePerUnit = Number(rule.price_per_unit ?? Number.NaN);
+	if (!Number.isFinite(pricePerUnit) || !Number.isFinite(unitSize) || unitSize <= 0) {
+		return null;
+	}
+	const meter = String(rule.meter ?? "")
+		.trim()
+		.toLowerCase();
+	const unit = String(rule.unit ?? "")
+		.trim()
+		.toLowerCase();
+	if (meter.includes("token") || ["token", "tokens"].includes(unit)) {
+		return pricePerUnit * (1_000_000 / unitSize);
+	}
+	if (["minute", "minutes", "min", "mins", "m"].includes(unit)) {
+		return pricePerUnit / unitSize / 60;
+	}
+	if (["hour", "hours", "hr", "hrs", "h"].includes(unit)) {
+		return pricePerUnit / unitSize / 3600;
+	}
+	return pricePerUnit / unitSize;
+}
+
+function formatPriceAmount(value: number): string {
+	if (!Number.isFinite(value) || value < 0) return "$0";
+	if (value === 0) return "$0";
+	if (value < 0.001) return `$${value.toFixed(4)}`;
+	if (value < 0.1) return `$${value.toFixed(3)}`;
+	if (value < 1) return `$${value.toFixed(2)}`;
+	return `$${value.toLocaleString(undefined, { maximumFractionDigits: 2 })}`;
+}
+
+function formatDetailValue(price: number, unit: string): string {
+	const amount = formatPriceAmount(price);
+	if (unit === "1M tokens") return `${amount} /M tokens`;
+	return `${amount} / ${unit}`;
+}
+
+function formatDetailValueRange(prices: number[], unit: string): string {
+	const sorted = [...prices]
+		.filter((value) => Number.isFinite(value))
+		.sort((a, b) => a - b);
+	if (sorted.length === 0) return formatDetailValue(0, unit);
+	const min = sorted[0]!;
+	const max = sorted[sorted.length - 1]!;
+	if (min === max) return formatDetailValue(min, unit);
+	const minText = formatPriceAmount(min);
+	const maxText = formatPriceAmount(max);
+	if (unit === "1M tokens") return `${minText}-${maxText} /M tokens`;
+	return `${minText}-${maxText} / ${unit}`;
+}
+
+function toTitleCase(value: string): string {
+	return value.replace(/\b([a-z])([a-z]*)/gi, (_, first: string, rest: string) => {
+		return `${first.toUpperCase()}${rest.toLowerCase()}`;
+	});
+}
+
+function formatMatchValue(value: unknown): string | null {
+	if (Array.isArray(value)) {
+		const parts = value
+			.map((entry) => formatMatchValue(entry))
+			.filter((entry): entry is string => Boolean(entry));
+		return parts.length > 0 ? parts.join("/") : null;
+	}
+	if (typeof value === "boolean") return value ? "with audio" : "no audio";
+	if (typeof value === "number") return Number.isFinite(value) ? `${value}s` : null;
+	if (typeof value === "string") {
+		const normalized = value.trim();
+		return normalized.length > 0 ? normalized : null;
+	}
+	return null;
+}
+
+function formatThresholdTokenCount(value: unknown): string | null {
+	const numeric = Number(value);
+	if (!Number.isFinite(numeric) || numeric <= 0) return null;
+	if (numeric >= 1_000_000) {
+		const scaled = numeric / 1_000_000;
+		return `${scaled % 1 === 0 ? scaled.toFixed(0) : scaled.toFixed(1)}M`;
+	}
+	if (numeric >= 1_000) {
+		const scaled = numeric / 1_000;
+		return `${scaled % 1 === 0 ? scaled.toFixed(0) : scaled.toFixed(1)}K`;
+	}
+	return `${numeric}`;
+}
+
+function getInputTokenTierLabel(match: unknown): string | null {
+	if (!Array.isArray(match)) return null;
+	const inputTokenRule = match.find(
+		(entry) =>
+			entry &&
+			typeof entry === "object" &&
+			"path" in entry &&
+			(entry as { path?: unknown }).path === "input_tokens" &&
+			"op" in entry &&
+			"value" in entry,
+	) as { op?: unknown; value?: unknown } | undefined;
+	if (!inputTokenRule) return null;
+	const threshold = formatThresholdTokenCount(inputTokenRule.value);
+	if (!threshold) return null;
+	const op = String(inputTokenRule.op ?? "").trim().toLowerCase();
+	if (op === "lte" || op === "lt") return `Up to ${threshold} context`;
+	if (op === "gte" || op === "gt") return `Over ${threshold} context`;
+	if (op === "eq") return `${threshold} context`;
+	return null;
+}
+
+function findMatchValue(match: unknown, path: string): string | null {
+	if (!Array.isArray(match)) return null;
+	const entry = match.find(
+		(candidate) =>
+			candidate &&
+			typeof candidate === "object" &&
+			"path" in candidate &&
+			(candidate as { path?: unknown }).path === path &&
+			"value" in candidate,
+	) as { value?: unknown } | undefined;
+	return formatMatchValue(entry?.value);
+}
+
+function getMatchMeta(match: unknown): {
+	quality: string | null;
+	resolution: string | null;
+	videoSeconds: string | null;
+	videoAudio: string | null;
+	inputTokenTier: string | null;
+} {
+	return {
+		quality: findMatchValue(match, "image_params.quality"),
+		resolution:
+			findMatchValue(match, "image_params.resolution") ??
+			findMatchValue(match, "video_params.resolution"),
+		videoSeconds: findMatchValue(match, "video_params.seconds"),
+		videoAudio: findMatchValue(match, "video_params.audio"),
+		inputTokenTier: getInputTokenTierLabel(match),
+	};
+}
+
+function getVariantLabel(matchMeta: {
+	quality: string | null;
+	resolution: string | null;
+	videoSeconds: string | null;
+	videoAudio: string | null;
+	inputTokenTier: string | null;
+}): string | null {
+	const hasVideoMeta = Boolean(matchMeta.videoSeconds || matchMeta.videoAudio);
+	if (hasVideoMeta) {
+		const videoParts = [
+			matchMeta.resolution,
+			matchMeta.videoSeconds,
+			matchMeta.videoAudio,
+		].filter((value): value is string => Boolean(value));
+		if (videoParts.length > 0) return videoParts.join(", ");
+	}
+
+	const imageParts = [matchMeta.quality, matchMeta.resolution].filter(
+		(value): value is string => Boolean(value),
+	);
+	if (imageParts.length > 0) return imageParts.map((part) => toTitleCase(part)).join(", ");
+
+	if (matchMeta.inputTokenTier) return matchMeta.inputTokenTier;
+
+	return null;
+}
+
+async function fetchPricingSupplements(
+	rpcRows: MonitorModelRpcRow[],
+): Promise<Map<string, PricingSupplement>> {
+	const supabase = createAdminClient();
+	const modelKeys = Array.from(
+		new Set(
+			rpcRows
+				.map((row) =>
+					row.provider_id && row.api_model_id && row.capability_id
+						? `${row.provider_id}:${row.api_model_id}:${row.capability_id}`
+						: "",
+				)
+				.filter(Boolean),
+		),
+	);
+	if (modelKeys.length === 0) return new Map();
+
+	const pricingRows: PricingRuleSupplementRow[] = [];
+	for (let index = 0; index < modelKeys.length; index += 200) {
+		const chunk = modelKeys.slice(index, index + 200);
+		const { data, error } = await supabase
+			.from("data_api_pricing_rules")
+			.select(
+				"model_key, pricing_plan, meter, unit, unit_size, price_per_unit, effective_from, effective_to, match",
+			)
+			.in("model_key", chunk);
+		if (error) throw error;
+		pricingRows.push(...((data ?? []) as PricingRuleSupplementRow[]));
+	}
+
+	const nowMs = Date.now();
+	const rowsByKey = new Map<string, PricingRuleSupplementRow[]>();
+	for (const row of pricingRows) {
+		const modelKey = String(row.model_key ?? "").trim();
+		if (!modelKey) continue;
+		if (!isRuleActive(row.effective_from, row.effective_to, nowMs)) continue;
+		if (String(row.pricing_plan ?? "").trim().toLowerCase() !== "standard") continue;
+		const existing = rowsByKey.get(modelKey) ?? [];
+		existing.push(row);
+		rowsByKey.set(modelKey, existing);
+	}
+
+	const result = new Map<string, PricingSupplement>();
+	for (const [modelKey, rows] of rowsByKey) {
+		const supplement: PricingSupplement = {
+			standardInputPrice: null,
+			standardOutputPrice: null,
+			standardInputPriceLabel: null,
+			standardInputPriceUnit: null,
+			standardOutputPriceLabel: null,
+			standardOutputPriceUnit: null,
+			fromPrice: null,
+			fromPriceUnit: null,
+			pricingDetailRows: [],
+		};
+		const displayRows: Array<{ price: number; unit: string }> = [];
+		const displayUnits = new Set<string>();
+		const rawDetailRows: Array<{
+			side: "input" | "output";
+			baseLabel: string;
+			price: number;
+			unit: string;
+			quality: string | null;
+			resolution: string | null;
+			videoSeconds: string | null;
+			videoAudio: string | null;
+			inputTokenTier: string | null;
+			variantLabel: string | null;
+		}> = [];
+
+		for (const row of rows) {
+			const displayPrice = computeDisplayPrice(row);
+			const displayUnit = normalizeDisplayUnit(row.unit);
+			if (displayPrice !== null && displayUnit) {
+				displayRows.push({ price: displayPrice, unit: displayUnit });
+				displayUnits.add(displayUnit);
+			}
+			const { side, label } = getStandardSideAndLabel(row.meter);
+			if (!side || !label || displayPrice === null || !displayUnit) continue;
+			const matchMeta = getMatchMeta(row.match);
+			rawDetailRows.push({
+				side,
+				baseLabel: label,
+				price: displayPrice,
+				unit: displayUnit,
+				quality: matchMeta.quality,
+				resolution: matchMeta.resolution,
+				videoSeconds: matchMeta.videoSeconds,
+				videoAudio: matchMeta.videoAudio,
+				inputTokenTier: matchMeta.inputTokenTier,
+				variantLabel: getVariantLabel(matchMeta),
+			});
+			if (side === "input") {
+				if (
+					supplement.standardInputPrice === null ||
+					displayPrice < supplement.standardInputPrice
+				) {
+					supplement.standardInputPrice = displayPrice;
+					supplement.standardInputPriceLabel = label;
+					supplement.standardInputPriceUnit = displayUnit;
+				}
+			} else if (
+				supplement.standardOutputPrice === null ||
+				displayPrice < supplement.standardOutputPrice
+			) {
+				supplement.standardOutputPrice = displayPrice;
+				supplement.standardOutputPriceLabel = label;
+				supplement.standardOutputPriceUnit = displayUnit;
+			}
+		}
+
+		if (displayUnits.size === 1 && displayRows.length > 0) {
+			displayRows.sort((a, b) => a.price - b.price);
+			supplement.fromPrice = displayRows[0]?.price ?? null;
+			supplement.fromPriceUnit = displayRows[0]?.unit ?? null;
+		}
+		const hasMatchedOutputVariants = rawDetailRows.some(
+			(row) => row.side === "output" && Boolean(row.variantLabel),
+		);
+		const outputBaseLabelsWithVariants = new Set(
+			rawDetailRows
+				.filter((row) => row.side === "output" && Boolean(row.variantLabel))
+				.map((row) => row.baseLabel),
+		);
+		const dedupRows = Array.from(
+			new Map(
+				rawDetailRows.map((row) => {
+					const label = row.variantLabel
+						? `${row.baseLabel} (${row.variantLabel})`
+						: row.baseLabel;
+					const value = formatDetailValue(row.price, row.unit);
+					return [`${label}::${value}`, { label, value }] as const;
+				}),
+			).values(),
+		);
+		if (dedupRows.length > 6) {
+			const groupedRows: Array<{ label: string; value: string }> = [];
+			const inputGroups = new Map<string, { unit: string; prices: number[] }>();
+			const outputQualityGroups = new Map<string, { unit: string; prices: number[] }>();
+			const otherOutputGroups = new Map<string, { unit: string; prices: number[] }>();
+
+			for (const row of rawDetailRows) {
+				if (
+					hasMatchedOutputVariants &&
+					row.side === "output" &&
+					!row.variantLabel &&
+					outputBaseLabelsWithVariants.has(row.baseLabel)
+				) {
+					continue;
+				}
+				if (row.side === "input") {
+					const label = row.variantLabel
+						? `${row.baseLabel} (${row.variantLabel})`
+						: row.baseLabel;
+					const group = inputGroups.get(label) ?? {
+						unit: row.unit,
+						prices: [],
+					};
+					group.prices.push(row.price);
+					inputGroups.set(label, group);
+					continue;
+				}
+				if (row.quality) {
+					const label = `${row.baseLabel} (${toTitleCase(row.quality)})`;
+					const group = outputQualityGroups.get(label) ?? {
+						unit: row.unit,
+						prices: [],
+					};
+					group.prices.push(row.price);
+					outputQualityGroups.set(label, group);
+					continue;
+				}
+				const label = row.variantLabel
+					? `${row.baseLabel} (${row.variantLabel})`
+					: row.baseLabel;
+				const group = otherOutputGroups.get(label) ?? {
+					unit: row.unit,
+					prices: [],
+				};
+				group.prices.push(row.price);
+				otherOutputGroups.set(label, group);
+			}
+
+			for (const [label, group] of inputGroups) {
+				groupedRows.push({
+					label,
+					value: formatDetailValueRange(group.prices, group.unit),
+				});
+			}
+			const qualityOrder = new Map([
+				["low", 0],
+				["medium", 1],
+				["high", 2],
+			]);
+			for (const [label, group] of Array.from(outputQualityGroups.entries()).sort(
+				(a, b) =>
+					(qualityOrder.get(a[0].match(/\(([^)]+)\)/)?.[1]?.toLowerCase() ?? "") ?? 99) -
+					(qualityOrder.get(b[0].match(/\(([^)]+)\)/)?.[1]?.toLowerCase() ?? "") ?? 99),
+			)) {
+				groupedRows.push({
+					label,
+					value: formatDetailValueRange(group.prices, group.unit),
+				});
+			}
+			for (const [label, group] of otherOutputGroups) {
+				groupedRows.push({
+					label,
+					value: formatDetailValueRange(group.prices, group.unit),
+				});
+			}
+			supplement.pricingDetailRows = groupedRows.slice(0, 6);
+		} else {
+			supplement.pricingDetailRows = dedupRows;
+		}
+
+		result.set(modelKey, supplement);
+	}
+
+	return result;
+}
+
 export async function getMonitorModels(
 	filters: MonitorModelFilters = {},
 	includeHidden: boolean
@@ -114,19 +592,8 @@ export async function getMonitorModels(
 	allFeatures: string[];
 	allStatuses: string[];
 }> {
-	"use cache";
-
-	cacheLife("minutes");
-	cacheTag("models:monitor");
-	cacheTag("monitor-models");
-	cacheTag("data:data_api_model_aliases");
-	cacheTag("data:data_api_provider_model_capabilities");
-	cacheTag("data:data_api_provider_models");
-	cacheTag("data:data_api_pricing_rules");
-	cacheTag("data:models");
-	cacheTag("data:api_providers");
-
 	const rpcRows = await fetchAllMonitorModelRows(includeHidden);
+	const pricingSupplements = await fetchPricingSupplements(rpcRows);
 
 	const featureOrderIndexForRow = new Map(
 		featureOrder.map((feature, index) => [feature, index]),
@@ -205,6 +672,11 @@ export async function getMonitorModels(
 			row.quantization_scheme.trim()
 				? row.quantization_scheme
 				: undefined;
+		const modelKey =
+			row.provider_id && row.api_model_id && row.capability_id
+				? `${row.provider_id}:${row.api_model_id}:${row.capability_id}`
+				: "";
+		const pricingSupplement = pricingSupplements.get(modelKey);
 
 		const monitorModel: MonitorModelData = {
 			id: `${modelId}-${gatewayModel.api_provider_id}-${gatewayModel.key}`,
@@ -218,20 +690,43 @@ export async function getMonitorModels(
 				id: gatewayModel.api_provider_id,
 				inputPrice: Number(row.input_price ?? 0) || 0,
 				outputPrice: Number(row.output_price ?? 0) || 0,
-				standardInputPrice: Number.isFinite(Number(row.standard_input_price))
+				standardInputPrice:
+					row.standard_input_price !== null &&
+					row.standard_input_price !== undefined &&
+					Number.isFinite(Number(row.standard_input_price))
 					? Number(row.standard_input_price)
-					: null,
-				standardOutputPrice: Number.isFinite(Number(row.standard_output_price))
+					: pricingSupplement?.standardInputPrice ?? null,
+				standardOutputPrice:
+					row.standard_output_price !== null &&
+					row.standard_output_price !== undefined &&
+					Number.isFinite(Number(row.standard_output_price))
 					? Number(row.standard_output_price)
-					: null,
-				standardInputPriceLabel: row.standard_input_price_label ?? null,
-				standardInputPriceUnit: row.standard_input_price_unit ?? null,
-				standardOutputPriceLabel: row.standard_output_price_label ?? null,
-				standardOutputPriceUnit: row.standard_output_price_unit ?? null,
-				fromPrice: Number.isFinite(Number(row.from_price))
+					: pricingSupplement?.standardOutputPrice ?? null,
+				standardInputPriceLabel:
+					row.standard_input_price_label ??
+					pricingSupplement?.standardInputPriceLabel ??
+					null,
+				standardInputPriceUnit:
+					row.standard_input_price_unit ??
+					pricingSupplement?.standardInputPriceUnit ??
+					null,
+				standardOutputPriceLabel:
+					row.standard_output_price_label ??
+					pricingSupplement?.standardOutputPriceLabel ??
+					null,
+				standardOutputPriceUnit:
+					row.standard_output_price_unit ??
+					pricingSupplement?.standardOutputPriceUnit ??
+					null,
+				fromPrice:
+					row.from_price !== null &&
+					row.from_price !== undefined &&
+					Number.isFinite(Number(row.from_price))
 					? Number(row.from_price)
-					: null,
-				fromPriceUnit: row.from_price_unit ?? null,
+					: pricingSupplement?.fromPrice ?? null,
+				fromPriceUnit:
+					row.from_price_unit ?? pricingSupplement?.fromPriceUnit ?? null,
+				pricingDetailRows: pricingSupplement?.pricingDetailRows ?? [],
 				features: sortedFeatures,
 			},
 			endpoint: normalizeEndpoint(String(row.capability_id ?? "")),

--- a/apps/web/src/lib/fetchers/models/table-view/types.ts
+++ b/apps/web/src/lib/fetchers/models/table-view/types.ts
@@ -20,6 +20,10 @@ export interface MonitorModelData {
         standardOutputPriceUnit?: string | null;
         fromPrice?: number | null;
         fromPriceUnit?: string | null;
+        pricingDetailRows?: Array<{
+            label: string;
+            value: string;
+        }>;
         features: string[];
     };
     endpoint: string; // The specific endpoint/key


### PR DESCRIPTION
## Summary
This PR improves pricing presentation on the main `/models` catalogue so the model cards and pricing hover cards are descriptive for non-trivial pricing structures instead of being misleading or incomplete.

## Problem
The list view was reasonably fine for simple text-token pricing, but it broke down for media and tiered models.

Users were seeing several concrete issues:
- provider-backed pricing rows from the monitor RPC were incomplete for image, audio, and video meters
- the `/models` index could silently miss pricing detail rows that were available in the underlying pricing rules
- image and video hover cards either showed too little detail, showed repetitive labels, or hid important output-side pricing entirely
- tiered text models such as `x-ai/grok-4.3` surfaced duplicate input/output prices with no explanation of the context threshold behind them
- GPT Image family cards could show compressed summaries that did not line up with what the hover card explained, which made the cards hard to trust

## Root Cause
There were two broad causes:
- the monitor feed and models-page aggregation were only carrying a narrow set of pricing fields, so richer pricing-rule context was lost before the card renderer saw it
- the card renderer was optimized for simple text pricing and did not have good grouping rules for image, video, or tiered text variants

## What changed
### Monitor feed and aggregation
- paged the `get_monitor_model_rows` RPC fetch so the `/models` index no longer truncates at 1000 rows
- supplemented monitor rows with active pricing-rule data from `data_api_pricing_rules`
- added support for media meters and richer detail rows in the monitor-model types and aggregation path
- preserved pricing detail rows through the models-page compact-card projection
- fixed null/zero coercion issues so missing standard prices do not overwrite supplemented pricing data

### Pricing detail labelling
- added variant extraction for image quality and resolution
- added variant extraction for video resolution, duration, and audio/no-audio distinctions
- added context-threshold labels for tiered text models like Grok (`Up to 200K context`, `Over 200K context`)
- normalized image quality labels to title case

### Card and hover-card UX
- enabled pricing hover cards for non-text models instead of leaving them inert
- merged explicit pricing rows with fallback rows so input/output information is not dropped
- improved compressed summary chips for media models, including cheapest-tier signalling where appropriate
- grouped repeated rows under shared headings instead of repeating labels like `Video Output` over and over
- simplified dense image output pricing to a single descriptive range in the hover card when the full quality breakdown is too noisy for a list view
- made hover-card width size to content more naturally instead of forcing a narrow fixed width

## Result
The `/models` cards now behave much more like a lightweight version of the individual model pricing pages:
- image models show input costs and a meaningful basic output range
- video models show grouped output pricing with audio/no-audio and resolution distinctions
- tiered text models explain why multiple prices exist instead of looking broken
- summary chips and hover-card details line up much better, which makes the catalogue easier to trust when scanning quickly

## Validation
- `pnpm --filter @ai-stats/web typecheck`

## Scope
This PR is intentionally limited to the web models catalogue pricing/feed path:
- `apps/web/src/lib/fetchers/models/table-view/getMonitorModels.ts`
- `apps/web/src/app/(dashboard)/models/page.tsx`
- `apps/web/src/components/(data)/models/Models/ModelCard.tsx`
- supporting types in the related models fetcher files


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved pricing display on model cards with enhanced organization and structured grouping of pricing information
  * Modality-aware pricing presentation with specialized formatting for different pricing variant types
  * More compact and readable pricing summaries for models with multiple pricing tiers

<!-- end of auto-generated comment: release notes by coderabbit.ai -->