### PR TITLE
[codex] fix mythos provider hover ids and notice

### DIFF
--- a/apps/web/src/components/(data)/model/ProviderInfoHoverIcons.tsx
+++ b/apps/web/src/components/(data)/model/ProviderInfoHoverIcons.tsx
@@ -317,8 +317,7 @@ export default function ProviderInfoHoverIcons({
 }) {
 	const slugs = uniqueDefined(providerModelSlugs);
 	const modelIds = uniqueDefined(apiModelIds);
-	const slugSet = new Set(modelIds.map((value) => value.toLowerCase()));
-	const distinctSlugs = slugs.filter((slug) => !slugSet.has(slug.toLowerCase()));
+	const displayModelIds = slugs.length > 0 ? slugs : modelIds;
 	const quantization = getFirstDefined([
 		normalizeQuantizationScheme(quantizationScheme),
 		...quantizationSchemes.map((value) => normalizeQuantizationScheme(value)),
@@ -408,7 +407,7 @@ export default function ProviderInfoHoverIcons({
 		),
 	);
 	const hasQuantization = Boolean(quantization);
-	const hasSlug = distinctSlugs.length > 0 || modelIds.length > 0;
+	const hasSlug = displayModelIds.length > 0;
 	const hasPromptTraining = promptTrainingEntries.length > 0;
 	const hasResidency = residencyEntries.some(
 		(entry) =>
@@ -645,20 +644,12 @@ export default function ProviderInfoHoverIcons({
 								This provider exposes this mapping as:
 							</p>
 							<div className="flex flex-col items-start gap-1">
-								{modelIds.map((modelId) => (
+								{displayModelIds.map((modelId) => (
 									<code
 										key={`model:${modelId}`}
 										className="inline-flex max-w-full overflow-x-auto whitespace-nowrap rounded bg-muted px-1 py-0.5 text-foreground"
 									>
 										{modelId}
-									</code>
-								))}
-								{distinctSlugs.map((slug) => (
-									<code
-										key={`slug:${slug}`}
-										className="inline-flex max-w-full overflow-x-auto whitespace-nowrap rounded bg-muted px-1 py-0.5 text-foreground"
-									>
-										{slug}
 									</code>
 								))}
 							</div>

--- a/packages/data/catalog/src/data/models/anthropic/claude-mythos-5/model.json
+++ b/packages/data/catalog/src/data/models/anthropic/claude-mythos-5/model.json
@@ -4,7 +4,7 @@
   "name": "Claude Mythos 5",
   "status": "Rumoured",
   "previous_model_id": null,
-  "description": "Claude Mythos 5 is a newly surfaced Anthropic API model ID tracked as a separate Mythos-line model alongside Claude Mythos Preview. This placeholder entry keeps the catalog ready ahead of formal pricing and fuller public capability documentation.",
+  "description": "Claude Mythos 5 is a leaked Anthropic API model ID tracked as a separate Mythos-line model alongside Claude Mythos Preview. This placeholder entry keeps the catalog ready in preparation for a wider release, ahead of formal pricing and fuller public capability documentation.",
   "announced_date": null,
   "release_date": null,
   "deprecation_date": null,
@@ -17,7 +17,7 @@
   "details": [
     {
       "name": "availability",
-      "value": "Observed as an Anthropic API model ID; pricing and full public documentation are not yet confirmed."
+      "value": "Observed as a leaked Anthropic API model ID; pricing and full public documentation are not yet confirmed."
     }
   ],
   "benchmarks": []

--- a/supabase/migrations/20260607092536_mythos_5_page_notice.sql
+++ b/supabase/migrations/20260607092536_mythos_5_page_notice.sql
@@ -1,0 +1,15 @@
+insert into public.data_api_model_page_notices (
+  api_model_id,
+  tone,
+  markdown
+)
+values (
+  'anthropic/claude-mythos-5',
+  'info',
+  'This Anthropic API model ID appears to have leaked ahead of a wider release. AI Stats has added this page in preparation while formal pricing and fuller public documentation remain unconfirmed.'
+)
+on conflict (api_model_id) do update
+set
+  tone = excluded.tone,
+  markdown = excluded.markdown,
+  updated_at = now();


### PR DESCRIPTION
## Summary

This PR fixes the provider ID hover on model pages so it shows the upstream provider-facing model identifier rather than the canonical AI Stats model ID when a provider slug is available. It also adds a Mythos 5 page notice and updates the Mythos 5 model copy to make it clear that the entry was added in preparation for a wider release after the model ID surfaced publicly.

The user-facing effect is that Anthropic Mythos mappings now display only `claude-mythos-preview` and `claude-mythos-5` in the provider hover, which matches the actual upstream IDs users would expect to see from Anthropic. The Mythos 5 overview also gains an informational notice explaining that the model ID appears to have leaked and that the catalog entry exists ahead of fuller public documentation.

The root cause was that the hover could surface canonical catalog IDs alongside provider slugs, which blurred the distinction between AI Stats model IDs and provider-specific upstream IDs. For Anthropic Mythos that made the hover show `anthropic/...` values that are internal to the catalog rather than the upstream display identifier we want to present there.

The fix makes the hover prefer `provider_model_slug` for display and only fall back when a provider slug is absent. On the data side, the PR adds a database migration that inserts or updates the Mythos 5 page notice, which is the deploy artifact needed for the new informational banner.

## Type of change

- [x] Bug fix
- [ ] New feature
- [x] Improvement / refactor
- [ ] Docs only
- [ ] Chore / tooling
- [x] Data / content update

## Related issues / tickets

N/A

## Affected areas

- [x] Web: frontend
- [ ] Web: backend
- [ ] API / gateway
- [ ] SDK-TS
- [ ] SDK-PY
- [x] Database
- [x] Data / scrapers
- [ ] Docs
- [ ] General / repo-wide

## Deployment impact

- [ ] Breaking change
- [ ] No migration / no special steps
- [x] Requires DB migration
- [ ] Changes CI/CD
- [x] User-facing behaviour change

## Notes

Validation used for this diff:

- `pnpm validate:data`
- `pnpm --filter @ai-stats/web typecheck`

There is no additional generated artifact required for the notice in this repository beyond shipping the SQL migration file.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Simplified model information hover display logic for cleaner presentation.

* **Documentation**
  * Updated Claude Mythos 5 model description to clarify its status as a leaked API model ID.
  * Added informational notice to the Claude Mythos 5 model page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->