### PR TITLE
ci: switch Issue Triage OpenCode model to Big Pickle

### DIFF
--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -33,7 +33,7 @@ jobs:
               env:
                   OPENCODE_API_KEY: ${{ secrets.OPENCODE_API_KEY }}
               with:
-                  model: opencode/gpt-5-nano
+                  model: opencode/big-pickle
                   prompt: |
                       You are responding to a new GitHub issue on AI Stats.
                       AI Stats is an open-source monorepo with a Next.js web app, Cloudflare


### PR DESCRIPTION
### Motivation
- Replace the OpenCode model used by the Issue Triage workflow so triage runs use `opencode/big-pickle` instead of `opencode/gpt-5-nano`.

### Description
- Update the model setting in `.github/workflows/issue-triage.yml` from `opencode/gpt-5-nano` to `opencode/big-pickle` with no other workflow changes.

### Testing
- Ran `pnpm lint` from the repo root which exercised workspace linting, and it failed due to pre-existing unrelated issues (Raycast extension lint/format errors and a network resolution error to `www.raycast.com`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a160ab2c624833382c5bcb7c4934e08)