### PR TITLE
[codex] Add Microsoft AI model catalog entries

### DIFF
--- a/packages/data/catalog/src/data/api_providers/azure/models.json
+++ b/packages/data/catalog/src/data/api_providers/azure/models.json
@@ -28,5 +28,183 @@
     "effective_from": null,
     "effective_to": null,
     "capabilities": []
+  },
+  {
+    "api_model_id": "microsoft/mai-image-2",
+    "provider_api_model_id": "azure:microsoft/mai-image-2",
+    "provider_model_slug": "mai-image-2",
+    "internal_model_id": "microsoft/mai-image-2",
+    "is_active_gateway": false,
+    "quantization_scheme": null,
+    "input_modalities": "text",
+    "output_modalities": "image",
+    "context_length": null,
+    "max_output_tokens": null,
+    "effective_from": "2026-04-02T00:00:00Z",
+    "effective_to": null,
+    "capabilities": [
+      {
+        "capability_id": "image.generate",
+        "status": "active",
+        "params": []
+      }
+    ]
+  },
+  {
+    "api_model_id": "microsoft/mai-image-2.5",
+    "provider_api_model_id": "azure:microsoft/mai-image-2.5",
+    "provider_model_slug": "mai-image-2.5",
+    "internal_model_id": "microsoft/mai-image-2.5",
+    "is_active_gateway": false,
+    "quantization_scheme": null,
+    "input_modalities": "text,image",
+    "output_modalities": "image",
+    "context_length": null,
+    "max_output_tokens": null,
+    "effective_from": "2026-06-02T00:00:00Z",
+    "effective_to": null,
+    "capabilities": [
+      {
+        "capability_id": "image.generate",
+        "status": "active",
+        "params": []
+      },
+      {
+        "capability_id": "image.edit",
+        "status": "active",
+        "params": []
+      }
+    ]
+  },
+  {
+    "api_model_id": "microsoft/mai-image-2.5-flash",
+    "provider_api_model_id": "azure:microsoft/mai-image-2.5-flash",
+    "provider_model_slug": "mai-image-2.5-flash",
+    "internal_model_id": "microsoft/mai-image-2.5-flash",
+    "is_active_gateway": false,
+    "quantization_scheme": null,
+    "input_modalities": "text,image",
+    "output_modalities": "image",
+    "context_length": null,
+    "max_output_tokens": null,
+    "effective_from": "2026-06-02T00:00:00Z",
+    "effective_to": null,
+    "capabilities": [
+      {
+        "capability_id": "image.generate",
+        "status": "active",
+        "params": []
+      },
+      {
+        "capability_id": "image.edit",
+        "status": "active",
+        "params": []
+      }
+    ]
+  },
+  {
+    "api_model_id": "microsoft/mai-image-2e",
+    "provider_api_model_id": "azure:microsoft/mai-image-2e",
+    "provider_model_slug": "mai-image-2e",
+    "internal_model_id": "microsoft/mai-image-2e",
+    "is_active_gateway": false,
+    "quantization_scheme": null,
+    "input_modalities": "text",
+    "output_modalities": "image",
+    "context_length": null,
+    "max_output_tokens": null,
+    "effective_from": "2026-04-14T00:00:00Z",
+    "effective_to": null,
+    "capabilities": [
+      {
+        "capability_id": "image.generate",
+        "status": "active",
+        "params": []
+      }
+    ]
+  },
+  {
+    "api_model_id": "microsoft/mai-transcribe-1",
+    "provider_api_model_id": "azure:microsoft/mai-transcribe-1",
+    "provider_model_slug": "mai-transcribe-1",
+    "internal_model_id": "microsoft/mai-transcribe-1",
+    "is_active_gateway": false,
+    "quantization_scheme": null,
+    "input_modalities": "audio",
+    "output_modalities": "text",
+    "context_length": null,
+    "max_output_tokens": null,
+    "effective_from": "2026-04-02T00:00:00Z",
+    "effective_to": null,
+    "capabilities": [
+      {
+        "capability_id": "audio.transcription",
+        "status": "active",
+        "params": []
+      }
+    ]
+  },
+  {
+    "api_model_id": "microsoft/mai-transcribe-1.5",
+    "provider_api_model_id": "azure:microsoft/mai-transcribe-1.5",
+    "provider_model_slug": "mai-transcribe-1.5",
+    "internal_model_id": "microsoft/mai-transcribe-1.5",
+    "is_active_gateway": false,
+    "quantization_scheme": null,
+    "input_modalities": "audio",
+    "output_modalities": "text",
+    "context_length": null,
+    "max_output_tokens": null,
+    "effective_from": "2026-06-02T00:00:00Z",
+    "effective_to": null,
+    "capabilities": [
+      {
+        "capability_id": "audio.transcription",
+        "status": "active",
+        "params": []
+      }
+    ]
+  },
+  {
+    "api_model_id": "microsoft/mai-voice-1",
+    "provider_api_model_id": "azure:microsoft/mai-voice-1",
+    "provider_model_slug": "mai-voice-1",
+    "internal_model_id": "microsoft/mai-voice-1",
+    "is_active_gateway": false,
+    "quantization_scheme": null,
+    "input_modalities": "text",
+    "output_modalities": "audio_tts",
+    "context_length": null,
+    "max_output_tokens": null,
+    "effective_from": "2026-04-02T00:00:00Z",
+    "effective_to": null,
+    "capabilities": [
+      {
+        "capability_id": "audio.speech",
+        "status": "active",
+        "params": []
+      }
+    ]
+  },
+  {
+    "api_model_id": "microsoft/mai-voice-2",
+    "provider_api_model_id": "azure:microsoft/mai-voice-2",
+    "provider_model_slug": "mai-voice-2",
+    "internal_model_id": "microsoft/mai-voice-2",
+    "is_active_gateway": false,
+    "quantization_scheme": null,
+    "input_modalities": "text,audio",
+    "output_modalities": "audio_tts",
+    "context_length": null,
+    "max_output_tokens": null,
+    "effective_from": "2026-06-02T00:00:00Z",
+    "effective_to": null,
+    "capabilities": [
+      {
+        "capability_id": "audio.speech",
+        "status": "active",
+        "params": []
+      }
+    ]
   }
 ]

