### PR TITLE
[codex] Add account deletion Discord webhook notification

### DIFF
--- a/apps/web/src/app/(dashboard)/settings/account/actions.ts
+++ b/apps/web/src/app/(dashboard)/settings/account/actions.ts
@@ -62,19 +62,17 @@ export async function deleteAccount() {
     const { error } = await (admin as any).auth.admin.deleteUser(authUser.id)
     if (error) throw new Error(error.message)
 
-    try {
-        await sendAccountLifecycleDiscordWebhook({
-            event: 'account_deleted',
-            userId: authUser.id,
-            email: authUser.email ?? null,
-            timestampIso: new Date().toISOString(),
-        })
-    } catch (error) {
+    void sendAccountLifecycleDiscordWebhook({
+        event: 'account_deleted',
+        userId: authUser.id,
+        email: authUser.email ?? null,
+        timestampIso: new Date().toISOString(),
+    }).catch((error) => {
         console.error('Failed sending account deletion Discord webhook', {
             userId: authUser.id,
             error: error instanceof Error ? error.message : String(error),
         })
-    }
+    })
 
     return { ok: true }
 }

--- a/apps/web/src/app/(dashboard)/settings/account/actions.ts
+++ b/apps/web/src/app/(dashboard)/settings/account/actions.ts
@@ -7,6 +7,7 @@ import { redirect } from 'next/navigation'
 import { createHash, randomBytes } from 'crypto'
 import { cookies } from 'next/headers'
 import { OBFUSCATE_INFO_COOKIE, serializeObfuscateInfo } from '@/lib/obfuscation'
