### PR TITLE
Make upstream model-discovery issue sync source-aware and wire HF private discovery

### DIFF
--- a/.github/workflows/check-new-models.yml
+++ b/.github/workflows/check-new-models.yml
@@ -90,6 +90,7 @@ jobs:
               env:
                   DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
                   DISCORD_ROLE_ID_DEV: ${{ env.DISCORD_ROLE_ID_DEV }}
+                  GITHUB_TOKEN: ${{ github.token }}
               run: |
                   pnpm exec tsx scripts/model-discovery/run-hf-private.ts \
                     --discord-role-id "${{ env.DISCORD_ROLE_ID_DEV }}" \

--- a/scripts/model-discovery/README.md
+++ b/scripts/model-discovery/README.md
@@ -17,8 +17,17 @@ On subsequent runs, the runner computes per-provider:
 - removed models
 - changed model payloads
 
-Discord alerts are filtered to provider model IDs already known in the database table `data_api_provider_models` (`provider_model_slug` and the `api_model_id` tail), regardless of `is_active_gateway` status. Provider/model changes with no database mapping are ignored for notification and issue creation.
-If any known filtered diff exists, the runner sends a Discord webhook notification. It also syncs GitHub issues automatically when `GITHUB_TOKEN`/`GH_TOKEN` and `GITHUB_REPOSITORY` are available. Issue state is stored in `scripts/model-discovery/state/provider-change-issues.json`, and issue threads are grouped by provider and action type so batched additions, changes, or deletions stay together instead of creating one issue per model. Deletion issues are only created for provider model IDs that still have a `data_api_provider_models` mapping, which avoids ghost issues for unknown upstream removals. Set `MODEL_DISCOVERY_GITHUB_ISSUES=false` to disable issue sync.
+## Private upstream discovery
+
+Private upstream discovery checks model sources outside AI Stats, including provider `/models` APIs and watched Hugging Face organisations/models. These checks send private Discord notifications and can create or update GitHub triage issues when `GITHUB_TOKEN`/`GH_TOKEN` and `GITHUB_REPOSITORY` are available.
+
+Provider `/models` Discord alerts are filtered to provider model IDs already known in the database table `data_api_provider_models` (`provider_model_slug` and the `api_model_id` tail), regardless of `is_active_gateway` status. GitHub issue sync is intentionally not filtered by that allowlist: unknown upstream models are included in triage issues so newly exposed provider or Hugging Face models are not silently discarded.
+
+Issue state is stored in `scripts/model-discovery/state/provider-change-issues.json`. Issue threads are grouped by source, provider/org, and action type so provider API and Hugging Face signals cannot collide.
+
+## Public AI Stats catalog discovery
+
+Public AI Stats catalog discovery checks AI Stats-owned state such as database records, public model/catalog files, provider mapping data, and generated SDK/OpenAPI model surfaces. These checks may send Discord notifications or write reports, but they do not create, update, comment on, close, label, or otherwise mutate GitHub issues.
 
 Internal model file checks read from `packages/data/catalog/src/data/models`.
 Internal Discord alerts are sent as embed payloads when internal models are added or when lifecycle fields change:
@@ -40,12 +49,12 @@ Providers not present in `discovery-policy.ts` are also treated as inactive by d
 
 ## Script entrypoints
 
-- `scripts/model-discovery/run-internal-public.ts`
-  - Public internal model watcher notifications (new models + lifecycle updates).
 - `scripts/model-discovery/run.ts`
-  - Private external provider tracking notifications.
+  - Private upstream provider `/models` API discovery. Sends Discord notifications for known catalog-relevant changes and creates/updates GitHub triage issues for all upstream changes, including unknown models.
 - `scripts/model-discovery/run-hf-private.ts`
-  - Private Hugging Face org tracking notifications.
+  - Private upstream Hugging Face discovery. Sends private Discord notifications and creates/updates GitHub triage issues.
+- `scripts/model-discovery/run-internal-public.ts`
+  - Public AI Stats catalog/database discovery. Sends public/internal catalog notifications or reports only; it intentionally does not mutate GitHub issues.
 
 ## Local run
 
@@ -65,8 +74,10 @@ pnpm run data:check-new-models:test
 - `DISCORD_ROLE_ID_DEV` (optional dev role mention for Hugging Face private notifications)
 - `DISCORD_USER_ID` (optional mention)
 - `DISCORD_MODEL_DISCOVERY_AVATAR_URL` (optional manual override when calling internal runner scripts with `--discord-avatar-url`)
-- `GITHUB_TOKEN` or `GH_TOKEN` plus `GITHUB_REPOSITORY` (optional, enables automatic GitHub issues for external provider additions/changes/deletions)
-- `MODEL_DISCOVERY_GITHUB_ISSUES=false` (optional, disables automatic GitHub issue sync)
+- `GITHUB_TOKEN` or `GH_TOKEN` plus `GITHUB_REPOSITORY` (optional, enables automatic GitHub issues for private upstream provider and Hugging Face additions/changes/deletions)
+- `MODEL_DISCOVERY_GITHUB_ISSUES=false` (optional, disables all private upstream GitHub issue sync)
+- `MODEL_DISCOVERY_PROVIDER_GITHUB_ISSUES=false` (optional, disables provider `/models` API GitHub issue sync only)
+- `MODEL_DISCOVERY_HF_GITHUB_ISSUES=false` (optional, disables Hugging Face GitHub issue sync only)
 - `NEXT_PUBLIC_SUPABASE_URL` (required for known provider model DB allowlist)
 - `SUPABASE_SERVICE_ROLE_KEY` (required for known provider model DB allowlist)
 - Provider-specific API keys declared in each provider module.

--- a/scripts/model-discovery/github-issues.test.ts
+++ b/scripts/model-discovery/github-issues.test.ts
@@ -247,14 +247,20 @@ async function main(): Promise<void> {
     };
     console.log = () => {};
     try {
-        await syncHfIssues([
-            {
-                org: "openai",
-                addedModelIds: ["openai/example-hf-model"],
-            },
-        ], async () => {
-            throw new Error("simulated GitHub outage");
-        });
+        await assert.rejects(
+            syncHfIssues(
+                [
+                    {
+                        org: "openai",
+                        addedModelIds: ["openai/example-hf-model"],
+                    },
+                ],
+                async () => {
+                    throw new Error("simulated GitHub outage");
+                }
+            ),
+            /simulated GitHub outage/
+        );
     } finally {
         console.error = originalConsoleError;
         console.log = originalConsoleLog;
@@ -292,6 +298,18 @@ async function main(): Promise<void> {
             logger,
         });
         assert.deepEqual(allowedHfSync, { created: 1, updated: 0, skipped: false });
+
+        requests.length = 0;
+        const mixedSourceSync = await syncUpstreamDiscoveryIssues([providerEntry, hfEntry], {
+            token: "test-token",
+            repository: "AI-Stats/AI-Stats",
+            statePath: path.join(tempDir, "provider-disabled-mixed.json"),
+            requestImpl,
+            logger,
+        });
+        assert.deepEqual(mixedSourceSync, { created: 1, updated: 0, skipped: false });
+        assert.equal(issueTitle, "[upstream-discovery] Hugging Face: model additions for openai");
+        assert.ok(requests.some((request) => request.url.endsWith("/repos/AI-Stats/AI-Stats/issues") && request.method === "POST"));
     });
 
     await withEnv({ MODEL_DISCOVERY_HF_GITHUB_ISSUES: "false" }, async () => {
@@ -312,6 +330,18 @@ async function main(): Promise<void> {
             logger,
         });
         assert.deepEqual(providerAllowedSync, { created: 1, updated: 0, skipped: false });
+
+        requests.length = 0;
+        const mixedSourceSync = await syncUpstreamDiscoveryIssues([providerDeleteEntry, hfEntry], {
+            token: "test-token",
+            repository: "AI-Stats/AI-Stats",
+            statePath: path.join(tempDir, "hf-disabled-mixed.json"),
+            requestImpl,
+            logger,
+        });
+        assert.deepEqual(mixedSourceSync, { created: 1, updated: 0, skipped: false });
+        assert.equal(issueTitle, "[upstream-discovery] OpenAI: provider model deletions");
+        assert.ok(requests.some((request) => request.url.endsWith("/repos/AI-Stats/AI-Stats/issues") && request.method === "POST"));
     });
 
     const publicRunnerSource = fs.readFileSync(path.join(process.cwd(), "scripts", "model-discovery", "run-internal-public.ts"), "utf-8");

--- a/scripts/model-discovery/github-issues.test.ts
+++ b/scripts/model-discovery/github-issues.test.ts
@@ -7,6 +7,7 @@ import {
     testingExports,
     type UpstreamDiscoveryIssueEntry,
 } from "./github-issues";
