### PR TITLE
Sync Baseten model support and deprecations

### DIFF
--- a/packages/data/catalog/src/data/api_providers/baseten/models.json
+++ b/packages/data/catalog/src/data/api_providers/baseten/models.json
@@ -11,7 +11,7 @@
     "context_length": 163840,
     "max_output_tokens": 131072,
     "effective_from": "2026-03-25T00:00:00",
-    "effective_to": "2026-06-18T00:00:00Z",
+    "effective_to": "2026-05-02T00:00:00Z",
     "capabilities": [
       {
         "capability_id": "text.generate",
@@ -32,7 +32,7 @@
     "context_length": 163840,
     "max_output_tokens": 131072,
     "effective_from": "2026-03-25T00:00:00",
-    "effective_to": null,
+    "effective_to": "2026-06-18T00:00:00Z",
     "capabilities": [
       {
         "capability_id": "text.generate",

--- a/packages/data/catalog/src/data/api_providers/baseten/models.json
+++ b/packages/data/catalog/src/data/api_providers/baseten/models.json
@@ -299,7 +299,7 @@
     "context_length": 200000,
     "max_output_tokens": 200000,
     "effective_from": "2026-03-25T00:00:00",
-    "effective_to": null,
+    "effective_to": "2026-05-02T00:00:00Z",
     "capabilities": [
       {
         "capability_id": "text.generate",
@@ -341,6 +341,27 @@
     "context_length": 202800,
     "max_output_tokens": 202800,
     "effective_from": "2026-03-25T00:00:00",
+    "effective_to": null,
+    "capabilities": [
+      {
+        "capability_id": "text.generate",
+        "status": "active",
+        "params": []
+      }
+    ]
+  },
+  {
+    "api_model_id": "z-ai/glm-5.1",
+    "provider_api_model_id": "baseten:z-ai/glm-5.1",
+    "provider_model_slug": "zai-org/GLM-5.1",
+    "internal_model_id": "z-ai/glm-5.1",
+    "is_active_gateway": true,
+    "quantization_scheme": null,
+    "input_modalities": "text",
+    "output_modalities": "text",
+    "context_length": 202000,
+    "max_output_tokens": 202000,
+    "effective_from": "2026-05-27T00:00:00",
     "effective_to": null,
     "capabilities": [
       {

--- a/packages/data/catalog/src/data/manifest.json
+++ b/packages/data/catalog/src/data/manifest.json
@@ -1992,6 +1992,7 @@
     "baseten:text.generate:z-ai-glm-4.6",
     "baseten:text.generate:z-ai-glm-4.7",
     "baseten:text.generate:z-ai-glm-5",
+    "baseten:text.generate:z-ai-glm-5.1",
     "black-forest-labs:image.edits:black-forest-labs-flux-2-klein-4b",
     "black-forest-labs:image.generate:black-forest-labs-flux-2-klein-4b",
     "byteplus:text.generate:bytedance-seed-1.6",

--- a/packages/data/catalog/src/data/pricing/baseten/deepseek-deepseek-v3-0324/text.generate/pricing.json
+++ b/packages/data/catalog/src/data/pricing/baseten/deepseek-deepseek-v3-0324/text.generate/pricing.json
@@ -15,7 +15,8 @@
       "note": null,
       "match": [],
       "priority": 100,
-      "effective_from": "2026-03-25T00:00:00Z"
+      "effective_from": "2026-03-25T00:00:00Z",
+      "effective_to": "2026-05-02T00:00:00Z"
     },
     {
       "meter": "output_text_tokens",
@@ -27,7 +28,8 @@
       "note": null,
       "match": [],
       "priority": 100,
-      "effective_from": "2026-03-25T00:00:00Z"
+      "effective_from": "2026-03-25T00:00:00Z",
+      "effective_to": "2026-05-02T00:00:00Z"
     }
   ]
 }

--- a/packages/data/catalog/src/data/pricing/baseten/z-ai-glm-5.1/text.generate/pricing.json
+++ b/packages/data/catalog/src/data/pricing/baseten/z-ai-glm-5.1/text.generate/pricing.json
@@ -1,35 +1,45 @@
 {
-  "key": "baseten:z-ai/glm-4.6:text.generate",
+  "key": "baseten:z-ai/glm-5.1:text.generate",
   "api_provider_id": "baseten",
   "provider_slug": "baseten",
-  "api_model_id": "z-ai/glm-4.6",
+  "api_model_id": "z-ai/glm-5.1",
   "capability_id": "text.generate",
   "rules": [
     {
       "meter": "input_text_tokens",
       "unit": "token",
       "unit_size": 1000000,
-      "price_per_unit": 0.6,
+      "price_per_unit": 1.3,
       "currency": "USD",
       "pricing_plan": "standard",
       "note": null,
       "match": [],
       "priority": 100,
-      "effective_from": "2026-03-25T00:00:00Z",
-      "effective_to": "2026-05-02T00:00:00Z"
+      "effective_from": "2026-05-27T00:00:00Z"
+    },
+    {
+      "meter": "cached_read_text_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 0.26,
+      "currency": "USD",
+      "pricing_plan": "standard",
+      "note": null,
+      "match": [],
+      "priority": 100,
+      "effective_from": "2026-05-27T00:00:00Z"
     },
     {
       "meter": "output_text_tokens",
       "unit": "token",
       "unit_size": 1000000,
-      "price_per_unit": 2.2,
+      "price_per_unit": 4.3,
       "currency": "USD",
       "pricing_plan": "standard",
       "note": null,
       "match": [],
       "priority": 100,
-      "effective_from": "2026-03-25T00:00:00Z",
-      "effective_to": "2026-05-02T00:00:00Z"
+      "effective_from": "2026-05-27T00:00:00Z"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- sync Baseten model support after reviewing the current Baseten Model API docs and the recent deprecation / launch changelog entries

## What changed
- set Baseten `deepseek/deepseek-v3-0324` provider support and pricing to end at `2026-05-02T00:00:00Z`
- set Baseten `deepseek/deepseek-v3.1` provider support to end at `2026-06-18T00:00:00Z`
- set Baseten `z-ai/glm-4.6` provider support and pricing to end at `2026-05-02T00:00:00Z`
- add active Baseten support for `z-ai/glm-5.1`
- add Baseten `z-ai/glm-5.1` pricing at `$1.30` input, `$0.26` cached input, and `$4.30` output per 1M tokens

## Notes
- Baseten `minimax/minimax-m2.5` was already correctly end-dated to `2026-06-18T00:00:00Z`, so no additional change was needed there
- this PR is scoped to Baseten provider support and pricing only; it does not globally deprecate any model records that remain active elsewhere

## Validation
- `pnpm validate:data`
- `pnpm validate:pricing`
- `pnpm validate:gateway`

## Sources
- https://www.baseten.co/resources/changelog/model-api-deprecation-notice-deepseek-v3-0324-glm-46/
- https://www.baseten.co/resources/changelog/model-api-deprecation-notice-deepseek-v31-minimax-m25/
- https://www.baseten.co/resources/changelog/glm-51-available-on-baseten/
- https://docs.baseten.co/development/model-apis/overview
- https://www.baseten.co/pricing/
