### PR TITLE
[codex] Fix model detail scroll reset

### DIFF
--- a/apps/web/src/app/(dashboard)/models/[organisationId]/[modelId]/ScrollToTopOnModelChange.tsx
+++ b/apps/web/src/app/(dashboard)/models/[organisationId]/[modelId]/ScrollToTopOnModelChange.tsx
@@ -1,0 +1,15 @@
+"use client";
+
+import { useLayoutEffect } from "react";
+
+export default function ScrollToTopOnModelChange({
+	routeKey,
+}: {
+	routeKey: string;
+}) {
+	useLayoutEffect(() => {
+		window.scrollTo(0, 0);
+	}, [routeKey]);
+
+	return null;
+}

--- a/apps/web/src/app/(dashboard)/models/[organisationId]/[modelId]/layout.tsx
+++ b/apps/web/src/app/(dashboard)/models/[organisationId]/[modelId]/layout.tsx
@@ -1,10 +1,22 @@
 import type { ReactNode } from "react";
 import ShowFooterStyle from "@/components/layout/ShowFooterStyle";
+import type { ModelRouteParams } from "@/components/(data)/model/model-route-helpers";
+import ScrollToTopOnModelChange from "./ScrollToTopOnModelChange";
 
-export default function ModelDetailLayout({ children }: { children: ReactNode }) {
+export default async function ModelDetailLayout({
+	children,
+	params,
+}: {
+	children: ReactNode;
+	params: Promise<ModelRouteParams>;
+}) {
+	const { organisationId, modelId } = await params;
+	const routeKey = `${organisationId}/${modelId}`;
+
 	return (
 		<>
 			<ShowFooterStyle />
+			<ScrollToTopOnModelChange routeKey={routeKey} />
 			{children}
 		</>
 	);

--- a/apps/web/src/components/(data)/models/Models/ModelCard.tsx
+++ b/apps/web/src/components/(data)/models/Models/ModelCard.tsx
@@ -838,7 +838,7 @@ function ModelCardImpl({
 		) {
 			return;
 		}
-		router.push(modelHref);
+		router.push(modelHref, { scroll: true });
 	};
 
 	return (
@@ -879,6 +879,7 @@ function ModelCardImpl({
 							<Link
 								href={modelHref}
 								prefetch={false}
+								scroll
 								className="font-semibold text-sm leading-[1.1] text-foreground hover:underline underline-offset-4 transition-colors duration-200 line-clamp-1"
 							>
 								{modelDisplayName}
@@ -929,6 +930,7 @@ function ModelCardImpl({
 						<Link
 							href={modelHref}
 							prefetch={false}
+							scroll
 							aria-label={`Open ${modelDisplayName}`}
 							className="group/open"
 						>


### PR DESCRIPTION
## What changed
- added a model-detail route hook that forces `window.scrollTo(0, 0)` whenever the active `organisationId/modelId` changes
- wired that hook into the model detail layout so `/models/[organisationId]/[modelId]` always opens from the top
- kept explicit `scroll` hints on the model card navigation paths for consistency

## Why
Clicking a model from the main `/models` page could preserve the previous list scroll position and land the destination page partway down. This was most noticeable from the virtualized models list.

## Root cause
The app was relying on client-side navigation behavior to restore scroll correctly during a list-to-detail route transition. In this route, Next's default handling was inconsistent, so the destination page needed to own its own scroll reset.

## Impact
Model detail pages now open at the top consistently, even when the user clicks from deep in the models list.

## Validation
- reproduced the issue in the in-app Browser from `/models` after scrolling far down the list
- verified the fix in the in-app Browser for both title-link clicks and card-surface clicks
- ran `pnpm --filter @ai-stats/web exec eslint "src/app/(dashboard)/models/[organisationId]/[modelId]/layout.tsx" "src/app/(dashboard)/models/[organisationId]/[modelId]/ScrollToTopOnModelChange.tsx" "src/components/(data)/models/Models/ModelCard.tsx"`
- eslint completed without errors; `ModelCard.tsx` still has the pre-existing `max-lines` warning