### PR TITLE
[codex] Fix Watchers Supabase WebSocket transport

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -140,6 +140,7 @@
 		"tokenlens": "^1.3.1",
 		"use-stick-to-bottom": "^1.1.3",
 		"vaul": "^1.1.2",
+		"ws": "^8.21.0",
 		"zod": "^4.4.3"
 	},
 	"devDependencies": {

--- a/apps/web/src/utils/supabase/admin.ts
+++ b/apps/web/src/utils/supabase/admin.ts
@@ -1,5 +1,6 @@
 // utils/supabase/admin.ts
 import { createClient } from '@supabase/supabase-js'
+import NodeWebSocket from 'ws'
 
 const DEFAULT_FETCH_RETRIES = Number(process.env.SUPABASE_FETCH_RETRIES ?? "3");
 const DEFAULT_FETCH_TIMEOUT_MS = Number(process.env.SUPABASE_FETCH_TIMEOUT_MS ?? "20000");
@@ -68,8 +69,17 @@ export function createAdminClient() {
     if (!key) {
         throw new Error("Missing SUPABASE_SERVICE_ROLE_KEY for admin Supabase client");
     }
+    const realtime =
+        typeof process !== "undefined" &&
+        Boolean(process.versions?.node) &&
+        typeof NodeWebSocket !== "undefined" &&
+        typeof globalThis.WebSocket === "undefined"
+            ? { transport: NodeWebSocket }
+            : undefined;
+
     return createClient(url, key, {
         auth: { persistSession: false, autoRefreshToken: false },
         global: { fetch: fetchWithRetry },
+        realtime,
     })
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -476,6 +476,9 @@ importers:
       vaul:
         specifier: ^1.1.2
         version: 1.1.2(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      ws:
+        specifier: ^8.21.0
+        version: 8.21.0
       zod:
         specifier: ^4.4.3
         version: 4.4.3
@@ -18335,7 +18338,7 @@ snapshots:
       eslint: 10.4.0(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.10
       eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(eslint@10.4.0(jiti@2.6.1)))(eslint@10.4.0(jiti@2.6.1))
-      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@10.4.0(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@10.4.0(jiti@2.6.1)))(eslint@10.4.0(jiti@2.6.1)))(eslint@10.4.0(jiti@2.6.1))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@10.4.0(jiti@2.6.1))
       eslint-plugin-react: 7.37.5(eslint@10.4.0(jiti@2.6.1))
       eslint-plugin-react-hooks: 7.1.1(eslint@10.4.0(jiti@2.6.1))
@@ -18372,7 +18375,7 @@ snapshots:
       tinyglobby: 0.2.16
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@10.4.0(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@10.4.0(jiti@2.6.1)))(eslint@10.4.0(jiti@2.6.1)))(eslint@10.4.0(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
@@ -18386,7 +18389,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@10.4.0(jiti@2.6.1)):
+  eslint-plugin-import@2.32.0(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@10.4.0(jiti@2.6.1)))(eslint@10.4.0(jiti@2.6.1)))(eslint@10.4.0(jiti@2.6.1)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9


### PR DESCRIPTION
## Summary
- fix the Watchers workflow failure caused by Supabase Realtime initialization under Node 20
- provide `ws` as the Realtime transport for the admin Supabase client when native `WebSocket` is unavailable
- add `ws` as a direct `@ai-stats/web` dependency and update the lockfile

## Root cause
The scheduled `Watchers` workflow was failing before any watcher logic ran. `createAdminClient()` now initializes a Supabase client path that expects a WebSocket transport for Realtime. On GitHub Actions' Node 20 runtime, `globalThis.WebSocket` is not available natively, so both watcher jobs exited during client construction.

## Validation
- `pnpm --filter @ai-stats/web exec eslint src/utils/supabase/admin.ts`
- `pnpm --filter @ai-stats/web exec tsx -e "import { createAdminClient } from './src/utils/supabase/admin.ts'; globalThis.WebSocket = undefined as any; process.env.NEXT_PUBLIC_SUPABASE_URL='https://example.supabase.co'; process.env.SUPABASE_SERVICE_ROLE_KEY='test-service-role-key'; createAdminClient(); console.log('admin client ok without native websocket');"`
- `pnpm --filter @ai-stats/web typecheck` (currently blocked by a pre-existing generated-file parse failure in `apps/web/.next/dev/types/validator.ts`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Added WebSocket support to enhance real-time data synchronization capabilities across the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->