### PR TITLE
[codex] Update Novita MiMo serverless models

### DIFF
--- a/packages/data/catalog/src/data/api_providers/novita/models.json
+++ b/packages/data/catalog/src/data/api_providers/novita/models.json
@@ -8004,7 +8004,7 @@
         "context_length":  262144,
         "max_output_tokens":  32000,
         "effective_from":  "2026-03-25T00:00:00",
-        "effective_to":  null,
+        "effective_to":  "2026-06-05T00:00:00Z",
         "capabilities":  [
                              {
                                  "capability_id":  "text.generate",
@@ -9543,6 +9543,29 @@
                                                     "provider_default":  null,
                                                     "notes":  null
                                                 }
+                                            ]
+                             }
+                         ]
+    },
+    {
+        "api_model_id":  "xiaomi/mimo-v2.5",
+        "provider_api_model_id":  "novita:xiaomi/mimo-v2.5",
+        "provider_model_slug":  "xiaomimimo/mimo-v2.5",
+        "internal_model_id":  "xiaomi/mimo-v2.5",
+        "is_active_gateway":  true,
+        "quantization_scheme":  null,
+        "input_modalities":  "text,image,video",
+        "output_modalities":  "text",
+        "context_length":  1048576,
+        "max_output_tokens":  131072,
+        "effective_from":  "2026-05-29T00:00:00Z",
+        "effective_to":  null,
+        "capabilities":  [
+                             {
+                                 "capability_id":  "text.generate",
+                                 "status":  "active",
+                                 "params":  [
+
                                             ]
                              }
                          ]

--- a/packages/data/catalog/src/data/manifest.json
+++ b/packages/data/catalog/src/data/manifest.json
@@ -2312,6 +2312,7 @@
     "novita:text.generate:qwen-qwen3.5-35b-a3b",
     "novita:text.generate:qwen-qwen3.5-397b-a17b",
     "novita:text.generate:xiaomi-mimo-v2-flash",
+    "novita:text.generate:xiaomi-mimo-v2.5",
     "novita:text.generate:xiaomi-mimo-v2.5-pro",
     "novita:text.generate:z-ai-glm-4.5",
     "novita:text.generate:z-ai-glm-4.5-air",

--- a/packages/data/catalog/src/data/pricing/novita/xiaomi-mimo-v2-flash/text.generate/pricing.json
+++ b/packages/data/catalog/src/data/pricing/novita/xiaomi-mimo-v2-flash/text.generate/pricing.json
@@ -15,7 +15,8 @@
       "note": null,
       "match": [],
       "priority": 100,
-      "effective_from": "2026-01-01T00:00:00Z"
+      "effective_from": "2026-01-01T00:00:00Z",
+      "effective_to": "2026-06-05T00:00:00Z"
     },
     {
       "meter": "cached_read_text_tokens",
@@ -27,7 +28,8 @@
       "note": null,
       "match": [],
       "priority": 100,
-      "effective_from": "2026-01-01T00:00:00Z"
+      "effective_from": "2026-01-01T00:00:00Z",
+      "effective_to": "2026-06-05T00:00:00Z"
     },
     {
       "meter": "output_text_tokens",
@@ -39,7 +41,8 @@
       "note": null,
       "match": [],
       "priority": 100,
-      "effective_from": "2026-01-01T00:00:00Z"
+      "effective_from": "2026-01-01T00:00:00Z",
+      "effective_to": "2026-06-05T00:00:00Z"
     },
     {
       "meter": "input_text_tokens",
@@ -50,7 +53,8 @@
       "pricing_plan": "standard",
       "note": null,
       "match": [],
-      "priority": 100
+      "priority": 100,
+      "effective_to": "2026-06-05T00:00:00Z"
     },
     {
       "meter": "cached_read_text_tokens",
@@ -61,7 +65,8 @@
       "pricing_plan": "standard",
       "note": null,
       "match": [],
-      "priority": 100
+      "priority": 100,
+      "effective_to": "2026-06-05T00:00:00Z"
     },
     {
       "meter": "output_text_tokens",
@@ -72,7 +77,8 @@
       "pricing_plan": "standard",
       "note": null,
       "match": [],
-      "priority": 100
+      "priority": 100,
+      "effective_to": "2026-06-05T00:00:00Z"
     }
   ]
 }

--- a/packages/data/catalog/src/data/pricing/novita/xiaomi-mimo-v2.5/text.generate/pricing.json
+++ b/packages/data/catalog/src/data/pricing/novita/xiaomi-mimo-v2.5/text.generate/pricing.json
@@ -1,0 +1,45 @@
+{
+  "key": "novita:xiaomi/mimo-v2.5:text.generate",
+  "api_provider_id": "novita",
+  "provider_slug": "novita",
+  "api_model_id": "xiaomi/mimo-v2.5",
+  "capability_id": "text.generate",
+  "rules": [
+    {
+      "meter": "input_text_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 0.3,
+      "currency": "USD",
+      "pricing_plan": "standard",
+      "note": null,
+      "match": [],
+      "priority": 100,
+      "effective_from": "2026-05-29T00:00:00Z"
+    },
+    {
+      "meter": "cached_read_text_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 0.056,
+      "currency": "USD",
+      "pricing_plan": "standard",
+      "note": null,
+      "match": [],
+      "priority": 100,
+      "effective_from": "2026-05-29T00:00:00Z"
+    },
+    {
+      "meter": "output_text_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 1.4,
+      "currency": "USD",
+      "pricing_plan": "standard",
+      "note": null,
+      "match": [],
+      "priority": 100,
+      "effective_from": "2026-05-29T00:00:00Z"
+    }
+  ]
+}


### PR DESCRIPTION
## What changed

This updates our Novita serverless Xiaomi MiMo coverage based on Novita's May 29, 2026 deprecation notice.

- end-dates `novita:xiaomi/mimo-v2-flash` provider support on `2026-06-05T00:00:00Z`
- end-dates the matching Novita pricing rows for `xiaomi/mimo-v2-flash` on the same EOL date
- adds active Novita serverless coverage for `xiaomi/mimo-v2.5`
- adds Novita pricing for `xiaomi/mimo-v2.5`
- adds the new Novita pricing key to the manifest

## Why it changed

Novita's changelog now says `xiaomimimo/mimo-v2-flash` will be removed from Serverless Endpoints on June 5, 2026 UTC, and recommends switching to `xiaomimimo/mimo-v2.5`.

I also verified from Novita's current model/pricing pages that `xiaomimimo/mimo-v2.5` is already available via Novita's serverless API with:

- `1,048,576` context length
- `131,072` max output
- input pricing `$0.3 / Mt`
- cache read pricing `$0.056 / Mt`
- output pricing `$1.4 / Mt`

## Scope

This is intentionally a Novita provider-level change only.

- I did not globally deprecate `xiaomi/mimo-v2-flash`, because the Novita notice is about Novita Serverless Endpoints specifically, not the underlying Xiaomi model everywhere.

## Validation

- `pnpm validate:data`
- `pnpm validate:pricing`
- `pnpm validate:gateway`
