### PR TITLE
[codex] Fix model date ordering

### DIFF
--- a/apps/web/src/app/(dashboard)/api-providers/[apiProvider]/models/page.tsx
+++ b/apps/web/src/app/(dashboard)/api-providers/[apiProvider]/models/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from "next";
 import APIProviderDetailShell from "@/components/(data)/api-providers/APIProviderDetailShell";
-import { getAPIProviderModelsListByAddedCached } from "@/lib/fetchers/api-providers/getAPIProvider";
+import { getAPIProviderModelsListByModelDateCached } from "@/lib/fetchers/api-providers/getAPIProvider";
 import getAPIProviderHeader from "@/lib/fetchers/api-providers/getAPIProviderHeader";
 import { buildMetadata } from "@/lib/seo";
 import ProviderModelsClient from "./ProviderModelsClient";
@@ -29,7 +29,7 @@ export async function generateMetadata(props: {
 		return buildMetadata({
 			title: "API Provider Models",
 			description:
-				"Browse all models available from this API provider on AI Stats, including date-added ordering, capability support, pricing visibility, and which variants are gateway accessible.",
+				"Browse all models available from this API provider on AI Stats, ordered by model release date with announcement-date fallback, plus capability support, pricing visibility, and gateway accessibility.",
 			path,
 			imagePath,
 		});
@@ -37,8 +37,8 @@ export async function generateMetadata(props: {
 
 	const providerName = header.api_provider_name ?? "AI API provider";
 	return buildMetadata({
-		title: `${providerName} Models - Ordered by Date Added`,
-		description: `View all ${providerName} models on AI Stats in date-added order, with gateway accessibility, supported capabilities, and quick visibility into pricing and integration coverage.`,
+		title: `${providerName} Models - Ordered by Model Date`,
+		description: `View all ${providerName} models on AI Stats ordered by release date, with announcement date fallback, gateway accessibility, supported capabilities, and quick visibility into pricing and integration coverage.`,
 		path,
 		imagePath,
 	});
@@ -53,7 +53,7 @@ export default async function Page({
 	const header = await fetchProviderMeta(apiProvider);
 	const providerLabel = header?.api_provider_name ?? apiProvider;
 
-	const models = await getAPIProviderModelsListByAddedCached(apiProvider, false);
+	const models = await getAPIProviderModelsListByModelDateCached(apiProvider, false);
 
 	return (
 		<APIProviderDetailShell apiProviderId={apiProvider}>

--- a/apps/web/src/components/(data)/api-providers/Gateway/Updates.tsx
+++ b/apps/web/src/components/(data)/api-providers/Gateway/Updates.tsx
@@ -23,6 +23,8 @@ type OrganisationRow = {
 type DataModelRelation = {
 	name?: string | null;
 	organisation_id?: string | null;
+	release_date?: string | null;
+	announcement_date?: string | null;
 	organisation?: OrganisationRow | OrganisationRow[] | null;
 };
 
@@ -33,6 +35,33 @@ type RecentModel = {
 	is_active_gateway: boolean;
 	data_models?: DataModelRelation | DataModelRelation[] | null;
 };
+
+type LifecycleDateInfo = {
+	date: string | null;
+	label: "Released" | "Announced" | null;
+};
+
+function toSortableDateMs(value?: string | null): number {
+	if (!value) return Number.NEGATIVE_INFINITY;
+	const parsed = new Date(value).getTime();
+	return Number.isFinite(parsed) ? parsed : Number.NEGATIVE_INFINITY;
+}
+
+function getLifecycleDateInfo(model: RecentModel): LifecycleDateInfo {
+	const relatedModel = Array.isArray(model.data_models)
+		? model.data_models[0] ?? null
+		: model.data_models ?? null;
+
+	if (relatedModel?.release_date) {
+		return { date: relatedModel.release_date, label: "Released" };
+	}
+
+	if (relatedModel?.announcement_date) {
+		return { date: relatedModel.announcement_date, label: "Announced" };
+	}
+
+	return { date: null, label: null };
+}
 
 function isoSevenDaysAgo(from = new Date()): string {
 	const d = new Date(from);
@@ -48,18 +77,12 @@ async function getRecentModels(
 	const limit = opts?.limit ?? 5;
 
 	try {
-		let q = supabase
+		const { data: providerModels, error } = await supabase
 			.from("data_api_provider_models")
 			.select(
 				"model_id, api_model_id, created_at, is_active_gateway"
 			)
-			.eq("provider_id", apiProviderId)
-			.order("created_at", { ascending: false })
-			.limit(limit);
-
-		if (opts?.sinceTs) q = q.gte("created_at", opts.sinceTs);
-
-		const { data: providerModels, error } = await q;
+			.eq("provider_id", apiProviderId);
 
 		if (error) {
 			console.error("Error fetching recent models:", error);
@@ -76,7 +99,7 @@ async function getRecentModels(
 		const { data: models } = await supabase
 			.from("data_models")
 			.select(
-				"model_id, name, organisation_id, organisation:data_organisations!data_models_organisation_id_fkey(organisation_id, name)"
+				"model_id, name, organisation_id, release_date, announcement_date, organisation:data_organisations!data_models_organisation_id_fkey(organisation_id, name)"
 			)
 			.in("model_id", modelIds);
 
@@ -86,19 +109,77 @@ async function getRecentModels(
 			modelMap.set(model.model_id, {
 				name: model.name ?? null,
 				organisation_id: model.organisation_id ?? null,
+				release_date: model.release_date ?? null,
+				announcement_date: model.announcement_date ?? null,
 				organisation: model.organisation ?? null,
 			});
 		}
 
-		return (providerModels ?? []).map((row: any) => ({
-			model_id: row.model_id,
-			api_model_id: row.api_model_id,
-			created_at: row.created_at,
-			is_active_gateway: row.is_active_gateway,
-			data_models: row.model_id
-				? modelMap.get(row.model_id) ?? null
-				: null,
-		})) as RecentModel[];
+		const mergedByModelId = new Map<string, RecentModel>();
+		for (const row of providerModels ?? []) {
+			const modelKey = row.model_id ?? row.api_model_id;
+			if (!modelKey) continue;
+
+			const nextModel: RecentModel = {
+				model_id: row.model_id ?? row.api_model_id,
+				api_model_id: row.api_model_id,
+				created_at: row.created_at,
+				is_active_gateway: Boolean(row.is_active_gateway),
+				data_models: row.model_id
+					? modelMap.get(row.model_id) ?? null
+					: null,
+			};
+
+			const existing = mergedByModelId.get(modelKey);
+			if (!existing) {
+				mergedByModelId.set(modelKey, nextModel);
+				continue;
+			}
+
+			const existingCreatedAtMs = toSortableDateMs(existing.created_at);
+			const nextCreatedAtMs = toSortableDateMs(nextModel.created_at);
+			if (nextCreatedAtMs > existingCreatedAtMs) {
+				existing.created_at = nextModel.created_at;
+				existing.api_model_id = nextModel.api_model_id;
+			}
+			existing.is_active_gateway =
+				existing.is_active_gateway || nextModel.is_active_gateway;
+			if (!existing.data_models && nextModel.data_models) {
+				existing.data_models = nextModel.data_models;
+			}
+		}
+
+		const modelsByLifecycleDate = Array.from(mergedByModelId.values())
+			.filter((model) => {
+				if (!opts?.sinceTs) return true;
+				return (
+					toSortableDateMs(getLifecycleDateInfo(model).date) >=
+					toSortableDateMs(opts.sinceTs)
+				);
+			})
+			.sort((a, b) => {
+				const aLifecycleMs = toSortableDateMs(
+					getLifecycleDateInfo(a).date,
+				);
+				const bLifecycleMs = toSortableDateMs(
+					getLifecycleDateInfo(b).date,
+				);
+				if (aLifecycleMs !== bLifecycleMs) {
+					return bLifecycleMs - aLifecycleMs;
+				}
+
+				const aCreatedAtMs = toSortableDateMs(a.created_at);
+				const bCreatedAtMs = toSortableDateMs(b.created_at);
+				if (aCreatedAtMs !== bCreatedAtMs) {
+					return bCreatedAtMs - aCreatedAtMs;
+				}
+
+				return resolveModelDisplayInfo(a).name.localeCompare(
+					resolveModelDisplayInfo(b).name,
+				);
+			});
+
+		return modelsByLifecycleDate.slice(0, limit);
 	} catch (err) {
 		console.error("Unexpected error fetching recent models:", err);
 		return [];
@@ -148,27 +229,33 @@ export default async function Updates({
 		recentModels.length > 0
 			? resolveModelDisplayInfo(recentModels[0])
 			: undefined;
-	const latestModelDate =
+	const latestModelDateInfo =
 		recentModels.length > 0
-			? formatModelDate(recentModels[0].created_at)
-			: undefined;
+			? getLifecycleDateInfo(recentModels[0])
+			: { date: null, label: null };
+	const latestModelDate = latestModelDateInfo.date
+		? formatModelDate(latestModelDateInfo.date)
+		: "Unknown";
+	const latestModelDateLabel = latestModelDateInfo.label ?? "Date";
 
 	return (
 		<div className="grid grid-cols-1 md:grid-cols-2 gap-6 mt-6">
 			<div className="border border-gray-200 dark:border-gray-700 rounded-lg p-6">
 				<div className="mb-4">
-					<h3 className="text-lg font-semibold mb-2">New Models</h3>
+					<h3 className="text-lg font-semibold mb-2">Latest Models</h3>
 					<p className="text-sm text-muted-foreground">
-						Recently added models with gateway availability status.
+						Sorted by release date, with announcement date as fallback.
 					</p>
 				</div>
 				{newModels.length > 0 ? (
 					<div className="space-y-3">
 						{newModels.map((model) => {
 							const display = resolveModelDisplayInfo(model);
-							const formattedDate = formatModelDate(
-								model.created_at
-							);
+							const dateInfo = getLifecycleDateInfo(model);
+							const formattedDate = dateInfo.date
+								? formatModelDate(dateInfo.date)
+								: "Unknown";
+							const dateLabel = dateInfo.label ?? "Date";
 
 							return (
 								<div
@@ -200,7 +287,7 @@ export default async function Updates({
 										</div>
 										<div className="flex flex-col items-end gap-1 text-right text-xs text-muted-foreground">
 											<span className="text-[11px] font-semibold uppercase tracking-wide">
-												Added
+												{dateLabel}
 											</span>
 											<span className="text-sm font-medium text-foreground">
 												{formattedDate}
@@ -218,10 +305,10 @@ export default async function Updates({
 								<EmptyMedia variant="icon">
 									<Sparkles className="h-5 w-5" />
 								</EmptyMedia>
-								<EmptyTitle>No New Models</EmptyTitle>
+								<EmptyTitle>No Recent Models</EmptyTitle>
 								<EmptyDescription>
-									New models will appear here when added to
-									the platform.
+									No model releases or announcements landed
+									in the last 7 days.
 								</EmptyDescription>
 							</EmptyHeader>
 						</Empty>
@@ -266,7 +353,7 @@ export default async function Updates({
 						<div className="pt-2 border-t border-gray-200 dark:border-gray-700">
 							<p className="text-xs text-muted-foreground mb-3 flex items-center gap-1">
 								<Calendar className="h-3 w-3" />
-								Latest model added:
+								Latest model:
 							</p>
 							<div className="p-3 border border-gray-200 dark:border-gray-700 rounded-lg">
 								<div className="flex items-start justify-between gap-4">
@@ -308,7 +395,7 @@ export default async function Updates({
 									</div>
 									<div className="flex flex-col items-end gap-1 text-right text-xs text-muted-foreground">
 										<span className="text-[11px] font-semibold uppercase tracking-wide">
-											Added
+											{latestModelDateLabel}
 										</span>
 										<span className="text-sm font-semibold text-foreground">
 											{latestModelDate}

--- a/apps/web/src/lib/fetchers/api-providers/getAPIProvider.ts
+++ b/apps/web/src/lib/fetchers/api-providers/getAPIProvider.ts
@@ -21,6 +21,7 @@ export interface APIProviderModels {
 	input_modalities?: string[] | string | null;
 	output_modalities?: string[] | string | null;
 	release_date?: string | null;
+	announcement_date?: string | null;
 }
 
 export interface APIProviderModelListItem extends APIProviderModels {
@@ -43,6 +44,19 @@ export interface APIProviderModelPricingMeter {
 	price_per_1m_usd: number | null;
 	estimated_price_per_image_usd: number | null;
 	display_unit_label: string;
+}
+
+function toSortableDateMs(value?: string | null): number {
+	if (!value) return Number.NEGATIVE_INFINITY;
+	const parsed = new Date(value).getTime();
+	return Number.isFinite(parsed) ? parsed : Number.NEGATIVE_INFINITY;
+}
+
+function getModelLifecycleDate(model: {
+	release_date?: string | null;
+	announcement_date?: string | null;
+}): string | null {
+	return model.release_date ?? model.announcement_date ?? null;
 }
 
 export type ModelOutputType =
@@ -305,7 +319,7 @@ export async function getAPIProviderModels(
 		? await applyHiddenFilter(
 				supabase
 					.from("data_models")
-					.select("model_id, name, release_date, hidden")
+					.select("model_id, name, release_date, announcement_date, hidden")
 					.in("model_id", modelIds),
 				includeHidden,
 			)
@@ -313,7 +327,11 @@ export async function getAPIProviderModels(
 
 	const modelMapById = new Map<
 		string,
-		{ name: string | null; release_date: string | null }
+		{
+			name: string | null;
+			release_date: string | null;
+			announcement_date: string | null;
+		}
 	>();
 	const visibleModelIds = new Set<string>();
 	for (const model of modelsResponse.data ?? []) {
@@ -322,6 +340,7 @@ export async function getAPIProviderModels(
 		modelMapById.set(model.model_id, {
 			name: model.name ?? null,
 			release_date: model.release_date ?? null,
+			announcement_date: model.announcement_date ?? null,
 		});
 	}
 
@@ -378,6 +397,7 @@ export async function getAPIProviderModels(
 				input_modalities: r.input_modalities ?? null,
 				output_modalities: r.output_modalities ?? null,
 				release_date: r.data_models?.release_date ?? null,
+				announcement_date: r.data_models?.announcement_date ?? null,
 			});
 		} else {
 			const existing = modelMap.get(model_id)!;
@@ -394,15 +414,8 @@ export async function getAPIProviderModels(
 	);
 
 	results.sort((a, b) => {
-		const aDate = a.release_date ?? null;
-		const bDate = b.release_date ?? null;
-
-		const aTime = aDate
-			? new Date(aDate).getTime()
-			: Number.NEGATIVE_INFINITY;
-		const bTime = bDate
-			? new Date(bDate).getTime()
-			: Number.NEGATIVE_INFINITY;
+		const aTime = toSortableDateMs(getModelLifecycleDate(a));
+		const bTime = toSortableDateMs(getModelLifecycleDate(b));
 
 		if (aTime === bTime) {
 			return a.model_name.localeCompare(b.model_name);
@@ -469,7 +482,7 @@ export async function getAPIProviderImageModelsCached(
 	return getAPIProviderModels(apiProviderId, "image", includeHidden);
 }
 
-export async function getAPIProviderModelsListByAdded(
+export async function getAPIProviderModelsListByModelDate(
 	apiProviderId: string,
 	includeHidden: boolean,
 ): Promise<APIProviderModelListItem[]> {
@@ -522,19 +535,28 @@ export async function getAPIProviderModelsListByAdded(
 		? await applyHiddenFilter(
 				supabase
 					.from("data_models")
-					.select("model_id, name, hidden")
+					.select("model_id, name, release_date, announcement_date, hidden")
 					.in("model_id", modelIds),
 				includeHidden,
 			)
 		: { data: [] as any[] };
 
-	const modelMapById = new Map<string, { name: string | null }>();
+	const modelMapById = new Map<
+		string,
+		{
+			name: string | null;
+			release_date: string | null;
+			announcement_date: string | null;
+		}
+	>();
 	const visibleModelIds = new Set<string>();
 	for (const model of modelsResponse.data ?? []) {
 		if (!model.model_id) continue;
 		visibleModelIds.add(model.model_id);
 		modelMapById.set(model.model_id, {
 			name: model.name ?? null,
+			release_date: model.release_date ?? null,
+			announcement_date: model.announcement_date ?? null,
 		});
 	}
 
@@ -597,6 +619,10 @@ export async function getAPIProviderModelsListByAdded(
 				is_active_gateway: Boolean(row.is_active_gateway),
 				input_modalities: inputModalities,
 				output_modalities: outputModalities,
+				release_date:
+					modelMapById.get(row.model_id ?? "")?.release_date ?? null,
+				announcement_date:
+					modelMapById.get(row.model_id ?? "")?.announcement_date ?? null,
 				created_at: createdAt,
 			});
 			continue;
@@ -762,24 +788,23 @@ export async function getAPIProviderModelsListByAdded(
 	}
 
 	results.sort((a, b) => {
-		const aTs = a.created_at
-			? new Date(a.created_at).getTime()
-			: Number.NEGATIVE_INFINITY;
-		const bTs = b.created_at
-			? new Date(b.created_at).getTime()
-			: Number.NEGATIVE_INFINITY;
-		if (aTs === bTs) {
+		const aDateMs = toSortableDateMs(getModelLifecycleDate(a));
+		const bDateMs = toSortableDateMs(getModelLifecycleDate(b));
+		if (aDateMs === bDateMs) {
+			const aCreatedMs = toSortableDateMs(a.created_at);
+			const bCreatedMs = toSortableDateMs(b.created_at);
+			if (aCreatedMs !== bCreatedMs) return bCreatedMs - aCreatedMs;
 			return (a.model_name ?? a.model_id).localeCompare(
 				b.model_name ?? b.model_id,
 			);
 		}
-		return bTs - aTs;
+		return bDateMs - aDateMs;
 	});
 
 	return results;
 }
 
-export async function getAPIProviderModelsListByAddedCached(
+export async function getAPIProviderModelsListByModelDateCached(
 	apiProviderId: string,
 	includeHidden: boolean,
 ): Promise<APIProviderModelListItem[]> {
@@ -791,7 +816,7 @@ export async function getAPIProviderModelsListByAddedCached(
 	cacheTag("data:data_api_pricing_rules");
 	cacheTag("data:models");
 
-	return getAPIProviderModelsListByAdded(apiProviderId, includeHidden);
+	return getAPIProviderModelsListByModelDate(apiProviderId, includeHidden);
 }
 
 function cacheAPIProviderTags(apiProviderId: string) {

--- a/apps/web/src/lib/fetchers/models/getAllModels.ts
+++ b/apps/web/src/lib/fetchers/models/getAllModels.ts
@@ -157,6 +157,38 @@ type GetModelsFilter = {
     includeHidden?: boolean;
 };
 
+const PAGE_SIZE = 1000;
+
+async function fetchPagedRows(
+    runQuery: (from: number, to: number) => Promise<{ data: any[] | null; error: any }>,
+    errorContext: string,
+): Promise<any[]> {
+    const rows: any[] = [];
+
+    for (let from = 0; ; from += PAGE_SIZE) {
+        const to = from + PAGE_SIZE - 1;
+        const { data, error } = await runQuery(from, to);
+
+        if (error) {
+            // eslint-disable-next-line no-console
+            console.warn(`[getAllModels] supabase error ${errorContext}`, error.message);
+            throw error;
+        }
+
+        if (!Array.isArray(data) || data.length === 0) {
+            break;
+        }
+
+        rows.push(...data);
+
+        if (data.length < PAGE_SIZE) {
+            break;
+        }
+    }
+
+    return rows;
+}
+
 async function fetchModelsFromDb(filters: GetModelsFilter): Promise<any[]> {
     const supabase = await createClient();
     const includeHidden = Boolean(filters.includeHidden);
@@ -178,49 +210,40 @@ async function fetchModelsFromDb(filters: GetModelsFilter): Promise<any[]> {
 
     // No search filter: simple ordered query
     if (!search) {
-        const query = applyHiddenFilter(
-            supabase.from("data_models").select(baseSelect),
-            includeHidden
+        return fetchPagedRows(
+            (from, to) =>
+                applyHiddenFilter(
+                    supabase.from("data_models").select(baseSelect),
+                    includeHidden
+                )
+                    .order("name", { ascending: true })
+                    .range(from, to),
+            "fetching models",
         );
-        const { data, error } = await query.order("name", { ascending: true });
-
-        if (error) {
-            // eslint-disable-next-line no-console
-            console.warn(
-                "[getAllModels] supabase error fetching models",
-                error.message
-            );
-            throw error;
-        }
-
-        return (data ?? []) as any[];
     }
 
     const like = `%${search}%`;
 
     // 1) Models whose name matches the search
     const [
-        { data: byNameData, error: byNameError },
+        byNameData,
         { data: orgsData, error: orgsError },
     ] = await Promise.all([
-        applyHiddenFilter(
-            supabase.from("data_models").select(baseSelect),
-            includeHidden
-        ).ilike("name", like),
+        fetchPagedRows(
+            (from, to) =>
+                applyHiddenFilter(
+                    supabase.from("data_models").select(baseSelect),
+                    includeHidden
+                )
+                    .ilike("name", like)
+                    .range(from, to),
+            "fetching models by name",
+        ),
         supabase
             .from("data_organisations")
             .select("organisation_id")
             .ilike("name", like),
     ]);
-
-    if (byNameError) {
-        // eslint-disable-next-line no-console
-        console.warn(
-            "[getAllModels] supabase error fetching models by name",
-            byNameError.message
-        );
-        throw byNameError;
-    }
 
     if (orgsError) {
         // eslint-disable-next-line no-console
@@ -238,24 +261,16 @@ async function fetchModelsFromDb(filters: GetModelsFilter): Promise<any[]> {
     let byOrgData: any[] = [];
 
     if (orgIds.length > 0) {
-        const {
-            data: modelsByOrg,
-            error: modelsByOrgError,
-        } = await applyHiddenFilter(
-            supabase.from("data_models").select(baseSelect),
-            includeHidden
-        ).in("organisation_id", orgIds);
-
-        if (modelsByOrgError) {
-            // eslint-disable-next-line no-console
-            console.warn(
-                "[getAllModels] supabase error fetching models by organisation",
-                modelsByOrgError.message
-            );
-            throw modelsByOrgError;
-        }
-
-        byOrgData = (modelsByOrg ?? []) as any[];
+        byOrgData = await fetchPagedRows(
+            (from, to) =>
+                applyHiddenFilter(
+                    supabase.from("data_models").select(baseSelect),
+                    includeHidden
+                )
+                    .in("organisation_id", orgIds)
+                    .range(from, to),
+            "fetching models by organisation",
+        );
     }
 
     // Merge and de-duplicate by model_id


### PR DESCRIPTION
## Summary
- order provider model lists by canonical model lifecycle date (`release_date` with `announcement_date` fallback) instead of provider-added timestamps
- update the provider updates UI copy so the surfaced dates are labeled as `Released` or `Announced` rather than `Added`
- page through `data_models` fetches so `/models` does not silently drop rows after Supabase's default 1000-row window

## Root Cause
`/models` was only loading the first 1000 rows from `data_models`. Once the table grew past that, some canonical model rows were missing from the merge, so the page fell back to newer provider availability timestamps. That made older models like `openai/whisper-1` appear at the top with an incorrect 2026 date.

## Validation
- `pnpm --filter @ai-stats/web typecheck`
- verified locally that `/models` no longer renders `Whisper 1` at the top after reload

## Notes
- the successful typecheck and browser verification were run from the source workspace where dependencies were already installed
- the clean PR worktree was used only to isolate and publish the intended files


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Models now sorted and displayed by release/announcement date
  * UI displays "Released" or "Announced" date labels instead of "Added"

* **Improvements**
  * Enhanced data sourcing with release and announcement date support
  * Improved model data retrieval with robust pagination handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->