### PR TITLE
Fix organisation link platform enum mismatch

### DIFF
--- a/packages/data/catalog/src/data/organisations/github/organisation.json
+++ b/packages/data/catalog/src/data/organisations/github/organisation.json
@@ -10,10 +10,6 @@
       "url": "https://github.com"
     },
     {
-      "platform": "docs",
-      "url": "https://docs.github.com/en/copilot"
-    },
-    {
       "platform": "x",
       "url": "https://x.com/github"
     },

--- a/packages/data/catalog/src/data/organisations/poe/organisation.json
+++ b/packages/data/catalog/src/data/organisations/poe/organisation.json
@@ -10,14 +10,6 @@
       "url": "https://poe.com"
     },
     {
-      "platform": "help",
-      "url": "https://help.poe.com"
-    },
-    {
-      "platform": "company",
-      "url": "https://company.quora.com"
-    },
-    {
       "platform": "x",
       "url": "https://x.com/poe_platform"
     }

--- a/packages/data/catalog/src/data/organisations/windsurf/organisation.json
+++ b/packages/data/catalog/src/data/organisations/windsurf/organisation.json
@@ -10,10 +10,6 @@
       "url": "https://windsurf.com"
     },
     {
-      "platform": "docs",
-      "url": "https://docs.windsurf.com"
-    },
-    {
       "platform": "x",
       "url": "https://x.com/windsurf_ai"
     },

--- a/packages/data/catalog/src/data/types.ts
+++ b/packages/data/catalog/src/data/types.ts
@@ -14,7 +14,7 @@ export interface Organisation {
 export interface OrganisationLinks {
     organisation_link_id: string;
     organisation_id: string;
-    platform: 'website' | 'x' | 'github' | 'linkedin' | 'discord' | 'facebook' | 'instagram' | 'youtube' | 'tiktok' | 'threads' | 'reddit';
+    platform: 'website' | 'x' | 'github' | 'hugging_face' | 'linkedin' | 'discord' | 'facebook' | 'instagram' | 'youtube' | 'tiktok' | 'threads' | 'reddit';
     url: string;
     created_at: string;
     updated_at: string;
@@ -23,7 +23,7 @@ export interface OrganisationLinks {
 
 // Old JSON types
 export interface SocialLink {
-    platform: 'x' | 'github' | 'instagram' | 'youtube' | 'linkedin' | 'reddit' | 'tiktok' | 'threads' | 'discord';
+    platform: 'x' | 'github' | 'hugging_face' | 'instagram' | 'youtube' | 'linkedin' | 'reddit' | 'tiktok' | 'threads' | 'discord' | 'website';
     url: string;
 }
 

--- a/packages/data/catalog/src/data/validate.ts
+++ b/packages/data/catalog/src/data/validate.ts
@@ -374,6 +374,21 @@ function looksLikeDateKey(name: string): boolean {
     return DETAIL_DATE_HINTS.some((hint) => lower.includes(hint));
 }
 
+const ALLOWED_ORGANISATION_LINK_PLATFORMS = new Set([
+    'website',
+    'x',
+    'github',
+    'hugging_face',
+    'linkedin',
+    'discord',
+    'facebook',
+    'instagram',
+    'youtube',
+    'tiktok',
+    'threads',
+    'reddit',
+]);
+
 function checkOrganisations(state: ValidationState): string[] {
     const errors: string[] = [];
     const organisationsDir = path.join(DATA_ROOT, 'organisations');
@@ -393,6 +408,30 @@ function checkOrganisations(state: ValidationState): string[] {
         state.organisationIds.set(organisationId, filePath);
         if (typeof data.name !== 'string' || !data.name.trim()) {
             errors.push(`Organisation ${organisationId} missing name`);
+        }
+        const links = Array.isArray(data.organisation_links) ? data.organisation_links : [];
+        const seenPlatforms = new Set<string>();
+        for (const [index, link] of links.entries()) {
+            const platform = typeof link?.platform === 'string' ? link.platform.trim() : '';
+            const url = typeof link?.url === 'string' ? link.url.trim() : '';
+            if (!platform) {
+                errors.push(`Organisation ${organisationId} link ${index} missing platform`);
+                continue;
+            }
+            if (!ALLOWED_ORGANISATION_LINK_PLATFORMS.has(platform)) {
+                errors.push(
+                    `Organisation ${organisationId} link ${index} has unsupported platform '${platform}'`
+                );
+            }
+            if (seenPlatforms.has(platform)) {
+                errors.push(
+                    `Organisation ${organisationId} has duplicate organisation_links platform '${platform}'`
+                );
+            }
+            seenPlatforms.add(platform);
+            if (!url) {
+                errors.push(`Organisation ${organisationId} link ${index} missing url`);
+            }
         }
     }
     return errors;

--- a/packages/data/catalog/src/data/validate.ts
+++ b/packages/data/catalog/src/data/validate.ts
@@ -412,11 +412,17 @@ function checkOrganisations(state: ValidationState): string[] {
         const links = Array.isArray(data.organisation_links) ? data.organisation_links : [];
         const seenPlatforms = new Set<string>();
         for (const [index, link] of links.entries()) {
-            const platform = typeof link?.platform === 'string' ? link.platform.trim() : '';
+            const rawPlatform = typeof link?.platform === 'string' ? link.platform : '';
+            const platform = rawPlatform.trim();
             const url = typeof link?.url === 'string' ? link.url.trim() : '';
             if (!platform) {
                 errors.push(`Organisation ${organisationId} link ${index} missing platform`);
                 continue;
+            }
+            if (rawPlatform !== platform) {
+                errors.push(
+                    `Organisation ${organisationId} link ${index} has non-canonical platform '${rawPlatform}'`
+                );
             }
             if (!ALLOWED_ORGANISATION_LINK_PLATFORMS.has(platform)) {
                 errors.push(


### PR DESCRIPTION
## Summary
- remove unsupported organisation link platforms introduced in the subscription plan catalog refresh (`docs`, `help`, `company`)
- keep organisation link data aligned with the importer/database enum by retaining only supported platform values
- add validation for organisation link platforms, duplicate platform entries, and missing URLs so this fails in `validate:data` before merge next time
- align catalog organisation link types with the already-supported `hugging_face` platform

## Root cause
`main` CI fails in `Run importer on main` with:

```text
invalid input value for enum organisation_social_platforms: docs
```

The merged `organisation.json` files for `github`, `windsurf`, and `poe` introduced organisation link platform values that the importer writes into `data_organisation_links.platform`, but the backing enum does not accept them.

## Validation
- `pnpm validate:data`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Removed outdated documentation and company links from several organization profiles (GitHub, Poe, Windsurf).
  * Added support for "website" as a recognized link type in organization data.

* **Bug Fixes**
  * Improved validation to require platform and URL values, reject unsupported or non-canonical platforms, and prevent duplicate platform links per organization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->