### PR TITLE
data: add MiniMax M3 family + model catalog placeholders

### DIFF
--- a/packages/data/catalog/src/data/api_providers/minimax/models.json
+++ b/packages/data/catalog/src/data/api_providers/minimax/models.json
@@ -456,10 +456,31 @@
             "provider_max": null,
             "provider_default": null,
             "notes": null
-          }
-        ]
       }
     ]
+  },
+  {
+    "api_model_id": "minimax/minimax-m3",
+    "provider_api_model_id": "minimax:minimax/minimax-m3",
+    "provider_model_slug": "MiniMax-M3",
+    "internal_model_id": "minimax/minimax-m3",
+    "is_active_gateway": false,
+    "quantization_scheme": null,
+    "input_modalities": "text",
+    "output_modalities": "text",
+    "context_length": null,
+    "max_output_tokens": null,
+    "effective_from": null,
+    "effective_to": null,
+    "capabilities": [
+      {
+        "capability_id": "text.generate",
+        "status": "coming_soon",
+        "params": []
+      }
+    ]
+  }
+]
   },
   {
     "api_model_id": "minimax/music-1.5",

--- a/packages/data/catalog/src/data/families/minimax-minimax-m3/family.json
+++ b/packages/data/catalog/src/data/families/minimax-minimax-m3/family.json
@@ -1,0 +1,5 @@
+{
+    "family_id": "minimax/minimax-m3",
+    "family_name": "MiniMax M3",
+    "organisation_id": "minimax"
+}

--- a/packages/data/catalog/src/data/models/minimax/minimax-m3/model.json
+++ b/packages/data/catalog/src/data/models/minimax/minimax-m3/model.json
@@ -13,6 +13,7 @@
     "input_types": "text",
     "output_types": "text",
     "api_model_id": "minimax/minimax-m3",
+    "family_id": "minimax/minimax-m3",
     "links": [],
     "details": [],
     "benchmarks": []

--- a/packages/data/catalog/src/data/models/minimax/minimax-m3/model.json
+++ b/packages/data/catalog/src/data/models/minimax/minimax-m3/model.json
@@ -1,0 +1,19 @@
+{
+    "model_id": "minimax/minimax-m3",
+    "organisation_id": "minimax",
+    "name": "MiniMax M3",
+    "status": "Rumoured",
+    "previous_model_id": "minimax/minimax-m2.7",
+    "description": "MiniMax M3 is a rumoured next-generation MiniMax flagship language model expected to succeed the M2 series.",
+    "announced_date": null,
+    "release_date": null,
+    "deprecation_date": null,
+    "retirement_date": null,
+    "license": null,
+    "input_types": "text",
+    "output_types": "text",
+    "api_model_id": "minimax/minimax-m3",
+    "links": [],
+    "details": [],
+    "benchmarks": []
+}


### PR DESCRIPTION
### Motivation
- Prepare the data catalog for an imminent MiniMax M3 launch by adding a placeholder model record and family so the family and API model id exist ahead of official details.

### Description
- Add `packages/data/catalog/src/data/families/minimax-minimax-m3/family.json` and `packages/data/catalog/src/data/models/minimax/minimax-m3/model.json` with `status: "Rumoured"`, a short description, and `api_model_id: "minimax/minimax-m3"` wired for future API usage.

### Testing
- Ran `pnpm validate:data` which succeeded, and ran `pnpm lint` which failed due to unrelated existing workspace lint issues (Raycast extension network-dependent checks and icon size errors) rather than the new data files.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a175295004c8333a3dafb4352a719df)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added MiniMax M3 model to the catalog with text input and output capabilities.
  * Model is currently in Rumoured status and linked to MiniMax M2.7 as the previous version.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/AI-Stats/AI-Stats/pull/511?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->