### PR TITLE
[codex] perf(web): defer header search index loading

### DIFF
--- a/apps/web/src/app/api/frontend/search/route.ts
+++ b/apps/web/src/app/api/frontend/search/route.ts
@@ -1,13 +1,15 @@
 import { NextResponse } from "next/server";
-import { getSearchDataCached } from "@/lib/fetchers/search/getSearchData";
+import {
+	compactSearchData,
+	getSearchDataCached,
+} from "@/lib/fetchers/search/getSearchData";
+import { PUBLIC_CDN_CACHE_HEADERS } from "@/lib/cache/publicCacheHeaders";
 
 export async function GET() {
 	try {
 		const data = await getSearchDataCached(false);
-		return NextResponse.json(data, {
-			headers: {
-				"Cache-Control": "public, s-maxage=86400, stale-while-revalidate=604800",
-			},
+		return NextResponse.json(compactSearchData(data), {
+			headers: PUBLIC_CDN_CACHE_HEADERS,
 		});
 	} catch (error) {
 		console.error("[api/frontend/search] failed to fetch search data", error);

--- a/apps/web/src/components/header/Search/Search.tsx
+++ b/apps/web/src/components/header/Search/Search.tsx
@@ -16,7 +16,10 @@ import { cn } from "@/lib/utils";
 import { Search as SearchIcon, Sparkles } from "lucide-react";
 import { curatedGroups } from "./Search.constants";
 import { SearchRowItem } from "./SearchRowItem";
-import type { SearchData } from "@/lib/fetchers/search/getSearchData";
+import type {
+	CompactSearchData,
+	SearchData,
+} from "@/lib/fetchers/search/getSearchData";
 
 interface Props {
 	className?: string;
@@ -26,7 +29,10 @@ interface Props {
 type SearchableItem = {
 	id: string;
 	title: string;
-	searchKeywords: string[];
+	subtitle?: string | null;
+	href?: string;
+	logoId?: string | null;
+	flagIso?: string;
 };
 
 function normalizeSearchTerm(value: string): string {
@@ -39,6 +45,101 @@ function normalizeSearchTerm(value: string): string {
 
 let cachedSearchData: SearchData | null = null;
 let searchDataRequest: Promise<SearchData> | null = null;
+
+function buildSearchKeywords(item: SearchableItem): string[] {
+	const keywords = new Set<string>();
+	const terms = [
+		item.id,
+		item.title,
+		item.subtitle,
+		item.href,
+		item.logoId,
+		item.flagIso,
+	];
+
+	for (const term of terms) {
+		if (!term) continue;
+
+		keywords.add(term);
+
+		const normalized = normalizeSearchTerm(term);
+		if (normalized) keywords.add(normalized);
+
+		const dotted = term.replace(/-/g, ".");
+		const dashed = term.replace(/\./g, "-");
+		const compact = term.replace(/[\s._-]+/g, "");
+
+		keywords.add(dotted);
+		keywords.add(dashed);
+		keywords.add(compact);
+		keywords.add(normalizeSearchTerm(dotted));
+		keywords.add(normalizeSearchTerm(dashed));
+		keywords.add(normalizeSearchTerm(compact));
+	}
+
+	return Array.from(keywords).filter(Boolean);
+}
+
+function isCompactSearchData(value: unknown): value is CompactSearchData {
+	return Boolean(
+		value &&
+			typeof value === "object" &&
+			Array.isArray((value as CompactSearchData).m) &&
+			Array.isArray((value as CompactSearchData).o) &&
+			Array.isArray((value as CompactSearchData).b) &&
+			Array.isArray((value as CompactSearchData).p) &&
+			Array.isArray((value as CompactSearchData).s) &&
+			Array.isArray((value as CompactSearchData).c),
+	);
+}
+
+function expandSearchData(value: SearchData | CompactSearchData): SearchData {
+	if (!isCompactSearchData(value)) return value;
+
+	return {
+		models: value.m.map(([id, title, subtitle, href, logoId]) => ({
+			id,
+			title,
+			subtitle,
+			href,
+			logoId,
+		})),
+		organisations: value.o.map(([id, title, subtitle, href, logoId]) => ({
+			id,
+			title,
+			subtitle,
+			href,
+			logoId,
+		})),
+		benchmarks: value.b.map(([id, title, subtitle, href]) => ({
+			id,
+			title,
+			subtitle,
+			href,
+		})),
+		apiProviders: value.p.map(([id, title, subtitle, href, logoId]) => ({
+			id,
+			title,
+			subtitle,
+			href,
+			logoId,
+		})),
+		subscriptionPlans: value.s.map(([id, title, subtitle, href, logoId]) => ({
+			id,
+			title,
+			subtitle,
+			href,
+			logoId,
+		})),
+		countries: value.c.map(([id, title, subtitle, href, flagIso]) => ({
+			id,
+			title,
+			subtitle,
+			href,
+			flagIso,
+		})),
+	};
+}
 
 async function fetchSearchData(): Promise<SearchData> {
 	if (cachedSearchData) return cachedSearchData;
@@ -53,7 +154,9 @@ async function fetchSearchData(): Promise<SearchData> {
 			if (!response.ok) {
 				throw new Error("Failed to load search data");
 			}
-			return (await response.json()) as SearchData;
+			return expandSearchData(
+				(await response.json()) as SearchData | CompactSearchData,
+			);
 		})
 		.then((data) => {
 			cachedSearchData = data;
@@ -106,7 +209,7 @@ function getMatchScore(item: SearchableItem, term: string): number {
 		return 500;
 	}
 	if (
-		item.searchKeywords.some((keyword) => {
+		buildSearchKeywords(item).some((keyword) => {
 			const keywordLower = keyword.toLowerCase();
 			if (keywordLower.includes(rawTerm)) return true;
 			if (!hasNormalizedTerm) return false;
@@ -339,7 +442,7 @@ export default function Search({ className, initialData = null }: Props) {
 											<SearchRowItem
 												key={item.id}
 												{...item}
-												keywords={item.searchKeywords}
+												keywords={buildSearchKeywords(item)}
 												onSelect={handleSelect}
 												type={categoryConfig.type}
 											/>

--- a/apps/web/src/components/header/Search/SearchWrapper.tsx
+++ b/apps/web/src/components/header/Search/SearchWrapper.tsx
@@ -1,11 +1,9 @@
 import Search from "./Search";
-import { getSearchDataCached } from "@/lib/fetchers/search/getSearchData";
 
 interface SearchWrapperProps {
 	className?: string;
 }
 
-export async function SearchWrapper({ className }: SearchWrapperProps) {
-	const initialData = await getSearchDataCached(false);
-	return <Search className={className} initialData={initialData} />;
+export function SearchWrapper({ className }: SearchWrapperProps) {
+	return <Search className={className} />;
 }

--- a/apps/web/src/lib/cache/publicCacheHeaders.ts
+++ b/apps/web/src/lib/cache/publicCacheHeaders.ts
@@ -1,0 +1,17 @@
+export const PUBLIC_CDN_CACHE_CONTROL =
+	"public, max-age=0, s-maxage=86400, stale-while-revalidate=604800";
+
+export const PUBLIC_LONG_CDN_CACHE_CONTROL =
+	"public, max-age=0, s-maxage=31536000, stale-while-revalidate=604800, stale-if-error=604800";
+
+export const PUBLIC_CATALOGUE_CDN_CACHE_TAG = "public-model-catalogue";
+
+export const PUBLIC_CDN_CACHE_HEADERS = {
+	"Cache-Control": PUBLIC_CDN_CACHE_CONTROL,
+	"Vercel-Cache-Tag": PUBLIC_CATALOGUE_CDN_CACHE_TAG,
+} as const;
+
+export const PUBLIC_LONG_CDN_CACHE_HEADERS = {
+	"Cache-Control": PUBLIC_LONG_CDN_CACHE_CONTROL,
+	"Vercel-Cache-Tag": PUBLIC_CATALOGUE_CDN_CACHE_TAG,
+} as const;

--- a/apps/web/src/lib/fetchers/search/getSearchData.ts
+++ b/apps/web/src/lib/fetchers/search/getSearchData.ts
@@ -7,44 +7,6 @@ import { getAllAPIProvidersCached, APIProviderCard } from "@/lib/fetchers/api-pr
 import { getCountrySummariesCached, CountrySummary } from "@/lib/fetchers/countries/getCountrySummaries";
 import { createClient } from "@/utils/supabase/client";
 
-// Normalized search keyword generation
-function normalizeSearchTerm(value: string): string {
-    return value
-        .toLowerCase()
-        .replace(/[\s._-]+/g, " ")
-        .replace(/[^a-z0-9 ]/g, "")
-        .trim();
-}
-
-function buildSearchKeywords(...terms: (string | null | undefined)[]): string[] {
-    const keywords = new Set<string>();
-
-    for (const term of terms) {
-        if (!term) continue;
-
-        // Add original
-        keywords.add(term);
-
-        // Add normalized
-        const normalized = normalizeSearchTerm(term);
-        if (normalized) keywords.add(normalized);
-
-        // Add variants with different separators
-        const dotted = term.replace(/-/g, ".");
-        const dashed = term.replace(/\./g, "-");
-        const compact = term.replace(/[\s._-]+/g, "");
-
-        keywords.add(dotted);
-        keywords.add(dashed);
-        keywords.add(compact);
-        keywords.add(normalizeSearchTerm(dotted));
-        keywords.add(normalizeSearchTerm(dashed));
-        keywords.add(normalizeSearchTerm(compact));
-    }
-
-    return Array.from(keywords).filter(Boolean);
-}
-
 // Searchable entity interfaces
 export interface SearchableModel {
     id: string;
@@ -52,7 +14,6 @@ export interface SearchableModel {
     subtitle: string | null;
     href: string;
     logoId: string;
-    searchKeywords: string[];
 }
 
 export interface SearchableOrganisation {
@@ -61,7 +22,6 @@ export interface SearchableOrganisation {
     subtitle: string | null;
     href: string;
     logoId: string;
-    searchKeywords: string[];
 }
 
 export interface SearchableBenchmark {
@@ -69,7 +29,6 @@ export interface SearchableBenchmark {
     title: string;
     subtitle: string | null;
     href: string;
-    searchKeywords: string[];
 }
 
 export interface SearchableAPIProvider {
@@ -78,7 +37,6 @@ export interface SearchableAPIProvider {
     subtitle: string | null;
     href: string;
     logoId: string;
-    searchKeywords: string[];
 }
 
 export interface SearchableSubscriptionPlan {
@@ -87,7 +45,6 @@ export interface SearchableSubscriptionPlan {
     subtitle: string | null;
     href: string;
     logoId: string | null;
-    searchKeywords: string[];
 }
 
 export interface SearchableCountry {
@@ -96,7 +53,6 @@ export interface SearchableCountry {
     subtitle: string | null;
     href: string;
     flagIso: string;
-    searchKeywords: string[];
 }
 
 export interface SearchData {
@@ -108,6 +64,66 @@ export interface SearchData {
     countries: SearchableCountry[];
 }
 
+type SearchLogoTuple = [string, string, string | null, string, string];
+type SearchBenchmarkTuple = [string, string, string | null, string];
+type SearchNullableLogoTuple = [string, string, string | null, string, string | null];
+type SearchCountryTuple = [string, string, string | null, string, string];
+
+export interface CompactSearchData {
+    m: SearchLogoTuple[];
+    o: SearchLogoTuple[];
+    b: SearchBenchmarkTuple[];
+    p: SearchLogoTuple[];
+    s: SearchNullableLogoTuple[];
+    c: SearchCountryTuple[];
+}
+
+export function compactSearchData(data: SearchData): CompactSearchData {
+    return {
+        m: data.models.map((item) => [
+            item.id,
+            item.title,
+            item.subtitle,
+            item.href,
+            item.logoId,
+        ]),
+        o: data.organisations.map((item) => [
+            item.id,
+            item.title,
+            item.subtitle,
+            item.href,
+            item.logoId,
+        ]),
+        b: data.benchmarks.map((item) => [
+            item.id,
+            item.title,
+            item.subtitle,
+            item.href,
+        ]),
+        p: data.apiProviders.map((item) => [
+            item.id,
+            item.title,
+            item.subtitle,
+            item.href,
+            item.logoId,
+        ]),
+        s: data.subscriptionPlans.map((item) => [
+            item.id,
+            item.title,
+            item.subtitle,
+            item.href,
+            item.logoId,
+        ]),
+        c: data.countries.map((item) => [
+            item.id,
+            item.title,
+            item.subtitle,
+            item.href,
+            item.flagIso,
+        ]),
+    };
+}
+
 // Transform functions
 function transformModels(models: ModelCard[]): SearchableModel[] {
     return models.map(model => ({
@@ -116,12 +132,6 @@ function transformModels(models: ModelCard[]): SearchableModel[] {
         subtitle: model.organisation_name,
         href: `/models/${model.model_id}`,
         logoId: model.organisation_id,
-        searchKeywords: buildSearchKeywords(
-            model.model_id,
-            model.name,
-            model.organisation_id,
-            model.organisation_name
-        ),
     }));
 }
 
@@ -132,10 +142,6 @@ function transformOrganisations(organisations: OrganisationCard[]): SearchableOr
         subtitle: null,
         href: `/organisations/${org.organisation_id}`,
         logoId: org.organisation_id,
-        searchKeywords: buildSearchKeywords(
-            org.organisation_id,
-            org.organisation_name
-        ),
     }));
 }
 
@@ -145,10 +151,6 @@ function transformBenchmarks(benchmarks: BenchmarkCard[]): SearchableBenchmark[]
         title: benchmark.benchmark_name,
         subtitle: `${benchmark.total_models} models`,
         href: `/benchmarks/${benchmark.benchmark_id}`,
-        searchKeywords: buildSearchKeywords(
-            benchmark.benchmark_id,
-            benchmark.benchmark_name
-        ),
     }));
 }
 
@@ -159,10 +161,6 @@ function transformAPIProviders(providers: APIProviderCard[]): SearchableAPIProvi
         subtitle: null,
         href: `/api-providers/${provider.api_provider_id}`,
         logoId: provider.api_provider_id,
-        searchKeywords: buildSearchKeywords(
-            provider.api_provider_id,
-            provider.api_provider_name
-        ),
     }));
 }
 
@@ -208,13 +206,6 @@ async function transformSubscriptionPlans(): Promise<SearchableSubscriptionPlan[
             subtitle,
             href: `/subscription-plans/${plan.plan_id}`,
             logoId: plan.organisation_id,
-            searchKeywords: buildSearchKeywords(
-                plan.plan_uuid,
-                plan.plan_id,
-                plan.name,
-                plan.frequency,
-                plan.data_organisations?.name
-            ),
         };
     });
 }
@@ -227,10 +218,6 @@ function transformCountries(countries: CountrySummary[]): SearchableCountry[] {
         subtitle: `${country.totalModels} models`,
         href: `/countries/${country.iso.toLowerCase()}`,
         flagIso: country.iso.toLowerCase(),
-        searchKeywords: buildSearchKeywords(
-            country.iso,
-            country.countryName
-        ),
     }));
 }
 


### PR DESCRIPTION
## Summary
- defer header search index loading until the search dialog is actually opened
- move keyword expansion from the server payload to the client so the search API returns a smaller compact shape
- serve the search payload through shared public CDN cache headers for better Vercel caching behaviour

## Why
This isolates the search-bar/FOT experiment into a small web-only PR so Vercel preview metrics can show whether the change materially improves the initial page experience.

## Validation
- `E:\ai-stats-public-pr-search-fot\apps\web\node_modules\.bin\tsc.CMD --noEmit -p apps/web/tsconfig.json`

## Notes
- `eslint` could not be run successfully from the ad hoc split worktree because `apps/web/eslint.config.mjs` could not resolve `eslint-config-next` there, even after reusing the existing workspace `node_modules`. This appears to be a worktree-local module resolution issue rather than a lint error from this diff.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Performance**
  * Optimized search API responses with compact data format
  * Improved CDN cache configuration for faster content delivery

* **Refactor**
  * Streamlined search keyword generation for enhanced maintainability

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/AI-Stats/AI-Stats/pull/494)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->