### PR TITLE
[codex] clean mythos preview benchmarks and family links

### DIFF
--- a/packages/data/catalog/src/data/families/anthropic-claude-mythos/family.json
+++ b/packages/data/catalog/src/data/families/anthropic-claude-mythos/family.json
@@ -1,0 +1,5 @@
+{
+  "family_id": "anthropic/claude-mythos",
+  "family_name": "Claude Mythos",
+  "organisation_id": "anthropic"
+}

--- a/packages/data/catalog/src/data/models/anthropic/claude-mythos-5/model.json
+++ b/packages/data/catalog/src/data/models/anthropic/claude-mythos-5/model.json
@@ -13,6 +13,7 @@
   "input_types": null,
   "output_types": null,
   "api_model_id": "anthropic/claude-mythos-5",
+  "family_id": "anthropic/claude-mythos",
   "links": [],
   "details": [
     {

--- a/packages/data/catalog/src/data/models/anthropic/claude-mythos-preview/model.json
+++ b/packages/data/catalog/src/data/models/anthropic/claude-mythos-preview/model.json
@@ -13,6 +13,7 @@
   "input_types": "text,image",
   "output_types": "text",
   "api_model_id": "anthropic/claude-mythos-preview",
+  "family_id": "anthropic/claude-mythos",
   "links": [
     {
       "platform": "announcement",
@@ -63,7 +64,7 @@
       "rank": 1
     },
     {
-      "benchmark_id": "swe-bench",
+      "benchmark_id": "swe-bench-multimodal",
       "score": 59,
       "is_self_reported": true,
       "other_info": "Multimodal (internal implementation)",

--- a/packages/data/catalog/src/data/models/anthropic/claude-mythos-preview/model.json
+++ b/packages/data/catalog/src/data/models/anthropic/claude-mythos-preview/model.json
@@ -69,7 +69,7 @@
       "is_self_reported": true,
       "other_info": "Multimodal (internal implementation)",
       "source_link": "https://www.anthropic.com/glasswing",
-      "rank": 90
+      "rank": 1
     },
     {
       "benchmark_id": "swe-bench-multilingual",

--- a/packages/data/catalog/src/data/models/anthropic/claude-opus-4.7/model.json
+++ b/packages/data/catalog/src/data/models/anthropic/claude-opus-4.7/model.json
@@ -152,7 +152,7 @@
       "is_self_reported": true,
       "other_info": null,
       "source_link": "https://cdn.sanity.io/files/4zrzovbb/website/037f06850df7fbe871e206dad004c3db5fd50340.pdf",
-      "rank": 1
+      "rank": 2
     },
     {
       "benchmark_id": "charxiv-reasoning",


### PR DESCRIPTION
## Summary

This PR cleans up the Claude Mythos Preview benchmark mapping and links the Mythos Preview and Mythos 5 entries through a shared Mythos family.

On benchmarks, the main fix is to use the dedicated `swe-bench-multimodal` benchmark ID for the Glasswing multimodal result instead of storing that score under the generic `swe-bench` benchmark with a descriptive note. That keeps the Anthropic Mythos Preview benchmark set aligned with the benchmark taxonomy already present in the catalog.

On model linking, this PR adds a new `anthropic/claude-mythos` family and assigns both `anthropic/claude-mythos-preview` and `anthropic/claude-mythos-5` to it. This creates the expected family-level backlinking between the two Mythos entries without implying that Mythos 5 is a direct successor to Mythos Preview via `previous_model_id`.

The user-facing effect is that the Mythos family section can group the two models together correctly, and the Mythos Preview benchmark data is less lossy.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Improvement / refactor
- [ ] Docs only
- [ ] Chore / tooling
- [x] Data / content update

## Related issues / tickets

N/A

## Affected areas

- [ ] Web: frontend
- [ ] Web: backend
- [ ] API / gateway
- [ ] SDK-TS
- [ ] SDK-PY
- [ ] Database
- [x] Data / scrapers
- [ ] Docs
- [ ] General / repo-wide

## Deployment impact

- [ ] Breaking change
- [x] No migration / no special steps
- [ ] Requires DB migration
- [ ] Changes CI/CD
- [x] User-facing behaviour change

## Notes

Validation used for this diff:

- `pnpm validate:data`
