### PR TITLE
Stage Claude Opus 4.8 catalog entry

### DIFF
--- a/packages/data/catalog/src/data/manifest.json
+++ b/packages/data/catalog/src/data/manifest.json
@@ -112,6 +112,7 @@
       "anthropic/claude-opus-4.1",
       "anthropic/claude-opus-4.5",
       "anthropic/claude-opus-4.6",
+      "anthropic/claude-opus-4.8",
       "anthropic/claude-sonnet-4",
       "anthropic/claude-sonnet-4.5",
       "anthropic/claude-sonnet-4.6"

--- a/packages/data/catalog/src/data/models/anthropic/claude-opus-4.8/model.json
+++ b/packages/data/catalog/src/data/models/anthropic/claude-opus-4.8/model.json
@@ -1,0 +1,28 @@
+{
+  "model_id": "anthropic/claude-opus-4.8",
+  "organisation_id": "anthropic",
+  "name": "Claude Opus 4.8",
+  "status": "Available",
+  "previous_model_id": "anthropic/claude-opus-4.7",
+  "description": "Claude Opus 4.8 is a staged AI Stats catalog entry following Anthropic's recent Opus release pattern. Provider routing, pricing, and benchmark metadata can be added once public launch details are finalized.",
+  "announced_date": "2026-05-28T00:00:00",
+  "release_date": "2026-05-28T00:00:00",
+  "deprecation_date": null,
+  "retirement_date": null,
+  "license": "Proprietary",
+  "input_types": "text,image",
+  "output_types": "text",
+  "api_model_id": "anthropic/claude-opus-4.8",
+  "links": [],
+  "details": [
+    {
+      "name": "input_context_length",
+      "value": 1000000
+    },
+    {
+      "name": "output_context_length",
+      "value": 128000
+    }
+  ],
+  "benchmarks": []
+}


### PR DESCRIPTION
## Summary

This PR stages a catalog-only entry for `anthropic/claude-opus-4.8` so the model can exist in AI Stats ahead of broader provider and pricing rollout work later today.

## Problem

We wanted the Claude Opus 4.8 release represented in the model catalog on release day, but there was no model record yet. At the same time, pricing, provider routing, and benchmark metadata were not ready to publish.

## Root Cause

The catalog had not yet been prepared with a minimal model entry for the new Opus release, so the model could not appear in AI Stats at all without bundling it together with incomplete downstream metadata.

## Fix

This PR adds a minimal `anthropic/claude-opus-4.8` model record and includes it in the manifest. It intentionally does not add pricing, provider mappings, or generated SDK/OpenAPI callable model surfaces yet. The record uses today's date, follows the existing Opus lineage from `anthropic/claude-opus-4.7`, and leaves later rollout details to a follow-up.

## Validation

I ran:

- `pnpm validate:data`

That validation passed.
