### PR TITLE
[codex] Fix Venice standard pricing view

### DIFF
--- a/apps/web/src/components/(data)/model/pricing/pricingHelpers.test.ts
+++ b/apps/web/src/components/(data)/model/pricing/pricingHelpers.test.ts
@@ -144,4 +144,99 @@ describe("buildProviderSections", () => {
 			label: "≥ 272k",
 		});
 	});
+
+	test("keeps hidden fast sibling standard pricing out of the standard view", () => {
+		const provider = makeProviderPricing();
+		provider.provider.api_provider_id = "venice";
+		provider.provider.api_provider_name = "Venice";
+		provider.provider.provider_family_id = "venice";
+		provider.provider_models = [
+			{
+				id: "venice:anthropic/claude-opus-4.8:text.generate",
+				api_provider_id: "venice",
+				model_id: "anthropic/claude-opus-4.8",
+				provider_model_slug: "claude-opus-4-8",
+				endpoint: "text.generate",
+				capability_status: "active",
+				is_active_gateway: true,
+				input_modalities: "text,image",
+				output_modalities: "text",
+				context_length: 1_000_000,
+				max_input_tokens: 1_000_000,
+				max_output_tokens: 128_000,
+			},
+			{
+				id: "venice:anthropic/claude-opus-4.8-fast:text.generate",
+				api_provider_id: "venice",
+				model_id: "anthropic/claude-opus-4.8-fast",
+				provider_model_slug: "claude-opus-4-8-fast",
+				endpoint: "text.generate",
+				capability_status: "deranked_lvl2",
+				is_active_gateway: false,
+				input_modalities: "text,image",
+				output_modalities: "text",
+				context_length: 1_000_000,
+				max_input_tokens: 1_000_000,
+				max_output_tokens: 128_000,
+			},
+		];
+		provider.pricing_rules = [
+			{
+				id: "venice-std-input",
+				model_key: "venice:anthropic/claude-opus-4.8:text.generate",
+				pricing_plan: "standard",
+				meter: "input_text_tokens",
+				unit: "token",
+				unit_size: 1000000,
+				price_per_unit: 6,
+				currency: "USD",
+				note: null,
+				priority: 100,
+				effective_from: "2026-05-29T00:00:00.000Z",
+				effective_to: null,
+				match: [],
+			},
+			{
+				id: "venice-priority-input",
+				model_key: "venice:anthropic/claude-opus-4.8:text.generate",
+				pricing_plan: "priority",
+				meter: "input_text_tokens",
+				unit: "token",
+				unit_size: 1000000,
+				price_per_unit: 12,
+				currency: "USD",
+				note: null,
+				priority: 100,
+				effective_from: "2026-05-29T00:00:00.000Z",
+				effective_to: null,
+				match: [],
+			},
+			{
+				id: "venice-hidden-fast-std-input",
+				model_key: "venice:anthropic/claude-opus-4.8-fast:text.generate",
+				pricing_plan: "standard",
+				meter: "input_text_tokens",
+				unit: "token",
+				unit_size: 1000000,
+				price_per_unit: 12,
+				currency: "USD",
+				note: null,
+				priority: 100,
+				effective_from: "2026-05-29T00:00:00.000Z",
+				effective_to: null,
+				match: [],
+			},
+		];
+
+		const standardSections = buildProviderSections(provider, "standard");
+		const prioritySections = buildProviderSections(provider, "priority");
+
+		expect(standardSections.textTokens?.in?.[0]).toMatchObject({
+			per1M: 6,
+		});
+		expect(prioritySections.textTokens?.in?.[0]).toMatchObject({
+			per1M: 12,
+			basePer1M: 6,
+		});
+	});
 });

--- a/apps/web/src/components/(data)/model/pricing/pricingHelpers.ts
+++ b/apps/web/src/components/(data)/model/pricing/pricingHelpers.ts
@@ -3,6 +3,7 @@ import {
     formatProviderOfferDisplayName,
     resolveProviderLogoId,
 } from "@/lib/providers/providerOffers";
+import { getProviderPricingRulesForPlan } from "@/components/(data)/model/pricing/providerPlanRouting";
 
 /* ---------- shared types ---------- */
 export type Direction = "input" | "output" | "cached" | "cachewrite" | "other";
@@ -673,19 +674,8 @@ export function buildProviderSections(p: ProviderPricing, plan: string): Provide
     const now = new Date();
     const nowMs = now.getTime();
     const normalizedPlan = normalizePricingPlan(plan);
-    const allRules = p.pricing_rules;
-    const standardRules = allRules.filter(
-        (r) => normalizePricingPlan(r.pricing_plan) === "standard"
-    );
-    const planRules = allRules.filter(
-        (r) => normalizePricingPlan(r.pricing_plan) === normalizedPlan
-    );
-    const rules =
-        planRules.length > 0 || normalizedPlan === "standard"
-            ? planRules
-            : allRules.filter(
-                (r) => normalizePricingPlan(r.pricing_plan) === "standard"
-            );
+    const standardRules = getProviderPricingRulesForPlan(p, "standard");
+    const rules = getProviderPricingRulesForPlan(p, normalizedPlan);
     const endpointByKey = new Map<string, string>();
     for (const pm of p.provider_models) {
         if (!pm.endpoint) continue;


### PR DESCRIPTION
## What changed

This fixes the Venice pricing view for `anthropic/claude-opus-4.8` so the Standard tab no longer renders the hidden fast-sibling pricing.

- switched `buildProviderSections()` to use the same plan-scoped pricing helper as the rest of the provider card
- added a regression test that mirrors the Venice hidden `-fast` sibling setup

## Why it changed

The provider card had split pricing sources:

- plan badges/status used plan-scoped helpers
- the visible pricing tables rebuilt from the provider's raw full rule list

Because Venice keeps an internal hidden `anthropic/claude-opus-4.8-fast` row, the Standard view could accidentally ingest that sibling's `standard` price rows, which matched the Priority numbers.

## Impact

`anthropic/claude-opus-4.8` on Venice now shows:

- Standard from the base Opus 4.8 pricing card
- Priority from the explicit priority rows

This keeps the UI aligned with the underlying routing/pricing model.

## Validation

- `pnpm --filter @ai-stats/web exec jest --runInBand --runTestsByPath 'src/components/(data)/model/pricing/pricingHelpers.test.ts' 'src/components/(data)/model/pricing/providerPlanRouting.test.ts'`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test for pricing display logic across different pricing tiers.

* **Refactor**
  * Updated pricing rule sourcing mechanism to streamline how pricing data is selected and applied.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/AI-Stats/AI-Stats/pull/532?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->