### PR TITLE
Schedule CrofAI pricing refresh

### DIFF
--- a/packages/data/catalog/src/data/api_providers/crofai/models.json
+++ b/packages/data/catalog/src/data/api_providers/crofai/models.json
@@ -11,6 +11,27 @@
     "context_length": 1000000,
     "max_output_tokens": 131072,
     "effective_from": "2026-04-27T00:00:00",
+    "effective_to": "2026-05-31T22:00:00",
+    "capabilities": [
+      {
+        "capability_id": "text.generate",
+        "status": "active",
+        "params": []
+      }
+    ]
+  },
+  {
+    "api_model_id": "deepseek/deepseek-v4-pro",
+    "provider_api_model_id": "crofai:deepseek-v4-pro",
+    "provider_model_slug": "deepseek-v4-pro",
+    "internal_model_id": "deepseek/deepseek-v4-pro",
+    "is_active_gateway": true,
+    "quantization_scheme": "Q8_0",
+    "input_modalities": "text",
+    "output_modalities": "text",
+    "context_length": 1000000,
+    "max_output_tokens": 131072,
+    "effective_from": "2026-05-31T22:00:00",
     "effective_to": null,
     "capabilities": [
       {
@@ -32,7 +53,7 @@
     "context_length": 1000000,
     "max_output_tokens": 131072,
     "effective_from": "2026-04-28T00:00:00",
-    "effective_to": null,
+    "effective_to": "2026-05-31T22:00:00",
     "capabilities": [
       {
         "capability_id": "text.generate",
@@ -53,6 +74,27 @@
     "context_length": 1000000,
     "max_output_tokens": 131072,
     "effective_from": "2026-05-29T00:00:00",
+    "effective_to": "2026-05-31T22:00:00",
+    "capabilities": [
+      {
+        "capability_id": "text.generate",
+        "status": "active",
+        "params": []
+      }
+    ]
+  },
+  {
+    "api_model_id": "deepseek/deepseek-v4-pro-lightning",
+    "provider_api_model_id": "crofai:deepseek-v4-pro-lightning",
+    "provider_model_slug": "deepseek-v4-pro-lightning",
+    "internal_model_id": "deepseek/deepseek-v4-pro-lightning",
+    "is_active_gateway": true,
+    "quantization_scheme": "Q8_0",
+    "input_modalities": "text",
+    "output_modalities": "text",
+    "context_length": 1000000,
+    "max_output_tokens": 131072,
+    "effective_from": "2026-05-31T22:00:00",
     "effective_to": null,
     "capabilities": [
       {
@@ -116,6 +158,27 @@
     "context_length": 1000000,
     "max_output_tokens": 131072,
     "effective_from": "2026-05-12T00:00:00",
+    "effective_to": "2026-05-31T22:00:00",
+    "capabilities": [
+      {
+        "capability_id": "text.generate",
+        "status": "active",
+        "params": []
+      }
+    ]
+  },
+  {
+    "api_model_id": "xiaomi/mimo-v2.5-pro",
+    "provider_api_model_id": "crofai:mimo-v2.5-pro",
+    "provider_model_slug": "mimo-v2.5-pro",
+    "internal_model_id": "xiaomi/mimo-v2.5-pro",
+    "is_active_gateway": true,
+    "quantization_scheme": "Q8_0",
+    "input_modalities": "text",
+    "output_modalities": "text",
+    "context_length": 1000000,
+    "max_output_tokens": 131072,
+    "effective_from": "2026-05-31T22:00:00",
     "effective_to": null,
     "capabilities": [
       {
@@ -137,7 +200,7 @@
     "context_length": 1000000,
     "max_output_tokens": 131072,
     "effective_from": "2026-05-12T00:00:00",
-    "effective_to": null,
+    "effective_to": "2026-05-31T22:00:00",
     "capabilities": [
       {
         "capability_id": "text.generate",
@@ -158,6 +221,27 @@
     "context_length": 202752,
     "max_output_tokens": 202752,
     "effective_from": "2026-04-27T00:00:00",
+    "effective_to": "2026-05-31T22:00:00",
+    "capabilities": [
+      {
+        "capability_id": "text.generate",
+        "status": "active",
+        "params": []
+      }
+    ]
+  },
+  {
+    "api_model_id": "z-ai/glm-5.1",
+    "provider_api_model_id": "crofai:glm-5.1",
+    "provider_model_slug": "glm-5.1",
+    "internal_model_id": "z-ai/glm-5.1",
+    "is_active_gateway": true,
+    "quantization_scheme": "Q8_0",
+    "input_modalities": "text",
+    "output_modalities": "text",
+    "context_length": 202752,
+    "max_output_tokens": 202752,
+    "effective_from": "2026-05-31T22:00:00",
     "effective_to": null,
     "capabilities": [
       {
@@ -179,7 +263,7 @@
     "context_length": 202752,
     "max_output_tokens": 202752,
     "effective_from": "2026-04-27T00:00:00",
-    "effective_to": null,
+    "effective_to": "2026-05-31T22:00:00",
     "capabilities": [
       {
         "capability_id": "text.generate",
@@ -305,6 +389,27 @@
     "context_length": 262144,
     "max_output_tokens": 262144,
     "effective_from": "2026-04-27T00:00:00",
+    "effective_to": "2026-05-31T22:00:00",
+    "capabilities": [
+      {
+        "capability_id": "text.generate",
+        "status": "active",
+        "params": []
+      }
+    ]
+  },
+  {
+    "api_model_id": "moonshotai/kimi-k2.6",
+    "provider_api_model_id": "crofai:kimi-k2.6",
+    "provider_model_slug": "kimi-k2.6",
+    "internal_model_id": "moonshotai/kimi-k2.6",
+    "is_active_gateway": true,
+    "quantization_scheme": "int4",
+    "input_modalities": "text,image",
+    "output_modalities": "text",
+    "context_length": 262144,
+    "max_output_tokens": 262144,
+    "effective_from": "2026-05-31T22:00:00",
     "effective_to": null,
     "capabilities": [
       {
@@ -326,7 +431,7 @@
     "context_length": 262144,
     "max_output_tokens": 262144,
     "effective_from": "2026-04-27T00:00:00",
-    "effective_to": null,
+    "effective_to": "2026-05-31T22:00:00",
     "capabilities": [
       {
         "capability_id": "text.generate",

--- a/packages/data/catalog/src/data/api_providers/crofai/models.json
+++ b/packages/data/catalog/src/data/api_providers/crofai/models.json
@@ -11,7 +11,7 @@
     "context_length": 1000000,
     "max_output_tokens": 131072,
     "effective_from": "2026-04-27T00:00:00",
-    "effective_to": "2026-05-31T22:00:00",
+    "effective_to": "2026-06-01T05:00:00",
     "capabilities": [
       {
         "capability_id": "text.generate",
@@ -31,7 +31,7 @@
     "output_modalities": "text",
     "context_length": 1000000,
     "max_output_tokens": 131072,
-    "effective_from": "2026-05-31T22:00:00",
+    "effective_from": "2026-06-01T05:00:00",
     "effective_to": null,
     "capabilities": [
       {
@@ -53,7 +53,7 @@
     "context_length": 1000000,
     "max_output_tokens": 131072,
     "effective_from": "2026-04-28T00:00:00",
-    "effective_to": "2026-05-31T22:00:00",
+    "effective_to": "2026-06-01T05:00:00",
     "capabilities": [
       {
         "capability_id": "text.generate",
@@ -74,7 +74,7 @@
     "context_length": 1000000,
     "max_output_tokens": 131072,
     "effective_from": "2026-05-29T00:00:00",
-    "effective_to": "2026-05-31T22:00:00",
+    "effective_to": "2026-06-01T05:00:00",
     "capabilities": [
       {
         "capability_id": "text.generate",
@@ -94,7 +94,7 @@
     "output_modalities": "text",
     "context_length": 1000000,
     "max_output_tokens": 131072,
-    "effective_from": "2026-05-31T22:00:00",
+    "effective_from": "2026-06-01T05:00:00",
     "effective_to": null,
     "capabilities": [
       {
@@ -158,7 +158,7 @@
     "context_length": 1000000,
     "max_output_tokens": 131072,
     "effective_from": "2026-05-12T00:00:00",
-    "effective_to": "2026-05-31T22:00:00",
+    "effective_to": "2026-06-01T05:00:00",
     "capabilities": [
       {
         "capability_id": "text.generate",
@@ -178,7 +178,7 @@
     "output_modalities": "text",
     "context_length": 1000000,
     "max_output_tokens": 131072,
-    "effective_from": "2026-05-31T22:00:00",
+    "effective_from": "2026-06-01T05:00:00",
     "effective_to": null,
     "capabilities": [
       {
@@ -200,7 +200,7 @@
     "context_length": 1000000,
     "max_output_tokens": 131072,
     "effective_from": "2026-05-12T00:00:00",
-    "effective_to": "2026-05-31T22:00:00",
+    "effective_to": "2026-06-01T05:00:00",
     "capabilities": [
       {
         "capability_id": "text.generate",
@@ -221,7 +221,7 @@
     "context_length": 202752,
     "max_output_tokens": 202752,
     "effective_from": "2026-04-27T00:00:00",
-    "effective_to": "2026-05-31T22:00:00",
+    "effective_to": "2026-06-01T05:00:00",
     "capabilities": [
       {
         "capability_id": "text.generate",
@@ -241,7 +241,7 @@
     "output_modalities": "text",
     "context_length": 202752,
     "max_output_tokens": 202752,
-    "effective_from": "2026-05-31T22:00:00",
+    "effective_from": "2026-06-01T05:00:00",
     "effective_to": null,
     "capabilities": [
       {
@@ -263,7 +263,7 @@
     "context_length": 202752,
     "max_output_tokens": 202752,
     "effective_from": "2026-04-27T00:00:00",
-    "effective_to": "2026-05-31T22:00:00",
+    "effective_to": "2026-06-01T05:00:00",
     "capabilities": [
       {
         "capability_id": "text.generate",
@@ -389,7 +389,7 @@
     "context_length": 262144,
     "max_output_tokens": 262144,
     "effective_from": "2026-04-27T00:00:00",
-    "effective_to": "2026-05-31T22:00:00",
+    "effective_to": "2026-06-01T05:00:00",
     "capabilities": [
       {
         "capability_id": "text.generate",
@@ -409,7 +409,7 @@
     "output_modalities": "text",
     "context_length": 262144,
     "max_output_tokens": 262144,
-    "effective_from": "2026-05-31T22:00:00",
+    "effective_from": "2026-06-01T05:00:00",
     "effective_to": null,
     "capabilities": [
       {
@@ -431,7 +431,7 @@
     "context_length": 262144,
     "max_output_tokens": 262144,
     "effective_from": "2026-04-27T00:00:00",
-    "effective_to": "2026-05-31T22:00:00",
+    "effective_to": "2026-06-01T05:00:00",
     "capabilities": [
       {
         "capability_id": "text.generate",

--- a/packages/data/catalog/src/data/pricing/crofai/deepseek-deepseek-v4-pro-lightning/text.generate/pricing.json
+++ b/packages/data/catalog/src/data/pricing/crofai/deepseek-deepseek-v4-pro-lightning/text.generate/pricing.json
@@ -15,7 +15,8 @@
       "note": null,
       "match": [],
       "priority": 100,
-      "effective_from": "2026-05-29T00:00:00Z"
+      "effective_from": "2026-05-29T00:00:00Z",
+      "effective_to": "2026-05-31T22:00:00Z"
     },
     {
       "meter": "cached_read_text_tokens",
@@ -27,7 +28,8 @@
       "note": "Derived from CrofAI live pricing page model payload.",
       "match": [],
       "priority": 100,
-      "effective_from": "2026-05-29T00:00:00Z"
+      "effective_from": "2026-05-29T00:00:00Z",
+      "effective_to": "2026-05-31T22:00:00Z"
     },
     {
       "meter": "output_text_tokens",
@@ -39,7 +41,44 @@
       "note": null,
       "match": [],
       "priority": 100,
-      "effective_from": "2026-05-29T00:00:00Z"
+      "effective_from": "2026-05-29T00:00:00Z",
+      "effective_to": "2026-05-31T22:00:00Z"
+    },
+    {
+      "meter": "input_text_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 0.8,
+      "currency": "USD",
+      "pricing_plan": "standard",
+      "note": null,
+      "match": [],
+      "priority": 100,
+      "effective_from": "2026-05-31T22:00:00Z"
+    },
+    {
+      "meter": "cached_read_text_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 0.02,
+      "currency": "USD",
+      "pricing_plan": "standard",
+      "note": "Updated from CrofAI pricing changes effective 2026-05-31T22:00:00Z.",
+      "match": [],
+      "priority": 100,
+      "effective_from": "2026-05-31T22:00:00Z"
+    },
+    {
+      "meter": "output_text_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 1.6,
+      "currency": "USD",
+      "pricing_plan": "standard",
+      "note": null,
+      "match": [],
+      "priority": 100,
+      "effective_from": "2026-05-31T22:00:00Z"
     }
   ]
 }

--- a/packages/data/catalog/src/data/pricing/crofai/deepseek-deepseek-v4-pro-lightning/text.generate/pricing.json
+++ b/packages/data/catalog/src/data/pricing/crofai/deepseek-deepseek-v4-pro-lightning/text.generate/pricing.json
@@ -16,7 +16,7 @@
       "match": [],
       "priority": 100,
       "effective_from": "2026-05-29T00:00:00Z",
-      "effective_to": "2026-05-31T22:00:00Z"
+      "effective_to": "2026-06-01T05:00:00Z"
     },
     {
       "meter": "cached_read_text_tokens",
@@ -29,7 +29,7 @@
       "match": [],
       "priority": 100,
       "effective_from": "2026-05-29T00:00:00Z",
-      "effective_to": "2026-05-31T22:00:00Z"
+      "effective_to": "2026-06-01T05:00:00Z"
     },
     {
       "meter": "output_text_tokens",
@@ -42,7 +42,7 @@
       "match": [],
       "priority": 100,
       "effective_from": "2026-05-29T00:00:00Z",
-      "effective_to": "2026-05-31T22:00:00Z"
+      "effective_to": "2026-06-01T05:00:00Z"
     },
     {
       "meter": "input_text_tokens",
@@ -54,7 +54,7 @@
       "note": null,
       "match": [],
       "priority": 100,
-      "effective_from": "2026-05-31T22:00:00Z"
+      "effective_from": "2026-06-01T05:00:00Z"
     },
     {
       "meter": "cached_read_text_tokens",
@@ -63,10 +63,10 @@
       "price_per_unit": 0.02,
       "currency": "USD",
       "pricing_plan": "standard",
-      "note": "Updated from CrofAI pricing changes effective 2026-05-31T22:00:00Z.",
+      "note": "Updated from CrofAI pricing changes effective 2026-06-01T05:00:00Z.",
       "match": [],
       "priority": 100,
-      "effective_from": "2026-05-31T22:00:00Z"
+      "effective_from": "2026-06-01T05:00:00Z"
     },
     {
       "meter": "output_text_tokens",
@@ -78,7 +78,7 @@
       "note": null,
       "match": [],
       "priority": 100,
-      "effective_from": "2026-05-31T22:00:00Z"
+      "effective_from": "2026-06-01T05:00:00Z"
     }
   ]
 }

--- a/packages/data/catalog/src/data/pricing/crofai/deepseek-deepseek-v4-pro-precision/text.generate/pricing.json
+++ b/packages/data/catalog/src/data/pricing/crofai/deepseek-deepseek-v4-pro-precision/text.generate/pricing.json
@@ -16,7 +16,7 @@
       "match": [],
       "priority": 100,
       "effective_from": "2026-05-29T00:00:00Z",
-      "effective_to": "2026-05-31T22:00:00Z"
+      "effective_to": "2026-06-01T05:00:00Z"
     },
     {
       "meter": "cached_read_text_tokens",
@@ -29,7 +29,7 @@
       "match": [],
       "priority": 100,
       "effective_from": "2026-05-29T00:00:00Z",
-      "effective_to": "2026-05-31T22:00:00Z"
+      "effective_to": "2026-06-01T05:00:00Z"
     },
     {
       "meter": "output_text_tokens",
@@ -42,7 +42,7 @@
       "match": [],
       "priority": 100,
       "effective_from": "2026-05-29T00:00:00Z",
-      "effective_to": "2026-05-31T22:00:00Z"
+      "effective_to": "2026-06-01T05:00:00Z"
     }
   ]
 }

--- a/packages/data/catalog/src/data/pricing/crofai/deepseek-deepseek-v4-pro-precision/text.generate/pricing.json
+++ b/packages/data/catalog/src/data/pricing/crofai/deepseek-deepseek-v4-pro-precision/text.generate/pricing.json
@@ -15,7 +15,8 @@
       "note": null,
       "match": [],
       "priority": 100,
-      "effective_from": "2026-05-29T00:00:00Z"
+      "effective_from": "2026-05-29T00:00:00Z",
+      "effective_to": "2026-05-31T22:00:00Z"
     },
     {
       "meter": "cached_read_text_tokens",
@@ -27,7 +28,8 @@
       "note": "Derived from CrofAI live pricing page model payload.",
       "match": [],
       "priority": 100,
-      "effective_from": "2026-05-29T00:00:00Z"
+      "effective_from": "2026-05-29T00:00:00Z",
+      "effective_to": "2026-05-31T22:00:00Z"
     },
     {
       "meter": "output_text_tokens",
@@ -39,7 +41,8 @@
       "note": null,
       "match": [],
       "priority": 100,
-      "effective_from": "2026-05-29T00:00:00Z"
+      "effective_from": "2026-05-29T00:00:00Z",
+      "effective_to": "2026-05-31T22:00:00Z"
     }
   ]
 }

--- a/packages/data/catalog/src/data/pricing/crofai/deepseek-deepseek-v4-pro/text.generate/pricing.json
+++ b/packages/data/catalog/src/data/pricing/crofai/deepseek-deepseek-v4-pro/text.generate/pricing.json
@@ -16,7 +16,7 @@
       "match": [],
       "priority": 100,
       "effective_from": "2026-05-29T00:00:00Z",
-      "effective_to": "2026-05-31T22:00:00Z"
+      "effective_to": "2026-06-01T05:00:00Z"
     },
     {
       "meter": "cached_read_text_tokens",
@@ -29,7 +29,7 @@
       "match": [],
       "priority": 100,
       "effective_from": "2026-05-29T00:00:00Z",
-      "effective_to": "2026-05-31T22:00:00Z"
+      "effective_to": "2026-06-01T05:00:00Z"
     },
     {
       "meter": "output_text_tokens",
@@ -42,7 +42,7 @@
       "match": [],
       "priority": 100,
       "effective_from": "2026-05-29T00:00:00Z",
-      "effective_to": "2026-05-31T22:00:00Z"
+      "effective_to": "2026-06-01T05:00:00Z"
     },
     {
       "meter": "input_text_tokens",
@@ -54,7 +54,7 @@
       "note": null,
       "match": [],
       "priority": 100,
-      "effective_from": "2026-05-31T22:00:00Z"
+      "effective_from": "2026-06-01T05:00:00Z"
     },
     {
       "meter": "cached_read_text_tokens",
@@ -63,10 +63,10 @@
       "price_per_unit": 0.003,
       "currency": "USD",
       "pricing_plan": "standard",
-      "note": "Updated from CrofAI pricing changes effective 2026-05-31T22:00:00Z.",
+      "note": "Updated from CrofAI pricing changes effective 2026-06-01T05:00:00Z.",
       "match": [],
       "priority": 100,
-      "effective_from": "2026-05-31T22:00:00Z"
+      "effective_from": "2026-06-01T05:00:00Z"
     },
     {
       "meter": "output_text_tokens",
@@ -78,7 +78,7 @@
       "note": null,
       "match": [],
       "priority": 100,
-      "effective_from": "2026-05-31T22:00:00Z"
+      "effective_from": "2026-06-01T05:00:00Z"
     }
   ]
 }

--- a/packages/data/catalog/src/data/pricing/crofai/deepseek-deepseek-v4-pro/text.generate/pricing.json
+++ b/packages/data/catalog/src/data/pricing/crofai/deepseek-deepseek-v4-pro/text.generate/pricing.json
@@ -15,7 +15,8 @@
       "note": null,
       "match": [],
       "priority": 100,
-      "effective_from": "2026-05-29T00:00:00Z"
+      "effective_from": "2026-05-29T00:00:00Z",
+      "effective_to": "2026-05-31T22:00:00Z"
     },
     {
       "meter": "cached_read_text_tokens",
@@ -27,7 +28,8 @@
       "note": "Derived from CrofAI live pricing page model payload.",
       "match": [],
       "priority": 100,
-      "effective_from": "2026-05-29T00:00:00Z"
+      "effective_from": "2026-05-29T00:00:00Z",
+      "effective_to": "2026-05-31T22:00:00Z"
     },
     {
       "meter": "output_text_tokens",
@@ -39,7 +41,44 @@
       "note": null,
       "match": [],
       "priority": 100,
-      "effective_from": "2026-05-29T00:00:00Z"
+      "effective_from": "2026-05-29T00:00:00Z",
+      "effective_to": "2026-05-31T22:00:00Z"
+    },
+    {
+      "meter": "input_text_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 0.4,
+      "currency": "USD",
+      "pricing_plan": "standard",
+      "note": null,
+      "match": [],
+      "priority": 100,
+      "effective_from": "2026-05-31T22:00:00Z"
+    },
+    {
+      "meter": "cached_read_text_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 0.003,
+      "currency": "USD",
+      "pricing_plan": "standard",
+      "note": "Updated from CrofAI pricing changes effective 2026-05-31T22:00:00Z.",
+      "match": [],
+      "priority": 100,
+      "effective_from": "2026-05-31T22:00:00Z"
+    },
+    {
+      "meter": "output_text_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 0.8,
+      "currency": "USD",
+      "pricing_plan": "standard",
+      "note": null,
+      "match": [],
+      "priority": 100,
+      "effective_from": "2026-05-31T22:00:00Z"
     }
   ]
 }

--- a/packages/data/catalog/src/data/pricing/crofai/moonshotai-kimi-k2.6-precision/text.generate/pricing.json
+++ b/packages/data/catalog/src/data/pricing/crofai/moonshotai-kimi-k2.6-precision/text.generate/pricing.json
@@ -15,7 +15,8 @@
       "note": null,
       "match": [],
       "priority": 100,
-      "effective_from": "2026-04-27T00:00:00Z"
+      "effective_from": "2026-04-27T00:00:00Z",
+      "effective_to": "2026-05-31T22:00:00Z"
     },
     {
       "meter": "cached_read_text_tokens",
@@ -27,7 +28,8 @@
       "note": "Derived from CrofAI pricing page cache pricing display.",
       "match": [],
       "priority": 100,
-      "effective_from": "2026-04-27T00:00:00Z"
+      "effective_from": "2026-04-27T00:00:00Z",
+      "effective_to": "2026-05-31T22:00:00Z"
     },
     {
       "meter": "output_text_tokens",
@@ -39,7 +41,8 @@
       "note": null,
       "match": [],
       "priority": 100,
-      "effective_from": "2026-04-27T00:00:00Z"
+      "effective_from": "2026-04-27T00:00:00Z",
+      "effective_to": "2026-05-31T22:00:00Z"
     }
   ]
 }

--- a/packages/data/catalog/src/data/pricing/crofai/moonshotai-kimi-k2.6-precision/text.generate/pricing.json
+++ b/packages/data/catalog/src/data/pricing/crofai/moonshotai-kimi-k2.6-precision/text.generate/pricing.json
@@ -16,7 +16,7 @@
       "match": [],
       "priority": 100,
       "effective_from": "2026-04-27T00:00:00Z",
-      "effective_to": "2026-05-31T22:00:00Z"
+      "effective_to": "2026-06-01T05:00:00Z"
     },
     {
       "meter": "cached_read_text_tokens",
@@ -29,7 +29,7 @@
       "match": [],
       "priority": 100,
       "effective_from": "2026-04-27T00:00:00Z",
-      "effective_to": "2026-05-31T22:00:00Z"
+      "effective_to": "2026-06-01T05:00:00Z"
     },
     {
       "meter": "output_text_tokens",
@@ -42,7 +42,7 @@
       "match": [],
       "priority": 100,
       "effective_from": "2026-04-27T00:00:00Z",
-      "effective_to": "2026-05-31T22:00:00Z"
+      "effective_to": "2026-06-01T05:00:00Z"
     }
   ]
 }

--- a/packages/data/catalog/src/data/pricing/crofai/moonshotai-kimi-k2.6/text.generate/pricing.json
+++ b/packages/data/catalog/src/data/pricing/crofai/moonshotai-kimi-k2.6/text.generate/pricing.json
@@ -16,7 +16,7 @@
       "match": [],
       "priority": 100,
       "effective_from": "2026-04-27T00:00:00Z",
-      "effective_to": "2026-05-31T22:00:00Z"
+      "effective_to": "2026-06-01T05:00:00Z"
     },
     {
       "meter": "cached_read_text_tokens",
@@ -29,7 +29,7 @@
       "match": [],
       "priority": 100,
       "effective_from": "2026-04-27T00:00:00Z",
-      "effective_to": "2026-05-31T22:00:00Z"
+      "effective_to": "2026-06-01T05:00:00Z"
     },
     {
       "meter": "output_text_tokens",
@@ -42,7 +42,7 @@
       "match": [],
       "priority": 100,
       "effective_from": "2026-04-27T00:00:00Z",
-      "effective_to": "2026-05-31T22:00:00Z"
+      "effective_to": "2026-06-01T05:00:00Z"
     },
     {
       "meter": "input_text_tokens",
@@ -54,7 +54,7 @@
       "note": null,
       "match": [],
       "priority": 100,
-      "effective_from": "2026-05-31T22:00:00Z"
+      "effective_from": "2026-06-01T05:00:00Z"
     },
     {
       "meter": "cached_read_text_tokens",
@@ -63,10 +63,10 @@
       "price_per_unit": 0.05,
       "currency": "USD",
       "pricing_plan": "standard",
-      "note": "Updated from CrofAI pricing changes effective 2026-05-31T22:00:00Z.",
+      "note": "Updated from CrofAI pricing changes effective 2026-06-01T05:00:00Z.",
       "match": [],
       "priority": 100,
-      "effective_from": "2026-05-31T22:00:00Z"
+      "effective_from": "2026-06-01T05:00:00Z"
     },
     {
       "meter": "output_text_tokens",
@@ -78,7 +78,7 @@
       "note": null,
       "match": [],
       "priority": 100,
-      "effective_from": "2026-05-31T22:00:00Z"
+      "effective_from": "2026-06-01T05:00:00Z"
     }
   ]
 }

--- a/packages/data/catalog/src/data/pricing/crofai/moonshotai-kimi-k2.6/text.generate/pricing.json
+++ b/packages/data/catalog/src/data/pricing/crofai/moonshotai-kimi-k2.6/text.generate/pricing.json
@@ -15,7 +15,8 @@
       "note": null,
       "match": [],
       "priority": 100,
-      "effective_from": "2026-04-27T00:00:00Z"
+      "effective_from": "2026-04-27T00:00:00Z",
+      "effective_to": "2026-05-31T22:00:00Z"
     },
     {
       "meter": "cached_read_text_tokens",
@@ -27,7 +28,8 @@
       "note": "Derived from CrofAI pricing page cache pricing display.",
       "match": [],
       "priority": 100,
-      "effective_from": "2026-04-27T00:00:00Z"
+      "effective_from": "2026-04-27T00:00:00Z",
+      "effective_to": "2026-05-31T22:00:00Z"
     },
     {
       "meter": "output_text_tokens",
@@ -39,7 +41,44 @@
       "note": null,
       "match": [],
       "priority": 100,
-      "effective_from": "2026-04-27T00:00:00Z"
+      "effective_from": "2026-04-27T00:00:00Z",
+      "effective_to": "2026-05-31T22:00:00Z"
+    },
+    {
+      "meter": "input_text_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 0.5,
+      "currency": "USD",
+      "pricing_plan": "standard",
+      "note": null,
+      "match": [],
+      "priority": 100,
+      "effective_from": "2026-05-31T22:00:00Z"
+    },
+    {
+      "meter": "cached_read_text_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 0.05,
+      "currency": "USD",
+      "pricing_plan": "standard",
+      "note": "Updated from CrofAI pricing changes effective 2026-05-31T22:00:00Z.",
+      "match": [],
+      "priority": 100,
+      "effective_from": "2026-05-31T22:00:00Z"
+    },
+    {
+      "meter": "output_text_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 1.99,
+      "currency": "USD",
+      "pricing_plan": "standard",
+      "note": null,
+      "match": [],
+      "priority": 100,
+      "effective_from": "2026-05-31T22:00:00Z"
     }
   ]
 }

--- a/packages/data/catalog/src/data/pricing/crofai/xiaomi-mimo-v2.5-pro-precision/text.generate/pricing.json
+++ b/packages/data/catalog/src/data/pricing/crofai/xiaomi-mimo-v2.5-pro-precision/text.generate/pricing.json
@@ -15,7 +15,8 @@
       "note": null,
       "match": [],
       "priority": 100,
-      "effective_from": "2026-05-12T00:00:00Z"
+      "effective_from": "2026-05-12T00:00:00Z",
+      "effective_to": "2026-05-31T22:00:00Z"
     },
     {
       "meter": "cached_read_text_tokens",
@@ -27,7 +28,8 @@
       "note": null,
       "match": [],
       "priority": 100,
-      "effective_from": "2026-05-12T00:00:00Z"
+      "effective_from": "2026-05-12T00:00:00Z",
+      "effective_to": "2026-05-31T22:00:00Z"
     },
     {
       "meter": "output_text_tokens",
@@ -39,7 +41,8 @@
       "note": null,
       "match": [],
       "priority": 100,
-      "effective_from": "2026-05-12T00:00:00Z"
+      "effective_from": "2026-05-12T00:00:00Z",
+      "effective_to": "2026-05-31T22:00:00Z"
     }
   ]
 }

--- a/packages/data/catalog/src/data/pricing/crofai/xiaomi-mimo-v2.5-pro-precision/text.generate/pricing.json
+++ b/packages/data/catalog/src/data/pricing/crofai/xiaomi-mimo-v2.5-pro-precision/text.generate/pricing.json
@@ -16,7 +16,7 @@
       "match": [],
       "priority": 100,
       "effective_from": "2026-05-12T00:00:00Z",
-      "effective_to": "2026-05-31T22:00:00Z"
+      "effective_to": "2026-06-01T05:00:00Z"
     },
     {
       "meter": "cached_read_text_tokens",
@@ -29,7 +29,7 @@
       "match": [],
       "priority": 100,
       "effective_from": "2026-05-12T00:00:00Z",
-      "effective_to": "2026-05-31T22:00:00Z"
+      "effective_to": "2026-06-01T05:00:00Z"
     },
     {
       "meter": "output_text_tokens",
@@ -42,7 +42,7 @@
       "match": [],
       "priority": 100,
       "effective_from": "2026-05-12T00:00:00Z",
-      "effective_to": "2026-05-31T22:00:00Z"
+      "effective_to": "2026-06-01T05:00:00Z"
     }
   ]
 }

--- a/packages/data/catalog/src/data/pricing/crofai/xiaomi-mimo-v2.5-pro/text.generate/pricing.json
+++ b/packages/data/catalog/src/data/pricing/crofai/xiaomi-mimo-v2.5-pro/text.generate/pricing.json
@@ -15,7 +15,8 @@
       "note": null,
       "match": [],
       "priority": 100,
-      "effective_from": "2026-05-12T00:00:00Z"
+      "effective_from": "2026-05-12T00:00:00Z",
+      "effective_to": "2026-05-31T22:00:00Z"
     },
     {
       "meter": "cached_read_text_tokens",
@@ -27,7 +28,8 @@
       "note": null,
       "match": [],
       "priority": 100,
-      "effective_from": "2026-05-12T00:00:00Z"
+      "effective_from": "2026-05-12T00:00:00Z",
+      "effective_to": "2026-05-31T22:00:00Z"
     },
     {
       "meter": "output_text_tokens",
@@ -39,7 +41,44 @@
       "note": null,
       "match": [],
       "priority": 100,
-      "effective_from": "2026-05-12T00:00:00Z"
+      "effective_from": "2026-05-12T00:00:00Z",
+      "effective_to": "2026-05-31T22:00:00Z"
+    },
+    {
+      "meter": "input_text_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 0.4,
+      "currency": "USD",
+      "pricing_plan": "standard",
+      "note": null,
+      "match": [],
+      "priority": 100,
+      "effective_from": "2026-05-31T22:00:00Z"
+    },
+    {
+      "meter": "cached_read_text_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 0.003,
+      "currency": "USD",
+      "pricing_plan": "standard",
+      "note": "Updated from CrofAI pricing changes effective 2026-05-31T22:00:00Z.",
+      "match": [],
+      "priority": 100,
+      "effective_from": "2026-05-31T22:00:00Z"
+    },
+    {
+      "meter": "output_text_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 0.8,
+      "currency": "USD",
+      "pricing_plan": "standard",
+      "note": null,
+      "match": [],
+      "priority": 100,
+      "effective_from": "2026-05-31T22:00:00Z"
     }
   ]
 }

--- a/packages/data/catalog/src/data/pricing/crofai/xiaomi-mimo-v2.5-pro/text.generate/pricing.json
+++ b/packages/data/catalog/src/data/pricing/crofai/xiaomi-mimo-v2.5-pro/text.generate/pricing.json
@@ -16,7 +16,7 @@
       "match": [],
       "priority": 100,
       "effective_from": "2026-05-12T00:00:00Z",
-      "effective_to": "2026-05-31T22:00:00Z"
+      "effective_to": "2026-06-01T05:00:00Z"
     },
     {
       "meter": "cached_read_text_tokens",
@@ -29,7 +29,7 @@
       "match": [],
       "priority": 100,
       "effective_from": "2026-05-12T00:00:00Z",
-      "effective_to": "2026-05-31T22:00:00Z"
+      "effective_to": "2026-06-01T05:00:00Z"
     },
     {
       "meter": "output_text_tokens",
@@ -42,7 +42,7 @@
       "match": [],
       "priority": 100,
       "effective_from": "2026-05-12T00:00:00Z",
-      "effective_to": "2026-05-31T22:00:00Z"
+      "effective_to": "2026-06-01T05:00:00Z"
     },
     {
       "meter": "input_text_tokens",
@@ -54,7 +54,7 @@
       "note": null,
       "match": [],
       "priority": 100,
-      "effective_from": "2026-05-31T22:00:00Z"
+      "effective_from": "2026-06-01T05:00:00Z"
     },
     {
       "meter": "cached_read_text_tokens",
@@ -63,10 +63,10 @@
       "price_per_unit": 0.003,
       "currency": "USD",
       "pricing_plan": "standard",
-      "note": "Updated from CrofAI pricing changes effective 2026-05-31T22:00:00Z.",
+      "note": "Updated from CrofAI pricing changes effective 2026-06-01T05:00:00Z.",
       "match": [],
       "priority": 100,
-      "effective_from": "2026-05-31T22:00:00Z"
+      "effective_from": "2026-06-01T05:00:00Z"
     },
     {
       "meter": "output_text_tokens",
@@ -78,7 +78,7 @@
       "note": null,
       "match": [],
       "priority": 100,
-      "effective_from": "2026-05-31T22:00:00Z"
+      "effective_from": "2026-06-01T05:00:00Z"
     }
   ]
 }

--- a/packages/data/catalog/src/data/pricing/crofai/z-ai-glm-5.1-precision/text.generate/pricing.json
+++ b/packages/data/catalog/src/data/pricing/crofai/z-ai-glm-5.1-precision/text.generate/pricing.json
@@ -15,7 +15,8 @@
       "note": null,
       "match": [],
       "priority": 100,
-      "effective_from": "2026-04-27T00:00:00Z"
+      "effective_from": "2026-04-27T00:00:00Z",
+      "effective_to": "2026-05-31T22:00:00Z"
     },
     {
       "meter": "cached_read_text_tokens",
@@ -27,7 +28,8 @@
       "note": null,
       "match": [],
       "priority": 100,
-      "effective_from": "2026-04-27T00:00:00Z"
+      "effective_from": "2026-04-27T00:00:00Z",
+      "effective_to": "2026-05-31T22:00:00Z"
     },
     {
       "meter": "output_text_tokens",
@@ -39,7 +41,8 @@
       "note": null,
       "match": [],
       "priority": 100,
-      "effective_from": "2026-04-27T00:00:00Z"
+      "effective_from": "2026-04-27T00:00:00Z",
+      "effective_to": "2026-05-31T22:00:00Z"
     }
   ]
 }

--- a/packages/data/catalog/src/data/pricing/crofai/z-ai-glm-5.1-precision/text.generate/pricing.json
+++ b/packages/data/catalog/src/data/pricing/crofai/z-ai-glm-5.1-precision/text.generate/pricing.json
@@ -16,7 +16,7 @@
       "match": [],
       "priority": 100,
       "effective_from": "2026-04-27T00:00:00Z",
-      "effective_to": "2026-05-31T22:00:00Z"
+      "effective_to": "2026-06-01T05:00:00Z"
     },
     {
       "meter": "cached_read_text_tokens",
@@ -29,7 +29,7 @@
       "match": [],
       "priority": 100,
       "effective_from": "2026-04-27T00:00:00Z",
-      "effective_to": "2026-05-31T22:00:00Z"
+      "effective_to": "2026-06-01T05:00:00Z"
     },
     {
       "meter": "output_text_tokens",
@@ -42,7 +42,7 @@
       "match": [],
       "priority": 100,
       "effective_from": "2026-04-27T00:00:00Z",
-      "effective_to": "2026-05-31T22:00:00Z"
+      "effective_to": "2026-06-01T05:00:00Z"
     }
   ]
 }