+import { syncHfIssues } from "./run-hf-private";
 
 const providerEntry: UpstreamDiscoveryIssueEntry = {
     source: "provider-api",
@@ -237,6 +238,30 @@ async function main(): Promise<void> {
     assert.deepEqual(legacySync, { created: 0, updated: 1, skipped: false });
     assert.ok(legacyRequests.some((request) => request.url.endsWith("/repos/AI-Stats/AI-Stats/issues/777") && request.method === "PATCH"));
     assert.ok(!legacyRequests.some((request) => request.url.endsWith("/repos/AI-Stats/AI-Stats/issues") && request.method === "POST"));
+
+    const originalConsoleError = console.error;
+    const originalConsoleLog = console.log;
+    const capturedErrors: string[] = [];
+    console.error = (...args: unknown[]) => {
+        capturedErrors.push(args.map(String).join(" "));
+    };
+    console.log = () => {};
+    try {
+        await syncHfIssues([
+            {
+                org: "openai",
+                addedModelIds: ["openai/example-hf-model"],
+            },
+        ], async () => {
+            throw new Error("simulated GitHub outage");
+        });
+    } finally {
+        console.error = originalConsoleError;
+        console.log = originalConsoleLog;
+    }
+    assert.ok(
+        capturedErrors.some((line) => line.includes("Hugging Face GitHub issue sync failed: simulated GitHub outage"))
+    );
 
     await withEnv({ MODEL_DISCOVERY_GITHUB_ISSUES: "false" }, async () => {
         const sync = await syncUpstreamDiscoveryIssues([providerEntry], {

--- a/scripts/model-discovery/github-issues.test.ts
+++ b/scripts/model-discovery/github-issues.test.ts
@@ -2,9 +2,14 @@ import assert from "node:assert/strict";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { syncProviderChangeIssues, testingExports, type ProviderIssueChangeEntry } from "./github-issues";
+import {
+    syncUpstreamDiscoveryIssues,
+    testingExports,
+    type UpstreamDiscoveryIssueEntry,
+} from "./github-issues";
 
-const baseEntry: ProviderIssueChangeEntry = {
+const providerEntry: UpstreamDiscoveryIssueEntry = {
+    source: "provider-api",
     ts: "2026-05-28T12:00:00.000Z",
     action: "create",
     platformId: "openai",
@@ -12,55 +17,105 @@ const baseEntry: ProviderIssueChangeEntry = {
     providerId: "openai",
     providerName: "OpenAI",
     modelId: "gpt-5.4-preview",
+    reason: "Detected from upstream provider /models API",
 };
-const siblingEntry: ProviderIssueChangeEntry = {
-    ...baseEntry,
+const providerSiblingEntry: UpstreamDiscoveryIssueEntry = {
+    ...providerEntry,
     modelId: "gpt-5.4-mini-preview",
 };
-const deleteEntry: ProviderIssueChangeEntry = {
-    ...baseEntry,
+const providerDeleteEntry: UpstreamDiscoveryIssueEntry = {
+    ...providerEntry,
     action: "delete",
     modelId: "gpt-5.3-preview",
 };
+const hfEntry: UpstreamDiscoveryIssueEntry = {
+    source: "huggingface",
+    ts: "2026-05-28T12:00:00.000Z",
+    action: "create",
+    platformId: "huggingface",
+    platformName: "Hugging Face",
+    providerId: "openai",
+    providerName: "openai",
+    modelId: "openai/example-hf-model",
+    modelUrl: "https://huggingface.co/openai/example-hf-model",
+};
 
-const key = testingExports.issueKeyForGroup(baseEntry);
-assert.equal(testingExports.issueKeyForGroup({ providerId: baseEntry.providerId, action: baseEntry.action }), key);
-assert.notEqual(testingExports.issueKeyForGroup(deleteEntry), key);
-assert.match(testingExports.markerForKey(key), /^ai-stats-model-discovery:/);
+const providerKey = testingExports.issueKeyForGroup(providerEntry);
+const hfKey = testingExports.issueKeyForGroup(hfEntry);
+assert.equal(testingExports.issueKeyForGroup({ source: "provider-api", providerId: providerEntry.providerId, action: providerEntry.action }), providerKey);
+assert.notEqual(testingExports.issueKeyForGroup(providerDeleteEntry), providerKey);
+assert.notEqual(hfKey, providerKey);
+assert.match(testingExports.markerForKey(providerKey), /^ai-stats-upstream-discovery:/);
 
-const knownModelIdsByProvider = new Map([[baseEntry.providerId, new Set(["gpt-5.4-preview", "gpt-5.4-mini-preview"])]]);
-const knownEntries = testingExports.filterEntriesByKnownProviderModels([baseEntry, siblingEntry, deleteEntry], knownModelIdsByProvider);
-assert.deepEqual(knownEntries.map((entry) => entry.modelId), ["gpt-5.4-preview", "gpt-5.4-mini-preview"]);
-
-const grouped = testingExports.groupProviderIssueEntries([baseEntry, siblingEntry, deleteEntry]);
-assert.equal(grouped.length, 2);
-const additionGroup = grouped.find((group) => group.action === "create");
-assert.ok(additionGroup);
-assert.equal(additionGroup.entries.length, 2);
-assert.equal(testingExports.issueTitleForGroup(additionGroup), "[model-discovery] OpenAI: provider model additions");
+const grouped = testingExports.groupUpstreamIssueEntries([providerEntry, providerSiblingEntry, providerDeleteEntry, hfEntry]);
+assert.equal(grouped.length, 3);
+const providerAdditionGroup = grouped.find((group) => group.source === "provider-api" && group.action === "create");
+const hfAdditionGroup = grouped.find((group) => group.source === "huggingface" && group.action === "create");
+assert.ok(providerAdditionGroup);
+assert.ok(hfAdditionGroup);
+assert.equal(providerAdditionGroup.entries.length, 2);
+assert.equal(testingExports.issueTitleForGroup(providerAdditionGroup), "[upstream-discovery] OpenAI: provider model additions");
+assert.equal(testingExports.issueTitleForGroup(hfAdditionGroup), "[upstream-discovery] Hugging Face: model additions for openai");
 
 const body = testingExports.buildIssueBody({
-    group: additionGroup,
+    group: providerAdditionGroup,
     recentEvents: [
-        { ...baseEntry, runUrl: "https://github.com/AI-Stats/AI-Stats/actions/runs/1" },
-        siblingEntry,
+        { ...providerEntry, runUrl: "https://github.com/AI-Stats/AI-Stats/actions/runs/1" },
+        providerSiblingEntry,
     ],
 });
-assert.match(body, /Tracking key: `ai-stats-model-discovery:/);
-assert.match(body, /provider model additions/);
+assert.match(body, /Tracking key: `ai-stats-upstream-discovery:/);
+assert.match(body, /Source: provider API/);
+assert.match(body, /provider API model additions/);
 assert.match(body, /Models in this signal: 2/);
 assert.match(body, /`gpt-5\.4-preview`/);
 assert.match(body, /workflow run/);
+assert.match(body, /Unknown upstream models are intentionally included/);
 
-const comment = testingExports.buildIssueComment(additionGroup, [baseEntry, siblingEntry]);
-assert.match(comment, /another additions signal/);
+const hfBody = testingExports.buildIssueBody({
+    group: hfAdditionGroup,
+    recentEvents: [hfEntry],
+});
+assert.match(hfBody, /Source: Hugging Face/);
+assert.match(hfBody, /Provider\/org: openai/);
+assert.match(hfBody, /https:\/\/huggingface\.co\/openai\/example-hf-model/);
+
+const comment = testingExports.buildIssueComment(providerAdditionGroup, [providerEntry, providerSiblingEntry]);
+assert.match(comment, /another provider API additions signal/);
 assert.match(comment, /gpt-5\.4-mini-preview/);
+
+async function withEnv<T>(updates: Record<string, string | undefined>, callback: () => Promise<T>): Promise<T> {
+    const previous = new Map<string, string | undefined>();
+    for (const key of Object.keys(updates)) {
+        previous.set(key, process.env[key]);
+        const value = updates[key];
+        if (value === undefined) {
+            delete process.env[key];
+        } else {
+            process.env[key] = value;
+        }
+    }
+
+    try {
+        return await callback();
+    } finally {
+        for (const [key, value] of previous) {
+            if (value === undefined) {
+                delete process.env[key];
+            } else {
+                process.env[key] = value;
+            }
+        }
+    }
+}
 
 async function main(): Promise<void> {
     const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "model-discovery-issues-"));
     const statePath = path.join(tempDir, "state.json");
     const requests: Array<{ url: string; method: string; body?: unknown }> = [];
     let issueBody = "";
+    let issueTitle = "";
+    let nextIssueNumber = 123;
     const requestImpl: typeof fetch = async (input, init) => {
         const url = String(input);
         const method = init?.method ?? "GET";
@@ -74,79 +129,168 @@ async function main(): Promise<void> {
 
         if (url.endsWith("/repos/AI-Stats/AI-Stats/issues") && method === "POST") {
             issueBody = parsedBody.body;
-            return Response.json({ number: 123, html_url: "https://github.com/AI-Stats/AI-Stats/issues/123", state: "open" });
+            issueTitle = parsedBody.title;
+            const issueNumber = nextIssueNumber;
+            nextIssueNumber += 1;
+            return Response.json({ number: issueNumber, html_url: `https://github.com/AI-Stats/AI-Stats/issues/${issueNumber}`, state: "open" });
         }
 
-        if (url.endsWith("/repos/AI-Stats/AI-Stats/issues/123") && method === "GET") {
-            return Response.json({ number: 123, html_url: "https://github.com/AI-Stats/AI-Stats/issues/123", state: "open" });
+        const issueMatch = url.match(/\/repos\/AI-Stats\/AI-Stats\/issues\/(\d+)$/);
+        if (issueMatch && method === "GET") {
+            const issueNumber = Number(issueMatch[1]);
+            return Response.json({ number: issueNumber, html_url: `https://github.com/AI-Stats/AI-Stats/issues/${issueNumber}`, state: "open" });
         }
 
-        if (url.endsWith("/repos/AI-Stats/AI-Stats/issues/123") && method === "PATCH") {
+        if (issueMatch && method === "PATCH") {
+            const issueNumber = Number(issueMatch[1]);
             issueBody = parsedBody.body;
-            return Response.json({ number: 123, html_url: "https://github.com/AI-Stats/AI-Stats/issues/123", state: "open" });
+            issueTitle = parsedBody.title;
+            return Response.json({ number: issueNumber, html_url: `https://github.com/AI-Stats/AI-Stats/issues/${issueNumber}`, state: "open" });
         }
 
-        if (url.endsWith("/repos/AI-Stats/AI-Stats/issues/123/comments") && method === "POST") {
+        if (/\/repos\/AI-Stats\/AI-Stats\/issues\/\d+\/comments$/.test(url) && method === "POST") {
             return Response.json({ id: 456 });
         }
 
         return new Response("not found", { status: 404 });
     };
+    const logger = { log() {}, warn() {} };
 
-    const additionKnownModelIdsByProvider = new Map([[baseEntry.providerId, new Set(["gpt-5.4-preview", "gpt-5.4-mini-preview"])]]);
-    const ghostDeleteSync = await syncProviderChangeIssues([deleteEntry], {
-        token: "test-token",
-        repository: "AI-Stats/AI-Stats",
-        statePath,
-        knownModelIdsByProvider: additionKnownModelIdsByProvider,
-        requestImpl,
-        logger: console,
-    });
-    assert.deepEqual(ghostDeleteSync, { created: 0, updated: 0, skipped: false });
-    assert.equal(requests.length, 0);
-
-    const deleteKnownModelIdsByProvider = new Map([
-        [baseEntry.providerId, new Set(["gpt-5.4-preview", "gpt-5.4-mini-preview", "gpt-5.3-preview"])],
-    ]);
-    const deleteSync = await syncProviderChangeIssues([deleteEntry], {
-        token: "test-token",
-        repository: "AI-Stats/AI-Stats",
-        statePath,
-        knownModelIdsByProvider: deleteKnownModelIdsByProvider,
-        requestImpl,
-        logger: console,
-    });
-    assert.deepEqual(deleteSync, { created: 1, updated: 0, skipped: false });
-    assert.match(issueBody, /provider model deletions/);
-    assert.match(issueBody, /Latest action: deletions/);
-    assert.ok(requests.some((request) => request.url.endsWith("/repos/AI-Stats/AI-Stats/issues") && request.method === "POST"));
-    requests.length = 0;
-    issueBody = "";
-
-    const firstSync = await syncProviderChangeIssues([baseEntry, siblingEntry], {
+    const firstProviderSync = await syncUpstreamDiscoveryIssues([providerEntry, providerSiblingEntry], {
         token: "test-token",
         repository: "AI-Stats/AI-Stats",
         statePath,
         runUrl: "https://github.com/AI-Stats/AI-Stats/actions/runs/1",
-        knownModelIdsByProvider: additionKnownModelIdsByProvider,
         requestImpl,
-        logger: console,
+        logger,
     });
-    assert.deepEqual(firstSync, { created: 1, updated: 0, skipped: false });
+    assert.deepEqual(firstProviderSync, { created: 1, updated: 0, skipped: false });
+    assert.equal(issueTitle, "[upstream-discovery] OpenAI: provider model additions");
     assert.match(issueBody, /Latest action: additions/);
     assert.match(issueBody, /Models in this signal: 2/);
 
-    const secondSync = await syncProviderChangeIssues([{ ...baseEntry, ts: "2026-05-28T12:15:00.000Z" }], {
+    const secondProviderSync = await syncUpstreamDiscoveryIssues([{ ...providerEntry, ts: "2026-05-28T12:15:00.000Z" }], {
         token: "test-token",
         repository: "AI-Stats/AI-Stats",
         statePath,
-        knownModelIdsByProvider: additionKnownModelIdsByProvider,
         requestImpl,
-        logger: console,
+        logger,
     });
-    assert.deepEqual(secondSync, { created: 0, updated: 1, skipped: false });
-    assert.match(issueBody, /Latest action: additions/);
-    assert.ok(requests.some((request) => request.url.endsWith("/issues/123/comments") && request.method === "POST"));
+    assert.deepEqual(secondProviderSync, { created: 0, updated: 1, skipped: false });
+    assert.ok(requests.some((request) => /\/issues\/123\/comments$/.test(request.url) && request.method === "POST"));
+
+    requests.length = 0;
+    const hfSync = await syncUpstreamDiscoveryIssues([hfEntry], {
+        token: "test-token",
+        repository: "AI-Stats/AI-Stats",
+        statePath,
+        requestImpl,
+        logger,
+    });
+    assert.deepEqual(hfSync, { created: 1, updated: 0, skipped: false });
+    assert.equal(issueTitle, "[upstream-discovery] Hugging Face: model additions for openai");
+    assert.match(issueBody, /Source: Hugging Face/);
+    assert.ok(requests.some((request) => request.url.endsWith("/repos/AI-Stats/AI-Stats/issues") && request.method === "POST"));
+
+    requests.length = 0;
+    const unknownProviderSync = await syncUpstreamDiscoveryIssues([{ ...providerEntry, modelId: "brand-new-unknown-upstream-model" }], {
+        token: "test-token",
+        repository: "AI-Stats/AI-Stats",
+        statePath: path.join(tempDir, "unknown-state.json"),
+        requestImpl,
+        logger,
+    });
+    assert.deepEqual(unknownProviderSync, { created: 1, updated: 0, skipped: false });
+    assert.ok(requests.some((request) => request.url.endsWith("/repos/AI-Stats/AI-Stats/issues") && request.method === "POST"));
+
+
+    const legacyRequests: Array<{ url: string; method: string; body?: unknown }> = [];
+    const legacyKey = testingExports.legacyProviderIssueKeyForGroup(providerEntry);
+    const legacyRequestImpl: typeof fetch = async (input, init) => {
+        const url = String(input);
+        const method = init?.method ?? "GET";
+        const bodyText = typeof init?.body === "string" ? init.body : undefined;
+        const parsedBody = bodyText ? JSON.parse(bodyText) : undefined;
+        legacyRequests.push({ url, method, body: parsedBody });
+
+        if (url.includes("/search/issues") && url.includes(encodeURIComponent(testingExports.legacyMarkerForKey(legacyKey)))) {
+            return Response.json({ items: [{ number: 777, html_url: "https://github.com/AI-Stats/AI-Stats/issues/777", state: "open" }] });
+        }
+        if (url.includes("/search/issues")) {
+            return Response.json({ items: [] });
+        }
+        if (url.endsWith("/repos/AI-Stats/AI-Stats/issues/777") && method === "PATCH") {
+            return Response.json({ number: 777, html_url: "https://github.com/AI-Stats/AI-Stats/issues/777", state: "open" });
+        }
+        if (url.endsWith("/repos/AI-Stats/AI-Stats/issues/777/comments") && method === "POST") {
+            return Response.json({ id: 778 });
+        }
+        return new Response("not found", { status: 404 });
+    };
+    const legacySync = await syncUpstreamDiscoveryIssues([providerEntry], {
+        token: "test-token",
+        repository: "AI-Stats/AI-Stats",
+        statePath: path.join(tempDir, "legacy-state.json"),
+        requestImpl: legacyRequestImpl,
+        logger,
+    });
+    assert.deepEqual(legacySync, { created: 0, updated: 1, skipped: false });
+    assert.ok(legacyRequests.some((request) => request.url.endsWith("/repos/AI-Stats/AI-Stats/issues/777") && request.method === "PATCH"));
+    assert.ok(!legacyRequests.some((request) => request.url.endsWith("/repos/AI-Stats/AI-Stats/issues") && request.method === "POST"));
+
+    await withEnv({ MODEL_DISCOVERY_GITHUB_ISSUES: "false" }, async () => {
+        const sync = await syncUpstreamDiscoveryIssues([providerEntry], {
+            token: "test-token",
+            repository: "AI-Stats/AI-Stats",
+            statePath: path.join(tempDir, "global-disabled.json"),
+            requestImpl,
+            logger,
+        });
+        assert.deepEqual(sync, { created: 0, updated: 0, skipped: true });
+    });
+
+    await withEnv({ MODEL_DISCOVERY_PROVIDER_GITHUB_ISSUES: "false" }, async () => {
+        const providerSync = await syncUpstreamDiscoveryIssues([providerEntry], {
+            token: "test-token",
+            repository: "AI-Stats/AI-Stats",
+            statePath: path.join(tempDir, "provider-disabled.json"),
+            requestImpl,
+            logger,
+        });
+        assert.deepEqual(providerSync, { created: 0, updated: 0, skipped: true });
+
+        const allowedHfSync = await syncUpstreamDiscoveryIssues([hfEntry], {
+            token: "test-token",
+            repository: "AI-Stats/AI-Stats",
+            statePath: path.join(tempDir, "provider-disabled-hf-allowed.json"),
+            requestImpl,
+            logger,
+        });
+        assert.deepEqual(allowedHfSync, { created: 1, updated: 0, skipped: false });
+    });
+
+    await withEnv({ MODEL_DISCOVERY_HF_GITHUB_ISSUES: "false" }, async () => {
+        const hfDisabledSync = await syncUpstreamDiscoveryIssues([hfEntry], {
+            token: "test-token",
+            repository: "AI-Stats/AI-Stats",
+            statePath: path.join(tempDir, "hf-disabled.json"),
+            requestImpl,
+            logger,
+        });
+        assert.deepEqual(hfDisabledSync, { created: 0, updated: 0, skipped: true });
+
+        const providerAllowedSync = await syncUpstreamDiscoveryIssues([providerDeleteEntry], {
+            token: "test-token",
+            repository: "AI-Stats/AI-Stats",
+            statePath: path.join(tempDir, "hf-disabled-provider-allowed.json"),
+            requestImpl,
+            logger,
+        });
+        assert.deepEqual(providerAllowedSync, { created: 1, updated: 0, skipped: false });
+    });
+
+    const publicRunnerSource = fs.readFileSync(path.join(process.cwd(), "scripts", "model-discovery", "run-internal-public.ts"), "utf-8");
+    assert.doesNotMatch(publicRunnerSource, /github-issues|syncUpstreamDiscoveryIssues|syncProviderChangeIssues/);
 
     console.log("github-issues helper tests passed");
 }

--- a/scripts/model-discovery/github-issues.ts
+++ b/scripts/model-discovery/github-issues.ts
@@ -424,11 +424,6 @@ async function findOpenIssue(args: {
 }
 
 function shouldSkipForEnv(source: UpstreamDiscoveryIssueSource, logger: Pick<Console, "log">): boolean {
-    if (process.env.MODEL_DISCOVERY_GITHUB_ISSUES === "false") {
-        logger.log("[model-discovery] GitHub issue sync disabled by MODEL_DISCOVERY_GITHUB_ISSUES=false.");
-        return true;
-    }
-
     if (source === "provider-api" && process.env.MODEL_DISCOVERY_PROVIDER_GITHUB_ISSUES === "false") {
         logger.log("[model-discovery] Provider API GitHub issue sync disabled by MODEL_DISCOVERY_PROVIDER_GITHUB_ISSUES=false.");
         return true;
@@ -440,6 +435,23 @@ function shouldSkipForEnv(source: UpstreamDiscoveryIssueSource, logger: Pick<Con
     }
 
     return false;
+}
+
+function filterEntriesForEnabledSources(
+    entries: UpstreamDiscoveryIssueEntry[],
+    logger: Pick<Console, "log">
+): UpstreamDiscoveryIssueEntry[] {
+    const disabledSources = new Set<UpstreamDiscoveryIssueSource>();
+    const activeSources = new Set(entries.map((entry) => entry.source));
+
+    for (const source of activeSources) {
+        if (shouldSkipForEnv(source, logger)) {
+            disabledSources.add(source);
+        }
+    }
+
+    if (disabledSources.size === 0) return entries;
+    return entries.filter((entry) => !disabledSources.has(entry.source));
 }
 
 function logSyncSummary(args: {
@@ -481,16 +493,33 @@ export async function syncUpstreamDiscoveryIssues(
         return { created: 0, updated: 0, skipped: false };
     }
 
-    if (sources.some((source) => shouldSkipForEnv(source, logger))) {
+    if (process.env.MODEL_DISCOVERY_GITHUB_ISSUES === "false") {
+        logger.log("[model-discovery] GitHub issue sync disabled by MODEL_DISCOVERY_GITHUB_ISSUES=false.");
         logSyncSummary({
             logger,
             source: sourceForLog,
             inputEvents: rawEntries.length,
-            filteredEvents: entries.length,
+            filteredEvents: 0,
             created: 0,
             updated: 0,
             skipped: true,
-            reason: "disabled by environment",
+            reason: "disabled by MODEL_DISCOVERY_GITHUB_ISSUES",
+        });
+        return { created: 0, updated: 0, skipped: true };
+    }
+
+    const filteredEntries = filterEntriesForEnabledSources(entries, logger);
+
+    if (filteredEntries.length === 0) {
+        logSyncSummary({
+            logger,
+            source: sourceForLog,
+            inputEvents: rawEntries.length,
+            filteredEvents: filteredEntries.length,
+            created: 0,
+            updated: 0,
+            skipped: true,
+            reason: "all entries disabled by environment",
         });
         return { created: 0, updated: 0, skipped: true };
     }
@@ -503,7 +532,7 @@ export async function syncUpstreamDiscoveryIssues(
             logger,
             source: sourceForLog,
             inputEvents: rawEntries.length,
-            filteredEvents: entries.length,
+            filteredEvents: filteredEntries.length,
             created: 0,
             updated: 0,
             skipped: true,
@@ -524,7 +553,7 @@ export async function syncUpstreamDiscoveryIssues(
     let created = 0;
     let updated = 0;
 
-    for (const group of groupUpstreamIssueEntries(entries)) {
+    for (const group of groupUpstreamIssueEntries(filteredEntries)) {
         const legacyKey = group.source === "provider-api" ? legacyProviderIssueKeyForGroup(group) : undefined;
         const existingRecord = state.issues[group.key] ?? (legacyKey ? state.issues[legacyKey] : undefined);
         const events: UpstreamIssueHistoryEvent[] = group.entries.map((entry) => ({ ...entry, runUrl }));
@@ -567,7 +596,7 @@ export async function syncUpstreamDiscoveryIssues(
         logger,
         source: sourceForLog,
         inputEvents: rawEntries.length,
-        filteredEvents: entries.length,
+        filteredEvents: filteredEntries.length,
         created,
         updated,
         skipped: false,

--- a/scripts/model-discovery/github-issues.ts
+++ b/scripts/model-discovery/github-issues.ts
@@ -1,33 +1,44 @@
 import fs from "node:fs";
 import path from "node:path";
 
-export type ProviderIssueChangeAction = "create" | "update" | "delete";
+export type UpstreamDiscoveryIssueSource = "provider-api" | "huggingface";
 
-export type ProviderIssueChangeEntry = {
+export type UpstreamDiscoveryIssueAction = "create" | "update" | "delete";
+
+export type UpstreamDiscoveryIssueEntry = {
+    source: UpstreamDiscoveryIssueSource;
     ts: string;
-    action: ProviderIssueChangeAction;
+    action: UpstreamDiscoveryIssueAction;
     platformId: string;
     platformName: string;
     providerId: string;
     providerName: string;
     modelId: string;
+    modelUrl?: string;
+    reason?: string;
+    metadata?: Record<string, unknown>;
 };
 
-type ProviderIssueHistoryEvent = ProviderIssueChangeEntry & {
+export type ProviderIssueChangeAction = UpstreamDiscoveryIssueAction;
+export type ProviderIssueChangeEntry = Omit<UpstreamDiscoveryIssueEntry, "source"> & {
+    source?: UpstreamDiscoveryIssueSource;
+};
+
+type UpstreamIssueHistoryEvent = UpstreamDiscoveryIssueEntry & {
     runUrl?: string;
 };
 
-type ProviderIssueRecord = {
+type UpstreamIssueRecord = {
     issueNumber?: number;
     issueUrl?: string;
-    recentEvents: ProviderIssueHistoryEvent[];
+    recentEvents: UpstreamIssueHistoryEvent[];
     updatedAt: string;
 };
 
-type ProviderIssueState = {
+type UpstreamIssueState = {
     version: 1;
     updatedAt: string;
-    issues: Record<string, ProviderIssueRecord>;
+    issues: Record<string, UpstreamIssueRecord>;
 };
 
 type GitHubIssue = {
@@ -48,7 +59,6 @@ type GitHubIssueSyncOptions = {
     apiBaseUrl?: string | null;
     statePath: string;
     runUrl?: string | null;
-    knownModelIdsByProvider?: Map<string, Set<string>>;
     logger?: Pick<Console, "log" | "warn">;
     requestImpl?: typeof fetch;
 };
@@ -65,22 +75,6 @@ const MAX_RECENT_EVENTS = 20;
 const DEFAULT_GITHUB_API_BASE_URL = "https://api.github.com";
 const DEFAULT_GITHUB_REQUEST_TIMEOUT_MS = 30_000;
 
-function canonicalModelId(value: string): string {
-    return value.trim().toLowerCase().replace(/\s+/g, "");
-}
-
-function filterEntriesByKnownProviderModels(
-    entries: ProviderIssueChangeEntry[],
-    knownModelIdsByProvider: Map<string, Set<string>> | undefined
-): ProviderIssueChangeEntry[] {
-    if (!knownModelIdsByProvider) return entries;
-
-    return entries.filter((entry) => {
-        const knownModelIds = knownModelIdsByProvider.get(entry.providerId);
-        return Boolean(knownModelIds?.has(canonicalModelId(entry.modelId)));
-    });
-}
-
 function nowIso(): string {
     return new Date().toISOString();
 }
@@ -91,7 +85,14 @@ function trimOrNull(value: string | null | undefined): string | null {
     return trimmed || null;
 }
 
-function readIssueState(filePath: string): ProviderIssueState {
+function normalizeEntry(entry: ProviderIssueChangeEntry | UpstreamDiscoveryIssueEntry): UpstreamDiscoveryIssueEntry {
+    return {
+        ...entry,
+        source: entry.source ?? "provider-api",
+    };
+}
+
+function readIssueState(filePath: string): UpstreamIssueState {
     if (!fs.existsSync(filePath)) {
         return {
             version: 1,
@@ -101,7 +102,7 @@ function readIssueState(filePath: string): ProviderIssueState {
     }
 
     try {
-        const parsed = JSON.parse(fs.readFileSync(filePath, "utf-8")) as Partial<ProviderIssueState> | undefined;
+        const parsed = JSON.parse(fs.readFileSync(filePath, "utf-8")) as Partial<UpstreamIssueState> | undefined;
         if (!parsed || parsed.version !== 1 || !parsed.issues || typeof parsed.issues !== "object") {
             throw new Error("Invalid issue state");
         }
@@ -112,7 +113,7 @@ function readIssueState(filePath: string): ProviderIssueState {
             issues: Object.fromEntries(
                 Object.entries(parsed.issues).map(([key, record]) => {
                     const recentEvents = Array.isArray(record?.recentEvents)
-                        ? record.recentEvents.filter(isProviderIssueHistoryEvent).slice(0, MAX_RECENT_EVENTS)
+                        ? record.recentEvents.filter(isUpstreamIssueHistoryEvent).slice(0, MAX_RECENT_EVENTS)
                         : [];
                     return [
                         key,
@@ -121,7 +122,7 @@ function readIssueState(filePath: string): ProviderIssueState {
                             issueUrl: trimOrNull(record?.issueUrl) ?? undefined,
                             recentEvents,
                             updatedAt: trimOrNull(record?.updatedAt) ?? nowIso(),
-                        } satisfies ProviderIssueRecord,
+                        } satisfies UpstreamIssueRecord,
                     ];
                 })
             ),
@@ -135,15 +136,16 @@ function readIssueState(filePath: string): ProviderIssueState {
     }
 }
 
-function writeIssueState(filePath: string, state: ProviderIssueState): void {
+function writeIssueState(filePath: string, state: UpstreamIssueState): void {
     fs.mkdirSync(path.dirname(filePath), { recursive: true });
     fs.writeFileSync(filePath, `${JSON.stringify(state, null, 2)}\n`, "utf-8");
 }
 
-function isProviderIssueHistoryEvent(value: unknown): value is ProviderIssueHistoryEvent {
+function isUpstreamIssueHistoryEvent(value: unknown): value is UpstreamIssueHistoryEvent {
     if (!value || typeof value !== "object") return false;
-    const row = value as Partial<ProviderIssueHistoryEvent>;
+    const row = value as Partial<UpstreamIssueHistoryEvent>;
     return (
+        (row.source === "provider-api" || row.source === "huggingface") &&
         typeof row.ts === "string" &&
         (row.action === "create" || row.action === "update" || row.action === "delete") &&
         typeof row.platformId === "string" &&
@@ -154,38 +156,57 @@ function isProviderIssueHistoryEvent(value: unknown): value is ProviderIssueHist
     );
 }
 
-type ProviderIssueGroup = {
+type UpstreamIssueGroup = {
     key: string;
-    action: ProviderIssueChangeAction;
+    source: UpstreamDiscoveryIssueSource;
+    action: UpstreamDiscoveryIssueAction;
     platformId: string;
     platformName: string;
     providerId: string;
     providerName: string;
-    entries: ProviderIssueChangeEntry[];
+    entries: UpstreamDiscoveryIssueEntry[];
 };
 
-function issueKeyForGroup(input: Pick<ProviderIssueChangeEntry, "providerId" | "action">): string {
-    return Buffer.from(`${input.providerId.trim().toLowerCase()}\n${input.action}`).toString("base64url");
+function issueKeyForGroup(input: Pick<UpstreamDiscoveryIssueEntry, "source" | "providerId" | "action">): string {
+    return Buffer.from(`${input.source}\n${input.providerId.trim().toLowerCase()}\n${input.action}`).toString("base64url");
 }
 
 function markerForKey(key: string): string {
+    return `ai-stats-upstream-discovery:${key}`;
+}
+
+function legacyProviderIssueKeyForGroup(input: Pick<UpstreamDiscoveryIssueEntry, "providerId" | "action">): string {
+    return Buffer.from(`${input.providerId.trim().toLowerCase()}
+${input.action}`).toString("base64url");
+}
+
+function legacyMarkerForKey(key: string): string {
     return `ai-stats-model-discovery:${key}`;
 }
 
-function actionNoun(action: ProviderIssueChangeAction): string {
+function actionNoun(action: UpstreamDiscoveryIssueAction): string {
     if (action === "create") return "additions";
     if (action === "delete") return "deletions";
     return "changes";
 }
 
-function actionVerb(action: ProviderIssueChangeAction): string {
+function actionVerb(action: UpstreamDiscoveryIssueAction): string {
     if (action === "create") return "added";
     if (action === "delete") return "removed";
     return "changed";
 }
 
-function issueTitleForGroup(group: ProviderIssueGroup): string {
-    return `[model-discovery] ${group.providerName}: provider model ${actionNoun(group.action)}`.slice(0, 250);
+function sourceLabel(source: UpstreamDiscoveryIssueSource): string {
+    if (source === "huggingface") return "Hugging Face";
+    return "provider API";
+}
+
+function issueTitleForGroup(group: UpstreamIssueGroup): string {
+    if (group.source === "huggingface") {
+        return `[upstream-discovery] Hugging Face: model ${actionNoun(group.action)} for ${group.providerName}`.slice(0, 250);
+    }
+
+    return `[upstream-discovery] ${group.providerName}: provider model ${actionNoun(group.action)}`.slice(0, 250);
 }
 
 function formatDateTime(value: string): string {
@@ -194,65 +215,75 @@ function formatDateTime(value: string): string {
     return parsed.toISOString();
 }
 
-function formatEventLine(event: ProviderIssueHistoryEvent): string {
-    const runSuffix = event.runUrl ? ` ([workflow run](${event.runUrl}))` : "";
-    return `- ${formatDateTime(event.ts)}: ${actionVerb(event.action)} \`${event.modelId}\` on ${event.providerName} (${event.providerId})${runSuffix}`;
+function formatModelLink(event: Pick<UpstreamDiscoveryIssueEntry, "modelId" | "modelUrl">): string {
+    if (event.modelUrl) return `\`${event.modelId}\` (${event.modelUrl})`;
+    return `\`${event.modelId}\``;
 }
 
-function formatModelList(modelIds: string[]): string[] {
-    return modelIds.map((modelId) => `- \`${modelId}\``);
+function formatEventLine(event: UpstreamIssueHistoryEvent): string {
+    const runSuffix = event.runUrl ? ` ([workflow run](${event.runUrl}))` : "";
+    const reasonSuffix = event.reason ? ` — ${event.reason}` : "";
+    return `- ${formatDateTime(event.ts)}: ${actionVerb(event.action)} ${formatModelLink(event)} from ${sourceLabel(event.source)} ${event.providerName} (${event.providerId})${reasonSuffix}${runSuffix}`;
+}
+
+function formatModelList(entries: UpstreamDiscoveryIssueEntry[]): string[] {
+    return entries.map((entry) => `- ${formatModelLink(entry)}`);
 }
 
 function buildIssueBody(args: {
-    group: ProviderIssueGroup;
-    recentEvents: ProviderIssueHistoryEvent[];
+    group: UpstreamIssueGroup;
+    recentEvents: UpstreamIssueHistoryEvent[];
 }): string {
     const { group, recentEvents } = args;
     const marker = markerForKey(group.key);
     const latestEvent = recentEvents[0] ?? group.entries[0];
     const eventLines = recentEvents.length > 0 ? recentEvents.map(formatEventLine) : group.entries.map(formatEventLine);
-    const modelIds = group.entries.map((entry) => entry.modelId);
 
     return [
         `<!-- ${marker} -->`,
         `Tracking key: \`${marker}\``,
         "",
-        `The model discovery bot detected upstream provider model ${actionNoun(group.action)} for ${group.providerName}.`,
+        `The upstream discovery bot detected ${sourceLabel(group.source)} model ${actionNoun(group.action)} for ${group.providerName}.`,
         "",
         "## Current signal",
-        `- Cloud platform: ${group.platformName} (\`${group.platformId}\`)`,
-        `- Provider: ${group.providerName} (\`${group.providerId}\`)`,
+        `- Source: ${sourceLabel(group.source)}`,
+        `- Platform: ${group.platformName} (\`${group.platformId}\`)`,
+        `- Provider/org: ${group.providerName} (\`${group.providerId}\`)`,
         `- Latest action: ${actionNoun(group.action)}`,
         `- Latest detected at: ${latestEvent ? formatDateTime(latestEvent.ts) : "Unknown"}`,
-        `- Models in this signal: ${modelIds.length}`,
+        `- Models in this signal: ${group.entries.length}`,
         "",
         "## Models in this signal",
-        ...formatModelList(modelIds),
+        ...formatModelList(group.entries),
         "",
         "## Recent detections",
         ...eventLines,
         "",
+        "## Workflow run",
+        latestEvent?.runUrl ? `- ${latestEvent.runUrl}` : "- Not available",
+        "",
         "## Triage notes",
-        "- Reuse this issue for repeated signals with the same provider and action type.",
-        "- Only provider model IDs already present in `data_api_provider_models` are included here.",
-        "- Close this issue when the catalog has been updated or the upstream signal is confirmed as non-actionable.",
+        "- Check whether each upstream model should be added to AI Stats or mapped to an existing catalog entry.",
+        "- Unknown upstream models are intentionally included for triage instead of being filtered out.",
+        "- Reuse this issue for repeated signals with the same source, provider/org, and action type.",
+        "- Close this issue once the upstream signal has been triaged.",
     ].join("\n");
 }
 
-function buildIssueComment(group: ProviderIssueGroup, events: ProviderIssueHistoryEvent[]): string {
+function buildIssueComment(group: UpstreamIssueGroup, events: UpstreamIssueHistoryEvent[]): string {
     return [
-        `Model discovery detected another ${actionNoun(group.action)} signal for ${group.providerName}.`,
+        `Upstream discovery detected another ${sourceLabel(group.source)} ${actionNoun(group.action)} signal for ${group.providerName}.`,
         "",
         "Models in this signal:",
-        ...formatModelList(events.map((event) => event.modelId)),
+        ...formatModelList(events),
         "",
         "Events:",
         ...events.map(formatEventLine),
     ].join("\n");
 }
 
-function groupProviderIssueEntries(entries: ProviderIssueChangeEntry[]): ProviderIssueGroup[] {
-    const grouped = new Map<string, ProviderIssueGroup>();
+function groupUpstreamIssueEntries(entries: UpstreamDiscoveryIssueEntry[]): UpstreamIssueGroup[] {
+    const grouped = new Map<string, UpstreamIssueGroup>();
 
     for (const entry of entries) {
         const key = issueKeyForGroup(entry);
@@ -264,6 +295,7 @@ function groupProviderIssueEntries(entries: ProviderIssueChangeEntry[]): Provide
 
         grouped.set(key, {
             key,
+            source: entry.source,
             action: entry.action,
             platformId: entry.platformId,
             platformName: entry.platformName,
@@ -274,6 +306,8 @@ function groupProviderIssueEntries(entries: ProviderIssueChangeEntry[]): Provide
     }
 
     return Array.from(grouped.values()).sort((left, right) => {
+        const sourceComparison = sourceLabel(left.source).localeCompare(sourceLabel(right.source));
+        if (sourceComparison !== 0) return sourceComparison;
         const providerComparison = left.providerName.localeCompare(right.providerName);
         if (providerComparison !== 0) return providerComparison;
         return actionNoun(left.action).localeCompare(actionNoun(right.action));
@@ -368,7 +402,8 @@ async function findOpenIssue(args: {
     client: GitHubIssueClient;
     repository: string;
     key: string;
-    existingRecord?: ProviderIssueRecord;
+    legacyKey?: string;
+    existingRecord?: UpstreamIssueRecord;
 }): Promise<GitHubIssue | null> {
     const issueNumber = args.existingRecord?.issueNumber;
     if (typeof issueNumber === "number") {
@@ -377,29 +412,103 @@ async function findOpenIssue(args: {
     }
 
     const marker = markerForKey(args.key);
-    return await args.client.searchOpenIssue(`repo:${args.repository} is:issue is:open "${marker}"`);
+    const currentIssue = await args.client.searchOpenIssue(`repo:${args.repository} is:issue is:open "${marker}"`);
+    if (currentIssue) return currentIssue;
+
+    if (args.legacyKey) {
+        const legacyMarker = legacyMarkerForKey(args.legacyKey);
+        return await args.client.searchOpenIssue(`repo:${args.repository} is:issue is:open "${legacyMarker}"`);
+    }
+
+    return null;
 }
 
-export async function syncProviderChangeIssues(
-    entries: ProviderIssueChangeEntry[],
+function shouldSkipForEnv(source: UpstreamDiscoveryIssueSource, logger: Pick<Console, "log">): boolean {
+    if (process.env.MODEL_DISCOVERY_GITHUB_ISSUES === "false") {
+        logger.log("[model-discovery] GitHub issue sync disabled by MODEL_DISCOVERY_GITHUB_ISSUES=false.");
+        return true;
+    }
+
+    if (source === "provider-api" && process.env.MODEL_DISCOVERY_PROVIDER_GITHUB_ISSUES === "false") {
+        logger.log("[model-discovery] Provider API GitHub issue sync disabled by MODEL_DISCOVERY_PROVIDER_GITHUB_ISSUES=false.");
+        return true;
+    }
+
+    if (source === "huggingface" && process.env.MODEL_DISCOVERY_HF_GITHUB_ISSUES === "false") {
+        logger.log("[model-discovery] Hugging Face GitHub issue sync disabled by MODEL_DISCOVERY_HF_GITHUB_ISSUES=false.");
+        return true;
+    }
+
+    return false;
+}
+
+function logSyncSummary(args: {
+    logger: Pick<Console, "log">;
+    source: UpstreamDiscoveryIssueSource | "mixed";
+    inputEvents: number;
+    filteredEvents: number;
+    created: number;
+    updated: number;
+    skipped: boolean;
+    reason?: string;
+}): void {
+    const reason = args.reason ? ` reason=${JSON.stringify(args.reason)}` : "";
+    args.logger.log(
+        `[model-discovery] upstream issue sync: source=${args.source} inputEvents=${args.inputEvents} filteredEvents=${args.filteredEvents} created=${args.created} updated=${args.updated} skipped=${args.skipped}${reason}`
+    );
+}
+
+export async function syncUpstreamDiscoveryIssues(
+    rawEntries: UpstreamDiscoveryIssueEntry[],
     options: GitHubIssueSyncOptions
 ): Promise<{ created: number; updated: number; skipped: boolean }> {
-    const token = trimOrNull(options.token ?? process.env.GITHUB_TOKEN ?? process.env.GH_TOKEN);
-    const repository = trimOrNull(options.repository ?? process.env.GITHUB_REPOSITORY);
     const logger = options.logger ?? console;
+    const entries = rawEntries.map(normalizeEntry);
+    const sources = Array.from(new Set(entries.map((entry) => entry.source)));
+    const sourceForLog = sources.length === 1 ? sources[0] : "mixed";
 
-    const filteredEntries = filterEntriesByKnownProviderModels(entries, options.knownModelIdsByProvider);
-    if (filteredEntries.length === 0) {
+    if (entries.length === 0) {
+        logSyncSummary({
+            logger,
+            source: sourceForLog ?? "mixed",
+            inputEvents: rawEntries.length,
+            filteredEvents: 0,
+            created: 0,
+            updated: 0,
+            skipped: false,
+            reason: "no entries",
+        });
         return { created: 0, updated: 0, skipped: false };
     }
 
-    if (process.env.MODEL_DISCOVERY_GITHUB_ISSUES === "false") {
-        logger.log("[model-discovery] GitHub issue sync disabled by MODEL_DISCOVERY_GITHUB_ISSUES=false.");
+    if (sources.some((source) => shouldSkipForEnv(source, logger))) {
+        logSyncSummary({
+            logger,
+            source: sourceForLog,
+            inputEvents: rawEntries.length,
+            filteredEvents: entries.length,
+            created: 0,
+            updated: 0,
+            skipped: true,
+            reason: "disabled by environment",
+        });
         return { created: 0, updated: 0, skipped: true };
     }
 
+    const token = trimOrNull(options.token ?? process.env.GITHUB_TOKEN ?? process.env.GH_TOKEN);
+    const repository = trimOrNull(options.repository ?? process.env.GITHUB_REPOSITORY);
     if (!token || !repository) {
         logger.warn("[model-discovery] Skipping GitHub issue sync: GITHUB_TOKEN/GH_TOKEN or GITHUB_REPOSITORY is missing.");
+        logSyncSummary({
+            logger,
+            source: sourceForLog,
+            inputEvents: rawEntries.length,
+            filteredEvents: entries.length,
+            created: 0,
+            updated: 0,
+            skipped: true,
+            reason: "missing GitHub token or repository",
+        });
         return { created: 0, updated: 0, skipped: true };
     }
 
@@ -415,13 +524,14 @@ export async function syncProviderChangeIssues(
     let created = 0;
     let updated = 0;
 
-    for (const group of groupProviderIssueEntries(filteredEntries)) {
-        const existingRecord = state.issues[group.key];
-        const events: ProviderIssueHistoryEvent[] = group.entries.map((entry) => ({ ...entry, runUrl }));
+    for (const group of groupUpstreamIssueEntries(entries)) {
+        const legacyKey = group.source === "provider-api" ? legacyProviderIssueKeyForGroup(group) : undefined;
+        const existingRecord = state.issues[group.key] ?? (legacyKey ? state.issues[legacyKey] : undefined);
+        const events: UpstreamIssueHistoryEvent[] = group.entries.map((entry) => ({ ...entry, runUrl }));
         const recentEvents = [...events, ...(existingRecord?.recentEvents ?? [])].slice(0, MAX_RECENT_EVENTS);
         const body = buildIssueBody({ group, recentEvents });
         const title = issueTitleForGroup(group);
-        const existingIssue = await findOpenIssue({ client, repository, key: group.key, existingRecord });
+        const existingIssue = await findOpenIssue({ client, repository, key: group.key, legacyKey, existingRecord });
 
         if (existingIssue) {
             const issue = await client.updateIssue(existingIssue.number, { title, body });
@@ -453,15 +563,40 @@ export async function syncProviderChangeIssues(
     state.updatedAt = timestamp;
     writeIssueState(options.statePath, state);
 
+    logSyncSummary({
+        logger,
+        source: sourceForLog,
+        inputEvents: rawEntries.length,
+        filteredEvents: entries.length,
+        created,
+        updated,
+        skipped: false,
+    });
+
     return { created, updated, skipped: false };
+}
+
+export async function syncProviderChangeIssues(
+    entries: ProviderIssueChangeEntry[],
+    options: GitHubIssueSyncOptions & { knownModelIdsByProvider?: Map<string, Set<string>> }
+): Promise<{ created: number; updated: number; skipped: boolean }> {
+    if (options.knownModelIdsByProvider) {
+        const logger = options.logger ?? console;
+        logger.warn(
+            "[model-discovery] knownModelIdsByProvider is ignored for private upstream issue sync so unknown upstream models create triage issues."
+        );
+    }
+
+    return await syncUpstreamDiscoveryIssues(entries.map(normalizeEntry), options);
 }
 
 export const testingExports = {
     buildIssueBody,
     buildIssueComment,
-    filterEntriesByKnownProviderModels,
-    groupProviderIssueEntries,
+    groupUpstreamIssueEntries,
     issueKeyForGroup,
     issueTitleForGroup,
+    legacyMarkerForKey,
+    legacyProviderIssueKeyForGroup,
     markerForKey,
 };

--- a/scripts/model-discovery/run-hf-private.ts
+++ b/scripts/model-discovery/run-hf-private.ts
@@ -1,8 +1,56 @@
-import { runInternalModelDiscovery } from "./run-internal";
+import path from "node:path";
+import { syncUpstreamDiscoveryIssues, type UpstreamDiscoveryIssueEntry } from "./github-issues";
+import { runInternalModelDiscovery, type HuggingFaceDiscoveryIssueSignal } from "./run-internal";
+
+const ISSUE_STATE_PATH = path.join(process.cwd(), "scripts", "model-discovery", "state", "provider-change-issues.json");
+
+function nowIso(): string {
+    return new Date().toISOString();
+}
+
+function buildHfIssueEntries(hfAdditionsByOrg: HuggingFaceDiscoveryIssueSignal[]): UpstreamDiscoveryIssueEntry[] {
+    const ts = nowIso();
+    const out: UpstreamDiscoveryIssueEntry[] = [];
+
+    for (const orgEntry of hfAdditionsByOrg) {
+        for (const modelId of orgEntry.addedModelIds) {
+            out.push({
+                source: "huggingface",
+                ts,
+                action: "create",
+                platformId: "huggingface",
+                platformName: "Hugging Face",
+                providerId: orgEntry.org,
+                providerName: orgEntry.org,
+                modelId,
+                modelUrl: `https://huggingface.co/${modelId}`,
+                reason: "Detected from watched Hugging Face source",
+            });
+        }
+    }
+
+    return out;
+}
+
+async function syncHfIssues(hfAdditionsByOrg: HuggingFaceDiscoveryIssueSignal[]): Promise<void> {
+    const entries = buildHfIssueEntries(hfAdditionsByOrg);
+    console.log("[internal-model-check] Syncing GitHub issues for detected upstream Hugging Face model changes.");
+    const issueSync = await syncUpstreamDiscoveryIssues(entries, {
+        statePath: ISSUE_STATE_PATH,
+        logger: console,
+    });
+    if (!issueSync.skipped) {
+        console.log(
+            `[internal-model-check] Hugging Face GitHub issue sync complete: created=${issueSync.created}, updated=${issueSync.updated}.`
+        );
+    }
+}
 
 async function main(): Promise<void> {
     const args = [...process.argv.slice(2), "--skip-internal"];
-    await runInternalModelDiscovery(args);
+    await runInternalModelDiscovery(args, {
+        afterHfNotifications: syncHfIssues,
+    });
 }
 
 main().catch((error) => {

--- a/scripts/model-discovery/run-hf-private.ts
+++ b/scripts/model-discovery/run-hf-private.ts
@@ -1,4 +1,5 @@
 import path from "node:path";
+import { fileURLToPath } from "node:url";
 import { syncUpstreamDiscoveryIssues, type UpstreamDiscoveryIssueEntry } from "./github-issues";
 import { runInternalModelDiscovery, type HuggingFaceDiscoveryIssueSignal } from "./run-internal";
 
@@ -8,7 +9,7 @@ function nowIso(): string {
     return new Date().toISOString();
 }
 
-function buildHfIssueEntries(hfAdditionsByOrg: HuggingFaceDiscoveryIssueSignal[]): UpstreamDiscoveryIssueEntry[] {
+export function buildHfIssueEntries(hfAdditionsByOrg: HuggingFaceDiscoveryIssueSignal[]): UpstreamDiscoveryIssueEntry[] {
     const ts = nowIso();
     const out: UpstreamDiscoveryIssueEntry[] = [];
 
@@ -32,17 +33,28 @@ function buildHfIssueEntries(hfAdditionsByOrg: HuggingFaceDiscoveryIssueSignal[]
     return out;
 }
 
-async function syncHfIssues(hfAdditionsByOrg: HuggingFaceDiscoveryIssueSignal[]): Promise<void> {
+type HfIssueSyncImpl = typeof syncUpstreamDiscoveryIssues;
+
+export async function syncHfIssues(
+    hfAdditionsByOrg: HuggingFaceDiscoveryIssueSignal[],
+    syncIssues: HfIssueSyncImpl = syncUpstreamDiscoveryIssues
+): Promise<void> {
     const entries = buildHfIssueEntries(hfAdditionsByOrg);
     console.log("[internal-model-check] Syncing GitHub issues for detected upstream Hugging Face model changes.");
-    const issueSync = await syncUpstreamDiscoveryIssues(entries, {
-        statePath: ISSUE_STATE_PATH,
-        logger: console,
-    });
-    if (!issueSync.skipped) {
-        console.log(
-            `[internal-model-check] Hugging Face GitHub issue sync complete: created=${issueSync.created}, updated=${issueSync.updated}.`
-        );
+
+    try {
+        const issueSync = await syncIssues(entries, {
+            statePath: ISSUE_STATE_PATH,
+            logger: console,
+        });
+        if (!issueSync.skipped) {
+            console.log(
+                `[internal-model-check] Hugging Face GitHub issue sync complete: created=${issueSync.created}, updated=${issueSync.updated}.`
+            );
+        }
+    } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        console.error(`[internal-model-check] Hugging Face GitHub issue sync failed: ${message}`);
     }
 }
 
@@ -53,8 +65,16 @@ async function main(): Promise<void> {
     });
 }
 
-main().catch((error) => {
-    const message = error instanceof Error ? error.message : String(error);
-    console.error(`[internal-model-check] Fatal error: ${message}`);
-    process.exitCode = 1;
-});
+function isMainModule(): boolean {
+    const entry = process.argv[1];
+    if (!entry) return false;
+    return path.resolve(entry) === path.resolve(fileURLToPath(import.meta.url));
+}
+
+if (isMainModule()) {
+    main().catch((error) => {
+        const message = error instanceof Error ? error.message : String(error);
+        console.error(`[internal-model-check] Fatal error: ${message}`);
+        process.exitCode = 1;
+    });
+}

--- a/scripts/model-discovery/run-hf-private.ts
+++ b/scripts/model-discovery/run-hf-private.ts
@@ -55,6 +55,7 @@ export async function syncHfIssues(
     } catch (error) {
         const message = error instanceof Error ? error.message : String(error);
         console.error(`[internal-model-check] Hugging Face GitHub issue sync failed: ${message}`);
+        throw error;
     }
 }
 

--- a/scripts/model-discovery/run-internal-public.ts
+++ b/scripts/model-discovery/run-internal-public.ts
@@ -1,6 +1,7 @@
 import { runInternalModelDiscovery } from "./run-internal";
 
 async function main(): Promise<void> {
+    // Public AI Stats catalog checks intentionally do not mutate GitHub issues.
     const args = [...process.argv.slice(2), "--skip-hf"];
     await runInternalModelDiscovery(args);
 }

--- a/scripts/model-discovery/run-internal.ts
+++ b/scripts/model-discovery/run-internal.ts
@@ -58,6 +58,12 @@ type HuggingFaceOrgAdditions = {
     addedModelIds: string[];
 };
 
+export type HuggingFaceDiscoveryIssueSignal = HuggingFaceOrgAdditions;
+
+type InternalModelDiscoveryHooks = {
+    afterHfNotifications?: (hfAdditionsByOrg: HuggingFaceDiscoveryIssueSignal[]) => Promise<void>;
+};
+
 type AnnouncedInternalModelsState = {
     version: 1;
     updatedAt: string;
@@ -831,7 +837,7 @@ async function sendDiscordWebhook(
     }
 }
 
-export async function runInternalModelDiscovery(argv: string[]): Promise<void> {
+export async function runInternalModelDiscovery(argv: string[], hooks: InternalModelDiscoveryHooks = {}): Promise<void> {
     const options = parseArgs(argv);
     const internalWebhookUrl =
         options.internalWebhookUrl ??
@@ -1000,6 +1006,9 @@ export async function runInternalModelDiscovery(argv: string[]): Promise<void> {
     const holdHfBaseline = shouldCheckHf && hfAdditionsTotal > 0 && !shouldSendHf;
 
     if (!shouldSendInternal && !shouldSendHf) {
+        if (shouldCheckHf && hfAdditionsTotal > 0 && hooks.afterHfNotifications) {
+            await hooks.afterHfNotifications(hfAdditionsByOrg);
+        }
         writeDiscoveryState(
             statePath,
             holdInternalBaseline ? previousState.files : currentFiles,
@@ -1050,14 +1059,27 @@ export async function runInternalModelDiscovery(argv: string[]): Promise<void> {
         mentionsSent = true;
     }
 
+    let hfNotificationError: unknown = null;
     if (shouldSendHf && hfWebhookUrl) {
         const hfMessage = buildHfDiscordMessage(hfAdditionsByOrg);
-        await sendDiscordWebhook(hfMessage, {
-            webhookUrl: hfWebhookUrl,
-            discordUserId: options.discordUserId,
-            discordRoleId: options.discordRoleId,
-            includeMentions: !mentionsSent,
-        });
+        try {
+            await sendDiscordWebhook(hfMessage, {
+                webhookUrl: hfWebhookUrl,
+                discordUserId: options.discordUserId,
+                discordRoleId: options.discordRoleId,
+                includeMentions: !mentionsSent,
+            });
+        } catch (error) {
+            hfNotificationError = error;
+        }
+    }
+
+    if (shouldCheckHf && hfAdditionsTotal > 0 && hooks.afterHfNotifications) {
+        await hooks.afterHfNotifications(hfAdditionsByOrg);
+    }
+
+    if (hfNotificationError) {
+        throw hfNotificationError;
     }
 
     writeDiscoveryState(

--- a/scripts/model-discovery/run-internal.ts
+++ b/scripts/model-discovery/run-internal.ts
@@ -1022,6 +1022,7 @@ export async function runInternalModelDiscovery(argv: string[], hooks: InternalM
     );
 
     let mentionsSent = false;
+    const shouldRunHfNotificationHook = shouldCheckHf && hfAdditionsTotal > 0 && Boolean(hooks.afterHfNotifications);
 
     if (shouldSendInternal && internalWebhookUrl) {
         const avatarUrl = options.discordAvatarUrl ?? null;
@@ -1059,6 +1060,10 @@ export async function runInternalModelDiscovery(argv: string[], hooks: InternalM
         mentionsSent = true;
     }
 
+    if (shouldRunHfNotificationHook && shouldSendHf) {
+        await hooks.afterHfNotifications?.(hfAdditionsByOrg);
+    }
+
     let hfNotificationError: unknown = null;
     if (shouldSendHf && hfWebhookUrl) {
         const hfMessage = buildHfDiscordMessage(hfAdditionsByOrg);
@@ -1074,8 +1079,8 @@ export async function runInternalModelDiscovery(argv: string[], hooks: InternalM
         }
     }
 
-    if (shouldCheckHf && hfAdditionsTotal > 0 && hooks.afterHfNotifications) {
-        await hooks.afterHfNotifications(hfAdditionsByOrg);
+    if (shouldRunHfNotificationHook && !shouldSendHf) {
+        await hooks.afterHfNotifications?.(hfAdditionsByOrg);
     }
 
     if (hfNotificationError) {

--- a/scripts/model-discovery/run.ts
+++ b/scripts/model-discovery/run.ts
@@ -5,7 +5,7 @@ import { createAdminClient } from "../../apps/web/src/utils/supabase/admin";
 import { getProviderDiscoveryRule } from "./providers/discovery-policy";
 import type { ProviderDefinition, ProviderModel } from "./providers/_shared";
 import { asRecord, getMissingEnvVars, sortKeysDeep } from "./providers/_shared";
-import { syncProviderChangeIssues } from "./github-issues";
+import { syncUpstreamDiscoveryIssues, type UpstreamDiscoveryIssueEntry } from "./github-issues";
 
 type SupabaseAdminClient = ReturnType<typeof createAdminClient>;
 
@@ -820,6 +820,7 @@ async function main(): Promise<void> {
     const deleteRows: SeenModelDeleteRow[] = [];
     let staleModelsDeleted = 0;
     let runChangeEntries: ProviderChangeEntry[] = [];
+    let upstreamIssueEntries: UpstreamDiscoveryIssueEntry[] = [];
     let mergedFeed: ProviderChangeEntry[] = [];
     let notificationError: string | null = null;
     let issueSyncError: string | null = null;
@@ -966,6 +967,17 @@ async function main(): Promise<void> {
 
         const runTimestamp = nowIso();
         runChangeEntries = buildProviderChangeEntries(changes, runTimestamp);
+        upstreamIssueEntries = buildProviderChangeEntries(rawChanges, runTimestamp).map((entry) => ({
+            source: "provider-api",
+            ts: entry.ts,
+            action: entry.action,
+            platformId: entry.platformId,
+            platformName: entry.platformName,
+            providerId: entry.providerId,
+            providerName: entry.providerName,
+            modelId: entry.modelId,
+            reason: "Detected from upstream provider /models API",
+        } satisfies UpstreamDiscoveryIssueEntry));
         const existingFeed = readChangeFeed(CHANGE_FEED_PATH);
         const seenFeedIds = new Set<string>();
         mergedFeed = [];
@@ -1037,23 +1049,28 @@ async function main(): Promise<void> {
             }
         }
 
-        if (changes.length === 0) {
+        if (changes.length === 0 && upstreamIssueEntries.length === 0) {
             console.log("[model-discovery] No model changes detected.");
         } else {
-            const message = buildDiscordMessage(changes, runChangeEntries);
-            console.log(`[model-discovery] Changes detected in ${changes.length} provider(s). Sending Discord notification.`);
-            try {
-                await sendDiscordWebhook(message);
-            } catch (error) {
-                notificationError = error instanceof Error ? error.message : String(error);
-                console.error(`[model-discovery] Discord notification failed: ${notificationError}`);
+            if (changes.length > 0) {
+                const message = buildDiscordMessage(changes, runChangeEntries);
+                console.log(`[model-discovery] Changes detected in ${changes.length} provider(s). Sending Discord notification.`);
+                try {
+                    await sendDiscordWebhook(message);
+                } catch (error) {
+                    notificationError = error instanceof Error ? error.message : String(error);
+                    console.error(`[model-discovery] Discord notification failed: ${notificationError}`);
+                }
+            } else {
+                console.log(
+                    `[model-discovery] ${upstreamIssueEntries.length} upstream provider event(s) detected outside known catalog allowlist; skipping Discord catalog notification.`
+                );
             }
 
-            console.log("[model-discovery] Syncing GitHub issues for detected provider model changes.");
+            console.log("[model-discovery] Syncing GitHub issues for detected upstream provider model changes.");
             try {
-                const issueSync = await syncProviderChangeIssues(runChangeEntries, {
+                const issueSync = await syncUpstreamDiscoveryIssues(upstreamIssueEntries, {
                     statePath: ISSUE_STATE_PATH,
-                    knownModelIdsByProvider: apiModelAllowlistByProvider,
                     logger: console,
                 });
                 if (!issueSync.skipped) {


### PR DESCRIPTION
### Motivation
- Separate private upstream discovery (provider `/models` APIs and Hugging Face watched orgs) from public AI Stats catalog checks so only private upstream signals can create/update triage GitHub issues.
- Ensure Hugging Face notifications are treated as private upstream discovery and no longer get silently discarded or treated as internal/catalog signals.
- Avoid silently filtering unknown upstream models out of triage by the DB allowlist used for Discord/catalog notifications.
- Add clear source-awareness (provider-api vs huggingface) to issue grouping, titles, bodies, and logs to prevent collisions and aid triage.

### Description
- Introduce a source-aware upstream issue model (`UpstreamDiscoveryIssueEntry`) and refactor the GitHub helper to `syncUpstreamDiscoveryIssues` that supports `provider-api` and `huggingface` sources, source-aware keys, titles, bodies, and detailed sync logging.
- Preserve legacy lookup for existing provider-only issues so old tracking keys still update instead of duplicating threads, while new keys include `source` to avoid collisions.
- Wire provider-runner `scripts/model-discovery/run.ts` to build `UpstreamDiscoveryIssueEntry[]` from raw upstream changes (not the DB-filtered Discord diff) and call the new `syncUpstreamDiscoveryIssues`, so unknown upstream models generate triage issues.
- Wire Hugging Face private runner via `scripts/model-discovery/run-hf-private.ts` and `run-internal` hook (`afterHfNotifications`) to build HF-specific entries (with `modelUrl`, `platformId: "huggingface"`) and call the shared issue-sync helper.
- Keep public catalog runner `scripts/model-discovery/run-internal-public.ts` intentionally free of any issue-sync calls and add an explicit comment stating it must not mutate GitHub issues.
- Replace provider-only `github-issues.*` surface with source-neutral exports while retaining `syncProviderChangeIssues` compatibility shim that warns when old allowlist behavior would have been applied.
- Add environment knobs `MODEL_DISCOVERY_PROVIDER_GITHUB_ISSUES` and `MODEL_DISCOVERY_HF_GITHUB_ISSUES` (in addition to `MODEL_DISCOVERY_GITHUB_ISSUES`) to allow granular disabling of provider/HF issue sync.
- Update CI/workflow to pass `GITHUB_TOKEN` into the Hugging Face private step, update the discovery README to document the two discovery families and new env flags, and expand unit tests to cover source-aware behavior and flag handling.

### Testing
- Ran unit/helper tests with `pnpm exec tsx scripts/model-discovery/github-issues.test.ts`, which passed (`github-issues helper tests passed`).
- Exercised HF runner glue with `pnpm exec tsx scripts/model-discovery/run-hf-private.ts --hf-orgs ""` which ran cleanly and reported no detections for empty org list.
- Ran repository type checks with `pnpm typecheck`, which completed successfully across the repo.
- Ran provider validation with `pnpm run data:check-new-models:test` (`tsx scripts/model-discovery/validate-providers.ts`), which passed provider validation.
- Performed `git diff --check` (no whitespace/errors) and basic smoke assertions in tests; all new/updated tests passed.
- Ran `pnpm lint` locally but repo-wide lint failed due to unrelated pre-existing Raycast extension issues (DNS/schema fetch and icon/Prettier problems) which are out-of-scope for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a19c31b3e2883339e3b861ea5cfbde7)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced automatic GitHub issue creation for upstream model discoveries from provider APIs and Hugging Face organizations
  * New environment variable controls to filter GitHub issue creation by discovery source

* **Documentation**
  * Updated documentation on upstream discovery, Discord notifications, and GitHub issue tracking with new configuration options

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/AI-Stats/AI-Stats/pull/527?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->