### PR TITLE
Update Xiaomi Mimo v2.5 and v2.5-pro pricing: expire temporary rates and add unified pricing

### DIFF
--- a/packages/data/catalog/src/data/pricing/xiaomi/xiaomi-mimo-v2.5-pro/text.generate/pricing.json
+++ b/packages/data/catalog/src/data/pricing/xiaomi/xiaomi-mimo-v2.5-pro/text.generate/pricing.json
@@ -23,7 +23,7 @@
         }
       ],
       "priority": 100,
-      "effective_from": "2026-04-22T00:00:00",
+      "effective_from": "2026-04-22T00:00:00Z",
       "effective_to": "2026-05-27T01:00:00Z"
     },
     {
@@ -44,7 +44,7 @@
         }
       ],
       "priority": 100,
-      "effective_from": "2026-04-22T00:00:00",
+      "effective_from": "2026-04-22T00:00:00Z",
       "effective_to": "2026-05-27T01:00:00Z"
     },
     {
@@ -65,7 +65,7 @@
         }
       ],
       "priority": 100,
-      "effective_from": "2026-04-22T00:00:00",
+      "effective_from": "2026-04-22T00:00:00Z",
       "effective_to": "2026-05-27T01:00:00Z"
     },
     {
@@ -86,7 +86,7 @@
         }
       ],
       "priority": 100,
-      "effective_from": "2026-04-22T00:00:00",
+      "effective_from": "2026-04-22T00:00:00Z",
       "effective_to": "2026-05-27T01:00:00Z"
     },
     {
@@ -107,7 +107,7 @@
         }
       ],
       "priority": 100,
-      "effective_from": "2026-04-22T00:00:00",
+      "effective_from": "2026-04-22T00:00:00Z",
       "effective_to": "2026-05-27T01:00:00Z"
     },
     {
@@ -128,7 +128,7 @@
         }
       ],
       "priority": 100,
-      "effective_from": "2026-04-22T00:00:00",
+      "effective_from": "2026-04-22T00:00:00Z",
       "effective_to": "2026-05-27T01:00:00Z"
     },
     {
@@ -141,7 +141,7 @@
       "note": "Cache writes are free for a limited time",
       "match": [],
       "priority": 100,
-      "effective_from": "2026-04-22T00:00:00",
+      "effective_from": "2026-04-22T00:00:00Z",
       "effective_to": "2026-05-27T01:00:00Z"
     },
     {

--- a/packages/data/catalog/src/data/pricing/xiaomi/xiaomi-mimo-v2.5-pro/text.generate/pricing.json
+++ b/packages/data/catalog/src/data/pricing/xiaomi/xiaomi-mimo-v2.5-pro/text.generate/pricing.json
@@ -23,7 +23,8 @@
         }
       ],
       "priority": 100,
-      "effective_from": "2026-04-22T00:00:00"
+      "effective_from": "2026-04-22T00:00:00",
+      "effective_to": "2026-05-27T01:00:00Z"
     },
     {
       "meter": "cached_read_text_tokens",
@@ -43,7 +44,8 @@
         }
       ],
       "priority": 100,
-      "effective_from": "2026-04-22T00:00:00"
+      "effective_from": "2026-04-22T00:00:00",
+      "effective_to": "2026-05-27T01:00:00Z"
     },
     {
       "meter": "output_text_tokens",
@@ -63,7 +65,8 @@
         }
       ],
       "priority": 100,
-      "effective_from": "2026-04-22T00:00:00"
+      "effective_from": "2026-04-22T00:00:00",
+      "effective_to": "2026-05-27T01:00:00Z"
     },
     {
       "meter": "input_text_tokens",
@@ -83,7 +86,8 @@
         }
       ],
       "priority": 100,
-      "effective_from": "2026-04-22T00:00:00"
+      "effective_from": "2026-04-22T00:00:00",
+      "effective_to": "2026-05-27T01:00:00Z"
     },
     {
       "meter": "cached_read_text_tokens",
@@ -103,7 +107,8 @@
         }
       ],
       "priority": 100,
-      "effective_from": "2026-04-22T00:00:00"
+      "effective_from": "2026-04-22T00:00:00",
+      "effective_to": "2026-05-27T01:00:00Z"
     },
     {
       "meter": "output_text_tokens",
@@ -123,7 +128,8 @@
         }
       ],
       "priority": 100,
