### PR TITLE
fix(data): set AI Singapore country code

### DIFF
--- a/packages/data/catalog/src/data/organisations/aisingapore/organisation.json
+++ b/packages/data/catalog/src/data/organisations/aisingapore/organisation.json
@@ -1,7 +1,7 @@
 {
   "organisation_id": "aisingapore",
   "name": "AI Singapore",
-  "country_code": null,
+  "country_code": "SG",
   "description": "AI Singapore is an AI model developer or research organisation represented in the AI Stats catalog.",
   "colour": "#6B7280",
   "organisation_links": []


### PR DESCRIPTION
## Summary
- set `AI Singapore` organisation `country_code` to `SG`
- fix the `Run importer on main` failure on `main`

## Root cause
The importer was failing on `main` with:

```text
Error: upsert data_organisations: null value in column "country_code" of relation "data_organisations" violates not-null constraint
```

The failing catalog row was `packages/data/catalog/src/data/organisations/aisingapore/organisation.json`, which had `"country_code": null`.

## Validation
- `pnpm validate:data`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected missing country information for an organization profile entry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->