+import { sendAccountLifecycleDiscordWebhook } from '@/lib/auth/accountLifecycleDiscord'
 
 export async function updateAccount(payload: {
     display_name?: string | null
@@ -60,6 +61,20 @@ export async function deleteAccount() {
     // If this fails, throw so the client can show an error
     const { error } = await (admin as any).auth.admin.deleteUser(authUser.id)
     if (error) throw new Error(error.message)
+
+    try {
+        await sendAccountLifecycleDiscordWebhook({
+            event: 'account_deleted',
+            userId: authUser.id,
+            email: authUser.email ?? null,
+            timestampIso: new Date().toISOString(),
+        })
+    } catch (error) {
+        console.error('Failed sending account deletion Discord webhook', {
+            userId: authUser.id,
+            error: error instanceof Error ? error.message : String(error),
+        })
+    }
 
     return { ok: true }
 }

--- a/apps/web/src/lib/auth/accountLifecycleDiscord.test.ts
+++ b/apps/web/src/lib/auth/accountLifecycleDiscord.test.ts
@@ -1,0 +1,116 @@
+import {
+	buildAccountLifecycleDiscordPayload,
+	maskEmailForWebhook,
+	resolveAccountLifecycleDiscordWebhookUrl,
+	sendAccountLifecycleDiscordWebhook,
+} from "./accountLifecycleDiscord";
+
+describe("account lifecycle Discord webhook helpers", () => {
+	const originalSignupWebhookUrl = process.env.DISCORD_SIGNUP_WEBHOOK_URL;
+
+	afterEach(() => {
+		if (originalSignupWebhookUrl === undefined) {
+			delete process.env.DISCORD_SIGNUP_WEBHOOK_URL;
+		} else {
+			process.env.DISCORD_SIGNUP_WEBHOOK_URL = originalSignupWebhookUrl;
+		}
+
+		jest.restoreAllMocks();
+	});
+
+	it("masks the local part of an email for webhook payloads", () => {
+		expect(maskEmailForWebhook("daniel@example.com")).toBe("d*****@example.com");
+		expect(maskEmailForWebhook(null)).toBe("unknown");
+	});
+
+	it("reads the signup webhook env var for lifecycle notifications", () => {
+		process.env.DISCORD_SIGNUP_WEBHOOK_URL = "https://discord.example/signup";
+
+		expect(resolveAccountLifecycleDiscordWebhookUrl()).toBe(
+			"https://discord.example/signup",
+		);
+	});
+
+	it("builds a deletion payload with masked email and deletion timestamp", () => {
+		expect(
+			buildAccountLifecycleDiscordPayload({
+				event: "account_deleted",
+				userId: "user_123",
+				email: "daniel@example.com",
+				timestampIso: "2026-06-05T12:00:00.000Z",
+			}),
+		).toEqual({
+			content: [
+				"AI Stats account deleted",
+				"- event: `account_deleted`",
+				"- user_id: `user_123`",
+				"- email: `d*****@example.com`",
+				"- deleted_at: `2026-06-05T12:00:00.000Z`",
+			].join("\n"),
+			allowed_mentions: { parse: [] },
+		});
+	});
+
+	it("sends lifecycle notifications through the signup webhook env var", async () => {
+		process.env.DISCORD_SIGNUP_WEBHOOK_URL = "https://discord.example/signup";
+
+		const fetchImpl = jest.fn().mockResolvedValue({
+			ok: true,
+			status: 204,
+			statusText: "No Content",
+			text: async () => "",
+		});
+
+		await expect(
+			sendAccountLifecycleDiscordWebhook(
+				{
+					event: "account_deleted",
+					userId: "user_123",
+					email: "daniel@example.com",
+					timestampIso: "2026-06-05T12:00:00.000Z",
+				},
+				{ fetchImpl },
+			),
+		).resolves.toBe(true);
+
+		expect(fetchImpl).toHaveBeenCalledWith(
+			"https://discord.example/signup",
+			expect.objectContaining({
+				method: "POST",
+				headers: {
+					"Content-Type": "application/json",
+				},
+				body: JSON.stringify({
+					content: [
+						"AI Stats account deleted",
+						"- event: `account_deleted`",
+						"- user_id: `user_123`",
+						"- email: `d*****@example.com`",
+						"- deleted_at: `2026-06-05T12:00:00.000Z`",
+					].join("\n"),
+					allowed_mentions: { parse: [] },
+				}),
+			}),
+		);
+	});
+
+	it("returns false without calling fetch when no lifecycle webhook is configured", async () => {
+		delete process.env.DISCORD_SIGNUP_WEBHOOK_URL;
+
+		const fetchImpl = jest.fn();
+
+		await expect(
+			sendAccountLifecycleDiscordWebhook(
+				{
+					event: "signup",
+					userId: "user_123",
+					email: "daniel@example.com",
+					timestampIso: "2026-06-05T12:00:00.000Z",
+				},
+				{ fetchImpl },
+			),
+		).resolves.toBe(false);
+
+		expect(fetchImpl).not.toHaveBeenCalled();
+	});
+});

--- a/apps/web/src/lib/auth/accountLifecycleDiscord.ts
+++ b/apps/web/src/lib/auth/accountLifecycleDiscord.ts
@@ -1,0 +1,96 @@
+export type AccountLifecycleDiscordEvent = "signup" | "account_deleted";
+
+type AccountLifecycleDiscordPayload = {
+	content: string;
+	allowed_mentions: {
+		parse: string[];
+	};
+};
+
+const EVENT_METADATA: Record<
+	AccountLifecycleDiscordEvent,
+	{ title: string; timestampLabel: string }
+> = {
+	signup: {
+		title: "New AI Stats signup",
+		timestampLabel: "created_at",
+	},
+	account_deleted: {
+		title: "AI Stats account deleted",
+		timestampLabel: "deleted_at",
+	},
+};
+
+export function maskEmailForWebhook(email: string | null): string {
+	if (!email) return "unknown";
+	const atIndex = email.indexOf("@");
+	if (atIndex <= 0 || atIndex === email.length - 1) return "unknown";
+	const localPart = email.slice(0, atIndex);
+	const domain = email.slice(atIndex + 1);
+	const maskedLocal = `${localPart[0]}${"*".repeat(
+		Math.max(1, localPart.length - 1),
+	)}`;
+	return `${maskedLocal}@${domain}`;
+}
+
+export function resolveAccountLifecycleDiscordWebhookUrl(
+	env: NodeJS.ProcessEnv = process.env,
+): string {
+	return String(env.DISCORD_SIGNUP_WEBHOOK_URL ?? "").trim();
+}
+
+export function buildAccountLifecycleDiscordPayload(args: {
+	event: AccountLifecycleDiscordEvent;
+	userId: string;
+	email: string | null;
+	timestampIso: string;
+}): AccountLifecycleDiscordPayload {
+	const eventMetadata = EVENT_METADATA[args.event];
+
+	return {
+		content: [
+			eventMetadata.title,
+			`- event: \`${args.event}\``,
+			`- user_id: \`${args.userId}\``,
+			`- email: \`${maskEmailForWebhook(args.email)}\``,
+			`- ${eventMetadata.timestampLabel}: \`${args.timestampIso}\``,
+		].join("\n"),
+		allowed_mentions: { parse: [] },
+	};
+}
+
+export async function sendAccountLifecycleDiscordWebhook(
+	args: {
+		event: AccountLifecycleDiscordEvent;
+		userId: string;
+		email: string | null;
+		timestampIso: string;
+	},
+	options?: {
+		env?: NodeJS.ProcessEnv;
+		fetchImpl?: typeof fetch;
+	},
+): Promise<boolean> {
+	const webhookUrl = resolveAccountLifecycleDiscordWebhookUrl(options?.env);
+	if (!webhookUrl) return false;
+
+	const fetchImpl = options?.fetchImpl ?? fetch;
+	const payload = buildAccountLifecycleDiscordPayload(args);
+
+	const res = await fetchImpl(webhookUrl, {
+		method: "POST",
+		headers: {
+			"Content-Type": "application/json",
+		},
+		body: JSON.stringify(payload),
+	});
+
+	if (!res.ok) {
+		const detail = await res.text().catch(() => "");
+		throw new Error(
+			`discord_webhook_error:${res.status}:${detail || res.statusText}`,
+		);
+	}
+
+	return true;
+}

--- a/apps/web/src/lib/auth/post-login.ts
+++ b/apps/web/src/lib/auth/post-login.ts
@@ -3,6 +3,7 @@ import { Resend } from "resend";
 import { createAdminClient } from "@/utils/supabase/admin";
 import { classifyAuthMethodFromSession } from "@/lib/auth/method";
 import { evaluateTeamSsoEnforcementNoop } from "@/lib/auth/ssoEnforcement";
+import { sendAccountLifecycleDiscordWebhook } from "@/lib/auth/accountLifecycleDiscord";
 import {
 	isResendOnboardingAutomationsEnabled,
 	sendUserCreatedEvent,
@@ -47,18 +48,6 @@ function deriveFirstName(name: string): string {
 	const trimmed = name.trim();
 	if (!trimmed) return "";
 	return trimmed.split(/\s+/)[0] ?? "";
-}
-
-function maskEmailForWebhook(email: string | null): string {
-	if (!email) return "unknown";
-	const atIndex = email.indexOf("@");
-	if (atIndex <= 0 || atIndex === email.length - 1) return "unknown";
-	const localPart = email.slice(0, atIndex);
-	const domain = email.slice(atIndex + 1);
-	const maskedLocal = `${localPart[0]}${"*".repeat(
-		Math.max(1, localPart.length - 1),
-	)}`;
-	return `${maskedLocal}@${domain}`;
 }
 
 async function sendSignupWelcomeEmail(args: {
@@ -166,33 +155,12 @@ async function sendSignupDiscordWebhook(args: {
 	email: string | null;
 	createdAtIso: string;
 }) {
-	const webhookUrl = String(process.env.DISCORD_SIGNUP_WEBHOOK_URL ?? "").trim();
-	if (!webhookUrl) return;
-
-	const maskedEmail = maskEmailForWebhook(args.email);
-
-	const res = await fetch(webhookUrl, {
-		method: "POST",
-		headers: {
-			"Content-Type": "application/json",
-		},
-		body: JSON.stringify({
-			content: [
-				"New AI Stats signup",
-				`- user_id: \`${args.userId}\``,
-				`- email: \`${maskedEmail}\``,
-				`- created_at: \`${args.createdAtIso}\``,
-			].join("\n"),
-			allowed_mentions: { parse: [] },
-		}),
+	await sendAccountLifecycleDiscordWebhook({
+		event: "signup",
+		userId: args.userId,
+		email: args.email,
+		timestampIso: args.createdAtIso,
 	});
-
-	if (!res.ok) {
-		const detail = await res.text().catch(() => "");
-		throw new Error(
-			`discord_webhook_error:${res.status}:${detail || res.statusText}`,
-		);
-	}
 }
 
 async function ensureWalletRow(


### PR DESCRIPTION
## Summary
- send account deletion Discord notifications through the existing signup webhook channel
- extract shared account lifecycle Discord webhook logic for signup and deletion events
- cover the shared helper with focused unit tests for masking, payload shape, and no-webhook behavior

## Why
Issue #608 asked for account deletion notifications to mirror the existing signup Discord notification pattern. The delete-account flow previously removed the auth user without emitting any matching operational webhook.

## Impact
- account deletions now post a non-blocking Discord notification with masked email, user id, and deletion timestamp
- signup notifications continue to use the same webhook env var and delivery safety settings
- the shared helper keeps the lifecycle message formatting consistent across both events

## Validation
- `pnpm --filter @ai-stats/web test -- --runTestsByPath src/lib/auth/accountLifecycleDiscord.test.ts`
- `pnpm --filter @ai-stats/web typecheck`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Consolidated account lifecycle event tracking to use a unified webhook system for monitoring account operations including signup and deletion.

* **Tests**
  * Added comprehensive test coverage for account lifecycle webhook functionality, including event payload validation and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->