-      "effective_from": "2026-04-22T00:00:00"
+      "effective_from": "2026-04-22T00:00:00",
+      "effective_to": "2026-05-27T01:00:00Z"
     },
     {
       "meter": "cached_write_text_tokens",
@@ -135,7 +141,56 @@
       "note": "Cache writes are free for a limited time",
       "match": [],
       "priority": 100,
-      "effective_from": "2026-04-22T00:00:00"
+      "effective_from": "2026-04-22T00:00:00",
+      "effective_to": "2026-05-27T01:00:00Z"
+    },
+    {
+      "meter": "cached_read_text_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 0.0036,
+      "currency": "USD",
+      "pricing_plan": "standard",
+      "note": "Unified pricing across all context lengths",
+      "match": [],
+      "priority": 100,
+      "effective_from": "2026-05-27T01:00:00Z"
+    },
+    {
+      "meter": "input_text_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 0.435,
+      "currency": "USD",
+      "pricing_plan": "standard",
+      "note": "Unified pricing across all context lengths",
+      "match": [],
+      "priority": 100,
+      "effective_from": "2026-05-27T01:00:00Z"
+    },
+    {
+      "meter": "output_text_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 0.87,
+      "currency": "USD",
+      "pricing_plan": "standard",
+      "note": "Unified pricing across all context lengths",
+      "match": [],
+      "priority": 100,
+      "effective_from": "2026-05-27T01:00:00Z"
+    },
+    {
+      "meter": "cached_write_text_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 0,
+      "currency": "USD",
+      "pricing_plan": "standard",
+      "note": "Cache writes are free for a limited time",
+      "match": [],
+      "priority": 100,
+      "effective_from": "2026-05-27T01:00:00Z"
     }
   ]
 }

--- a/packages/data/catalog/src/data/pricing/xiaomi/xiaomi-mimo-v2.5/text.generate/pricing.json
+++ b/packages/data/catalog/src/data/pricing/xiaomi/xiaomi-mimo-v2.5/text.generate/pricing.json
@@ -23,7 +23,8 @@
         }
       ],
       "priority": 100,
-      "effective_from": "2026-04-22T00:00:00"
+      "effective_from": "2026-04-22T00:00:00",
+      "effective_to": "2026-05-27T01:00:00Z"
     },
     {
       "meter": "cached_read_text_tokens",
@@ -43,7 +44,8 @@
         }
       ],
       "priority": 100,
-      "effective_from": "2026-04-22T00:00:00"
+      "effective_from": "2026-04-22T00:00:00",
+      "effective_to": "2026-05-27T01:00:00Z"
     },
     {
       "meter": "output_text_tokens",
@@ -63,7 +65,8 @@
         }
       ],
       "priority": 100,
-      "effective_from": "2026-04-22T00:00:00"
+      "effective_from": "2026-04-22T00:00:00",
+      "effective_to": "2026-05-27T01:00:00Z"
     },
     {
       "meter": "input_text_tokens",
@@ -83,7 +86,8 @@
         }
       ],
       "priority": 100,
-      "effective_from": "2026-04-22T00:00:00"
+      "effective_from": "2026-04-22T00:00:00",
+      "effective_to": "2026-05-27T01:00:00Z"
     },
     {
       "meter": "cached_read_text_tokens",
@@ -103,7 +107,8 @@
         }
       ],
       "priority": 100,
-      "effective_from": "2026-04-22T00:00:00"
+      "effective_from": "2026-04-22T00:00:00",
+      "effective_to": "2026-05-27T01:00:00Z"
     },
     {
       "meter": "output_text_tokens",
@@ -123,7 +128,8 @@
         }
       ],
       "priority": 100,
-      "effective_from": "2026-04-22T00:00:00"
+      "effective_from": "2026-04-22T00:00:00",
+      "effective_to": "2026-05-27T01:00:00Z"
     },
     {
       "meter": "cached_write_text_tokens",
@@ -135,7 +141,56 @@
       "note": "Cache writes are free for a limited time",
       "match": [],
       "priority": 100,
-      "effective_from": "2026-04-22T00:00:00"
+      "effective_from": "2026-04-22T00:00:00",
+      "effective_to": "2026-05-27T01:00:00Z"
+    },
+    {
+      "meter": "cached_read_text_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 0.0028,
+      "currency": "USD",
+      "pricing_plan": "standard",
+      "note": "Unified pricing across all context lengths",
+      "match": [],
+      "priority": 100,
+      "effective_from": "2026-05-27T01:00:00Z"
+    },
+    {
+      "meter": "input_text_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 0.14,
+      "currency": "USD",
+      "pricing_plan": "standard",
+      "note": "Unified pricing across all context lengths",
+      "match": [],
+      "priority": 100,
+      "effective_from": "2026-05-27T01:00:00Z"
+    },
+    {
+      "meter": "output_text_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 0.28,
+      "currency": "USD",
+      "pricing_plan": "standard",
+      "note": "Unified pricing across all context lengths",
+      "match": [],
+      "priority": 100,
+      "effective_from": "2026-05-27T01:00:00Z"
+    },
+    {
+      "meter": "cached_write_text_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 0,
+      "currency": "USD",
+      "pricing_plan": "standard",
+      "note": "Cache writes are free for a limited time",
+      "match": [],
+      "priority": 100,
+      "effective_from": "2026-05-27T01:00:00Z"
     }
   ]
 }

