### PR TITLE
fix(web): sync quickstart model id selection

### DIFF
--- a/apps/web/src/components/(data)/model/quickstart/Quickstart.tsx
+++ b/apps/web/src/components/(data)/model/quickstart/Quickstart.tsx
@@ -554,13 +554,29 @@ export default function Quickstart({
 		safeDecodeURIComponent(modelId) ||
 		decodedAcceptedIdentifiers[0] ||
 		"model_id_here";
+	const acceptedIdentifierList = Array.from(
+		new Set([model, ...canonicalAcceptedIdentifiers, ...decodedAcceptedIdentifiers]),
+	).filter(Boolean);
+	const [selectedModelIdentifier, setSelectedModelIdentifier] = useState(model);
+
+	useEffect(() => {
+		if (!acceptedIdentifierList.includes(selectedModelIdentifier)) {
+			setSelectedModelIdentifier(model);
+		}
+	}, [acceptedIdentifierList, model, selectedModelIdentifier]);
+
+	const modelIdentifierInCode = acceptedIdentifierList.includes(
+		selectedModelIdentifier,
+	)
+		? selectedModelIdentifier
+		: model;
 	const endpointPath = resolveGatewayPath(selectedEndpoint);
 	const batchEndpointPath = resolveGatewayPath("batch.create");
 	const activeEndpointPath = batchEnabled ? batchEndpointPath : endpointPath;
 	const endpointUrl = `${BASE_URL}${activeEndpointPath}`;
 	const routingPreference = resolveRoutingPreference(requestContext);
 	const requestPayloadBase = applyRoutingPreferenceToPayload(
-		buildExamplePayload(selectedEndpoint, model),
+		buildExamplePayload(selectedEndpoint, modelIdentifierInCode),
 		routingPreference,
 	);
 	const requestPayload =
@@ -605,10 +621,6 @@ export default function Quickstart({
 		.split("\n")
 		.map((line) => `# ${line}`)
 		.join("\n");
-	const acceptedIdentifierList = Array.from(
-		new Set([model, ...canonicalAcceptedIdentifiers, ...decodedAcceptedIdentifiers]),
-	).filter(Boolean);
-
 	const curlCommandLabel = batchEnabled
 		? "Create a batch job"
 		: shouldStream
@@ -1480,8 +1492,9 @@ console.log(response);`
 					</div>
 
 					<QuickstartUsageSection
-						modelIdentifierInCode={model}
+						modelIdentifierInCode={modelIdentifierInCode}
 						acceptedIdentifiers={acceptedIdentifierList}
+						onSelectModelIdentifier={setSelectedModelIdentifier}
 						supportedParameters={supportedParameters}
 						selectedEndpointLabel={selectedEndpointLabel}
 						selectedEndpointValue={selectedEndpoint}
@@ -1539,8 +1552,9 @@ console.log(response);`
 					/>
 
 					{false ? <QuickstartUsageSection
-						modelIdentifierInCode={model}
+						modelIdentifierInCode={modelIdentifierInCode}
 						acceptedIdentifiers={acceptedIdentifierList}
+						onSelectModelIdentifier={setSelectedModelIdentifier}
 						supportedParameters={supportedParameters}
 						selectedEndpointLabel={selectedEndpointLabel}
 						selectedEndpointValue={selectedEndpoint}
@@ -1608,8 +1622,9 @@ console.log(response);`
 					/>
 
 					{false ? <QuickstartUsageSection
-						modelIdentifierInCode={model}
+						modelIdentifierInCode={modelIdentifierInCode}
 						acceptedIdentifiers={acceptedIdentifierList}
+						onSelectModelIdentifier={setSelectedModelIdentifier}
 						supportedParameters={supportedParameters}
 						selectedEndpointLabel={selectedEndpointLabel}
 						selectedEndpointValue={selectedEndpoint}

--- a/apps/web/src/components/(data)/model/quickstart/Quickstart.tsx
+++ b/apps/web/src/components/(data)/model/quickstart/Quickstart.tsx
@@ -523,29 +523,43 @@ export default function Quickstart({
 		acceptedModelIdentifiers ??
 		[];
 
-	const decodedAcceptedIdentifiers = Array.from(
-		new Set([
-			...(endpointAcceptedIdentifiers.map((identifier) =>
-				safeDecodeURIComponent(identifier),
-			) ?? []),
-			...(endpointAcceptedIdentifiers.length === 0
-				? [
-						...(apiModelIds?.map((identifier) =>
-							safeDecodeURIComponent(identifier),
-						) ?? []),
-						...(aliases?.map((alias) =>
-							safeDecodeURIComponent(alias),
-						) ?? []),
-				  ]
-				: []),
-		]),
-	).filter(Boolean);
-
-	const decodedAliases = new Set(
-		(aliases?.map((alias) => safeDecodeURIComponent(alias)) ?? []).filter(Boolean),
+	const decodedAcceptedIdentifiers = useMemo(
+		() =>
+			Array.from(
+				new Set([
+					...(endpointAcceptedIdentifiers.map((identifier) =>
+						safeDecodeURIComponent(identifier),
+					) ?? []),
+					...(endpointAcceptedIdentifiers.length === 0
+						? [
+								...(apiModelIds?.map((identifier) =>
+									safeDecodeURIComponent(identifier),
+								) ?? []),
+								...(aliases?.map((alias) =>
+									safeDecodeURIComponent(alias),
+								) ?? []),
+						  ]
+						: []),
+				]),
+			).filter(Boolean),
+		[aliases, apiModelIds, endpointAcceptedIdentifiers],
 	);
-	const canonicalAcceptedIdentifiers = decodedAcceptedIdentifiers.filter(
-		(identifier) => !decodedAliases.has(identifier),
+
+	const decodedAliases = useMemo(
+		() =>
+			new Set(
+				(aliases?.map((alias) => safeDecodeURIComponent(alias)) ?? []).filter(
+					Boolean,
+				),
+			),
+		[aliases],
+	);
+	const canonicalAcceptedIdentifiers = useMemo(
+		() =>
+			decodedAcceptedIdentifiers.filter(
+				(identifier) => !decodedAliases.has(identifier),
+			),
+		[decodedAcceptedIdentifiers, decodedAliases],
 	);
 
 	const model =
@@ -554,9 +568,17 @@ export default function Quickstart({
 		safeDecodeURIComponent(modelId) ||
 		decodedAcceptedIdentifiers[0] ||
 		"model_id_here";
-	const acceptedIdentifierList = Array.from(
-		new Set([model, ...canonicalAcceptedIdentifiers, ...decodedAcceptedIdentifiers]),
-	).filter(Boolean);
+	const acceptedIdentifierList = useMemo(
+		() =>
+			Array.from(
+				new Set([
+					model,
+					...canonicalAcceptedIdentifiers,
+					...decodedAcceptedIdentifiers,
+				]),
+			).filter(Boolean),
+		[model, canonicalAcceptedIdentifiers, decodedAcceptedIdentifiers],
+	);
 	const [selectedModelIdentifier, setSelectedModelIdentifier] = useState(model);
 
 	useEffect(() => {

--- a/apps/web/src/components/(data)/model/quickstart/QuickstartUsageSection.tsx
+++ b/apps/web/src/components/(data)/model/quickstart/QuickstartUsageSection.tsx
@@ -58,6 +58,7 @@ const SERVICE_TIER_OPTIONS: ServiceTierOption[] = [
 type QuickstartUsageSectionProps = {
 	modelIdentifierInCode: string;
 	acceptedIdentifiers: string[];
+	onSelectModelIdentifier: (value: string) => void;
 	supportedParameters: Array<{
 		param_id: string;
 		provider_count_supported: number;
@@ -537,6 +538,7 @@ function RequestCodePane({
 export function QuickstartUsageSection({
 	modelIdentifierInCode,
 	acceptedIdentifiers,
+	onSelectModelIdentifier,
 	supportedParameters,
 	selectedEndpointLabel,
 	selectedEndpointValue,
@@ -849,7 +851,7 @@ export function QuickstartUsageSection({
 							Accepted IDs
 						</span>
 						<span className="text-xs text-muted-foreground">
-							Click to copy
+							Click to use and copy
 						</span>
 					</div>
 					{acceptedIdentifiers.length > 0 ? (
@@ -864,8 +866,9 @@ export function QuickstartUsageSection({
 										size="sm"
 										className="h-auto min-h-8 max-w-full justify-start gap-2 rounded-md px-2.5 py-1.5 font-mono text-xs"
 										onClick={async () => {
+											onSelectModelIdentifier(identifier);
 											await navigator.clipboard.writeText(identifier);
-											toast.success("Copied model ID", {
+											toast.success("Updated model ID", {
 												description: identifier,
 											});
 										}}


### PR DESCRIPTION
## Summary
This fixes a quickstart UI regression where clicking an accepted model ID did not actually switch the identifier used in the request example.

On model pages such as `MiniMax M3`, the accepted ID pills visually implied a selectable state with a checkmark, but the code sample stayed pinned to the original identifier. That made the UI feel broken: users could click an alias, see no active-state change, and copy a sample that did not match the ID they had just chosen.

## Root cause
The accepted ID buttons were implemented as copy-only actions inside `QuickstartUsageSection`, while the checkmark and request payload were both driven by a fixed `modelIdentifierInCode` value computed in `Quickstart.tsx`. There was no selected-model-ID state connecting the accepted ID controls to the generated sample.

## Fix
This PR introduces explicit selected model ID state in `Quickstart.tsx` and uses that state when building the request payload and code sample.

It also updates `QuickstartUsageSection` so clicking an accepted ID now:
- selects that identifier for the quickstart sample
- updates the active checkmark
- still copies the chosen identifier to the clipboard

The selected ID is kept in sync when endpoint-specific accepted IDs change, so the sample falls back safely if the previous selection is no longer valid for the current route.

## Validation
- `pnpm install --frozen-lockfile`
- `pnpm --filter @ai-stats/web typecheck`
- browser verification against the local quickstart flow for `MiniMax M3`, confirming the active accepted ID and sample model ID update together


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Users can now select from multiple accepted model identifiers; selected identifier updates code examples and generated payloads accordingly.

* **UI/UX Improvements**
  * Updated helper text for accepted identifiers to "Click to use and copy".
  * Toast confirmation message now displays "Updated model ID" when selecting an identifier.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->