### PR TITLE
Fix homepage monthly token stats

### DIFF
--- a/apps/web/src/components/landingPage/DatabaseStatistics.tsx
+++ b/apps/web/src/components/landingPage/DatabaseStatistics.tsx
@@ -1,6 +1,6 @@
 import Link from "next/link";
 import getDbStats from "@/lib/fetchers/landing/dbStats";
-import { getGatewayMarketingMetrics } from "@/lib/fetchers/gateway/getMarketingMetrics";
+import { getPublicMonthlyTokenTotal } from "@/lib/fetchers/rankings/getRankingsData";
 
 function roundDisplayValue(raw: number, bucket: number) {
 	if (bucket <= 0) return raw;
@@ -27,15 +27,10 @@ function formatCompact(value: number) {
 	return value.toLocaleString();
 }
 
-function formatGatewayTokenValue(value: number) {
-	if (!Number.isFinite(value) || value <= 0) return "Live data pending";
-	return `${formatCompact(value)}+`;
-}
-
 export default async function DatabaseStats() {
-	const [data, gatewayMetrics] = await Promise.all([
+	const [data, monthlyTokenTotal] = await Promise.all([
 		getDbStats(),
-		getGatewayMarketingMetrics(24 * 30),
+		getPublicMonthlyTokenTotal(),
 	]);
 
 	const stats = [
@@ -50,8 +45,8 @@ export default async function DatabaseStats() {
 			route: "/api-providers",
 		},
 		{
-			label: "Gateway tokens (30d)",
-			value: formatGatewayTokenValue(gatewayMetrics.summary.tokens24h ?? 0),
+			label: "Monthly tokens",
+			value: `${formatCompact(monthlyTokenTotal ?? 0)}+`,
 			route: "/",
 		},
 	] as const;

--- a/apps/web/src/components/landingPage/DatabaseStatistics.tsx
+++ b/apps/web/src/components/landingPage/DatabaseStatistics.tsx
@@ -27,6 +27,11 @@ function formatCompact(value: number) {
 	return value.toLocaleString();
 }
 
+function formatGatewayTokenValue(value: number) {
+	if (!Number.isFinite(value) || value <= 0) return "Live data pending";
+	return `${formatCompact(value)}+`;
+}
+
 export default async function DatabaseStats() {
 	const [data, gatewayMetrics] = await Promise.all([
 		getDbStats(),
@@ -45,8 +50,8 @@ export default async function DatabaseStats() {
 			route: "/api-providers",
 		},
 		{
-			label: "Gateway monthly tokens",
-			value: `${formatCompact(gatewayMetrics.summary.tokens24h ?? 0)}+`,
+			label: "Gateway tokens (30d)",
+			value: formatGatewayTokenValue(gatewayMetrics.summary.tokens24h ?? 0),
 			route: "/",
 		},
 	] as const;

--- a/apps/web/src/lib/fetchers/api-providers/getAllAPIProviders.ts
+++ b/apps/web/src/lib/fetchers/api-providers/getAllAPIProviders.ts
@@ -1,7 +1,9 @@
 // lib/fetchers/api-providers/getAllAPIProviders.ts
 import { cacheLife, cacheTag } from "next/cache";
 import { filterVisibleAPIProviders } from "./visibility";
+import { fetchPublicGatewayRequestRows } from "@/lib/fetchers/gateway/fetchPublicGatewayRequests";
 import { createAdminClient } from "@/utils/supabase/admin";
+import { sumTokens } from "@/lib/utils/sumTokens";
 
 export type ProviderModalityKey =
     | "text"
@@ -51,12 +53,6 @@ type PricingRuleRow = {
     price_per_unit?: number | string | null;
     effective_from?: string | null;
     effective_to?: string | null;
-};
-
-type MarketShareRow = {
-    name?: string | null;
-    tokens?: number | string | null;
-    share_pct?: number | string | null;
 };
 
 const MODALITY_KEYS: ProviderModalityKey[] = [
@@ -137,26 +133,8 @@ function isFreePricingRule(row: PricingRuleRow): boolean {
     return String(row.model_key ?? "").toLowerCase().includes(":free:");
 }
 
-function toTokenMap(rows: unknown): Map<string, number> {
-    const out = new Map<string, number>();
-    for (const row of (rows ?? []) as MarketShareRow[]) {
-        const providerId = String(row.name ?? "").trim();
-        if (!providerId) continue;
-        const tokens = Number(row.tokens ?? 0);
-        out.set(providerId, Number.isFinite(tokens) ? Math.max(0, tokens) : 0);
-    }
-    return out;
-}
-
-function toShareMap(rows: unknown): Map<string, number> {
-    const out = new Map<string, number>();
-    for (const row of (rows ?? []) as MarketShareRow[]) {
-        const providerId = String(row.name ?? "").trim();
-        if (!providerId) continue;
-        const share = Number(row.share_pct ?? 0);
-        out.set(providerId, Number.isFinite(share) ? Math.max(0, share) : 0);
-    }
-    return out;
+function toTokenCount(value: unknown): number {
+    return Math.max(0, Math.round(sumTokens(value)));
 }
 
 export async function getAllAPIProviders(): Promise<APIProviderCard[]> {
@@ -178,7 +156,7 @@ export async function getAllAPIProviders(): Promise<APIProviderCard[]> {
         `and(effective_from.lte.${nowIso},effective_to.gt.${nowIso})`,
     ].join(",");
 
-    const [providersRes, providerModelsRes, pricingRulesRes, dailyUsageRes, monthlyUsageRes] = await Promise.all([
+    const [providersRes, providerModelsRes, pricingRulesRes, gatewayUsageRows] = await Promise.all([
         supabase
             .from("data_api_providers")
             .select("api_provider_id, api_provider_name, colour, country_code")
@@ -193,14 +171,7 @@ export async function getAllAPIProviders(): Promise<APIProviderCard[]> {
             .select("model_key, effective_from, effective_to")
             .ilike("model_key", "%:free:%")
             .or(activeWindowClause),
-        supabase.rpc("get_public_market_share", {
-            p_dimension: "provider",
-            p_time_range: "today",
-        }),
-        supabase.rpc("get_public_market_share", {
-            p_dimension: "provider",
-            p_time_range: "month",
-        }),
+        fetchPublicGatewayRequestRows(30, { successOnly: true }),
     ]);
 
     if (providersRes.error) {
@@ -310,22 +281,39 @@ export async function getAllAPIProviders(): Promise<APIProviderCard[]> {
         );
     }
 
-    if (dailyUsageRes.error) {
-        console.warn(
-            "[getAllAPIProviders] get_public_market_share(today) failed; defaulting daily token stats to 0.",
-            dailyUsageRes.error.message
+    const dayStartMs = Date.now() - 24 * 60 * 60 * 1000;
+    const dailyRequestsByProvider = new Map<string, number>();
+    const dailyTokensByProvider = new Map<string, number>();
+    const monthlyTokensByProvider = new Map<string, number>();
+
+    for (const row of gatewayUsageRows) {
+        const providerId = String(row.provider ?? "").trim();
+        if (!providerId) continue;
+
+        const createdAtMs = row.created_at ? new Date(row.created_at).getTime() : Number.NaN;
+        const tokens = toTokenCount(row.usage);
+
+        monthlyTokensByProvider.set(
+            providerId,
+            (monthlyTokensByProvider.get(providerId) ?? 0) + tokens,
         );
-    }
-    if (monthlyUsageRes.error) {
-        console.warn(
-            "[getAllAPIProviders] get_public_market_share(month) failed; defaulting monthly token stats to 0.",
-            monthlyUsageRes.error.message
+
+        if (!Number.isFinite(createdAtMs) || createdAtMs < dayStartMs) continue;
+
+        dailyRequestsByProvider.set(
+            providerId,
+            (dailyRequestsByProvider.get(providerId) ?? 0) + 1,
+        );
+        dailyTokensByProvider.set(
+            providerId,
+            (dailyTokensByProvider.get(providerId) ?? 0) + tokens,
         );
     }
 
-    const dailyTokensByProvider = toTokenMap(dailyUsageRes.data);
-    const monthlyTokensByProvider = toTokenMap(monthlyUsageRes.data);
-    const dailyShareByProvider = toShareMap(dailyUsageRes.data);
+    const totalDailyRequests = Array.from(dailyRequestsByProvider.values()).reduce(
+        (sum, value) => sum + value,
+        0
+    );
 
     const modalitySupportByProvider = new Map<string, ProviderModalitySupport>();
     for (const providerId of new Set([
@@ -367,7 +355,11 @@ export async function getAllAPIProviders(): Promise<APIProviderCard[]> {
                 total_monthly_tokens:
                     monthlyTokensByProvider.get(r.api_provider_id) ?? 0,
                 daily_share_pct:
-                    dailyShareByProvider.get(r.api_provider_id) ?? 0,
+                    totalDailyRequests > 0
+                        ? ((dailyRequestsByProvider.get(r.api_provider_id) ?? 0) /
+                                totalDailyRequests) *
+                            100
+                        : 0,
                 modality_support:
                     modalitySupportByProvider.get(r.api_provider_id) ??
                     createEmptyModalitySupport(),

--- a/apps/web/src/lib/fetchers/gateway/fetchPublicGatewayRequests.ts
+++ b/apps/web/src/lib/fetchers/gateway/fetchPublicGatewayRequests.ts
@@ -1,0 +1,50 @@
+import { createAdminClient } from "@/utils/supabase/admin";
+
+export type PublicGatewayRequestRow = {
+	created_at: string | null;
+	provider: string | null;
+	success: boolean | null;
+	usage: Record<string, unknown> | null;
+	latency_ms?: number | string | null;
+	model_id?: string | null;
+};
+
+const PAGE_SIZE = 1000;
+
+export async function fetchPublicGatewayRequestRows(
+	days: number,
+	options: { successOnly?: boolean } = {},
+): Promise<PublicGatewayRequestRow[]> {
+	const supabase = createAdminClient();
+	const windowDays = Number.isFinite(days) && days > 0 ? Math.round(days) : 30;
+	const sinceIso = new Date(Date.now() - windowDays * 24 * 60 * 60 * 1000).toISOString();
+	const successOnly = options.successOnly ?? true;
+	const rows: PublicGatewayRequestRow[] = [];
+
+	for (let offset = 0; ; offset += PAGE_SIZE) {
+		let query = supabase
+			.from("gateway_requests")
+			.select("created_at, provider, success, usage, latency_ms, model_id")
+			.gte("created_at", sinceIso)
+			.order("created_at", { ascending: true })
+			.range(offset, offset + PAGE_SIZE - 1);
+
+		if (successOnly) {
+			query = query.eq("success", true);
+		}
+
+		const { data, error } = await query;
+		if (error) {
+			throw new Error(error.message ?? "Failed to load public gateway requests");
+		}
+
+		const page = (data ?? []) as PublicGatewayRequestRow[];
+		rows.push(...page);
+
+		if (page.length < PAGE_SIZE) {
+			break;
+		}
+	}
+
+	return rows;
+}

--- a/apps/web/src/lib/fetchers/rankings/getRankingsData.ts
+++ b/apps/web/src/lib/fetchers/rankings/getRankingsData.ts
@@ -6,6 +6,8 @@
 "use cache";
 import { cacheLife, cacheTag } from "next/cache";
 import { createAdminClient } from "@/utils/supabase/admin";
+import { fetchPublicGatewayRequestRows } from "@/lib/fetchers/gateway/fetchPublicGatewayRequests";
+import { sumTokens } from "@/lib/utils/sumTokens";
 
 
 // Type definitions for API responses
@@ -50,6 +52,24 @@ export type RankingsResponse = {
     trending: TrendingModel[];
     summary: SummaryStats;
 };
+
+const DEFAULT_SUMMARY_STATS: SummaryStats = {
+    total_requests_24h: 0,
+    total_tokens_24h: 0,
+    total_models: 0,
+    total_providers: 0,
+    avg_latency_ms: 0,
+    success_rate_24h: 0,
+};
+
+function toFiniteNumber(value: unknown): number {
+	const parsed = Number(value);
+	return Number.isFinite(parsed) ? parsed : 0;
+}
+
+function roundTokens(value: unknown): number {
+	return Math.max(0, Math.round(sumTokens(value)));
+}
 
 export type PerformanceData = {
     model_id: string;
@@ -279,7 +299,7 @@ export async function getRankings(
         supabase.rpc("get_public_trending_models", {
             p_limit: 20,
         }),
-        supabase.rpc("get_public_summary_stats"),
+        getPublicSummaryStats(),
     ]);
 
     console.log("[getRankings] Rankings response:", {
@@ -293,8 +313,7 @@ export async function getRankings(
         data: trendingRes.data,
     });
     console.log("[getRankings] Summary response:", {
-        error: summaryRes.error,
-        data: summaryRes.data,
+        data: summaryRes,
     });
 
     if (rankingsRes.error) {
@@ -303,23 +322,73 @@ export async function getRankings(
     if (trendingRes.error) {
         console.error("[getRankings] Trending error:", trendingRes.error);
     }
-    if (summaryRes.error) {
-        console.error("[getRankings] Summary error:", summaryRes.error);
-    }
-
     return {
         ok: !rankingsRes.error,
         rankings: (rankingsRes.data ?? []) as RankingModel[],
         trending: (trendingRes.data ?? []) as TrendingModel[],
-        summary: summaryRes.data?.[0] ?? {
-            total_requests_24h: 0,
-            total_tokens_24h: 0,
-            total_models: 0,
-            total_providers: 0,
-            avg_latency_ms: 0,
-            success_rate_24h: 0,
-        },
+        summary: summaryRes ?? DEFAULT_SUMMARY_STATS,
     };
+}
+
+export async function getPublicSummaryStats(): Promise<SummaryStats> {
+	cacheLife("hours");
+	cacheTag("public-rankings");
+	cacheTag("data:gateway_requests");
+
+	const rows = await fetchPublicGatewayRequestRows(1, { successOnly: false });
+	if (!rows.length) {
+		return DEFAULT_SUMMARY_STATS;
+	}
+
+	let totalRequests = 0;
+	let totalTokens = 0;
+	let totalModels = 0;
+	let totalProviders = 0;
+	let totalLatency = 0;
+	let latencySamples = 0;
+	let successfulRequests = 0;
+	const modelIds = new Set<string>();
+	const providerIds = new Set<string>();
+
+	for (const row of rows) {
+		totalRequests += 1;
+		totalTokens += roundTokens(row.usage);
+		if (row.model_id) modelIds.add(row.model_id);
+		if (row.provider) providerIds.add(row.provider);
+
+		const latency = toFiniteNumber(row.latency_ms);
+		if (latency > 0) {
+			totalLatency += latency;
+			latencySamples += 1;
+		}
+
+		if (row.success) {
+			successfulRequests += 1;
+		}
+	}
+
+	totalModels = modelIds.size;
+	totalProviders = providerIds.size;
+
+	return {
+		total_requests_24h: totalRequests,
+		total_tokens_24h: totalTokens,
+		total_models: totalModels,
+		total_providers: totalProviders,
+		avg_latency_ms: latencySamples > 0 ? Math.round(totalLatency / latencySamples) : 0,
+		success_rate_24h: totalRequests > 0 ? successfulRequests / totalRequests : 0,
+	};
+}
+
+export async function getPublicMonthlyTokenTotal(): Promise<number> {
+	cacheLife("days");
+	cacheTag("public-rankings");
+	cacheTag("data:gateway_requests");
+
+	const rows = await fetchPublicGatewayRequestRows(30, { successOnly: true });
+	if (!rows.length) return 0;
+
+	return rows.reduce((total, row) => total + roundTokens(row.usage), 0);
 }
 
 /**


### PR DESCRIPTION
This updates the homepage token card to show a real monthly token total from raw `gateway_requests` data instead of the removed rollup tables. It also rewires the public provider metrics loader to stop calling the broken market-share RPC.

Verification:
- `pnpm --filter @ai-stats/web typecheck`
- Verified in the in-app browser at `http://localhost:3100/` showing `Monthly tokens` with a non-zero value (`278.3K+`)