### PR TITLE
Fix stale latest aliases for MiniMax and Claude Opus

### DIFF
--- a/apps/web/src/components/(chat)/playgroundConfig.ts
+++ b/apps/web/src/components/(chat)/playgroundConfig.ts
@@ -5,5 +5,5 @@ export const FEATURED_MODEL_IDS = [
 	"x-ai/grok-4.20-beta-0309",
 	"anthropic/claude-sonnet-4.6",
 	"anthropic/claude-opus-4.6",
-	"minimax/minimax-m2.7",
+	"minimax/minimax-m3",
 ];

--- a/apps/web/src/components/(experiments)/CouncilClient.tsx
+++ b/apps/web/src/components/(experiments)/CouncilClient.tsx
@@ -140,7 +140,7 @@ const DEFAULT_MODEL_OPTIONS = [
 	"anthropic/claude-opus-4.6",
 	"openai/gpt-5.4",
 	"google/gemini-3.1-pro-preview",
-	"minimax/minimax-m2.7",
+	"minimax/minimax-m3",
 ];
 
 function clampModels(models: string[]) {

--- a/apps/web/src/components/landingPage/Home/HomeQuickstartSection.tsx
+++ b/apps/web/src/components/landingPage/Home/HomeQuickstartSection.tsx
@@ -594,8 +594,8 @@ const BETA_OPEN_MODEL_INTEL: LandingOpenModelIntelEntry[] = [
 	},
 	{
 		providerId: "minimax",
-		name: "MiniMax M2.7",
-		model: "minimax/minimax-m2.7",
+		name: "MiniMax M3",
+		model: "minimax/minimax-m3",
 		latencyMs: 388,
 		throughputTps: 108,
 		inputPrice: 0.3,

--- a/apps/web/src/lib/experiments/councilPresets.ts
+++ b/apps/web/src/lib/experiments/councilPresets.ts
@@ -14,8 +14,8 @@ const INTELLIGENCE_CANDIDATES = [
 
 const BUDGET_CANDIDATES = [
 	"minimax/minimax-m3",
-	"deepseek/deepseek-v3.2",
-	"moonshotai/kimi-k2.5",
+	"deepseek/deepseek-v4-flash",
+	"moonshotai/kimi-k2.6",
 ];
 
 function pickPresetModels(candidates: string[], available: string[]): string[] {

--- a/apps/web/src/lib/experiments/councilPresets.ts
+++ b/apps/web/src/lib/experiments/councilPresets.ts
@@ -13,7 +13,7 @@ const INTELLIGENCE_CANDIDATES = [
 ];
 
 const BUDGET_CANDIDATES = [
-	"minimax/minimax-m2.7",
+	"minimax/minimax-m3",
 	"deepseek/deepseek-v3.2",
 	"moonshotai/kimi-k2.5",
 ];

--- a/apps/web/src/lib/indexeddb/experimentsCouncil.ts
+++ b/apps/web/src/lib/indexeddb/experimentsCouncil.ts
@@ -78,7 +78,7 @@ const DEFAULT_INTELLIGENCE_CANDIDATES = [
 ];
 
 const DEFAULT_BUDGET_CANDIDATES = [
-	"minimax/minimax-m2.7",
+	"minimax/minimax-m3",
 	"deepseek/deepseek-v3.2",
 	"moonshotai/kimi-k2.5",
 ];
@@ -330,7 +330,7 @@ export async function ensureExperimentsCouncilPresets(
 		"anthropic/claude-opus-4.6",
 		"openai/gpt-5.4",
 		"google/gemini-3.1-pro-preview",
-		"minimax/minimax-m2.7",
+		"minimax/minimax-m3",
 		"deepseek/deepseek-v3.2",
 		"moonshotai/kimi-k2.5",
 	],

--- a/apps/web/src/lib/indexeddb/experimentsCouncil.ts
+++ b/apps/web/src/lib/indexeddb/experimentsCouncil.ts
@@ -83,12 +83,6 @@ const DEFAULT_BUDGET_CANDIDATES = [
 	"moonshotai/kimi-k2.6",
 ];
 
-const PREVIOUS_BUDGET_CANDIDATES = [
-	"minimax/minimax-m2.7",
-	"deepseek/deepseek-v3.2",
-	"moonshotai/kimi-k2.5",
-];
-
 const LEGACY_INTELLIGENCE_CANDIDATES = [
 	"openai/gpt-5-mini",
 	"anthropic/claude-3.7-sonnet",
@@ -116,13 +110,6 @@ function clampModelList(models: string[]): string[] {
 		if (deduped.length >= 4) break;
 	}
 	return deduped;
-}
-
-function matchesExactModelList(models: string[], expected: string[]): boolean {
-	return (
-		models.length === expected.length &&
-		models.every((model, index) => model === expected[index])
-	);
 }
 
 function isConstraintError(error: unknown): boolean {
@@ -398,8 +385,10 @@ export async function ensureExperimentsCouncilPresets(
 				);
 			const budgetIsLegacy =
 				preset.key === "budget" &&
-				(matchesExactModelList(existing.sourceModels, LEGACY_BUDGET_CANDIDATES) ||
-					matchesExactModelList(existing.sourceModels, PREVIOUS_BUDGET_CANDIDATES));
+				existing.sourceModels.length > 0 &&
+				existing.sourceModels.every((modelId) =>
+					LEGACY_BUDGET_CANDIDATES.includes(modelId),
+				);
 			const customIsLegacy =
 				preset.key === "custom" &&
 				existing.sourceModels.length === 1 &&

--- a/apps/web/src/lib/indexeddb/experimentsCouncil.ts
+++ b/apps/web/src/lib/indexeddb/experimentsCouncil.ts
@@ -79,6 +79,12 @@ const DEFAULT_INTELLIGENCE_CANDIDATES = [
 
 const DEFAULT_BUDGET_CANDIDATES = [
 	"minimax/minimax-m3",
+	"deepseek/deepseek-v4-flash",
+	"moonshotai/kimi-k2.6",
+];
+
+const PREVIOUS_BUDGET_CANDIDATES = [
+	"minimax/minimax-m2.7",
 	"deepseek/deepseek-v3.2",
 	"moonshotai/kimi-k2.5",
 ];
@@ -110,6 +116,13 @@ function clampModelList(models: string[]): string[] {
 		if (deduped.length >= 4) break;
 	}
 	return deduped;
+}
+
+function matchesExactModelList(models: string[], expected: string[]): boolean {
+	return (
+		models.length === expected.length &&
+		models.every((model, index) => model === expected[index])
+	);
 }
 
 function isConstraintError(error: unknown): boolean {
@@ -331,8 +344,8 @@ export async function ensureExperimentsCouncilPresets(
 		"openai/gpt-5.4",
 		"google/gemini-3.1-pro-preview",
 		"minimax/minimax-m3",
-		"deepseek/deepseek-v3.2",
-		"moonshotai/kimi-k2.5",
+		"deepseek/deepseek-v4-flash",
+		"moonshotai/kimi-k2.6",
 	],
 ): Promise<ExperimentsCouncilPresetRecord[]> {
 	const available = modelOptions.length > 0 ? modelOptions : fallbackModels;
@@ -385,10 +398,8 @@ export async function ensureExperimentsCouncilPresets(
 				);
 			const budgetIsLegacy =
 				preset.key === "budget" &&
-				existing.sourceModels.length > 0 &&
-				existing.sourceModels.every((modelId) =>
-					LEGACY_BUDGET_CANDIDATES.includes(modelId),
-				);
+				(matchesExactModelList(existing.sourceModels, LEGACY_BUDGET_CANDIDATES) ||
+					matchesExactModelList(existing.sourceModels, PREVIOUS_BUDGET_CANDIDATES));
 			const customIsLegacy =
 				preset.key === "custom" &&
 				existing.sourceModels.length === 1 &&

--- a/packages/data/catalog/src/data/aliases/anthropic-claude-opus-latest/alias.json
+++ b/packages/data/catalog/src/data/aliases/anthropic-claude-opus-latest/alias.json
@@ -1,6 +1,6 @@
 {
   "alias_slug": "anthropic/claude-opus-latest",
-  "resolved_api_model_id": "anthropic/claude-opus-4.7",
+  "resolved_api_model_id": "anthropic/claude-opus-4.8",
   "channel": "stable",
   "is_enabled": true,
   "notes": null

--- a/packages/data/catalog/src/data/aliases/minimax-minimax-latest/alias.json
+++ b/packages/data/catalog/src/data/aliases/minimax-minimax-latest/alias.json
@@ -1,6 +1,6 @@
 {
   "alias_slug": "minimax/minimax-latest",
-  "resolved_api_model_id": "minimax/minimax-m2.7",
+  "resolved_api_model_id": "minimax/minimax-m3",
   "channel": "stable",
   "is_enabled": true,
   "notes": null


### PR DESCRIPTION
## Summary
- update `minimax/minimax-latest` to resolve to `minimax/minimax-m3`
- update `anthropic/claude-opus-latest` to resolve to `anthropic/claude-opus-4.8`
- refresh the obvious MiniMax `m2.7` web defaults that were intended to track the latest flagship model

## Validation
- `pnpm validate:data`

## Linear
- AI-110
- AI-111

Fixes #594
Fixes #595

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated supported model versions across playgrounds and presets: Minimax model upgraded to M3 and Claude Opus to version 4.8.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->