### PR TITLE
Add model page notices

### DIFF
--- a/apps/web/src/components/(data)/model/ModelDescriptionPanel.tsx
+++ b/apps/web/src/components/(data)/model/ModelDescriptionPanel.tsx
@@ -1,95 +1,16 @@
 "use client";
 
-import Link from "next/link";
 import { useMemo, useState } from "react";
-import type { Components } from "react-markdown";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import { Button } from "@/components/ui/button";
 import { markdownToPlainText } from "@/lib/models/modelDescription";
 import { cn } from "@/lib/utils";
+import { modelMarkdownComponents } from "./modelMarkdown";
 
 interface ModelDescriptionPanelProps {
 	description: string;
 }
-
-const KNOWN_INTERNAL_ROOTS = new Set([
-	"about",
-	"announcements",
-	"api-providers",
-	"benchmarks",
-	"chat",
-	"compare",
-	"contact",
-	"docs",
-	"families",
-	"gateway",
-	"help",
-	"models",
-	"organisations",
-	"pricing",
-	"providers",
-	"subscription-plans",
-]);
-
-function normalizeDescriptionHref(href: string | undefined): string | undefined {
-	if (!href) return href;
-	if (href.startsWith("#") || href.startsWith("//") || /^[a-z][a-z0-9+.-]*:/i.test(href)) {
-		return href;
-	}
-	if (!href.startsWith("/")) {
-		return href;
-	}
-
-	const segments = href.split("/").filter(Boolean);
-	if (segments.length >= 2 && !KNOWN_INTERNAL_ROOTS.has(segments[0]!)) {
-		return `/models${href}`;
-	}
-
-	return href;
-}
-
-const markdownComponents: Components = {
-	p: ({ node: _node, ...props }) => <span {...props} />,
-	a: ({ node: _node, href, children, ...props }) => {
-		const normalizedHref = normalizeDescriptionHref(href);
-		const className =
-			"font-medium text-foreground underline decoration-muted-foreground/40 underline-offset-4 transition-colors hover:text-primary hover:decoration-primary";
-		const isExternal =
-			typeof normalizedHref === "string" &&
-			(/^[a-z][a-z0-9+.-]*:/i.test(normalizedHref) || normalizedHref.startsWith("//"));
-
-		if (typeof normalizedHref === "string" && normalizedHref.startsWith("/")) {
-			return (
-				<Link href={normalizedHref} className={className}>
-					{children}
-				</Link>
-			);
-		}
-
-		return (
-			<a
-				{...props}
-				href={normalizedHref}
-				className={className}
-				target={isExternal ? "_blank" : undefined}
-				rel={isExternal ? "noreferrer noopener" : undefined}
-			>
-				{children}
-			</a>
-		);
-	},
-	code: ({ node: _node, ...props }) => (
-		<code
-			{...props}
-			className="rounded bg-muted px-1 py-0.5 text-[0.85em] text-foreground"
-		/>
-	),
-	strong: ({ node: _node, ...props }) => (
-		<strong {...props} className="font-semibold text-foreground" />
-	),
-	em: ({ node: _node, ...props }) => <em {...props} className="italic" />,
-};
 
 export default function ModelDescriptionPanel({
 	description,
@@ -112,7 +33,10 @@ export default function ModelDescriptionPanel({
 					canExpand && !expanded ? "line-clamp-4" : null,
 				)}
 			>
-				<ReactMarkdown remarkPlugins={[remarkGfm]} components={markdownComponents}>
+				<ReactMarkdown
+					remarkPlugins={[remarkGfm]}
+					components={modelMarkdownComponents}
+				>
 					{description}
 				</ReactMarkdown>
 			</div>

--- a/apps/web/src/components/(data)/model/ModelDetailShell.tsx
+++ b/apps/web/src/components/(data)/model/ModelDetailShell.tsx
@@ -13,6 +13,8 @@ import { redirect } from "next/navigation";
 import { Skeleton } from "@/components/ui/skeleton";
 import ModelIdentifierControl from "./ModelIdentifierControl";
 import ModelDescriptionPanel from "./ModelDescriptionPanel";
+import ModelPageNotice from "./ModelPageNotice";
+import { getModelPageNotice } from "@/lib/fetchers/models/getModelPageNotice";
 import { resolveModelDescription } from "@/lib/models/modelDescription";
 import {
 	FREE_ROUTER_DESCRIPTION,
@@ -64,7 +66,7 @@ export default async function ModelDetailShell({
 	includeHidden = false,
 }: ModelDetailShellProps) {
 	const isFreeRouter = isFreeRouterModelId(modelId);
-	const [header, modelOverview] = isFreeRouter
+	const [header, modelOverview, modelPageNotice] = isFreeRouter
 		? [
 				{
 					model_id: FREE_ROUTER_MODEL_ID,
@@ -79,6 +81,7 @@ export default async function ModelDetailShell({
 					hidden: false,
 				},
 				null,
+				null,
 			]
 		: await Promise.all([
 				getModelOverviewHeader(modelId, includeHidden).catch((error) => {
@@ -88,6 +91,7 @@ export default async function ModelDetailShell({
 					throw error;
 				}),
 				getModelOverviewCached(modelId, includeHidden).catch(() => null),
+				getModelPageNotice(modelId, includeHidden).catch(() => null),
 			]);
 
 	if (!header) {
@@ -110,6 +114,12 @@ export default async function ModelDetailShell({
 	return (
 		<main className="flex flex-col">
 			<div className="container mx-auto px-4 py-8">
+				{modelPageNotice ? (
+					<div className="mb-6">
+						<ModelPageNotice notice={modelPageNotice} />
+					</div>
+				) : null}
+
 				<div className="mb-8 flex w-full flex-col gap-4 md:flex-row md:items-start md:justify-between">
 					<div className="flex w-full items-start gap-4">
 						<div className="flex shrink-0 items-center justify-center">

--- a/apps/web/src/components/(data)/model/ModelPageNotice.tsx
+++ b/apps/web/src/components/(data)/model/ModelPageNotice.tsx
@@ -1,0 +1,68 @@
+"use client";
+
+import ReactMarkdown from "react-markdown";
+import remarkGfm from "remark-gfm";
+import { AlertCircle, AlertTriangle, Info } from "lucide-react";
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import type { ModelPageNotice as ModelPageNoticeData } from "@/lib/fetchers/models/getModelPageNotice";
+import { modelMarkdownComponents } from "./modelMarkdown";
+
+const TONE_STYLES: Record<
+	ModelPageNoticeData["tone"],
+	{
+		icon: typeof Info;
+		className: string;
+		descriptionClassName: string;
+	}
+> = {
+	info: {
+		icon: Info,
+		className:
+			"border-sky-200 bg-sky-50 text-sky-950 dark:border-sky-900/60 dark:bg-sky-950/20 dark:text-sky-50",
+		descriptionClassName: "text-sky-900/90 dark:text-sky-100/90",
+	},
+	warning: {
+		icon: AlertTriangle,
+		className:
+			"border-amber-200 bg-amber-50 text-amber-950 dark:border-amber-900/60 dark:bg-amber-900/20 dark:text-amber-50",
+		descriptionClassName: "text-amber-900/90 dark:text-amber-100/90",
+	},
+	critical: {
+		icon: AlertCircle,
+		className:
+			"border-red-200 bg-red-50 text-red-950 dark:border-red-900/60 dark:bg-red-950/20 dark:text-red-50",
+		descriptionClassName: "text-red-900/90 dark:text-red-100/90",
+	},
+};
+
+export default function ModelPageNotice({
+	notice,
+}: {
+	notice: ModelPageNoticeData;
+}) {
+	const style = TONE_STYLES[notice.tone];
+	const Icon = style.icon;
+
+	return (
+		<Alert className={style.className}>
+			<Icon className="h-4 w-4" />
+			<AlertDescription className={style.descriptionClassName}>
+				<div
+					className="
+						text-sm leading-6
+						[&_ol]:list-decimal [&_ol]:pl-5
+						[&_ul]:list-disc [&_ul]:pl-5
+						[&_li]:my-1
+					"
+				>
+					<ReactMarkdown
+						remarkPlugins={[remarkGfm]}
+						components={modelMarkdownComponents}
+					>
+						{notice.markdown}
+					</ReactMarkdown>
+				</div>
+			</AlertDescription>
+		</Alert>
+	);
+}

--- a/apps/web/src/components/(data)/model/modelMarkdown.tsx
+++ b/apps/web/src/components/(data)/model/modelMarkdown.tsx
@@ -1,0 +1,87 @@
+import Link from "next/link";
+import type { Components } from "react-markdown";
+
+const KNOWN_INTERNAL_ROOTS = new Set([
+	"about",
+	"announcements",
+	"api-providers",
+	"benchmarks",
+	"chat",
+	"compare",
+	"contact",
+	"docs",
+	"families",
+	"gateway",
+	"help",
+	"models",
+	"organisations",
+	"pricing",
+	"providers",
+	"subscription-plans",
+]);
+
+export function normalizeModelMarkdownHref(
+	href: string | undefined,
+): string | undefined {
+	if (!href) return href;
+	if (
+		href.startsWith("#") ||
+		href.startsWith("//") ||
+		/^[a-z][a-z0-9+.-]*:/i.test(href)
+	) {
+		return href;
+	}
+	if (!href.startsWith("/")) {
+		return href;
+	}
+
+	const segments = href.split("/").filter(Boolean);
+	if (segments.length >= 2 && !KNOWN_INTERNAL_ROOTS.has(segments[0]!)) {
+		return `/models${href}`;
+	}
+
+	return href;
+}
+
+export const modelMarkdownComponents: Components = {
+	p: ({ node: _node, ...props }) => <span {...props} />,
+	a: ({ node: _node, href, children, ...props }) => {
+		const normalizedHref = normalizeModelMarkdownHref(href);
+		const className =
+			"font-medium text-foreground underline decoration-muted-foreground/40 underline-offset-4 transition-colors hover:text-primary hover:decoration-primary";
+		const isExternal =
+			typeof normalizedHref === "string" &&
+			(/^[a-z][a-z0-9+.-]*:/i.test(normalizedHref) ||
+				normalizedHref.startsWith("//"));
+
+		if (typeof normalizedHref === "string" && normalizedHref.startsWith("/")) {
+			return (
+				<Link href={normalizedHref} className={className}>
+					{children}
+				</Link>
+			);
+		}
+
+		return (
+			<a
+				{...props}
+				href={normalizedHref}
+				className={className}
+				target={isExternal ? "_blank" : undefined}
+				rel={isExternal ? "noreferrer noopener" : undefined}
+			>
+				{children}
+			</a>
+		);
+	},
+	code: ({ node: _node, ...props }) => (
+		<code
+			{...props}
+			className="rounded bg-muted px-1 py-0.5 text-[0.85em] text-foreground"
+		/>
+	),
+	strong: ({ node: _node, ...props }) => (
+		<strong {...props} className="font-semibold text-foreground" />
+	),
+	em: ({ node: _node, ...props }) => <em {...props} className="italic" />,
+};

--- a/apps/web/src/lib/fetchers/models/getModelPageNotice.test.ts
+++ b/apps/web/src/lib/fetchers/models/getModelPageNotice.test.ts
@@ -1,0 +1,37 @@
+import { parseModelPageNoticeRow } from "./getModelPageNotice";
+
+describe("parseModelPageNoticeRow", () => {
+	it("parses a valid notice row", () => {
+		expect(
+			parseModelPageNoticeRow({
+				api_model_id: "openai/gpt-5",
+				tone: "warning",
+				markdown: "This **model** has limited availability.",
+			}),
+		).toEqual({
+			apiModelId: "openai/gpt-5",
+			tone: "warning",
+			markdown: "This **model** has limited availability.",
+		});
+	});
+
+	it("trims the markdown and rejects empty values", () => {
+		expect(
+			parseModelPageNoticeRow({
+				api_model_id: "openai/gpt-5",
+				tone: "info",
+				markdown: "   ",
+			}),
+		).toBeNull();
+	});
+
+	it("rejects invalid tone values", () => {
+		expect(
+			parseModelPageNoticeRow({
+				api_model_id: "openai/gpt-5",
+				tone: "notice",
+				markdown: "Heads up",
+			}),
+		).toBeNull();
+	});
+});

--- a/apps/web/src/lib/fetchers/models/getModelPageNotice.ts
+++ b/apps/web/src/lib/fetchers/models/getModelPageNotice.ts
@@ -145,16 +145,5 @@ export async function getModelPageNotice(
 	modelId: string,
 	includeHidden: boolean,
 ): Promise<ModelPageNotice | null> {
-	"use cache";
-
-	cacheLife({
-		stale: 60 * 60 * 24,
-		revalidate: 60 * 60 * 24 * 7,
-		expire: 60 * 60 * 24 * 30,
-	});
-
-	cacheTag("data:data_api_model_page_notices");
-	cacheTag(`model:notice:${modelId}`);
-
 	return getModelPageNoticeUncached(modelId, includeHidden);
 }

--- a/apps/web/src/lib/fetchers/models/getModelPageNotice.ts
+++ b/apps/web/src/lib/fetchers/models/getModelPageNotice.ts
@@ -1,0 +1,160 @@
+import { cacheLife, cacheTag } from "next/cache";
+import { z } from "zod";
+import { isFreeRouterModelId } from "@/lib/models/freeRouter";
+import { createClient } from "@/utils/supabase/client";
+import { applyHiddenFilter } from "./visibility";
+
+export type ModelPageNoticeTone = "info" | "warning" | "critical";
+
+export type ModelPageNotice = {
+	apiModelId: string;
+	tone: ModelPageNoticeTone;
+	markdown: string;
+};
+
+const modelPageNoticeSchema = z.object({
+	apiModelId: z.string().min(1),
+	tone: z.enum(["info", "warning", "critical"]),
+	markdown: z.string().min(1),
+});
+
+function isMissingRelationError(error: unknown): boolean {
+	const text = String((error as { message?: unknown })?.message ?? "").toLowerCase();
+	return (
+		text.includes("does not exist") ||
+		text.includes("could not find table") ||
+		text.includes("relation") ||
+		text.includes("schema cache")
+	);
+}
+
+function normalizeId(value: unknown): string | null {
+	const normalized = String(value ?? "").trim();
+	return normalized.length > 0 ? normalized : null;
+}
+
+function normalizeMarkdown(value: unknown): string | null {
+	const normalized = String(value ?? "").trim();
+	return normalized.length > 0 ? normalized : null;
+}
+
+export function parseModelPageNoticeRow(row: {
+	api_model_id?: unknown;
+	tone?: unknown;
+	markdown?: unknown;
+} | null | undefined): ModelPageNotice | null {
+	const parsed = modelPageNoticeSchema.safeParse({
+		apiModelId: normalizeId(row?.api_model_id),
+		tone: normalizeId(row?.tone),
+		markdown: normalizeMarkdown(row?.markdown),
+	});
+
+	if (!parsed.success) {
+		return null;
+	}
+
+	return parsed.data;
+}
+
+async function resolveApiModelIdForModelPageUncached(
+	modelId: string,
+	includeHidden: boolean,
+): Promise<string | null> {
+	if (isFreeRouterModelId(modelId)) return null;
+
+	const supabase = await createClient();
+	const [apiModelRes, aliasRes, internalRes, providerRes] = await Promise.all([
+		supabase
+			.from("data_api_models")
+			.select("api_model_id")
+			.eq("api_model_id", modelId)
+			.maybeSingle(),
+		supabase
+			.from("data_api_model_aliases")
+			.select("api_model_id")
+			.eq("alias_slug", modelId)
+			.eq("is_enabled", true)
+			.maybeSingle(),
+		applyHiddenFilter(
+			supabase.from("data_models").select("api_model_id"),
+			includeHidden,
+		)
+			.eq("model_id", modelId)
+			.maybeSingle(),
+		supabase
+			.from("data_api_provider_models")
+			.select("api_model_id")
+			.eq("model_id", modelId)
+			.not("api_model_id", "is", null)
+			.limit(1),
+	]);
+
+	return (
+		normalizeId(apiModelRes.data?.api_model_id) ??
+		normalizeId(aliasRes.data?.api_model_id) ??
+		normalizeId(internalRes.data?.api_model_id) ??
+		normalizeId(providerRes.data?.[0]?.api_model_id) ??
+		null
+	);
+}
+
+async function resolveApiModelIdForModelPage(
+	modelId: string,
+	includeHidden: boolean,
+): Promise<string | null> {
+	"use cache";
+
+	cacheLife({
+		stale: 60 * 60 * 24,
+		revalidate: 60 * 60 * 24 * 7,
+		expire: 60 * 60 * 24 * 30,
+	});
+
+	cacheTag("data:models");
+	cacheTag("data:data_api_models");
+	cacheTag("data:data_api_provider_models");
+	cacheTag("data:model_aliases");
+	cacheTag(`model:notice:resolve:${modelId}`);
+
+	return resolveApiModelIdForModelPageUncached(modelId, includeHidden);
+}
+
+async function getModelPageNoticeUncached(
+	modelId: string,
+	includeHidden: boolean,
+): Promise<ModelPageNotice | null> {
+	const apiModelId = await resolveApiModelIdForModelPage(modelId, includeHidden);
+	if (!apiModelId) return null;
+
+	const supabase = await createClient();
+	const { data, error } = await supabase
+		.from("data_api_model_page_notices")
+		.select("api_model_id, tone, markdown")
+		.eq("api_model_id", apiModelId)
+		.maybeSingle();
+
+	if (error) {
+		if (isMissingRelationError(error)) return null;
+		throw new Error(error.message || "Failed to fetch model page notice");
+	}
+
+	return parseModelPageNoticeRow(data);
+}
+
+export async function getModelPageNotice(
+	modelId: string,
+	includeHidden: boolean,
+): Promise<ModelPageNotice | null> {
+	"use cache";
+
+	cacheLife({
+		stale: 60 * 60 * 24,
+		revalidate: 60 * 60 * 24 * 7,
+		expire: 60 * 60 * 24 * 30,
+	});
+
+	cacheTag("data:data_api_model_page_notices");
+	cacheTag(`model:notice:${modelId}`);
+
+	return getModelPageNoticeUncached(modelId, includeHidden);
+}

--- a/supabase/migrations/20260606113000_add_data_api_model_page_notices.sql
+++ b/supabase/migrations/20260606113000_add_data_api_model_page_notices.sql
@@ -1,0 +1,22 @@
+create table if not exists public.data_api_model_page_notices (
+  api_model_id text primary key
+    check (length(trim(api_model_id)) > 0),
+  tone text not null
+    check (tone in ('info', 'warning', 'critical')),
+  markdown text not null
+    check (length(trim(markdown)) > 0),
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+alter table public.data_api_model_page_notices enable row level security;
+
+drop policy if exists "Public can read model page notices" on public.data_api_model_page_notices;
+create policy "Public can read model page notices"
+on public.data_api_model_page_notices
+for select
+to anon, authenticated
+using (true);
+
+grant select on public.data_api_model_page_notices to anon, authenticated;
+grant all on public.data_api_model_page_notices to service_role;


### PR DESCRIPTION
## Summary

This PR adds model page notices backed by a dedicated Supabase sidecar table keyed by API model ID.

Users can now attach a tone-based notice to a model page and have it render above the model header using the same markdown formatting conventions as the model description.

Closes #547.

## What changed

- added `public.data_api_model_page_notices` via `supabase/migrations/20260606113000_add_data_api_model_page_notices.sql`
- enabled RLS and added a public read policy for the notice table
- added `getModelPageNotice(...)` to resolve the page's API model identity and fetch a validated notice payload
- rendered the notice at the top of `ModelDetailShell`
- added a dedicated `ModelPageNotice` component with `info`, `warning`, and `critical` styles
- extracted shared markdown link/code rendering into `modelMarkdown.tsx`
- updated `ModelDescriptionPanel` to reuse the shared markdown renderer
- fixed markdown list styling so notice bullet points render correctly

## Data model note

The initial implementation idea used a foreign key to `data_api_models`, but the linked database in this workspace does not currently expose that table. The migration was adjusted to keep `api_model_id` as a validated text primary key instead, while still enforcing the notice shape and public-read access pattern needed by the app.

## Validation

- `pnpm --filter @ai-stats/web test -- --runTestsByPath src/lib/fetchers/models/getModelPageNotice.test.ts`
- `pnpm --filter @ai-stats/web typecheck`
- manual browser verification of `info`, `warning`, and `critical` notice tones on a live model page

## Follow-up

Notice fetches are intentionally cached. During the browser demo, tone/content changes required a dev-server restart to clear cached notice payloads, so a likely follow-up is adding write-side cache invalidation when notices are edited.
