### PR TITLE
Update DeepSWE leaderboard for MiniMax M3

### DIFF
--- a/packages/data/catalog/src/data/benchmarks/deepswe/benchmark.json
+++ b/packages/data/catalog/src/data/benchmarks/deepswe/benchmark.json
@@ -5,5 +5,5 @@
   "ascending_order": null,
   "type": "percentage",
   "link": "https://deepswe.datacurve.ai/",
-  "total_models": 15
+  "total_models": 16
 }

--- a/packages/data/catalog/src/data/models/deepseek/deepseek-v4-pro/model.json
+++ b/packages/data/catalog/src/data/models/deepseek/deepseek-v4-pro/model.json
@@ -136,7 +136,7 @@
       "is_self_reported": false,
       "other_info": "mini-swe-agent; 8% +/-3%; avg cost $4.22; avg time 37m; out tok 50k",
       "source_link": "https://deepswe.datacurve.ai/",
-      "rank": 14
+      "rank": 15
     },
     {
       "benchmark_id": "livebench",

--- a/packages/data/catalog/src/data/models/google/gemini-3-flash-preview/model.json
+++ b/packages/data/catalog/src/data/models/google/gemini-3-flash-preview/model.json
@@ -225,7 +225,7 @@
       "is_self_reported": false,
       "other_info": "DeepSWE label: gemini-3-flash; mini-swe-agent; 5% +/-2%; avg cost $1.53; avg time 39m; out tok 233k",
       "source_link": "https://deepswe.datacurve.ai/",
-      "rank": 15
+      "rank": 16
     },
     {
       "benchmark_id": "elimination-game",

--- a/packages/data/catalog/src/data/models/google/gemini-3.1-pro-preview/model.json
+++ b/packages/data/catalog/src/data/models/google/gemini-3.1-pro-preview/model.json
@@ -277,7 +277,7 @@
       "is_self_reported": false,
       "other_info": "DeepSWE label: gemini-3.1-pro; mini-swe-agent; 10% +/-3%; avg cost $1.84; avg time 36m; out tok 53k",
       "source_link": "https://deepswe.datacurve.ai/",
-      "rank": 13
+      "rank": 14
     },
     {
       "benchmark_id": "lisanbench",

--- a/packages/data/catalog/src/data/models/minimax/minimax-m3/model.json
+++ b/packages/data/catalog/src/data/models/minimax/minimax-m3/model.json
@@ -69,6 +69,14 @@
       "is_self_reported": true,
       "other_info": "Verified",
       "source_link": "https://www.minimax.io/models/text/m3"
+    },
+    {
+      "benchmark_id": "deepswe",
+      "score": 20,
+      "is_self_reported": false,
+      "other_info": "mini-swe-agent; 20% +/-4%; avg cost $5.57; avg time 57m; out tok 98k",
+      "source_link": "https://deepswe.datacurve.ai/",
+      "rank": 10
     }
   ]
 }

--- a/packages/data/catalog/src/data/models/x-ai/grok-build-0.1/model.json
+++ b/packages/data/catalog/src/data/models/x-ai/grok-build-0.1/model.json
@@ -32,7 +32,7 @@
       "is_self_reported": false,
       "other_info": "mini-swe-agent; 13% +/-2%; avg cost $6.60; avg time 44m; out tok 52k",
       "source_link": "https://deepswe.datacurve.ai/",
-      "rank": 12
+      "rank": 13
     }
   ]
 }

--- a/packages/data/catalog/src/data/models/xiaomi/mimo-v2.5-pro/model.json
+++ b/packages/data/catalog/src/data/models/xiaomi/mimo-v2.5-pro/model.json
@@ -40,7 +40,7 @@
       "is_self_reported": false,
       "other_info": "mini-swe-agent; 19% +/-2%; avg cost $1.99; avg time 28m; out tok 49k",
       "source_link": "https://deepswe.datacurve.ai/",
-      "rank": 10
+      "rank": 11
     },
     {
       "benchmark_id": "creative-story-writing",

--- a/packages/data/catalog/src/data/models/z-ai/glm-5.1/model.json
+++ b/packages/data/catalog/src/data/models/z-ai/glm-5.1/model.json
@@ -175,7 +175,7 @@
       "is_self_reported": false,
       "other_info": "mini-swe-agent; 18% +/-1%; avg cost $7.46; avg time 35m; out tok 49k",
       "source_link": "https://deepswe.datacurve.ai/",
-      "rank": 11
+      "rank": 12
     },
     {
       "benchmark_id": "creative-story-writing",


### PR DESCRIPTION
## Summary
- add the public DeepSWE result for MiniMax M3 from the June 7, 2026 leaderboard update
- increase the DeepSWE benchmark model count from 15 to 16
- shift downstream DeepSWE ranks by one where MiniMax M3 now inserts at rank 10

## Validation
- pnpm validate:data
- pnpm validate:pricing
- pnpm validate:gateway
- pnpm docs:links
- pnpm docs:build
- direct Node sanity check confirming 16 deepswe entries and expected ranks

## Source
- https://deepswe.datacurve.ai/ (updated June 7, 2026)