### PR TITLE
[codex] add Gemma 4 12B model metadata

### DIFF
--- a/packages/data/catalog/src/data/models/google/gemma-4-12b/model.json
+++ b/packages/data/catalog/src/data/models/google/gemma-4-12b/model.json
@@ -1,0 +1,41 @@
+{
+  "model_id": "google/gemma-4-12b",
+  "organisation_id": "google",
+  "name": "Gemma 4 12B",
+  "status": "Available",
+  "previous_model_id": null,
+  "description": "Gemma 4 12B is a dense, encoder-free multimodal model from Google DeepMind built for local AI workloads. It accepts text, image, audio, and video inputs and produces text outputs.",
+  "announced_date": "2026-06-03T00:00:00",
+  "release_date": "2026-06-03T00:00:00",
+  "deprecation_date": null,
+  "retirement_date": null,
+  "license": "Apache 2.0",
+  "input_types": "text,image,audio,video",
+  "output_types": "text",
+  "api_model_id": "google/gemma-4-12b",
+  "links": [
+    {
+      "platform": "announcement",
+      "url": "https://developers.googleblog.com/gemma-4-12b-the-developer-guide/"
+    },
+    {
+      "platform": "weights",
+      "url": "https://huggingface.co/google/gemma-4-12B-it"
+    }
+  ],
+  "details": [
+    {
+      "name": "input_context_length",
+      "value": 131072
+    },
+    {
+      "name": "output_context_length",
+      "value": 131072
+    },
+    {
+      "name": "parameter_count",
+      "value": 12000000000
+    }
+  ],
+  "benchmarks": []
+}

--- a/packages/data/catalog/src/data/models/google/gemma-4-12b/model.json
+++ b/packages/data/catalog/src/data/models/google/gemma-4-12b/model.json
@@ -26,11 +26,11 @@
   "details": [
     {
       "name": "input_context_length",
-      "value": 131072
+      "value": 262144
     },
     {
       "name": "output_context_length",
-      "value": 131072
+      "value": 262144
     },
     {
       "name": "parameter_count",


### PR DESCRIPTION
## Summary

Add a minimal catalog entry for `google/gemma-4-12b`.

## What changed

- added `packages/data/catalog/src/data/models/google/gemma-4-12b/model.json`
- included the official Google announcement link
- included the official Hugging Face weights link
- added basic model metadata only for now:
  - release date: 2026-06-03
  - license: Apache 2.0
  - input/output modalities
  - 128K context details
  - parameter count

## Why

Gemma 4 12B is now a real upstream release, and adding the model shell unblocks catalog visibility even before hosted provider mappings and pricing land.

## Follow-up

Provider mappings and pricing should be added in a later PR once tracked providers expose stable hosted support.

## Validation

- `pnpm validate:data`

## Tracking

- Linear: AI-114
- GitHub: #602

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the Google Gemma 4 12B model to the catalog with comprehensive metadata including capability specifications, context window details, parameter counts, Apache 2.0 licensing, and API identifiers for integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->