--- a/packages/data/catalog/src/data/families/microsoft-mai/family.json
+++ b/packages/data/catalog/src/data/families/microsoft-mai/family.json
@@ -1,0 +1,5 @@
+{
+  "family_id": "microsoft/mai",
+  "family_name": "MAI",
+  "organisation_id": "microsoft"
+}

--- a/packages/data/catalog/src/data/manifest.json
+++ b/packages/data/catalog/src/data/manifest.json
@@ -470,20 +470,10 @@
       "meta/llama-4-scout"
     ],
     "microsoft": [
-      "microsoft/mai-code-1-flash",
-      "microsoft/mai-image-2",
-      "microsoft/mai-image-2.5",
-      "microsoft/mai-image-2.5-flash",
-      "microsoft/mai-image-2e",
-      "microsoft/mai-thinking-1",
-      "microsoft/mai-transcribe-1",
-      "microsoft/mai-transcribe-1.5",
-      "microsoft/mai-voice-1",
-      "microsoft/mai-voice-2",
-      "microsoft/mai-voice-2-flash",
       "microsoft/phi-1",
       "microsoft/phi-1.5",
       "microsoft/phi-2",
+      "microsoft/phi-3-mini-4k-instruct",
       "microsoft/phi-3-medium-128k-instruct",
       "microsoft/phi-3-medium-4k-instruct",
       "microsoft/phi-3-mini-128k-instruct",
@@ -499,7 +489,12 @@
       "microsoft/phi-4-mini-reasoning",
       "microsoft/phi-4-multimodal-instruct",
       "microsoft/phi-4-reasoning",
-      "microsoft/phi-4-reasoning-plus"
+      "microsoft/phi-4-reasoning-plus",
+      "microsoft/phi-4-reasoning-vision-15b",
+      "microsoft/phi-ground",
+      "microsoft/phi-ground-any",
+      "microsoft/phi-mini-moe-instruct",
+      "microsoft/phi-tiny-moe-instruct"
     ],
     "minimax": [
       "minimax/hailuo-02",

--- a/packages/data/catalog/src/data/manifest.json
+++ b/packages/data/catalog/src/data/manifest.json
@@ -470,6 +470,17 @@
       "meta/llama-4-scout"
     ],
     "microsoft": [
+      "microsoft/mai-code-1-flash",
+      "microsoft/mai-image-2",
+      "microsoft/mai-image-2.5",
+      "microsoft/mai-image-2.5-flash",
+      "microsoft/mai-image-2e",
+      "microsoft/mai-thinking-1",
+      "microsoft/mai-transcribe-1",
+      "microsoft/mai-transcribe-1.5",
+      "microsoft/mai-voice-1",
+      "microsoft/mai-voice-2",
+      "microsoft/mai-voice-2-flash",
       "microsoft/phi-1",
       "microsoft/phi-1.5",
       "microsoft/phi-2",

--- a/packages/data/catalog/src/data/models/microsoft/mai-code-1-flash/model.json
+++ b/packages/data/catalog/src/data/models/microsoft/mai-code-1-flash/model.json
@@ -1,0 +1,34 @@
+{
+  "model_id": "microsoft/mai-code-1-flash",
+  "organisation_id": "microsoft",
+  "name": "MAI Code 1 Flash",
+  "status": "Announced",
+  "previous_model_id": null,
+  "description": "MAI Code 1 Flash is Microsoft's inference-efficient agentic coding model, tailored for GitHub Copilot, VS Code, and Microsoft developer workflows. This entry tracks the Build 2026 launch announcement.",
+  "announced_date": "2026-06-02T00:00:00",
+  "release_date": null,
+  "deprecation_date": null,
+  "retirement_date": null,
+  "license": "Proprietary",
+  "input_types": "text",
+  "output_types": "text",
+  "api_model_id": "microsoft/mai-code-1-flash",
+  "family_id": "microsoft/mai",
+  "links": [
+    {
+      "platform": "announcement",
+      "url": "https://microsoft.ai/news/introducingmai-code-1-flash/"
+    }
+  ],
+  "details": [
+    {
+      "name": "parameter_count",
+      "value": 5000000000
+    },
+    {
+      "name": "availability",
+      "value": "Microsoft announced MAI Code 1 Flash as deeply integrated into GitHub Copilot and VS Code rather than as a broadly documented standalone API."
+    }
+  ],
+  "benchmarks": []
+}

--- a/packages/data/catalog/src/data/models/microsoft/mai-image-2.5-flash/model.json
+++ b/packages/data/catalog/src/data/models/microsoft/mai-image-2.5-flash/model.json
@@ -1,0 +1,25 @@
+{
+  "model_id": "microsoft/mai-image-2.5-flash",
+  "organisation_id": "microsoft",
+  "name": "MAI Image 2.5 Flash",
+  "status": "Announced",
+  "previous_model_id": null,
+  "description": "MAI Image 2.5 Flash is the ultra-efficient variant of Microsoft's MAI Image 2.5 family for lower-cost text-to-image and image editing workflows. This entry tracks the Build 2026 announcement.",
+  "announced_date": "2026-06-02T00:00:00",
+  "release_date": null,
+  "deprecation_date": null,
+  "retirement_date": null,
+  "license": "Proprietary",
+  "input_types": "text,image",
+  "output_types": "image",
+  "api_model_id": "microsoft/mai-image-2.5-flash",
+  "family_id": "microsoft/mai",
+  "links": [
+    {
+      "platform": "announcement",
+      "url": "https://microsoft.ai/news/building-a-hillclimbing-machine-launching-seven-new-mai-models/"
+    }
+  ],
+  "details": [],
+  "benchmarks": []
+}

--- a/packages/data/catalog/src/data/models/microsoft/mai-image-2.5/model.json
+++ b/packages/data/catalog/src/data/models/microsoft/mai-image-2.5/model.json
@@ -1,0 +1,25 @@
+{
+  "model_id": "microsoft/mai-image-2.5",
+  "organisation_id": "microsoft",
+  "name": "MAI Image 2.5",
+  "status": "Available",
+  "previous_model_id": null,
+  "description": "MAI Image 2.5 is Microsoft's image generation model for both text-to-image and image editing workflows. Microsoft announced it at Build 2026 and described the image family as generally available in Microsoft Foundry and MAI Playground.",
+  "announced_date": "2026-06-02T00:00:00",
+  "release_date": "2026-06-02T00:00:00",
+  "deprecation_date": null,
+  "retirement_date": null,
+  "license": "Proprietary",
+  "input_types": "text,image",
+  "output_types": "image",
+  "api_model_id": "microsoft/mai-image-2.5",
+  "family_id": "microsoft/mai",
+  "links": [
+    {
+      "platform": "announcement",
+      "url": "https://microsoft.ai/news/introducing-mai-image-2-5/"
+    }
+  ],
+  "details": [],
+  "benchmarks": []
+}

--- a/packages/data/catalog/src/data/models/microsoft/mai-image-2/model.json
+++ b/packages/data/catalog/src/data/models/microsoft/mai-image-2/model.json
@@ -1,0 +1,25 @@
+{
+  "model_id": "microsoft/mai-image-2",
+  "organisation_id": "microsoft",
+  "name": "MAI Image 2",
+  "status": "Available",
+  "previous_model_id": null,
+  "description": "MAI Image 2 is Microsoft's text-to-image model for high-quality creative generation with strong photorealism and in-image text rendering.",
+  "announced_date": "2026-03-19T00:00:00",
+  "release_date": "2026-03-19T00:00:00",
+  "deprecation_date": null,
+  "retirement_date": null,
+  "license": "Proprietary",
+  "input_types": "text",
+  "output_types": "image",
+  "api_model_id": "microsoft/mai-image-2",
+  "family_id": "microsoft/mai",
+  "links": [
+    {
+      "platform": "announcement",
+      "url": "https://microsoft.ai/news/introducing-MAI-Image-2"
+    }
+  ],
+  "details": [],
+  "benchmarks": []
+}

--- a/packages/data/catalog/src/data/models/microsoft/mai-image-2e/model.json
+++ b/packages/data/catalog/src/data/models/microsoft/mai-image-2e/model.json
@@ -1,0 +1,25 @@
+{
+  "model_id": "microsoft/mai-image-2e",
+  "organisation_id": "microsoft",
+  "name": "MAI Image 2e",
+  "status": "Available",
+  "previous_model_id": "microsoft/mai-image-2",
+  "description": "MAI Image 2e is Microsoft's more efficient text-to-image variant of MAI Image 2, built for lower-cost production generation.",
+  "announced_date": "2026-04-14T00:00:00",
+  "release_date": "2026-04-14T00:00:00",
+  "deprecation_date": null,
+  "retirement_date": null,
+  "license": "Proprietary",
+  "input_types": "text",
+  "output_types": "image",
+  "api_model_id": "microsoft/mai-image-2e",
+  "family_id": "microsoft/mai",
+  "links": [
+    {
+      "platform": "announcement",
+      "url": "https://microsoft.ai/news/mai-image-2-efficient/"
+    }
+  ],
+  "details": [],
+  "benchmarks": []
+}

--- a/packages/data/catalog/src/data/models/microsoft/mai-thinking-1/model.json
+++ b/packages/data/catalog/src/data/models/microsoft/mai-thinking-1/model.json
@@ -1,0 +1,34 @@
+{
+  "model_id": "microsoft/mai-thinking-1",
+  "organisation_id": "microsoft",
+  "name": "MAI Thinking 1",
+  "status": "Announced",
+  "previous_model_id": null,
+  "description": "MAI Thinking 1 is Microsoft's flagship reasoning model for chat, code generation, and complex multi-step workflows. This entry tracks the Build 2026 launch ahead of broader public availability.",
+  "announced_date": "2026-06-02T00:00:00",
+  "release_date": null,
+  "deprecation_date": null,
+  "retirement_date": null,
+  "license": "Proprietary",
+  "input_types": "text",
+  "output_types": "text",
+  "api_model_id": "microsoft/mai-thinking-1",
+  "family_id": "microsoft/mai",
+  "links": [
+    {
+      "platform": "announcement",
+      "url": "https://microsoft.ai/news/introducing-mai-thinking-1/"
+    }
+  ],
+  "details": [
+    {
+      "name": "parameter_count",
+      "value": 35000000000
+    },
+    {
+      "name": "availability",
+      "value": "Microsoft positioned MAI Thinking 1 as open to select early partners at Build 2026."
+    }
+  ],
+  "benchmarks": []
+}

--- a/packages/data/catalog/src/data/models/microsoft/mai-transcribe-1.5/model.json
+++ b/packages/data/catalog/src/data/models/microsoft/mai-transcribe-1.5/model.json
@@ -1,0 +1,30 @@
+{
+  "model_id": "microsoft/mai-transcribe-1.5",
+  "organisation_id": "microsoft",
+  "name": "MAI Transcribe 1.5",
+  "status": "Available",
+  "previous_model_id": null,
+  "description": "MAI Transcribe 1.5 is Microsoft's speech-to-text model for production transcription workflows. Microsoft announced broad language support, domain-specific terminology handling, and general availability in Microsoft Foundry and MAI Playground at Build 2026.",
+  "announced_date": "2026-06-02T00:00:00",
+  "release_date": "2026-06-02T00:00:00",
+  "deprecation_date": null,
+  "retirement_date": null,
+  "license": "Proprietary",
+  "input_types": "audio",
+  "output_types": "text",
+  "api_model_id": "microsoft/mai-transcribe-1.5",
+  "family_id": "microsoft/mai",
+  "links": [
+    {
+      "platform": "announcement",
+      "url": "https://microsoft.ai/news/mai-transcribe-1-5more-accurate-context-aware-and-built-for-production/"
+    }
+  ],
+  "details": [
+    {
+      "name": "supported_languages",
+      "value": 43
+    }
+  ],
+  "benchmarks": []
+}

--- a/packages/data/catalog/src/data/models/microsoft/mai-transcribe-1/model.json
+++ b/packages/data/catalog/src/data/models/microsoft/mai-transcribe-1/model.json
@@ -1,0 +1,30 @@
+{
+  "model_id": "microsoft/mai-transcribe-1",
+  "organisation_id": "microsoft",
+  "name": "MAI Transcribe 1",
+  "status": "Available",
+  "previous_model_id": null,
+  "description": "MAI Transcribe 1 is Microsoft's multilingual speech-to-text model for production transcription across 25 major languages.",
+  "announced_date": "2026-04-02T00:00:00",
+  "release_date": "2026-04-02T00:00:00",
+  "deprecation_date": null,
+  "retirement_date": null,
+  "license": "Proprietary",
+  "input_types": "audio",
+  "output_types": "text",
+  "api_model_id": "microsoft/mai-transcribe-1",
+  "family_id": "microsoft/mai",
+  "links": [
+    {
+      "platform": "announcement",
+      "url": "https://microsoft.ai/news/state-of-the-art-speech-recognition-with-mai-transcribe-1/"
+    }
+  ],
+  "details": [
+    {
+      "name": "supported_languages",
+      "value": 25
+    }
+  ],
+  "benchmarks": []
+}

--- a/packages/data/catalog/src/data/models/microsoft/mai-voice-1/model.json
+++ b/packages/data/catalog/src/data/models/microsoft/mai-voice-1/model.json
@@ -1,0 +1,25 @@
+{
+  "model_id": "microsoft/mai-voice-1",
+  "organisation_id": "microsoft",
+  "name": "MAI Voice 1",
+  "status": "Available",
+  "previous_model_id": null,
+  "description": "MAI Voice 1 is Microsoft's text-to-speech model for fast, natural spoken output in production voice experiences.",
+  "announced_date": "2026-04-02T00:00:00",
+  "release_date": "2026-04-02T00:00:00",
+  "deprecation_date": null,
+  "retirement_date": null,
+  "license": "Proprietary",
+  "input_types": "text",
+  "output_types": "audio_tts",
+  "api_model_id": "microsoft/mai-voice-1",
+  "family_id": "microsoft/mai",
+  "links": [
+    {
+      "platform": "announcement",
+      "url": "https://microsoft.ai/news/today-were-announcing-3-new-world-class-mai-models-available-in-foundry/"
+    }
+  ],
+  "details": [],
+  "benchmarks": []
+}

--- a/packages/data/catalog/src/data/models/microsoft/mai-voice-2-flash/model.json
+++ b/packages/data/catalog/src/data/models/microsoft/mai-voice-2-flash/model.json
@@ -1,0 +1,25 @@
+{
+  "model_id": "microsoft/mai-voice-2-flash",
+  "organisation_id": "microsoft",
+  "name": "MAI Voice 2 Flash",
+  "status": "Announced",
+  "previous_model_id": null,
+  "description": "MAI Voice 2 Flash is the lower-cost, ultra-efficient variant of Microsoft's MAI Voice 2 text-to-speech family. This entry tracks the Build 2026 announcement ahead of release.",
+  "announced_date": "2026-06-02T00:00:00",
+  "release_date": null,
+  "deprecation_date": null,
+  "retirement_date": null,
+  "license": "Proprietary",
+  "input_types": "text,audio",
+  "output_types": "audio_tts",
+  "api_model_id": "microsoft/mai-voice-2-flash",
+  "family_id": "microsoft/mai",
+  "links": [
+    {
+      "platform": "announcement",
+      "url": "https://microsoft.ai/news/building-a-hillclimbing-machine-launching-seven-new-mai-models/"
+    }
+  ],
+  "details": [],
+  "benchmarks": []
+}

--- a/packages/data/catalog/src/data/models/microsoft/mai-voice-2/model.json
+++ b/packages/data/catalog/src/data/models/microsoft/mai-voice-2/model.json
@@ -1,0 +1,30 @@
+{
+  "model_id": "microsoft/mai-voice-2",
+  "organisation_id": "microsoft",
+  "name": "MAI Voice 2",
+  "status": "Available",
+  "previous_model_id": null,
+  "description": "MAI Voice 2 is Microsoft's multilingual text-to-speech model for natural spoken output with short-sample voice adaptation. Microsoft positioned the voice family as generally available in Microsoft Foundry and MAI Playground at Build 2026.",
+  "announced_date": "2026-06-02T00:00:00",
+  "release_date": "2026-06-02T00:00:00",
+  "deprecation_date": null,
+  "retirement_date": null,
+  "license": "Proprietary",
+  "input_types": "text,audio",
+  "output_types": "audio_tts",
+  "api_model_id": "microsoft/mai-voice-2",
+  "family_id": "microsoft/mai",
+  "links": [
+    {
+      "platform": "announcement",
+      "url": "https://microsoft.ai/news/mai-voice-2expressive-speech-in-10-languages/"
+    }
+  ],
+  "details": [
+    {
+      "name": "supported_languages",
+      "value": 15
+    }
+  ],
+  "benchmarks": []
+}

--- a/packages/data/catalog/src/data/models/microsoft/phi-3-mini-4k-instruct/model.json
+++ b/packages/data/catalog/src/data/models/microsoft/phi-3-mini-4k-instruct/model.json
@@ -1,0 +1,37 @@
+{
+  "model_id": "microsoft/phi-3-mini-4k-instruct",
+  "organisation_id": "microsoft",
+  "name": "Phi 3 Mini 4K Instruct",
+  "status": "Available",
+  "previous_model_id": null,
+  "description": "Phi 3 Mini 4K Instruct is Microsoft's compact 3.8B open-weight instruction model with a short 4K context window optimized for efficient reasoning and coding workloads.",
+  "announced_date": "2024-04-22T00:00:00",
+  "release_date": "2024-04-22T00:00:00",
+  "deprecation_date": null,
+  "retirement_date": null,
+  "license": "MIT",
+  "input_types": "text",
+  "output_types": "text",
+  "api_model_id": "microsoft/phi-3-mini-4k-instruct",
+  "links": [
+    {
+      "platform": "weights",
+      "url": "https://huggingface.co/microsoft/Phi-3-mini-4k-instruct"
+    },
+    {
+      "platform": "paper",
+      "url": "https://arxiv.org/abs/2404.14219"
+    }
+  ],
+  "details": [
+    {
+      "name": "parameter_count",
+      "value": 3800000000
+    },
+    {
+      "name": "input_context_length",
+      "value": 4096
+    }
+  ],
+  "benchmarks": []
+}

--- a/packages/data/catalog/src/data/models/microsoft/phi-4-reasoning-vision-15b/model.json
+++ b/packages/data/catalog/src/data/models/microsoft/phi-4-reasoning-vision-15b/model.json
@@ -1,0 +1,42 @@
+{
+  "model_id": "microsoft/phi-4-reasoning-vision-15b",
+  "organisation_id": "microsoft",
+  "name": "Phi 4 Reasoning Vision 15B",
+  "status": "Available",
+  "previous_model_id": "microsoft/phi-4-reasoning",
+  "description": "Phi 4 Reasoning Vision 15B is Microsoft's multimodal open-weight reasoning model for visual question answering, OCR, chart reasoning, and computer-use grounding tasks.",
+  "announced_date": "2026-03-04T00:00:00",
+  "release_date": "2026-03-04T00:00:00",
+  "deprecation_date": null,
+  "retirement_date": null,
+  "license": "MIT",
+  "input_types": "text,image",
+  "output_types": "text",
+  "api_model_id": "microsoft/phi-4-reasoning-vision-15b",
+  "family_id": "microsoft/phi-4.0",
+  "links": [
+    {
+      "platform": "announcement",
+      "url": "https://www.microsoft.com/en-us/research/blog/phi-4-reasoning-vision-and-the-lessons-of-training-a-multimodal-reasoning-model/"
+    },
+    {
+      "platform": "weights",
+      "url": "https://huggingface.co/microsoft/Phi-4-reasoning-vision-15B"
+    },
+    {
+      "platform": "paper",
+      "url": "https://aka.ms/Phi-4-reasoning-vision-15B-TR"
+    }
+  ],
+  "details": [
+    {
+      "name": "parameter_count",
+      "value": 15000000000
+    },
+    {
+      "name": "input_context_length",
+      "value": 16384
+    }
+  ],
+  "benchmarks": []
+}

--- a/packages/data/catalog/src/data/models/microsoft/phi-ground-any/model.json
+++ b/packages/data/catalog/src/data/models/microsoft/phi-ground-any/model.json
@@ -1,0 +1,28 @@
+{
+  "model_id": "microsoft/phi-ground-any",
+  "organisation_id": "microsoft",
+  "name": "Phi Ground Any",
+  "status": "Available",
+  "previous_model_id": "microsoft/phi-ground",
+  "description": "Phi Ground Any is Microsoft's broader GUI grounding model for click-point localization and computer-use tasks across arbitrary screen layouts.",
+  "announced_date": "2026-05-07T00:00:00",
+  "release_date": "2026-05-07T00:00:00",
+  "deprecation_date": null,
+  "retirement_date": null,
+  "license": "MIT",
+  "input_types": "text,image",
+  "output_types": "text",
+  "api_model_id": "microsoft/phi-ground-any",
+  "links": [
+    {
+      "platform": "weights",
+      "url": "https://huggingface.co/microsoft/Phi-Ground-Any"
+    },
+    {
+      "platform": "paper",
+      "url": "https://arxiv.org/abs/2605.12501"
+    }
+  ],
+  "details": [],
+  "benchmarks": []
+}

--- a/packages/data/catalog/src/data/models/microsoft/phi-ground/model.json
+++ b/packages/data/catalog/src/data/models/microsoft/phi-ground/model.json
@@ -1,0 +1,28 @@
+{
+  "model_id": "microsoft/phi-ground",
+  "organisation_id": "microsoft",
+  "name": "Phi Ground",
+  "status": "Available",
+  "previous_model_id": null,
+  "description": "Phi Ground is Microsoft's GUI grounding model, finetuned from Phi 3.5 Vision Instruct for element localization and computer-use agent workflows.",
+  "announced_date": "2025-08-15T00:00:00",
+  "release_date": "2025-08-15T00:00:00",
+  "deprecation_date": null,
+  "retirement_date": null,
+  "license": "MIT",
+  "input_types": "text,image",
+  "output_types": "text",
+  "api_model_id": "microsoft/phi-ground",
+  "links": [
+    {
+      "platform": "weights",
+      "url": "https://huggingface.co/microsoft/Phi-Ground"
+    },
+    {
+      "platform": "paper",
+      "url": "https://arxiv.org/abs/2507.23779"
+    }
+  ],
+  "details": [],
+  "benchmarks": []
+}

--- a/packages/data/catalog/src/data/models/microsoft/phi-mini-moe-instruct/model.json
+++ b/packages/data/catalog/src/data/models/microsoft/phi-mini-moe-instruct/model.json
@@ -1,0 +1,41 @@
+{
+  "model_id": "microsoft/phi-mini-moe-instruct",
+  "organisation_id": "microsoft",
+  "name": "Phi Mini MoE Instruct",
+  "status": "Available",
+  "previous_model_id": null,
+  "description": "Phi Mini MoE Instruct is Microsoft's open-weight mixture-of-experts instruction model with 7.6B total parameters and 2.4B active parameters.",
+  "announced_date": "2025-06-23T00:00:00",
+  "release_date": "2025-06-23T00:00:00",
+  "deprecation_date": null,
+  "retirement_date": null,
+  "license": "MIT",
+  "input_types": "text",
+  "output_types": "text",
+  "api_model_id": "microsoft/phi-mini-moe-instruct",
+  "links": [
+    {
+      "platform": "weights",
+      "url": "https://huggingface.co/microsoft/Phi-mini-MoE-instruct"
+    },
+    {
+      "platform": "paper",
+      "url": "https://arxiv.org/abs/2506.18349"
+    }
+  ],
+  "details": [
+    {
+      "name": "parameter_count",
+      "value": 7600000000
+    },
+    {
+      "name": "active_parameter_count",
+      "value": 2400000000
+    },
+    {
+      "name": "input_context_length",
+      "value": 4096
+    }
+  ],
+  "benchmarks": []
+}

--- a/packages/data/catalog/src/data/models/microsoft/phi-tiny-moe-instruct/model.json
+++ b/packages/data/catalog/src/data/models/microsoft/phi-tiny-moe-instruct/model.json
@@ -1,0 +1,41 @@
+{
+  "model_id": "microsoft/phi-tiny-moe-instruct",
+  "organisation_id": "microsoft",
+  "name": "Phi Tiny MoE Instruct",
+  "status": "Available",
+  "previous_model_id": null,
+  "description": "Phi Tiny MoE Instruct is Microsoft's smaller open-weight mixture-of-experts instruction model with 3.8B total parameters and 1.1B active parameters.",
+  "announced_date": "2025-06-23T00:00:00",
+  "release_date": "2025-06-23T00:00:00",
+  "deprecation_date": null,
+  "retirement_date": null,
+  "license": "MIT",
+  "input_types": "text",
+  "output_types": "text",
+  "api_model_id": "microsoft/phi-tiny-moe-instruct",
+  "links": [
+    {
+      "platform": "weights",
+      "url": "https://huggingface.co/microsoft/Phi-tiny-MoE-instruct"
+    },
+    {
+      "platform": "paper",
+      "url": "https://arxiv.org/abs/2506.18349"
+    }
+  ],
+  "details": [
+    {
+      "name": "parameter_count",
+      "value": 3800000000
+    },
+    {
+      "name": "active_parameter_count",
+      "value": 1100000000
+    },
+    {
+      "name": "input_context_length",
+      "value": 4096
+    }
+  ],
+  "benchmarks": []
+}

--- a/packages/data/catalog/src/data/pricing/azure/microsoft-mai-image-2.5/image.edit/pricing.json
+++ b/packages/data/catalog/src/data/pricing/azure/microsoft-mai-image-2.5/image.edit/pricing.json
@@ -1,0 +1,33 @@
+{
+  "key": "azure:microsoft/mai-image-2.5:image.edit",
+  "api_provider_id": "azure",
+  "provider_slug": "azure",
+  "api_model_id": "microsoft/mai-image-2.5",
+  "capability_id": "image.edit",
+  "rules": [
+    {
+      "meter": "input_text_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 5,
+      "currency": "USD",
+      "pricing_plan": "standard",
+      "note": null,
+      "match": [],
+      "priority": 100,
+      "effective_from": "2026-06-02T00:00:00Z"
+    },
+    {
+      "meter": "output_image_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 33,
+      "currency": "USD",
+      "pricing_plan": "standard",
+      "note": null,
+      "match": [],
+      "priority": 100,
+      "effective_from": "2026-06-02T00:00:00Z"
+    }
+  ]
+}

--- a/packages/data/catalog/src/data/pricing/azure/microsoft-mai-image-2.5/image.generate/pricing.json
+++ b/packages/data/catalog/src/data/pricing/azure/microsoft-mai-image-2.5/image.generate/pricing.json
@@ -1,0 +1,33 @@
+{
+  "key": "azure:microsoft/mai-image-2.5:image.generate",
+  "api_provider_id": "azure",
+  "provider_slug": "azure",
+  "api_model_id": "microsoft/mai-image-2.5",
+  "capability_id": "image.generate",
+  "rules": [
+    {
+      "meter": "input_text_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 5,
+      "currency": "USD",
+      "pricing_plan": "standard",
+      "note": null,
+      "match": [],
+      "priority": 100,
+      "effective_from": "2026-06-02T00:00:00Z"
+    },
+    {
+      "meter": "output_image_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 33,
+      "currency": "USD",
+      "pricing_plan": "standard",
+      "note": null,
+      "match": [],
+      "priority": 100,
+      "effective_from": "2026-06-02T00:00:00Z"
+    }
+  ]
+}

--- a/packages/data/catalog/src/data/pricing/azure/microsoft-mai-image-2/image.generate/pricing.json
+++ b/packages/data/catalog/src/data/pricing/azure/microsoft-mai-image-2/image.generate/pricing.json
@@ -1,0 +1,33 @@
+{
+  "key": "azure:microsoft/mai-image-2:image.generate",
+  "api_provider_id": "azure",
+  "provider_slug": "azure",
+  "api_model_id": "microsoft/mai-image-2",
+  "capability_id": "image.generate",
+  "rules": [
+    {
+      "meter": "input_text_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 5,
+      "currency": "USD",
+      "pricing_plan": "standard",
+      "note": null,
+      "match": [],
+      "priority": 100,
+      "effective_from": "2026-04-02T00:00:00Z"
+    },
+    {
+      "meter": "output_image_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 33,
+      "currency": "USD",
+      "pricing_plan": "standard",
+      "note": null,
+      "match": [],
+      "priority": 100,
+      "effective_from": "2026-04-02T00:00:00Z"
+    }
+  ]
+}

--- a/packages/data/catalog/src/data/pricing/azure/microsoft-mai-image-2e/image.generate/pricing.json
+++ b/packages/data/catalog/src/data/pricing/azure/microsoft-mai-image-2e/image.generate/pricing.json
@@ -1,0 +1,33 @@
+{
+  "key": "azure:microsoft/mai-image-2e:image.generate",
+  "api_provider_id": "azure",
+  "provider_slug": "azure",
+  "api_model_id": "microsoft/mai-image-2e",
+  "capability_id": "image.generate",
+  "rules": [
+    {
+      "meter": "input_text_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 5,
+      "currency": "USD",
+      "pricing_plan": "standard",
+      "note": null,
+      "match": [],
+      "priority": 100,
+      "effective_from": "2026-04-14T00:00:00Z"
+    },
+    {
+      "meter": "output_image_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 19.5,
+      "currency": "USD",
+      "pricing_plan": "standard",
+      "note": null,
+      "match": [],
+      "priority": 100,
+      "effective_from": "2026-04-14T00:00:00Z"
+    }
+  ]
+}

--- a/packages/data/catalog/src/data/pricing/azure/microsoft-mai-transcribe-1.5/audio.transcription/pricing.json
+++ b/packages/data/catalog/src/data/pricing/azure/microsoft-mai-transcribe-1.5/audio.transcription/pricing.json
@@ -1,0 +1,21 @@
+{
+  "key": "azure:microsoft/mai-transcribe-1.5:audio.transcription",
+  "api_provider_id": "azure",
+  "provider_slug": "azure",
+  "api_model_id": "microsoft/mai-transcribe-1.5",
+  "capability_id": "audio.transcription",
+  "rules": [
+    {
+      "meter": "input_audio_minutes",
+      "unit": "minute",
+      "unit_size": 1,
+      "price_per_unit": 0.006,
+      "currency": "USD",
+      "pricing_plan": "standard",
+      "note": null,
+      "match": [],
+      "priority": 100,
+      "effective_from": "2026-06-02T00:00:00Z"
+    }
+  ]
+}

--- a/packages/data/catalog/src/data/pricing/azure/microsoft-mai-transcribe-1/audio.transcription/pricing.json
+++ b/packages/data/catalog/src/data/pricing/azure/microsoft-mai-transcribe-1/audio.transcription/pricing.json
@@ -1,0 +1,21 @@
+{
+  "key": "azure:microsoft/mai-transcribe-1:audio.transcription",
+  "api_provider_id": "azure",
+  "provider_slug": "azure",
+  "api_model_id": "microsoft/mai-transcribe-1",
+  "capability_id": "audio.transcription",
+  "rules": [
+    {
+      "meter": "input_audio_minutes",
+      "unit": "minute",
+      "unit_size": 1,
+      "price_per_unit": 0.006,
+      "currency": "USD",
+      "pricing_plan": "standard",
+      "note": null,
+      "match": [],
+      "priority": 100,
+      "effective_from": "2026-04-02T00:00:00Z"
+    }
+  ]
+}

--- a/packages/data/catalog/src/data/pricing/azure/microsoft-mai-voice-1/audio.speech/pricing.json
+++ b/packages/data/catalog/src/data/pricing/azure/microsoft-mai-voice-1/audio.speech/pricing.json
@@ -1,0 +1,21 @@
+{
+  "key": "azure:microsoft/mai-voice-1:audio.speech",
+  "api_provider_id": "azure",
+  "provider_slug": "azure",
+  "api_model_id": "microsoft/mai-voice-1",
+  "capability_id": "audio.speech",
+  "rules": [
+    {
+      "meter": "input_characters",
+      "unit": "character",
+      "unit_size": 1000000,
+      "price_per_unit": 22,
+      "currency": "USD",
+      "pricing_plan": "standard",
+      "note": null,
+      "match": [],
+      "priority": 100,
+      "effective_from": "2026-04-02T00:00:00Z"
+    }
+  ]
+}


### PR DESCRIPTION
## What changed

This PR adds Microsoft AI catalog coverage across both the MAI and Phi model families.

Included in scope:
- new `microsoft-mai` family metadata
- MAI model records for the April 2026 releases and the June 2, 2026 Build wave
- Azure provider model mappings for the MAI models with public Azure or Foundry API availability
- Azure pricing entries for the MAI models where public pricing could be verified
- missing Microsoft Phi model records for additional official Phi checkpoints

## Why

The catalog was missing the MAI family entirely and was also missing several official Microsoft Phi releases already published by Microsoft.

## Notes

- Pricing is included only where public Microsoft or Azure pricing could be verified from primary sources.
- This PR does not add Azure provider or pricing coverage for Phi; it adds the missing model catalog entries only.

## Validation

- `pnpm validate:data`
- `pnpm validate:pricing`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added several new Microsoft MAI models to the catalog, including image generation, transcription, voice, and reasoning variants.
  * Added new Azure capabilities and pricing for image generation, image editing, speech, and transcription.
  * Expanded the Microsoft model family and catalog entries so more models appear in browsing and selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->