### PR TITLE
Add benchmark entries for MiniMax M3 and Gemma 4 12B

### DIFF
--- a/packages/data/catalog/src/data/models/google/gemma-4-12b/model.json
+++ b/packages/data/catalog/src/data/models/google/gemma-4-12b/model.json
@@ -110,7 +110,7 @@
     },
     {
       "benchmark_id": "omnidocbench-1.5",
-      "score": 0.164,
+      "score": 16.4,
       "is_self_reported": true,
       "other_info": "Average edit distance (lower is better)",
       "source_link": "https://huggingface.co/google/gemma-4-12B-it"

--- a/packages/data/catalog/src/data/models/google/gemma-4-12b/model.json
+++ b/packages/data/catalog/src/data/models/google/gemma-4-12b/model.json
@@ -37,5 +37,97 @@
       "value": 12000000000
     }
   ],
-  "benchmarks": []
+  "benchmarks": [
+    {
+      "benchmark_id": "mmlu-pro",
+      "score": 77.2,
+      "is_self_reported": true,
+      "other_info": null,
+      "source_link": "https://huggingface.co/google/gemma-4-12B-it"
+    },
+    {
+      "benchmark_id": "aime-2026",
+      "score": 77.5,
+      "is_self_reported": true,
+      "other_info": "No tools",
+      "source_link": "https://huggingface.co/google/gemma-4-12B-it"
+    },
+    {
+      "benchmark_id": "livecodebench-v6",
+      "score": 72.0,
+      "is_self_reported": true,
+      "other_info": null,
+      "source_link": "https://huggingface.co/google/gemma-4-12B-it"
+    },
+    {
+      "benchmark_id": "codeforces",
+      "score": 1659,
+      "is_self_reported": true,
+      "other_info": "ELO",
+      "source_link": "https://huggingface.co/google/gemma-4-12B-it"
+    },
+    {
+      "benchmark_id": "gpqa-diamond",
+      "score": 78.8,
+      "is_self_reported": true,
+      "other_info": null,
+      "source_link": "https://huggingface.co/google/gemma-4-12B-it"
+    },
+    {
+      "benchmark_id": "tau-2-bench",
+      "score": 69.0,
+      "is_self_reported": true,
+      "other_info": "Average over 3",
+      "source_link": "https://huggingface.co/google/gemma-4-12B-it"
+    },
+    {
+      "benchmark_id": "humanitys-last-exam",
+      "score": 5.2,
+      "is_self_reported": true,
+      "other_info": "No tools",
+      "source_link": "https://huggingface.co/google/gemma-4-12B-it"
+    },
+    {
+      "benchmark_id": "big-bench-extra-hard",
+      "score": 53.0,
+      "is_self_reported": true,
+      "other_info": null,
+      "source_link": "https://huggingface.co/google/gemma-4-12B-it"
+    },
+    {
+      "benchmark_id": "mmmlu",
+      "score": 83.4,
+      "is_self_reported": true,
+      "other_info": null,
+      "source_link": "https://huggingface.co/google/gemma-4-12B-it"
+    },
+    {
+      "benchmark_id": "mmmu-pro",
+      "score": 69.1,
+      "is_self_reported": true,
+      "other_info": null,
+      "source_link": "https://huggingface.co/google/gemma-4-12B-it"
+    },
+    {
+      "benchmark_id": "omnidocbench-1.5",
+      "score": 0.164,
+      "is_self_reported": true,
+      "other_info": "Average edit distance (lower is better)",
+      "source_link": "https://huggingface.co/google/gemma-4-12B-it"
+    },
+    {
+      "benchmark_id": "fleurs",
+      "score": 0.069,
+      "is_self_reported": true,
+      "other_info": "Lower is better; excluding Chinese language",
+      "source_link": "https://huggingface.co/google/gemma-4-12B-it"
+    },
+    {
+      "benchmark_id": "openai-mrcr-8-needle-128k",
+      "score": 43.4,
+      "is_self_reported": true,
+      "other_info": "Average",
+      "source_link": "https://huggingface.co/google/gemma-4-12B-it"
+    }
+  ]
 }

--- a/packages/data/catalog/src/data/models/minimax/minimax-m3/model.json
+++ b/packages/data/catalog/src/data/models/minimax/minimax-m3/model.json
@@ -34,5 +34,41 @@
       "value": 1000000
     }
   ],
-  "benchmarks": []
+  "benchmarks": [
+    {
+      "benchmark_id": "swe-bench-pro",
+      "score": 59.0,
+      "is_self_reported": true,
+      "other_info": null,
+      "source_link": "https://www.minimax.io/models/text/m3"
+    },
+    {
+      "benchmark_id": "terminal-bench-2.1",
+      "score": 66.0,
+      "is_self_reported": true,
+      "other_info": null,
+      "source_link": "https://www.minimax.io/models/text/m3"
+    },
+    {
+      "benchmark_id": "browsecomp",
+      "score": 83.5,
+      "is_self_reported": true,
+      "other_info": null,
+      "source_link": "https://www.minimax.io/models/text/m3"
+    },
+    {
+      "benchmark_id": "scale-mcp-atlas",
+      "score": 74.2,
+      "is_self_reported": true,
+      "other_info": "Public Set",
+      "source_link": "https://www.minimax.io/models/text/m3"
+    },
+    {
+      "benchmark_id": "os-world",
+      "score": 70.0,
+      "is_self_reported": true,
+      "other_info": "Verified",
+      "source_link": "https://www.minimax.io/models/text/m3"
+    }
+  ]
 }


### PR DESCRIPTION
## Summary

- add benchmark entries for `minimax/minimax-m3` using official MiniMax M3 benchmark data that maps cleanly to existing catalog benchmark IDs
- add benchmark entries for `google/gemma-4-12b` from the official Hugging Face model card / Google release materials
- keep the scope to source-backed benchmarks already represented by the catalog schema

## Benchmarks added

### MiniMax M3
- `swe-bench-pro`
- `terminal-bench-2.1`
- `browsecomp`
- `scale-mcp-atlas`
- `os-world` (`Verified`)

### Gemma 4 12B
- `mmlu-pro`
- `aime-2026`
- `livecodebench-v6`
- `codeforces`
- `gpqa-diamond`
- `tau-2-bench`
- `humanitys-last-exam`
- `big-bench-extra-hard`
- `mmmlu`
- `mmmu-pro`
- `omnidocbench-1.5`
- `fleurs`
- `openai-mrcr-8-needle-128k`

## Validation

- `pnpm validate:data`

Closes #604
Refs AI-115


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Added benchmark performance metrics for the Google Gemma-4-12B model across multiple evaluation categories.
  * Added benchmark performance metrics for the MiniMax M3 model across multiple evaluation categories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->