--- a/packages/data/catalog/src/data/pricing/xiaomi/xiaomi-mimo-v2.5/text.generate/pricing.json
+++ b/packages/data/catalog/src/data/pricing/xiaomi/xiaomi-mimo-v2.5/text.generate/pricing.json
@@ -23,7 +23,7 @@
         }
       ],
       "priority": 100,
-      "effective_from": "2026-04-22T00:00:00",
+      "effective_from": "2026-04-22T00:00:00Z",
       "effective_to": "2026-05-27T01:00:00Z"
     },
     {
@@ -44,7 +44,7 @@
         }
       ],
       "priority": 100,
-      "effective_from": "2026-04-22T00:00:00",
+      "effective_from": "2026-04-22T00:00:00Z",
       "effective_to": "2026-05-27T01:00:00Z"
     },
     {
@@ -65,7 +65,7 @@
         }
       ],
       "priority": 100,
-      "effective_from": "2026-04-22T00:00:00",
+      "effective_from": "2026-04-22T00:00:00Z",
       "effective_to": "2026-05-27T01:00:00Z"
     },
     {
@@ -86,7 +86,7 @@
         }
       ],
       "priority": 100,
-      "effective_from": "2026-04-22T00:00:00",
+      "effective_from": "2026-04-22T00:00:00Z",
       "effective_to": "2026-05-27T01:00:00Z"
     },
     {
@@ -107,7 +107,7 @@
         }
       ],
       "priority": 100,
-      "effective_from": "2026-04-22T00:00:00",
+      "effective_from": "2026-04-22T00:00:00Z",
       "effective_to": "2026-05-27T01:00:00Z"
     },
     {
@@ -128,7 +128,7 @@
         }
       ],
       "priority": 100,
-      "effective_from": "2026-04-22T00:00:00",
+      "effective_from": "2026-04-22T00:00:00Z",
       "effective_to": "2026-05-27T01:00:00Z"
     },
     {
@@ -141,7 +141,7 @@
       "note": "Cache writes are free for a limited time",
       "match": [],
       "priority": 100,
-      "effective_from": "2026-04-22T00:00:00",
+      "effective_from": "2026-04-22T00:00:00Z",
       "effective_to": "2026-05-27T01:00:00Z"
     },
     {


### PR DESCRIPTION
### Motivation

- Replace the temporary, context-length-dependent pricing rules with a unified pricing tier effective on 2026-05-27 and mark the prior temporary rules as expiring. 
- Make cache write pricing and notes explicit while preserving the limited-time free cache-write period.

### Description

- Added `effective_to: "2026-05-27T01:00:00Z"` to existing temporary pricing rules for both `xiaomi/mimo-v2.5` and `xiaomi/mimo-v2.5-pro` pricing files to mark those rates as expiring. 
- Introduced new unified pricing rules effective `2026-05-27T01:00:00Z` for `input_text_tokens`, `output_text_tokens`, and `cached_read_text_tokens` in both `packages/data/catalog/src/data/pricing/xiaomi/xiaomi-mimo-v2.5/text.generate/pricing.json` and `packages/data/catalog/src/data/pricing/xiaomi/xiaomi-mimo-v2.5-pro/text.generate/pricing.json`. 
- Kept `cached_write_text_tokens` entries and their note about free cache writes, adding new entries effective `2026-05-27T01:00:00Z` to continue the free-write behavior under the unified pricing window. 
- Updated `note` fields on the new rules to indicate "Unified pricing across all context lengths" where applicable.

### Testing

- Ran JSON lint/schema validation against the modified pricing files and they passed without errors. 
- Ran repository CI checks (`npm run lint` and `npm test`) and they completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a15f5840fe08333b17e4e3550157144)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated pricing schedules for Xiaomi MIMO v2.5 and v2.5 Pro text generation models.
  * Applied effective end dates to current pricing rules (May 27, 2026).
  * Introduced new unified pricing structure across all context lengths beginning May 27, 2026, with revised token pricing rates for cached read, input, and output tokens.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/AI-Stats/AI-Stats/pull/507?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->