### PR TITLE
Refresh DeepSWE confidence intervals

### DIFF
--- a/packages/data/catalog/src/data/models/anthropic/claude-opus-4.8/model.json
+++ b/packages/data/catalog/src/data/models/anthropic/claude-opus-4.8/model.json
@@ -158,7 +158,7 @@
       "benchmark_id": "deepswe",
       "score": 58,
       "is_self_reported": false,
-      "other_info": "mini-swe-agent; effort max; 58% +/-5%; avg cost $12.58; avg time 43m; out tok 136k",
+      "other_info": "mini-swe-agent; effort max; 58% +/-2%; avg cost $12.58; avg time 43m; out tok 136k",
       "source_link": "https://deepswe.datacurve.ai/",
       "rank": 2
     },

--- a/packages/data/catalog/src/data/models/anthropic/claude-sonnet-4.6/model.json
+++ b/packages/data/catalog/src/data/models/anthropic/claude-sonnet-4.6/model.json
@@ -250,7 +250,7 @@
       "benchmark_id": "deepswe",
       "score": 32,
       "is_self_reported": false,
-      "other_info": "mini-swe-agent; effort high; 32% +/-4%; avg cost $5.52; avg time 42m; out tok 76k",
+      "other_info": "mini-swe-agent; effort high; 32% +/-2%; avg cost $5.52; avg time 42m; out tok 76k",
       "source_link": "https://deepswe.datacurve.ai/",
       "rank": 5
     },

--- a/packages/data/catalog/src/data/models/deepseek/deepseek-v4-pro/model.json
+++ b/packages/data/catalog/src/data/models/deepseek/deepseek-v4-pro/model.json
@@ -134,7 +134,7 @@
       "benchmark_id": "deepswe",
       "score": 8,
       "is_self_reported": false,
-      "other_info": "mini-swe-agent; 8% +/-2%; avg cost $4.22; avg time 37m; out tok 50k",
+      "other_info": "mini-swe-agent; 8% +/-3%; avg cost $4.22; avg time 37m; out tok 50k",
       "source_link": "https://deepswe.datacurve.ai/",
       "rank": 14
     },

--- a/packages/data/catalog/src/data/models/moonshotai/kimi-k2.6/model.json
+++ b/packages/data/catalog/src/data/models/moonshotai/kimi-k2.6/model.json
@@ -21,7 +21,7 @@
       "benchmark_id": "deepswe",
       "score": 24,
       "is_self_reported": false,
-      "other_info": "mini-swe-agent; 24% +/-4%; avg cost $3.16; avg time 56m; out tok 84k",
+      "other_info": "mini-swe-agent; 24% +/-2%; avg cost $3.16; avg time 56m; out tok 84k",
       "source_link": "https://deepswe.datacurve.ai/",
       "rank": 9
     },

--- a/packages/data/catalog/src/data/models/openai/gpt-5.4-mini/model.json
+++ b/packages/data/catalog/src/data/models/openai/gpt-5.4-mini/model.json
@@ -183,7 +183,7 @@
       "benchmark_id": "deepswe",
       "score": 24,
       "is_self_reported": false,
-      "other_info": "mini-swe-agent; effort xhigh; 24% +/-4%; avg cost $2.08; avg time 33m; out tok 135k",
+      "other_info": "mini-swe-agent; effort xhigh; 24% +/-3%; avg cost $2.08; avg time 33m; out tok 135k",
       "source_link": "https://deepswe.datacurve.ai/",
       "rank": 8
     },

--- a/packages/data/catalog/src/data/models/openai/gpt-5.4/model.json
+++ b/packages/data/catalog/src/data/models/openai/gpt-5.4/model.json
@@ -271,7 +271,7 @@
       "benchmark_id": "deepswe",
       "score": 56,
       "is_self_reported": false,
-      "other_info": "mini-swe-agent; effort xhigh; 56% +/-5%; avg cost $4.38; avg time 27m; out tok 71k",
+      "other_info": "mini-swe-agent; effort xhigh; 56% +/-2%; avg cost $4.38; avg time 27m; out tok 71k",
       "source_link": "https://deepswe.datacurve.ai/",
       "rank": 3
     },

--- a/packages/data/catalog/src/data/models/openai/gpt-5.5/model.json
+++ b/packages/data/catalog/src/data/models/openai/gpt-5.5/model.json
@@ -339,7 +339,7 @@
       "benchmark_id": "deepswe",
       "score": 70,
       "is_self_reported": false,
-      "other_info": "mini-swe-agent; effort xhigh; 70% +/-4%; avg cost $6.61; avg time 21m; out tok 47k",
+      "other_info": "mini-swe-agent; effort xhigh; 70% +/-3%; avg cost $6.61; avg time 21m; out tok 47k",
       "source_link": "https://deepswe.datacurve.ai/",
       "rank": 1
     },

--- a/packages/data/catalog/src/data/models/x-ai/grok-build-0.1/model.json
+++ b/packages/data/catalog/src/data/models/x-ai/grok-build-0.1/model.json
@@ -30,7 +30,7 @@
       "benchmark_id": "deepswe",
       "score": 13,
       "is_self_reported": false,
-      "other_info": "mini-swe-agent; 13% +/-3%; avg cost $6.60; avg time 44m; out tok 52k",
+      "other_info": "mini-swe-agent; 13% +/-2%; avg cost $6.60; avg time 44m; out tok 52k",
       "source_link": "https://deepswe.datacurve.ai/",
       "rank": 12
     }

--- a/packages/data/catalog/src/data/models/xiaomi/mimo-v2.5-pro/model.json
+++ b/packages/data/catalog/src/data/models/xiaomi/mimo-v2.5-pro/model.json
@@ -38,7 +38,7 @@
       "benchmark_id": "deepswe",
       "score": 19,
       "is_self_reported": false,
-      "other_info": "mini-swe-agent; 19% +/-4%; avg cost $1.99; avg time 28m; out tok 49k",
+      "other_info": "mini-swe-agent; 19% +/-2%; avg cost $1.99; avg time 28m; out tok 49k",
       "source_link": "https://deepswe.datacurve.ai/",
       "rank": 10
     },

--- a/packages/data/catalog/src/data/models/z-ai/glm-5.1/model.json
+++ b/packages/data/catalog/src/data/models/z-ai/glm-5.1/model.json
@@ -173,7 +173,7 @@
       "benchmark_id": "deepswe",
       "score": 18,
       "is_self_reported": false,
-      "other_info": "mini-swe-agent; 18% +/-4%; avg cost $7.46; avg time 35m; out tok 49k",
+      "other_info": "mini-swe-agent; 18% +/-1%; avg cost $7.46; avg time 35m; out tok 49k",
       "source_link": "https://deepswe.datacurve.ai/",
       "rank": 11
     },


### PR DESCRIPTION
## Summary
- refresh 10 stale DeepSWE confidence interval strings in model benchmark `other_info` fields
- keep DeepSWE scores, ranks, model mappings, and benchmark metadata unchanged
- align repository metadata with the public DeepSWE leaderboard updated May 30, 2026

## Validation
- `cmd /c pnpm validate:data`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deepswe benchmark confidence intervals across multiple AI models to reflect refined uncertainty measurements and provide more precise accuracy reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->