--- a/packages/data/catalog/src/data/pricing/crofai/z-ai-glm-5.1/text.generate/pricing.json
+++ b/packages/data/catalog/src/data/pricing/crofai/z-ai-glm-5.1/text.generate/pricing.json
@@ -16,7 +16,7 @@
       "match": [],
       "priority": 100,
       "effective_from": "2026-04-27T00:00:00Z",
-      "effective_to": "2026-05-31T22:00:00Z"
+      "effective_to": "2026-06-01T05:00:00Z"
     },
     {
       "meter": "cached_read_text_tokens",
@@ -29,7 +29,7 @@
       "match": [],
       "priority": 100,
       "effective_from": "2026-04-27T00:00:00Z",
-      "effective_to": "2026-05-31T22:00:00Z"
+      "effective_to": "2026-06-01T05:00:00Z"
     },
     {
       "meter": "output_text_tokens",
@@ -42,7 +42,7 @@
       "match": [],
       "priority": 100,
       "effective_from": "2026-04-27T00:00:00Z",
-      "effective_to": "2026-05-31T22:00:00Z"
+      "effective_to": "2026-06-01T05:00:00Z"
     },
     {
       "meter": "input_text_tokens",
@@ -54,7 +54,7 @@
       "note": null,
       "match": [],
       "priority": 100,
-      "effective_from": "2026-05-31T22:00:00Z"
+      "effective_from": "2026-06-01T05:00:00Z"
     },
     {
       "meter": "cached_read_text_tokens",
@@ -63,10 +63,10 @@
       "price_per_unit": 0.08,
       "currency": "USD",
       "pricing_plan": "standard",
-      "note": "Updated from CrofAI pricing changes effective 2026-05-31T22:00:00Z.",
+      "note": "Updated from CrofAI pricing changes effective 2026-06-01T05:00:00Z.",
       "match": [],
       "priority": 100,
-      "effective_from": "2026-05-31T22:00:00Z"
+      "effective_from": "2026-06-01T05:00:00Z"
     },
     {
       "meter": "output_text_tokens",
@@ -78,7 +78,7 @@
       "note": null,
       "match": [],
       "priority": 100,
-      "effective_from": "2026-05-31T22:00:00Z"
+      "effective_from": "2026-06-01T05:00:00Z"
     }
   ]
 }

