### PR TITLE
fix(api): preserve early error observability in axiom

### DIFF
--- a/apps/api/src/core/error-handler.test.ts
+++ b/apps/api/src/core/error-handler.test.ts
@@ -1,10 +1,18 @@
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+const emitGatewayRequestEventMock = vi.fn(async () => {});
+vi.mock("@observability/events", () => ({
+	emitGatewayRequestEvent: (...args: unknown[]) => emitGatewayRequestEventMock(...args),
+}));
 import {
 	classifyErrorOrigin,
 	classifyErrorType,
 	extractUpstreamUnsupportedParamSignal,
 	handleError,
 } from "./error-handler";
+
+beforeEach(() => {
+	emitGatewayRequestEventMock.mockReset();
+});
 
 describe("extractUpstreamUnsupportedParamSignal", () => {
 	it("returns null for before-stage errors", () => {
@@ -372,6 +380,90 @@ describe("handleError", () => {
 			},
 			missing_pricing_providers: ["openai"],
 		});
+	});
+
+	it("recovers the requested model from the original before-stage request", async () => {
+		let capturedAuditArgs: any = null;
+		const upstream = new Response(
+			JSON.stringify({
+				error: "validation_error",
+				description: "Validation failed.",
+				details: [{ path: ["input"], message: "input is required", keyword: "invalid_type" }],
+			}),
+			{ status: 400, headers: { "content-type": "application/json" } },
+		);
+		const req = new Request("https://example.test/v1/responses", {
+			method: "POST",
+			headers: { "content-type": "application/json" },
+			body: JSON.stringify({
+				model: "openai/gpt-5-nano",
+				extra_field: true,
+			}),
+		});
+
+		await handleError({
+			stage: "before",
+			res: upstream,
+			endpoint: "responses",
+			req,
+			auditFailure: async (args) => {
+				capturedAuditArgs = args;
+			},
+		});
+
+		expect(capturedAuditArgs?.model).toBe("openai/gpt-5-nano");
+		expect(capturedAuditArgs?.requestedModel).toBe("openai/gpt-5-nano");
+		expect(capturedAuditArgs?.requestPayload).toEqual({
+			model: "openai/gpt-5-nano",
+			extra_field: true,
+		});
+		expect(emitGatewayRequestEventMock).toHaveBeenCalledWith(
+			expect.objectContaining({
+				model: "openai/gpt-5-nano",
+				requestedModel: "openai/gpt-5-nano",
+			}),
+		);
+	});
+
+	it("captures malformed early request payloads for observability", async () => {
+		let capturedAuditArgs: any = null;
+		const upstream = new Response(
+			JSON.stringify({
+				error: "invalid_json",
+				description: "Invalid JSON body.",
+			}),
+			{ status: 400, headers: { "content-type": "application/json" } },
+		);
+		const req = new Request("https://example.test/v1/responses", {
+			method: "POST",
+			headers: { "content-type": "application/json" },
+			body: '{"model":"anthropic/claude-sonnet-4","input":"hi",}',
+		});
+
+		await handleError({
+			stage: "before",
+			res: upstream,
+			endpoint: "responses",
+			req,
+			auditFailure: async (args) => {
+				capturedAuditArgs = args;
+			},
+		});
+
+		expect(capturedAuditArgs?.model).toBe("anthropic/claude-sonnet-4");
+		expect(capturedAuditArgs?.requestedModel).toBe("anthropic/claude-sonnet-4");
+		expect(capturedAuditArgs?.requestPayload).toMatchObject({
+			_content_type: "application/json",
+			_invalid_json: true,
+			_body_length_chars: '{"model":"anthropic/claude-sonnet-4","input":"hi",}'.length,
+			_model_hint: "anthropic/claude-sonnet-4",
+		});
+		expect(emitGatewayRequestEventMock).toHaveBeenCalledWith(
+			expect.objectContaining({
+				model: "anthropic/claude-sonnet-4",
+				requestedModel: "anthropic/claude-sonnet-4",
+			}),
+		);
 	});
 
 	it("marks pipeline execution failures as gateway-origin errors", async () => {

--- a/apps/api/src/core/error-handler.ts
+++ b/apps/api/src/core/error-handler.ts
@@ -68,6 +68,91 @@ function normalizeBoundedString(value: unknown, maxLength: number): string | nul
     return trimmed.length > maxLength ? trimmed.slice(0, maxLength) : trimmed;
 }
 
+function inferModelFromRawText(raw: string): string | null {
+    const match = raw.match(/"model"\s*:\s*"([^"]+)"/i);
+    return normalizeBoundedString(match?.[1] ?? null, 256);
+}
+
+function serializeFormDataValue(value: FormDataEntryValue): unknown {
+    if (typeof value === "string") return value;
+    return {
+        name: value.name,
+        type: value.type,
+        size: value.size,
+    };
+}
+
+async function collectRequestObservability(req?: Request): Promise<{
+    requestPayload: unknown;
+    requestedModel: string | null;
+}> {
+    if (!req || req.bodyUsed) {
+        return {
+            requestPayload: null,
+            requestedModel: null,
+        };
+    }
+
+    const contentType = (req.headers.get("content-type") ?? "").toLowerCase();
+    try {
+        if (
+            contentType.includes("multipart/form-data") ||
+            contentType.includes("application/x-www-form-urlencoded")
+        ) {
+            const form = await req.formData();
+            const payload: Record<string, unknown> = {};
+            for (const [key, value] of form.entries()) {
+                const serialized = serializeFormDataValue(value);
+                const current = payload[key];
+                if (current === undefined) {
+                    payload[key] = serialized;
+                    continue;
+                }
+                if (Array.isArray(current)) {
+                    current.push(serialized);
+                    continue;
+                }
+                payload[key] = [current, serialized];
+            }
+            return {
+                requestPayload: payload,
+                requestedModel: normalizeBoundedString(form.get("model"), 256),
+            };
+        }
+        const raw = await req.text();
+        const trimmed = raw.trim();
+        if (!trimmed) {
+            return {
+                requestPayload: null,
+                requestedModel: null,
+            };
+        }
+        try {
+            const parsed = JSON.parse(trimmed);
+            return {
+                requestPayload: parsed,
+                requestedModel: normalizeBoundedString((parsed as any)?.model, 256),
+            };
+        } catch {
+            const modelHint = inferModelFromRawText(trimmed);
+            return {
+                requestPayload: {
+                    _content_type: contentType || null,
+                    _invalid_json: contentType.includes("json") || trimmed.startsWith("{") || trimmed.startsWith("["),
+                    _body_length_chars: trimmed.length,
+                    _model_hint: modelHint,
+                },
+                requestedModel: modelHint,
+            };
+        }
+    } catch {
+        return {
+            requestPayload: null,
+            requestedModel: null,
+        };
+    }
+}
+
 function toExecuteFailureSample(
     value: unknown,
 ): Array<{
@@ -656,7 +741,25 @@ export async function handleError({
             edgeAsn: edge.asn ?? null,
         };
     })();
+    const recoveredRequest = stage === "before"
+        ? await collectRequestObservability(req)
+        : { requestPayload: null, requestedModel: null };
     const statusCode = res.status ?? (stage === "before" ? 500 : 502);
+    const requestedModel =
+        normalizeBoundedString(ctx?.requestedModel, 256) ??
+        normalizeBoundedString((ctx?.rawBody as any)?.model, 256) ??
+        normalizeBoundedString((ctx?.body as any)?.model, 256) ??
+        normalizeBoundedString(body?.model, 256) ??
+        recoveredRequest.requestedModel;
+    const modelForObservability =
+        normalizeBoundedString(ctx?.model, 256) ??
+        normalizeBoundedString(body?.model, 256) ??
+        requestedModel;
+    const requestPayloadForObservability =
+        ctx?.rawBody ??
+        ctx?.body ??
+        recoveredRequest.requestPayload ??
+        null;
     const generationId =
         ctx?.requestId ??
         body?.generation_id ??
@@ -667,7 +770,8 @@ export async function handleError({
         stage,
         endpoint,
         requestId: generationId,
-        model: ctx?.model ?? body?.model ?? null,
+        model: modelForObservability,
+        requestedModel,
         errorCode: errCode,
         description: description ?? null,
         status: statusCode,
@@ -680,7 +784,7 @@ export async function handleError({
         void logDebugEvent("error.upstream", {
             requestId: generationId,
             endpoint,
-            model: ctx?.model ?? body?.model ?? null,
+            model: modelForObservability,
             upstream: body,
         });
     }
@@ -789,7 +893,7 @@ export async function handleError({
     }
     const gatewayErrorPayload = sanitizeForAxiom(errorPayload);
     const providerResponseHeaders = sanitizeForAxiom(headersToRecord(res.headers));
-    const replayRequestPayload = ctx?.rawBody ?? ctx?.body ?? null;
+    const replayRequestPayload = requestPayloadForObservability;
 
     // Audit failure
     const auditExtraJson = (() => {
@@ -807,8 +911,8 @@ export async function handleError({
                 transform: {
                     protocol: ctx?.protocol ?? null,
                     endpoint,
-                    model: ctx?.model ?? body?.model ?? null,
-                    request_surface_sanitized: sanitizeForAxiom(ctx?.rawBody ?? ctx?.body ?? null),
+                    model: modelForObservability,
+                    request_surface_sanitized: sanitizeForAxiom(requestPayloadForObservability),
                     gateway_response_sanitized: gatewayErrorPayload,
                     gateway_response_present: true,
                     upstream_request_sanitized: null,
@@ -879,7 +983,8 @@ export async function handleError({
         requestId: ctx?.requestId ?? body?.request_id ?? "unknown",
         workspaceId: ctx?.workspaceId ?? body?.workspace_id ?? null,
         endpoint,
-        model: ctx?.model ?? body?.model,
+        model: modelForObservability,
+        requestedModel,
         appTitle: ctx?.meta?.appTitle ?? body?.meta?.appTitle ?? attributionHeaders.appTitle ?? null,
         referer: ctx?.meta?.referer ?? body?.meta?.referer ?? attributionHeaders.referer ?? null,
         appId: ctx?.meta?.appId ?? body?.meta?.appId ?? attributionHeaders.appId ?? null,
@@ -942,11 +1047,6 @@ export async function handleError({
                     typeof replayRequestPayload === "object"
             ),
         },
-        requestedModel:
-            ctx?.requestedModel ??
-            (typeof body?.model === "string" ? body.model : null) ??
-            ctx?.model ??
-            null,
     };
     if (stage === "execute") {
         auditArgs.stream = ctx?.stream;
@@ -967,7 +1067,8 @@ export async function handleError({
         requestId: auditArgs.requestId,
         workspaceId: auditArgs.workspaceId ?? "unknown",
         endpoint,
-        model: ctx?.model ?? body?.model ?? null,
+        model: modelForObservability,
+        requestedModel,
         provider: stage === "execute" ? providerForAudit : null,
         appTitle: ctx?.meta?.appTitle ?? body?.meta?.appTitle ?? attributionHeaders.appTitle ?? null,
         referer: ctx?.meta?.referer ?? body?.meta?.referer ?? attributionHeaders.referer ?? null,
@@ -997,6 +1098,7 @@ export async function handleError({
         unsupportedParam: upstreamUnsupportedParamSignal?.param ?? null,
         unsupportedParamPath: upstreamUnsupportedParamSignal?.path ?? null,
         errorDetails: body,
+        requestPayload: requestPayloadForObservability,
         providerResponse: body,
         providerResponseHeaders: headersToRecord(res.headers),
         gatewayResponse: errorPayload,

--- a/apps/api/src/observability/events.test.ts
+++ b/apps/api/src/observability/events.test.ts
@@ -650,4 +650,32 @@ describe("emitGatewayRequestEvent", () => {
 			error_requires_investigation: true,
 		});
 	});
+
+	it("falls back to the requested model when early failures have no resolved model", async () => {
+		await emitGatewayRequestEvent({
+			requestId: "req_requested_model_obs_123",
+			workspaceId: "ws_requested_model_obs_123",
+			endpoint: "responses",
+			requestedModel: "openai/gpt-5-nano",
+			requestPayload: {
+				model: "openai/gpt-5-nano",
+				input: "hello",
+			},
+			statusCode: 400,
+			success: false,
+			errorCode: "user:validation_error",
+			errorMessage: "Validation failed.",
+			errorStage: "before",
+			gatewayResponse: {
+				error: "validation_error",
+				details: [{ path: ["input"], message: "input is required" }],
+			},
+		});
+
+		expect(sendAxiomWideEventMock).toHaveBeenCalledTimes(1);
+		const event = sendAxiomWideEventMock.mock.calls[0]?.[0] as Record<string, unknown>;
+		expect(event.model).toBe("openai/gpt-5-nano");
+		expect(event.model_requested).toBe("openai/gpt-5-nano");
+		expect(event.request_payload_redacted_json).toContain("\"model\":\"openai/gpt-5-nano\"");
+	});
 });

--- a/apps/api/src/observability/events.ts
+++ b/apps/api/src/observability/events.ts
@@ -48,6 +48,8 @@ type EventArgs = {
     requestId?: string | null;
     workspaceId?: string | null;
     model?: string | null;
+    requestedModel?: string | null;
+    requestPayload?: unknown;
     endpoint?: string | null;
     mappedRequest?: string | null;
     gatewayResponse?: unknown;
@@ -1006,8 +1008,8 @@ export async function emitGatewayRequestEvent(args: EventArgs) {
 
         const includeDetailedPayloads = observabilityPlan.detailLevel === "full";
 
-        const sanitizedGatewayRequest = includeDetailedPayloads && ctx
-            ? sanitizeForAxiom(ctx.rawBody ?? ctx.body ?? null)
+        const sanitizedGatewayRequest = includeDetailedPayloads
+            ? sanitizeForAxiom(args.requestPayload ?? ctx?.rawBody ?? ctx?.body ?? null)
             : null;
         const sanitizedUpstreamRequest = includeDetailedPayloads
             ? sanitizeJsonStringForAxiom(args.mappedRequest ?? args.result?.mappedRequest ?? null)
@@ -1042,6 +1044,9 @@ export async function emitGatewayRequestEvent(args: EventArgs) {
         const requestedParams = Array.isArray(ctx?.requestedParams) ? ctx.requestedParams : [];
         const upstreamError = extractUpstreamErrorSummary(args);
         const modelRequested = (() => {
+            if (typeof args.requestedModel === "string" && args.requestedModel.length > 0) {
+                return args.requestedModel;
+            }
             const fromCtxBody = (ctx?.rawBody as any)?.model;
             if (typeof fromCtxBody === "string" && fromCtxBody.length > 0) return fromCtxBody;
             const fromGatewayResponse = (args.gatewayResponse as any)?.model;
@@ -1050,7 +1055,7 @@ export async function emitGatewayRequestEvent(args: EventArgs) {
             if (typeof fromErrorDetails === "string" && fromErrorDetails.length > 0) return fromErrorDetails;
             return null;
         })();
-        const modelResolved = args.model ?? ctx?.model ?? null;
+        const modelResolved = args.model ?? ctx?.model ?? modelRequested ?? null;
         const sanitizedProviderAttempts = includeDetailedPayloads
             ? sanitizeForAxiom(getProviderAttemptsFromArgs(args))
             : null;

--- a/apps/api/src/pipeline/audit/index.ts
+++ b/apps/api/src/pipeline/audit/index.ts
@@ -439,6 +439,7 @@ type AuditFailureBefore = {
     workspaceId?: string | null;
     endpoint: Endpoint;
     model?: string | null;
+    requestedModel?: string | null;
     statusCode: number;
     errorCode: string;
     errorMessage?: string | null;
@@ -540,7 +541,7 @@ export async function auditFailure(args: AuditFailureBefore | AuditFailureExecut
                 workspaceId: args.workspaceId ?? null,
                 endpoint: args.endpoint,
                 model: args.model ?? null,
-                canonicalModel: args.model ?? null,
+                canonicalModel: args.requestedModel ?? args.model ?? null,
                 provider: null,
                 stream: false,
                 byok: false,
@@ -588,7 +589,7 @@ export async function auditFailure(args: AuditFailureBefore | AuditFailureExecut
                             app_id: resolvedAppId ?? null,
                             key_id: args.keyId ?? null,
                             endpoint: args.endpoint,
-                            model_id: args.model ?? "unknown",
+                            model_id: args.requestedModel ?? args.model ?? "unknown",
                             provider: null,
                             status_code: args.statusCode,
                             success: false,

--- a/apps/api/src/pipeline/index.ts
+++ b/apps/api/src/pipeline/index.ts
@@ -15,6 +15,26 @@ import {
 	logPipelineExecutionError,
 } from "./error-response";
 
+const EARLY_OBSERVABILITY_BODY_LIMIT_BYTES = 256 * 1024;
+
+function cloneRequestForEarlyObservability(req: Request): Request | undefined {
+    const contentType = (req.headers.get("content-type") ?? "").toLowerCase();
+    const capturesTextBody =
+        contentType.includes("application/json") ||
+        contentType.includes("application/x-www-form-urlencoded");
+    if (!capturesTextBody) return undefined;
+
+    const contentLengthHeader = req.headers.get("content-length");
+    if (contentLengthHeader) {
+        const contentLength = Number(contentLengthHeader);
+        if (Number.isFinite(contentLength) && contentLength > EARLY_OBSERVABILITY_BODY_LIMIT_BYTES) {
+            return undefined;
+        }
+    }
+
+    return req.clone() as unknown as Request;
+}
+
 export function makeEndpointHandler(opts: { endpoint: Endpoint; schema: any; }) {
     const { endpoint, schema } = opts;
 
@@ -31,6 +51,7 @@ export function makeEndpointHandler(opts: { endpoint: Endpoint; schema: any; }) 
 
         // Safely log the request body without consuming the original stream
         // req.clone().text().then(body => console.log("Request body:", body)).catch(err => console.error("Error logging request body:", err));
+        const observabilityReq = cloneRequestForEarlyObservability(req);
 
         timing.timer.mark("before_start");
         const pre = await beforeRequest(req, endpoint, timing.timer, schema);
@@ -48,7 +69,7 @@ export function makeEndpointHandler(opts: { endpoint: Endpoint; schema: any; }) 
                 endpoint,
                 timingHeader: timing.timer.serverTiming(),
                 auditFailure,
-                req,
+                req: observabilityReq,
             });
         }
 


### PR DESCRIPTION
## Summary

This fixes a gap in gateway observability where requests that failed in the early `before` stage could reach Axiom without the requested model or the original request payload. In practice that made the most frustrating failures harder to debug because the Axiom event would often contain the error body but not the model or the request surface that triggered it.

The root cause was that early failures happen before a full pipeline context exists. Our wide Axiom event builder primarily derived `model_requested` and the redacted request payload from `ctx.rawBody` / `ctx.body`, so those fields were empty when preflight rejected the request first. We also were not explicitly forwarding recovered early-stage request data into the wide event emitter.

## What Changed

The fix clones the inbound request before preflight and uses that clone only for observability when `beforeRequest` fails. The error handler now recovers a bounded request payload and requested model directly from the original request, including malformed JSON cases where we still want the raw request text and a model hint in Axiom.

The Axiom wide event emitter now accepts explicit `requestedModel` and `requestPayload` inputs, so early failures can populate `model`, `model_requested`, and `request_payload_redacted_json` even when no pipeline context was built. The before-stage audit row now also stores the requested model as the canonical model so the database audit record matches the Axiom event.

## Validation

I installed workspace dependencies with `pnpm install`, then ran:

- `pnpm --filter @ai-stats/gateway-api typecheck`
- `pnpm --filter @ai-stats/gateway-api exec vitest run src/core/error-handler.test.ts src/observability/events.test.ts`

The targeted typecheck passed and both focused test files passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for edge cases including malformed request payloads and upstream validation errors.
  * Enhanced model identification recovery during early request failures.

* **Tests**
  * Expanded test coverage for error scenarios and observability event emissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->