### PR TITLE
End-date Baseten DeepSeek v3.1 and MiniMax M2.5

### DIFF
--- a/packages/data/catalog/src/data/api_providers/baseten/models.json
+++ b/packages/data/catalog/src/data/api_providers/baseten/models.json
@@ -11,7 +11,7 @@
     "context_length": 163840,
     "max_output_tokens": 131072,
     "effective_from": "2026-03-25T00:00:00",
-    "effective_to": null,
+    "effective_to": "2026-06-18T00:00:00Z",
     "capabilities": [
       {
         "capability_id": "text.generate",
@@ -74,7 +74,7 @@
     "context_length": 204000,
     "max_output_tokens": 204000,
     "effective_from": "2026-03-25T00:00:00",
-    "effective_to": null,
+    "effective_to": "2026-06-18T00:00:00Z",
     "capabilities": [
       {
         "capability_id": "text.generate",

--- a/packages/data/catalog/src/data/pricing/baseten/deepseek-deepseek-v3.1/text.generate/pricing.json
+++ b/packages/data/catalog/src/data/pricing/baseten/deepseek-deepseek-v3.1/text.generate/pricing.json
@@ -15,7 +15,8 @@
       "note": null,
       "match": [],
       "priority": 100,
-      "effective_from": "2026-03-25T00:00:00Z"
+      "effective_from": "2026-03-25T00:00:00Z",
+      "effective_to": "2026-06-18T00:00:00Z"
     },
     {
       "meter": "cached_read_text_tokens",
@@ -27,7 +28,8 @@
       "note": null,
       "match": [],
       "priority": 100,
-      "effective_from": "2026-03-25T00:00:00Z"
+      "effective_from": "2026-03-25T00:00:00Z",
+      "effective_to": "2026-06-18T00:00:00Z"
     },
     {
       "meter": "output_text_tokens",
@@ -39,7 +41,8 @@
       "note": null,
       "match": [],
       "priority": 100,
-      "effective_from": "2026-03-25T00:00:00Z"
+      "effective_from": "2026-03-25T00:00:00Z",
+      "effective_to": "2026-06-18T00:00:00Z"
     }
   ]
 }

--- a/packages/data/catalog/src/data/pricing/baseten/minimax-minimax-m2.5/text.generate/pricing.json
+++ b/packages/data/catalog/src/data/pricing/baseten/minimax-minimax-m2.5/text.generate/pricing.json
@@ -15,7 +15,8 @@
       "note": null,
       "match": [],
       "priority": 100,
-      "effective_from": "2026-03-25T00:00:00Z"
+      "effective_from": "2026-03-25T00:00:00Z",
+      "effective_to": "2026-06-18T00:00:00Z"
     },
     {
       "meter": "cached_read_text_tokens",
@@ -27,7 +28,8 @@
       "note": null,
       "match": [],
       "priority": 100,
-      "effective_from": "2026-03-25T00:00:00Z"
+      "effective_from": "2026-03-25T00:00:00Z",
+      "effective_to": "2026-06-18T00:00:00Z"
     },
     {
       "meter": "output_text_tokens",
@@ -39,7 +41,8 @@
       "note": null,
       "match": [],
       "priority": 100,
-      "effective_from": "2026-03-25T00:00:00Z"
+      "effective_from": "2026-03-25T00:00:00Z",
+      "effective_to": "2026-06-18T00:00:00Z"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- end-date Baseten support for `deepseek/deepseek-v3.1` and `minimax/minimax-m2.5`
- end-date the matching Baseten pricing rows to the same cutoff

## Details
Baseten announced on May 28, 2026 that the DeepSeek v3.1 and MiniMax M2.5 Model APIs will be deprecated at 5pm PT on June 17, 2026.

This PR updates only Baseten provider support and Baseten pricing windows. It does not retire the core model records globally.

## Effective cutoff
- `2026-06-18T00:00:00Z`

## Validation
- `pnpm validate:data`
- `pnpm validate:pricing`

## Source
- https://www.baseten.co/resources/changelog/model-api-deprecation-notice-deepseek-v31-minimax-m25/


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Set availability windows for deepseek-v3 and minimax-m2.5 models, establishing expiration dates through June 18, 2026.
  * Updated pricing rule validity periods for deepseek-v3 and minimax-m2.5 to define bounded time windows ending June 18, 2026.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/AI-Stats/AI-Stats/pull/536?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->