### PR TITLE
[codex] fix docs links and watcher runtime

### DIFF
--- a/.github/workflows/watchers.yml
+++ b/.github/workflows/watchers.yml
@@ -34,10 +34,10 @@ jobs:
               with:
                   version: 10.33.0
                   run_install: false
-            - name: Setup Node 20
+            - name: Setup Node 22
               uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
               with:
-                  node-version: "20"
+                  node-version: "22"
 
             - name: Restore lockfile (guard setup-node cache mutation)
               run: git checkout -- pnpm-lock.yaml

--- a/apps/docs/v1/api-reference/authentication.mdx
+++ b/apps/docs/v1/api-reference/authentication.mdx
@@ -45,7 +45,7 @@ Use them for elevated administration endpoints such as [Credits](./endpoint/cred
 
 ## Related pages
 
-- [Limits](./limits)
+- [Limits](./limits.mdx)
 - [Errors and Debugging](./errors)
 
 <Visibility for="agents">

--- a/apps/docs/v1/api-reference/errors.mdx
+++ b/apps/docs/v1/api-reference/errors.mdx
@@ -255,14 +255,14 @@ if (error.error === "rate_limit_error") {
 	<Card
 		title="Limits"
 		icon="gauge"
-		href="./limits"
+		href="./limits.mdx"
 	>
 		Handle provider-driven throttling and retries.
 	</Card>
 	<Card
 		title="Streaming"
 		icon="radio"
-		href="./streaming"
+		href="./streaming.mdx"
 	>
 		Use SSE safely in production flows.
 	</Card>

--- a/apps/docs/v1/api-reference/parameters.mdx
+++ b/apps/docs/v1/api-reference/parameters.mdx
@@ -54,8 +54,8 @@ Parameter support still varies by endpoint, model, and provider. The model quick
 
 `service_tier` is supported on the main text request surfaces:
 
-- [Anthropic Messages](/v1/api-reference/endpoint/anthropic-messages)
-- [Chat Completions](/v1/api-reference/endpoint/chat-completions)
+- [Anthropic Messages](./endpoint/anthropic-messages.mdx)
+- [Chat Completions](./endpoint/chat-completions.mdx)
 - [Responses](/v1/api-reference/endpoint/responses)
 
 Use `priority` or `flex` only when the selected model and provider combination supports them. `standard` is the default when `service_tier` is omitted.
@@ -561,8 +561,8 @@ If you want the deeper "how should I tune this?" guidance rather than the raw fi
 
 - [Inference Parameters](/v1/guides/inference-parameters)
 - [Sampling and Decoding](/v1/guides/sampling-and-decoding)
-- [Streaming](/v1/api-reference/streaming)
-- [Limits](/v1/api-reference/limits)
+- [Streaming](./streaming.mdx)
+- [Limits](./limits.mdx)
 - [Errors and Debugging](/v1/api-reference/errors)
 
 <Visibility for="agents">


### PR DESCRIPTION
## What changed

- fixed the pre-existing broken API reference links in the docs pages for authentication, errors, and parameters
- updated the scheduled `Watchers` workflow from Node 20 to Node 22

## Why

`pnpm docs:links` was failing on broken references in untouched API reference pages.

The scheduled watcher workflow was failing before either watcher could run. The current `@supabase/supabase-js` stack initializes Realtime during `createClient()`, and on Node 20 the workflow fails because native `WebSocket` support is not available. This PR fixes that by moving the workflow runtime to Node 22 instead of reintroducing `ws`.

## Impact

- docs link validation should stop failing on those API reference pages
- scheduled watcher runs should be able to construct the Supabase admin client again without the Node 20 WebSocket failure
- no `ws` dependency is reintroduced into the app codepath

## Validation

- `pnpm docs:links`
- `pnpm docs:build`