--- a/packages/data/catalog/src/data/pricing/crofai/z-ai-glm-5.1/text.generate/pricing.json
+++ b/packages/data/catalog/src/data/pricing/crofai/z-ai-glm-5.1/text.generate/pricing.json
@@ -15,7 +15,8 @@
       "note": null,
       "match": [],
       "priority": 100,
-      "effective_from": "2026-04-27T00:00:00Z"
+      "effective_from": "2026-04-27T00:00:00Z",
+      "effective_to": "2026-05-31T22:00:00Z"
     },
     {
       "meter": "cached_read_text_tokens",
@@ -27,7 +28,8 @@
       "note": "Derived from CrofAI pricing page cache pricing display.",
       "match": [],
       "priority": 100,
-      "effective_from": "2026-04-27T00:00:00Z"
+      "effective_from": "2026-04-27T00:00:00Z",
+      "effective_to": "2026-05-31T22:00:00Z"
     },
     {
       "meter": "output_text_tokens",
@@ -39,7 +41,44 @@
       "note": null,
       "match": [],
       "priority": 100,
-      "effective_from": "2026-04-27T00:00:00Z"
+      "effective_from": "2026-04-27T00:00:00Z",
+      "effective_to": "2026-05-31T22:00:00Z"
+    },
+    {
+      "meter": "input_text_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 0.45,
+      "currency": "USD",
+      "pricing_plan": "standard",
+      "note": null,
+      "match": [],
+      "priority": 100,
+      "effective_from": "2026-05-31T22:00:00Z"
+    },
+    {
+      "meter": "cached_read_text_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 0.08,
+      "currency": "USD",
+      "pricing_plan": "standard",
+      "note": "Updated from CrofAI pricing changes effective 2026-05-31T22:00:00Z.",
+      "match": [],
+      "priority": 100,
+      "effective_from": "2026-05-31T22:00:00Z"
+    },
+    {
+      "meter": "output_text_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 2.25,
+      "currency": "USD",
+      "pricing_plan": "standard",
+      "note": null,
+      "match": [],
+      "priority": 100,
+      "effective_from": "2026-05-31T22:00:00Z"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- schedule CrofAI provider support changes for `2026-06-01T05:00:00Z`
- end-date replaced `-precision` CrofAI provider rows and pricing rules
- add future CrofAI pricing rows for the surviving model IDs
- add future provider windows for models moving to Q8/int4 quantization

## Verification
- `pnpm validate:data`
- `pnpm validate:pricing`
- `pnpm validate:gateway`
- checked current `https://crof.ai/v1/models` output against the existing historical rows

## Sources
- https://crof.ai/blog/pricing-changes
- https://crof.ai/v1/models

## Notes
The subscription pricing cleanup from the brief is intentionally left for separate work. This PR is limited to the scheduled CrofAI provider and pricing update.

