### PR TITLE
[codex] Fix Stripe checkout recovery and add billing Discord notifications

### DIFF
--- a/apps/web/src/app/(dashboard)/gateway/usage/server-actions.performance.test.ts
+++ b/apps/web/src/app/(dashboard)/gateway/usage/server-actions.performance.test.ts
@@ -1,3 +1,5 @@
+export {};
+
 function percentile(values: number[], p: number): number {
         const sorted = values.slice().sort((a, b) => a - b);
         const index = Math.ceil((p / 100) * sorted.length) - 1;

--- a/apps/web/src/app/(dashboard)/settings/credits/page.tsx
+++ b/apps/web/src/app/(dashboard)/settings/credits/page.tsx
@@ -7,6 +7,7 @@ import BuyCreditsClient from "@/components/(gateway)/credits/CreditPurchases/Top
 import AutoTopUpClient from "@/components/(gateway)/credits/CreditPurchases/AutoTopUp/AutoTopUpClient";
 import LowBalanceEmailAlertsClient from "@/components/(gateway)/credits/LowBalanceEmailAlertsClient";
 import { getStripe } from "@/lib/stripe";
+import { ensureWorkspaceStripeWallet } from "@/lib/server/activeTeamStripe";
 import { Metadata } from "next";
 import { Suspense } from "react";
 import SettingsSectionFallback from "@/components/(gateway)/settings/SettingsSectionFallback";
@@ -68,6 +69,21 @@ async function CreditsSettingsContent(props: {
 	const obfuscateInfo = await getUserObfuscationPreference(authData.user?.id ?? null);
 
 	const workspaceId = await getWorkspaceIdFromCookie();
+
+	if (workspaceId && authData.user?.id) {
+		try {
+			await ensureWorkspaceStripeWallet({
+				workspaceId,
+				userId: authData.user.id,
+				email: authData.user.email ?? undefined,
+			});
+		} catch (error) {
+			console.warn(`${logPrefix} stripe wallet ensure failed`, {
+				workspaceId,
+				error: error instanceof Error ? error.message : String(error),
+			});
+		}
+	}
 
 	console.info(`${logPrefix} workspace resolution`, {
 		userId: authData.user?.id ?? null,

--- a/apps/web/src/app/(dashboard)/settings/payment-methods/page.tsx
+++ b/apps/web/src/app/(dashboard)/settings/payment-methods/page.tsx
@@ -3,6 +3,7 @@ import { Suspense } from "react";
 import { createClient } from "@/utils/supabase/server";
 import { getWorkspaceIdFromCookie } from "@/utils/workspaceCookie";
 import { getStripe } from "@/lib/stripe";
+import { ensureWorkspaceStripeWallet } from "@/lib/server/activeTeamStripe";
 import {
   Card,
   CardHeader,
@@ -42,6 +43,18 @@ async function PaymentMethodsContent() {
   const obfuscateInfo = await getUserObfuscationPreference(authData.user?.id ?? null);
   const workspaceId = await getWorkspaceIdFromCookie();
   const stripe = getStripe();
+
+  if (workspaceId && authData.user?.id) {
+    try {
+      await ensureWorkspaceStripeWallet({
+        workspaceId,
+        userId: authData.user.id,
+        email: authData.user.email ?? undefined,
+      });
+    } catch (err) {
+      console.log("[WARN] stripe wallet ensure (payment methods):", String(err));
+    }
+  }
 
   let customerId: string | null = null;
   let customer: Stripe.Customer | null = null;

--- a/apps/web/src/app/api/checkout/create/route.ts
+++ b/apps/web/src/app/api/checkout/create/route.ts
@@ -1,201 +1,33 @@
 import { NextRequest, NextResponse } from "next/server";
-import {
-	deriveFirstName,
-	sendCheckoutStartedEvent,
-} from "@/lib/automations/resend-events";
-import { getStripe } from "@/lib/stripe";
-import { requireActiveWorkspaceStripeCustomer } from "@/lib/server/activeTeamStripe";
+import { createStripeCheckoutResponse } from "@/lib/server/createStripeCheckoutResponse";
 
 export async function POST(req: NextRequest) {
-    try {
-        const { kind, amount_pence, currency = "usd", workspace_id } = await req.json();
-        const requestedTeamId =
-            typeof workspace_id === "string" && workspace_id.trim().length > 0
-                ? workspace_id.trim()
-                : undefined;
-        const { workspaceId, customerId, userId, userEmail, userDisplayName } = await requireActiveWorkspaceStripeCustomer({
-            createIfMissing: true,
-        });
-        const firstName = deriveFirstName(userDisplayName);
+	try {
+		const { kind, amount_pence, currency = "usd", workspace_id } =
+			await req.json();
+		const requestedWorkspaceId =
+			typeof workspace_id === "string" && workspace_id.trim().length > 0
+				? workspace_id.trim()
+				: undefined;
 
-        if (requestedTeamId && requestedTeamId !== workspaceId) {
-            return NextResponse.json({ error: "Workspace mismatch" }, { status: 403 });
-        }
-
-        // Derive a base URL: prefer NEXT_PUBLIC_BASE_URL, fall back to request origin, then localhost.
-        const requestOrigin = req.headers.get("origin") || req.headers.get("referer") || "http://localhost:3000";
-        const baseUrl = process.env.NEXT_PUBLIC_BASE_URL || requestOrigin.replace(/\/$/, "");
-
-        const settingsCreditsUrl = `${baseUrl}/settings/credits`;
-        const successUrl = `${settingsCreditsUrl}?checkout=success&kind=${kind}`;
-        const cancelUrl = `${baseUrl}/settings/credits/?checkout=cancelled`;
-
-        const stripe = getStripe();
-
-        // 1) One-off payment (do NOT save card)
-        if (kind === "oneoff") {
-            if (!amount_pence || amount_pence < 500) return NextResponse.json({ error: "Invalid amount" }, { status: 400 });
-            const paymentAttempt = Date.now();
-            const paymentSuccessUrl = `${settingsCreditsUrl}?checkout=success&kind=${kind}&payment_attempt=${paymentAttempt}`;
-
-            const session = await stripe.checkout.sessions.create({
-                mode: "payment",
-                // Allow card wallets (Apple Pay / Google Pay) to surface when
-                // available on the customer's device/browser. Including "link"
-                // also enables Stripe Link as an option.
-                payment_method_types: ["card", "link"],
-                payment_method_options: {
-                    card: {
-                        // Let Stripe decide whether to request 3DS when needed
-                        request_three_d_secure: "automatic",
-                    },
-                },
-                customer: customerId,
-                line_items: [{
-                    quantity: 1,
-                    price_data: {
-                        currency,
-                        unit_amount: amount_pence,
-                        product_data: { name: "AI Credits top-up (one-off)" },
-                    },
-                }],
-                payment_intent_data: {
-                    metadata: {
-                        purpose: "top_up_one_off",
-                        ...(workspaceId ? { workspace_id: workspaceId } : {}),
-                    },
-                },
-                // Do NOT set setup_future_usage here (keeps it strictly one-off)
-                success_url: paymentSuccessUrl,
-                cancel_url: cancelUrl,
-                // optional niceties:
-                allow_promotion_codes: false,
-                billing_address_collection: "auto",
-                metadata: {
-                    purpose: "top_up_one_off",
-                    ...(workspaceId ? { workspace_id: workspaceId } : {}),
-                },
-            });
-            if (userEmail) {
-                try {
-                    await sendCheckoutStartedEvent({
-                        email: userEmail,
-                        payload: {
-                            workspaceId,
-                            userId,
-                            firstName,
-                            checkoutSessionId: session.id,
-                            checkoutKind: "oneoff",
-                            currency,
-                            amountPence: Number(amount_pence),
-                            startedAtIso: new Date().toISOString(),
-                        },
-                    });
-                } catch (error) {
-                    console.error("Failed sending checkout.started event for oneoff checkout", {
-                        workspaceId,
-                        userId,
-                        checkoutSessionId: session.id,
-                        error: error instanceof Error ? error.message : String(error),
-                    });
-                }
-            }
-
-            return NextResponse.json({ url: session.url });
-        }
-
-        // 2) One-off but ALSO save for future (charge now + store card)
-        if (kind === "pay_and_save") {
-            if (!amount_pence || amount_pence < 500) return NextResponse.json({ error: "Invalid amount" }, { status: 400 });
-            const paymentAttempt = Date.now();
-            const paymentSuccessUrl = `${settingsCreditsUrl}?checkout=success&kind=${kind}&payment_attempt=${paymentAttempt}`;
-
-            const session = await stripe.checkout.sessions.create({
-                mode: "payment",
-                payment_method_types: ["card", "link"],
-                payment_method_options: {
-                    card: { request_three_d_secure: "automatic" },
-                },
-                customer: customerId,
-                line_items: [{
-                    quantity: 1,
-                    price_data: {
-                        currency,
-                        unit_amount: amount_pence,
-                        product_data: { name: "AI Credits top-up (save card)" },
-                    },
-                }],
-                payment_intent_data: {
-                    setup_future_usage: "off_session", // Save the card for later server-side charging
-                    metadata: {
-                        purpose: "top_up",
-                        ...(workspaceId ? { workspace_id: workspaceId } : {}),
-                    },
-                },
-                success_url: paymentSuccessUrl,
-                cancel_url: cancelUrl,
-            });
-            if (userEmail) {
-                try {
-                    await sendCheckoutStartedEvent({
-                        email: userEmail,
-                        payload: {
-                            workspaceId,
-                            userId,
-                            firstName,
-                            checkoutSessionId: session.id,
-                            checkoutKind: "pay_and_save",
-                            currency,
-                            amountPence: Number(amount_pence),
-                            startedAtIso: new Date().toISOString(),
-                        },
-                    });
-                } catch (error) {
-                    console.error("Failed sending checkout.started event for pay_and_save checkout", {
-                        workspaceId,
-                        userId,
-                        checkoutSessionId: session.id,
-                        error: error instanceof Error ? error.message : String(error),
-                    });
-                }
-            }
-
-            return NextResponse.json({ url: session.url });
-        }
-
-        // 3) Save card ONLY (no immediate charge)
-        if (kind === "save_only") {
-            // debug info
-            // eslint-disable-next-line no-console
-            console.log(`creating setup session (save_only) customerId=${customerId}`);
-            const session = await stripe.checkout.sessions.create({
-                mode: "setup",
-                payment_method_types: ["card", "link"],
-                customer: customerId,
-                success_url: successUrl,
-                cancel_url: cancelUrl,
-                setup_intent_data: {
-                    metadata: {
-                        purpose: "auto_topup_setup",
-                        ...(workspaceId ? { workspace_id: workspaceId } : {}),
-                    },
-                },
-            });
-
-            return NextResponse.json({ url: session.url });
-        }
-
-        return NextResponse.json({ error: "Unknown kind" }, { status: 400 });
-    } catch (e: any) {
-        if (e?.message === "unauthorized") {
-            return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-        }
-        if (e?.message === "missing_workspace") {
-            return NextResponse.json({ error: "Missing workspace" }, { status: 400 });
-        }
-        // log full error server-side for debugging
-        // eslint-disable-next-line no-console
-        console.error("checkout.create route error:", e);
-        return NextResponse.json({ error: e.message }, { status: 500 });
-    }
+		return await createStripeCheckoutResponse({
+			amountPence:
+				typeof amount_pence === "number" ? amount_pence : Number(amount_pence),
+			currency,
+			kind,
+			originHeader: req.headers.get("origin"),
+			refererHeader: req.headers.get("referer"),
+			requestedWorkspaceId,
+		});
+	} catch (e: any) {
+		if (e?.message === "unauthorized") {
+			return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+		}
+		if (e?.message === "missing_workspace") {
+			return NextResponse.json({ error: "Missing workspace" }, { status: 400 });
+		}
+		// eslint-disable-next-line no-console
+		console.error("checkout.create route error:", e);
+		return NextResponse.json({ error: e.message }, { status: 500 });
+	}
 }

--- a/apps/web/src/app/api/checkout/route.ts
+++ b/apps/web/src/app/api/checkout/route.ts
@@ -1,112 +1,41 @@
-import { getStripe } from "@/lib/stripe";
 import { NextRequest, NextResponse } from "next/server";
-import {
-	deriveFirstName,
-	sendCheckoutStartedEvent,
-} from "@/lib/automations/resend-events";
-import { requireActiveWorkspaceStripeCustomer } from "@/lib/server/activeTeamStripe";
+import { createStripeCheckoutResponse } from "@/lib/server/createStripeCheckoutResponse";
 
-// Minimal Stripe integration. Requires STRIPE_SECRET_KEY in environment.
-// Creates a Checkout session for a single one-time payment in cents (integer) passed as { amount }
+// Legacy compatibility route. The active UI uses /api/checkout/create.
 
 export async function POST(req: NextRequest) {
-    try {
-        const body = await req.json();
-        const purchaseAmount = Number(body?.purchase_amount_cents);
-        const totalAmount = Number(body?.total_amount_cents) || purchaseAmount;
-        const requestedTeamId =
-            typeof body?.workspace_id === "string" && body.workspace_id.trim().length > 0
-                ? body.workspace_id.trim()
-                : null;
-        const {
-            workspaceId,
-            customerId,
-            userId: authenticatedUserId,
-            userEmail,
-            userDisplayName,
-        } = await requireActiveWorkspaceStripeCustomer({
-            createIfMissing: true,
-        });
-        const firstName = deriveFirstName(userDisplayName);
-        if (requestedTeamId && requestedTeamId !== workspaceId) {
-            return NextResponse.json({ error: "Workspace mismatch" }, { status: 403 });
-        }
-        if (!purchaseAmount || isNaN(purchaseAmount) || purchaseAmount < 500) {
-            return NextResponse.json({ error: "Invalid purchase amount. Minimum $5 (500 cents)." }, { status: 400 });
-        }
+	try {
+		const body = await req.json();
+		const purchaseAmount = Number(body?.purchase_amount_cents);
+		const totalAmount = Number(body?.total_amount_cents) || purchaseAmount;
+		const requestedWorkspaceId =
+			typeof body?.workspace_id === "string" && body.workspace_id.trim().length > 0
+				? body.workspace_id.trim()
+				: undefined;
 
-        const stripeSecret = process.env.STRIPE_SECRET_KEY;
-        if (!stripeSecret) {
-            return NextResponse.json({ error: "Stripe key not configured" }, { status: 500 });
-        }
+		if (!purchaseAmount || Number.isNaN(purchaseAmount) || purchaseAmount < 500) {
+			return NextResponse.json(
+				{ error: "Invalid purchase amount. Minimum $5 (500 cents)." },
+				{ status: 400 },
+			);
+		}
 
-        const stripe = getStripe();
-
-        const origin = req.headers.get("origin") || process.env.NEXT_PUBLIC_APP_URL || "http://localhost:3000";
-        const paymentAttempt = Date.now();
-
-        // allow optional user_id to be passed from client so webhook can directly credit
-        const checkoutUserId = body?.user_id;
-
-        const session = await stripe.checkout.sessions.create({
-            mode: "payment",
-            payment_method_types: ["card"],
-            customer: customerId,
-            line_items: [
-                {
-                    price_data: {
-                        currency: "usd",
-                        product_data: { name: "Credits" },
-                        unit_amount: totalAmount,
-                    },
-                    quantity: 1,
-                },
-            ],
-            metadata: checkoutUserId ? { user_id: String(checkoutUserId), purchase_amount_cents: String(purchaseAmount) } : { purchase_amount_cents: String(purchaseAmount) },
-            payment_intent_data: {
-                description: 'Credits purchase',
-                metadata: {
-                    purpose: "top_up_one_off",
-                    workspace_id: workspaceId,
-                },
-            },
-            success_url: `${origin}/settings/credits?checkout=success&payment_attempt=${paymentAttempt}`,
-            cancel_url: `${origin}/settings/credits?checkout=cancelled`,
-        });
-        if (userEmail) {
-            try {
-                await sendCheckoutStartedEvent({
-                    email: userEmail,
-                    payload: {
-                        workspaceId,
-                        userId: authenticatedUserId,
-                        firstName,
-                        checkoutSessionId: session.id,
-                        checkoutKind: "legacy_checkout",
-                        currency: "usd",
-                        amountPence: Number(totalAmount),
-                        startedAtIso: new Date().toISOString(),
-                    },
-                });
-            } catch (error) {
-                console.error("Failed sending checkout.started event for legacy checkout", {
-                    workspaceId,
-                    userId: authenticatedUserId,
-                    checkoutSessionId: session.id,
-                    error: error instanceof Error ? error.message : String(error),
-                });
-            }
-        }
-
-        return NextResponse.json({ url: session.url });
-    } catch (err: any) {
-        if (err?.message === "unauthorized") {
-            return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-        }
-        if (err?.message === "missing_workspace") {
-            return NextResponse.json({ error: "Missing workspace" }, { status: 400 });
-        }
-        // don't leak internals; return generic message
-        return NextResponse.json({ error: err?.message || "unknown" }, { status: 500 });
-    }
+		return await createStripeCheckoutResponse({
+			amountPence: totalAmount,
+			currency: "usd",
+			kind: "oneoff",
+			notificationCheckoutKind: "legacy_checkout",
+			originHeader: req.headers.get("origin"),
+			refererHeader: req.headers.get("referer"),
+			requestedWorkspaceId,
+		});
+	} catch (err: any) {
+		if (err?.message === "unauthorized") {
+			return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+		}
+		if (err?.message === "missing_workspace") {
+			return NextResponse.json({ error: "Missing workspace" }, { status: 400 });
+		}
+		return NextResponse.json({ error: err?.message || "unknown" }, { status: 500 });
+	}
 }

--- a/apps/web/src/app/api/webhooks/stripe-checkout/route.ts
+++ b/apps/web/src/app/api/webhooks/stripe-checkout/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import Stripe from "stripe";
 import { createClient } from "@supabase/supabase-js";
+import { sendBillingDiscordWebhook } from "@/lib/automations/billingDiscord";
 import {
 	deriveFirstName,
 	sendCreditsPurchasedEvent,
@@ -115,70 +116,85 @@ async function resolveWalletForTopUpPaymentIntent(args: {
         ? "workspace_id,stripe_customer_id,balance_nanos"
         : "workspace_id,stripe_customer_id";
 
-    if (stripeCustomerId) {
-        const { data: byCustomerWalletRaw, error: byCustomerErr } = await supabase
+    async function resolveByWorkspaceId(workspaceId: string): Promise<WalletAttributionRow | null> {
+        const { data: byWorkspaceWalletRaw, error: byWorkspaceErr } = await supabase
             .from("wallets")
             .select(walletSelect as any)
-            .eq("stripe_customer_id", stripeCustomerId)
+            .eq("workspace_id", workspaceId)
             .maybeSingle();
-        if (byCustomerErr) throw byCustomerErr;
-        const byCustomerWallet = (byCustomerWalletRaw ?? null) as WalletAttributionRow | null;
-        if (byCustomerWallet?.workspace_id) {
-            return byCustomerWallet;
+        if (byWorkspaceErr) throw byWorkspaceErr;
+        const byWorkspaceWallet = (byWorkspaceWalletRaw ?? null) as WalletAttributionRow | null;
+        if (!byWorkspaceWallet?.workspace_id) return null;
+
+        if (!stripeCustomerId || byWorkspaceWallet.stripe_customer_id === stripeCustomerId) {
+            if (!stripeCustomerId) {
+                console.warn("[stripe-webhook] Resolved wallet without customer via metadata workspace_id fallback", {
+                    paymentIntentId,
+                    workspaceId: byWorkspaceWallet.workspace_id,
+                });
+            }
+            return byWorkspaceWallet;
+        }
+
+        const updateQuery = supabase
+            .from("wallets")
+            .update({ stripe_customer_id: stripeCustomerId })
+            .eq("workspace_id", byWorkspaceWallet.workspace_id);
+        if (byWorkspaceWallet.stripe_customer_id) {
+            updateQuery.eq("stripe_customer_id", byWorkspaceWallet.stripe_customer_id);
+        } else {
+            updateQuery.is("stripe_customer_id", null);
+        }
+
+        const { error: backfillErr } = await updateQuery;
+        if (backfillErr) {
+            console.warn("[stripe-webhook] Failed to refresh wallet stripe_customer_id from metadata fallback", {
+                paymentIntentId,
+                workspaceId: byWorkspaceWallet.workspace_id,
+                existingCustomerId: byWorkspaceWallet.stripe_customer_id,
+                newCustomerId: stripeCustomerId,
+                error: backfillErr.message,
+            });
+            return byWorkspaceWallet;
+        }
+
+        console.log("[stripe-webhook] Refreshed wallet stripe_customer_id from metadata fallback", {
+            paymentIntentId,
+            workspaceId: byWorkspaceWallet.workspace_id,
+            previousCustomerId: byWorkspaceWallet.stripe_customer_id,
+            newCustomerId: stripeCustomerId,
+        });
+        return { ...byWorkspaceWallet, stripe_customer_id: stripeCustomerId };
+    }
+
+    if (metadataTeamId) {
+        const byWorkspaceWallet = await resolveByWorkspaceId(metadataTeamId);
+        if (byWorkspaceWallet?.workspace_id) {
+            return byWorkspaceWallet;
         }
     }
 
-    if (!metadataTeamId) return null;
+    if (!stripeCustomerId) return null;
 
-    const { data: byTeamWalletRaw, error: byTeamErr } = await supabase
+    const { data: byCustomerWalletRaw, error: byCustomerErr } = await supabase
         .from("wallets")
         .select(walletSelect as any)
-        .eq("workspace_id", metadataTeamId)
+        .eq("stripe_customer_id", stripeCustomerId)
         .maybeSingle();
-    if (byTeamErr) throw byTeamErr;
-    const byTeamWallet = (byTeamWalletRaw ?? null) as WalletAttributionRow | null;
-    if (!byTeamWallet?.workspace_id) return null;
 
-    const resolvedWallet = byTeamWallet;
-    if (!stripeCustomerId || resolvedWallet.stripe_customer_id === stripeCustomerId) {
-        if (!stripeCustomerId) {
-            console.warn("[stripe-webhook] Resolved wallet without customer via metadata workspace_id fallback", {
+    if (byCustomerErr) {
+        if (byCustomerErr.code === "PGRST116") {
+            console.warn("[stripe-webhook] Multiple wallets share stripe_customer_id; workspace metadata required", {
                 paymentIntentId,
-                workspaceId: resolvedWallet.workspace_id,
+                stripeCustomerId,
+                workspaceId: metadataTeamId,
             });
+            return null;
         }
-        return resolvedWallet;
+        throw byCustomerErr;
     }
 
-    const updateQuery = supabase
-        .from("wallets")
-        .update({ stripe_customer_id: stripeCustomerId })
-        .eq("workspace_id", resolvedWallet.workspace_id);
-    if (resolvedWallet.stripe_customer_id) {
-        updateQuery.eq("stripe_customer_id", resolvedWallet.stripe_customer_id);
-    } else {
-        updateQuery.is("stripe_customer_id", null);
-    }
-
-    const { error: backfillErr } = await updateQuery;
-    if (backfillErr) {
-        console.warn("[stripe-webhook] Failed to refresh wallet stripe_customer_id from metadata fallback", {
-            paymentIntentId,
-            workspaceId: resolvedWallet.workspace_id,
-            existingCustomerId: resolvedWallet.stripe_customer_id,
-            newCustomerId: stripeCustomerId,
-            error: backfillErr.message,
-        });
-        return resolvedWallet;
-    }
-
-    console.log("[stripe-webhook] Refreshed wallet stripe_customer_id from metadata fallback", {
-        paymentIntentId,
-        workspaceId: resolvedWallet.workspace_id,
-        previousCustomerId: resolvedWallet.stripe_customer_id,
-        newCustomerId: stripeCustomerId,
-    });
-    return { ...resolvedWallet, stripe_customer_id: stripeCustomerId };
+    return (byCustomerWalletRaw ?? null) as WalletAttributionRow | null;
 }
 
 async function ensureReusablePaymentMethod(
@@ -492,7 +508,7 @@ export async function POST(req: Request) {
                 const tier = teamData?.tier ?? 'basic';
                 const feePct = 5.0;
 
-                console.log(`[stripe-webhook] Team ${wallet.workspace_id} tier: ${tier}, fee: ${feePct}%`);
+                console.log(`[stripe-webhook] Workspace ${wallet.workspace_id} tier: ${tier}, fee: ${feePct}%`);
 
                 if (paymentMethodId && stripeCustomerId) {
                     try {
@@ -540,21 +556,23 @@ export async function POST(req: Request) {
                 );
 
                 const customerIdentity = await resolveCustomerIdentity(stripe, stripeCustomerId);
+                const creditedAtIso = new Date().toISOString();
+                const checkoutSessionId = await resolveCheckoutSessionIdForPaymentIntent(stripe, pi.id);
+                const creditsPurchasedPayload = {
+                    workspaceId: wallet.workspace_id,
+                    paymentIntentId: pi.id,
+                    firstName: customerIdentity.firstName,
+                    checkoutSessionId,
+                    currency: String(pi.currency ?? "usd").toLowerCase(),
+                    amountNanos: netNanos,
+                    kind,
+                    creditedAtIso,
+                };
                 if (customerIdentity.email) {
-                    const checkoutSessionId = await resolveCheckoutSessionIdForPaymentIntent(stripe, pi.id);
                     try {
                         await sendCreditsPurchasedEvent({
                             email: customerIdentity.email,
-                            payload: {
-                                workspaceId: wallet.workspace_id,
-                                paymentIntentId: pi.id,
-                                firstName: customerIdentity.firstName,
-                                checkoutSessionId,
-                                currency: String(pi.currency ?? "usd").toLowerCase(),
-                                amountNanos: netNanos,
-                                kind,
-                                creditedAtIso: new Date().toISOString(),
-                            },
+                            payload: creditsPurchasedPayload,
                         });
                     } catch (error) {
                         console.error("[stripe-webhook] Failed sending credits.purchased event", {
@@ -564,6 +582,20 @@ export async function POST(req: Request) {
                             error: error instanceof Error ? error.message : String(error),
                         });
                     }
+                }
+                try {
+                    await sendBillingDiscordWebhook({
+                        event: "credits_purchased",
+                        email: customerIdentity.email,
+                        payload: creditsPurchasedPayload,
+                    });
+                } catch (error) {
+                    console.error("[stripe-webhook] Failed sending billing Discord webhook", {
+                        paymentIntentId: pi.id,
+                        workspaceId: wallet.workspace_id,
+                        checkoutSessionId: checkoutSessionId ?? null,
+                        error: error instanceof Error ? error.message : String(error),
+                    });
                 }
 
                 break;

--- a/apps/web/src/lib/automations/billingDiscord.test.ts
+++ b/apps/web/src/lib/automations/billingDiscord.test.ts
@@ -1,0 +1,174 @@
+import {
+	buildBillingDiscordPayload,
+	resolveBillingDiscordWebhookUrl,
+	sendBillingDiscordWebhook,
+} from "./billingDiscord";
+
+describe("billing Discord webhook helpers", () => {
+	const originalBillingWebhookUrl = process.env.DISCORD_BILLING_WEBHOOK_URL;
+
+	afterEach(() => {
+		if (originalBillingWebhookUrl === undefined) {
+			delete process.env.DISCORD_BILLING_WEBHOOK_URL;
+		} else {
+			process.env.DISCORD_BILLING_WEBHOOK_URL = originalBillingWebhookUrl;
+		}
+
+		jest.restoreAllMocks();
+	});
+
+	it("reads the billing webhook env var", () => {
+		process.env.DISCORD_BILLING_WEBHOOK_URL = "https://discord.example/billing";
+
+		expect(resolveBillingDiscordWebhookUrl()).toBe(
+			"https://discord.example/billing",
+		);
+	});
+
+	it("builds a checkout-started payload with masked email", () => {
+		expect(
+			buildBillingDiscordPayload({
+				event: "checkout_started",
+				email: "daniel@example.com",
+				payload: {
+					workspaceId: "workspace_123",
+					userId: "user_123",
+					firstName: "Daniel",
+					checkoutSessionId: "cs_test_123",
+					checkoutKind: "oneoff",
+					currency: "usd",
+					amountPence: 2625,
+					startedAtIso: "2026-06-06T10:00:00.000Z",
+				},
+			}),
+		).toEqual({
+			content: [
+				"AI Stats checkout started",
+				"- event: `checkout_started`",
+				"- workspace_id: `workspace_123`",
+				"- user_id: `user_123`",
+				"- email: `d*****@example.com`",
+				"- checkout_session_id: `cs_test_123`",
+				"- checkout_kind: `oneoff`",
+				"- amount: `26.25 usd`",
+				"- started_at: `2026-06-06T10:00:00.000Z`",
+			].join("\n"),
+			allowed_mentions: { parse: [] },
+		});
+	});
+
+	it("builds a purchase payload and tolerates a missing checkout session id", () => {
+		expect(
+			buildBillingDiscordPayload({
+				event: "credits_purchased",
+				email: null,
+				payload: {
+					workspaceId: "workspace_123",
+					paymentIntentId: "pi_123",
+					firstName: "Daniel",
+					currency: "usd",
+					amountNanos: 25_000_000_000,
+					kind: "top_up_one_off",
+					creditedAtIso: "2026-06-06T10:05:00.000Z",
+				},
+			}),
+		).toEqual({
+			content: [
+				"AI Stats credits purchased",
+				"- event: `credits_purchased`",
+				"- workspace_id: `workspace_123`",
+				"- payment_intent_id: `pi_123`",
+				"- email: `unknown`",
+				"- checkout_session_id: `unknown`",
+				"- purchase_kind: `top_up_one_off`",
+				"- amount: `25.00 usd`",
+				"- credited_at: `2026-06-06T10:05:00.000Z`",
+			].join("\n"),
+			allowed_mentions: { parse: [] },
+		});
+	});
+
+	it("sends checkout-started notifications through the billing webhook env var", async () => {
+		process.env.DISCORD_BILLING_WEBHOOK_URL =
+			"https://discord.example/billing";
+
+		const fetchImpl = jest.fn().mockResolvedValue({
+			ok: true,
+			status: 204,
+			statusText: "No Content",
+			text: async () => "",
+		});
+
+		await expect(
+			sendBillingDiscordWebhook(
+				{
+					event: "checkout_started",
+					email: "daniel@example.com",
+					payload: {
+						workspaceId: "workspace_123",
+						userId: "user_123",
+						firstName: "Daniel",
+						checkoutSessionId: "cs_test_123",
+						checkoutKind: "pay_and_save",
+						currency: "usd",
+						amountPence: 2625,
+						startedAtIso: "2026-06-06T10:00:00.000Z",
+					},
+				},
+				{ fetchImpl },
+			),
+		).resolves.toBe(true);
+
+		expect(fetchImpl).toHaveBeenCalledWith(
+			"https://discord.example/billing",
+			expect.objectContaining({
+				method: "POST",
+				headers: {
+					"Content-Type": "application/json",
+				},
+				body: JSON.stringify({
+					content: [
+						"AI Stats checkout started",
+						"- event: `checkout_started`",
+						"- workspace_id: `workspace_123`",
+						"- user_id: `user_123`",
+						"- email: `d*****@example.com`",
+						"- checkout_session_id: `cs_test_123`",
+						"- checkout_kind: `pay_and_save`",
+						"- amount: `26.25 usd`",
+						"- started_at: `2026-06-06T10:00:00.000Z`",
+					].join("\n"),
+					allowed_mentions: { parse: [] },
+				}),
+			}),
+		);
+	});
+
+	it("returns false without calling fetch when no billing webhook is configured", async () => {
+		delete process.env.DISCORD_BILLING_WEBHOOK_URL;
+
+		const fetchImpl = jest.fn();
+
+		await expect(
+			sendBillingDiscordWebhook(
+				{
+					event: "credits_purchased",
+					email: "daniel@example.com",
+					payload: {
+						workspaceId: "workspace_123",
+						paymentIntentId: "pi_123",
+						firstName: "Daniel",
+						checkoutSessionId: "cs_test_123",
+						currency: "usd",
+						amountNanos: 25_000_000_000,
+						kind: "top_up",
+						creditedAtIso: "2026-06-06T10:05:00.000Z",
+					},
+				},
+				{ fetchImpl },
+			),
+		).resolves.toBe(false);
+
+		expect(fetchImpl).not.toHaveBeenCalled();
+	});
+});

--- a/apps/web/src/lib/automations/billingDiscord.ts
+++ b/apps/web/src/lib/automations/billingDiscord.ts
@@ -1,0 +1,127 @@
+import type {
+	ResendCheckoutStartedPayload,
+	ResendCreditsPurchasedPayload,
+} from "@/lib/automations/resend-events";
+import { maskEmailForWebhook } from "@/lib/auth/accountLifecycleDiscord";
+
+export type BillingDiscordEvent = "checkout_started" | "credits_purchased";
+
+type BillingDiscordPayload = {
+	content: string;
+	allowed_mentions: {
+		parse: string[];
+	};
+};
+
+type BillingDiscordArgs =
+	| {
+		event: "checkout_started";
+		email: string | null;
+		payload: ResendCheckoutStartedPayload;
+	}
+	| {
+		event: "credits_purchased";
+		email: string | null;
+		payload: ResendCreditsPurchasedPayload;
+	};
+
+const BILLING_EVENT_METADATA: Record<
+	BillingDiscordEvent,
+	{ title: string; timestampLabel: string }
+> = {
+	checkout_started: {
+		title: "AI Stats checkout started",
+		timestampLabel: "started_at",
+	},
+	credits_purchased: {
+		title: "AI Stats credits purchased",
+		timestampLabel: "credited_at",
+	},
+};
+
+function formatCurrencyAmount(amountMajor: number, currency: string): string {
+	const normalizedCurrency = String(currency ?? "").trim().toLowerCase() || "usd";
+	if (!Number.isFinite(amountMajor)) return `unknown ${normalizedCurrency}`;
+	return `${amountMajor.toFixed(2)} ${normalizedCurrency}`;
+}
+
+export function resolveBillingDiscordWebhookUrl(
+	env: NodeJS.ProcessEnv = process.env,
+): string {
+	return String(env.DISCORD_BILLING_WEBHOOK_URL ?? "").trim();
+}
+
+export function buildBillingDiscordPayload(
+	args: BillingDiscordArgs,
+): BillingDiscordPayload {
+	const eventMetadata = BILLING_EVENT_METADATA[args.event];
+
+	if (args.event === "checkout_started") {
+		return {
+			content: [
+				eventMetadata.title,
+				`- event: \`${args.event}\``,
+				`- workspace_id: \`${args.payload.workspaceId}\``,
+				`- user_id: \`${args.payload.userId}\``,
+				`- email: \`${maskEmailForWebhook(args.email)}\``,
+				`- checkout_session_id: \`${args.payload.checkoutSessionId}\``,
+				`- checkout_kind: \`${args.payload.checkoutKind}\``,
+				`- amount: \`${formatCurrencyAmount(
+					args.payload.amountPence / 100,
+					args.payload.currency,
+				)}\``,
+				`- ${eventMetadata.timestampLabel}: \`${args.payload.startedAtIso}\``,
+			].join("\n"),
+			allowed_mentions: { parse: [] },
+		};
+	}
+
+	return {
+		content: [
+			eventMetadata.title,
+			`- event: \`${args.event}\``,
+			`- workspace_id: \`${args.payload.workspaceId}\``,
+			`- payment_intent_id: \`${args.payload.paymentIntentId}\``,
+			`- email: \`${maskEmailForWebhook(args.email)}\``,
+			`- checkout_session_id: \`${args.payload.checkoutSessionId ?? "unknown"}\``,
+			`- purchase_kind: \`${args.payload.kind}\``,
+			`- amount: \`${formatCurrencyAmount(
+				args.payload.amountNanos / 1_000_000_000,
+				args.payload.currency,
+			)}\``,
+			`- ${eventMetadata.timestampLabel}: \`${args.payload.creditedAtIso}\``,
+		].join("\n"),
+		allowed_mentions: { parse: [] },
+	};
+}
+
+export async function sendBillingDiscordWebhook(
+	args: BillingDiscordArgs,
+	options?: {
+		env?: NodeJS.ProcessEnv;
+		fetchImpl?: typeof fetch;
+	},
+): Promise<boolean> {
+	const webhookUrl = resolveBillingDiscordWebhookUrl(options?.env);
+	if (!webhookUrl) return false;
+
+	const fetchImpl = options?.fetchImpl ?? fetch;
+	const payload = buildBillingDiscordPayload(args);
+
+	const res = await fetchImpl(webhookUrl, {
+		method: "POST",
+		headers: {
+			"Content-Type": "application/json",
+		},
+		body: JSON.stringify(payload),
+	});
+
+	if (!res.ok) {
+		const detail = await res.text().catch(() => "");
+		throw new Error(
+			`discord_webhook_error:${res.status}:${detail || res.statusText}`,
+		);
+	}
+
+	return true;
+}

--- a/apps/web/src/lib/server/activeTeamStripe.test.ts
+++ b/apps/web/src/lib/server/activeTeamStripe.test.ts
@@ -1,0 +1,105 @@
+export {};
+
+const createClient = jest.fn();
+const createAdminClient = jest.fn();
+const getWorkspaceIdFromCookie = jest.fn();
+const requireWorkspaceMembership = jest.fn();
+const getStripe = jest.fn();
+
+jest.mock("@/utils/supabase/server", () => ({
+	createClient,
+}));
+
+jest.mock("@/utils/supabase/admin", () => ({
+	createAdminClient,
+}));
+
+jest.mock("@/utils/workspaceCookie", () => ({
+	getWorkspaceIdFromCookie,
+}));
+
+jest.mock("@/utils/serverActionAuth", () => ({
+	requireWorkspaceMembership,
+}));
+
+jest.mock("@/lib/stripe", () => ({
+	getStripe,
+}));
+
+describe("requireActiveTeamStripeCustomer", () => {
+	beforeEach(() => {
+		jest.resetModules();
+		createClient.mockReset();
+		createAdminClient.mockReset();
+		getWorkspaceIdFromCookie.mockReset();
+		requireWorkspaceMembership.mockReset();
+		getStripe.mockReset();
+	});
+
+	it("repairs a stored customer id that is missing in the current Stripe account", async () => {
+		const user = {
+			id: "user_1",
+			email: "owner@example.com",
+			user_metadata: { full_name: "Owner User" },
+		};
+
+		const walletQuery: any = {
+			select: jest.fn(() => walletQuery),
+			eq: jest.fn(() => walletQuery),
+			maybeSingle: jest.fn(async () => ({
+				data: { workspace_id: "ws_1", stripe_customer_id: "cus_stale" },
+				error: null,
+			})),
+		};
+
+		createClient.mockResolvedValue({
+			auth: {
+				getUser: jest.fn(async () => ({
+					data: { user },
+					error: null,
+				})),
+			},
+			from: jest.fn(() => walletQuery),
+		} as any);
+
+		const adminUpsert = jest.fn(async () => ({ error: null }));
+		createAdminClient.mockReturnValue({
+			from: jest.fn(() => ({
+				upsert: adminUpsert,
+			})),
+		} as any);
+
+		getWorkspaceIdFromCookie.mockResolvedValue("ws_1");
+		requireWorkspaceMembership.mockResolvedValue(undefined);
+
+		getStripe.mockReturnValue({
+			customers: {
+				retrieve: jest.fn(async () => {
+					const error: any = new Error("No such customer: 'cus_stale'");
+					error.code = "resource_missing";
+					error.param = "id";
+					throw error;
+				}),
+				search: jest.fn(async () => ({
+					data: [{ id: "cus_test_mode" }],
+				})),
+				list: jest.fn(async () => ({ data: [] })),
+				create: jest.fn(async () => ({ id: "cus_created" })),
+			},
+		});
+
+		const { requireActiveTeamStripeCustomer } = await import("./activeTeamStripe");
+		const result = await requireActiveTeamStripeCustomer();
+
+		expect(result).toMatchObject({
+			workspaceId: "ws_1",
+			customerId: "cus_test_mode",
+			userId: "user_1",
+			userEmail: "owner@example.com",
+		});
+		expect(adminUpsert).toHaveBeenCalledWith(
+			{ workspace_id: "ws_1", stripe_customer_id: "cus_test_mode" },
+			{ onConflict: "workspace_id", ignoreDuplicates: false },
+		);
+	});
+});

--- a/apps/web/src/lib/server/activeTeamStripe.ts
+++ b/apps/web/src/lib/server/activeTeamStripe.ts
@@ -3,6 +3,7 @@ import { createAdminClient } from "@/utils/supabase/admin";
 import { getWorkspaceIdFromCookie } from "@/utils/workspaceCookie";
 import { requireWorkspaceMembership } from "@/utils/serverActionAuth";
 import { getStripe } from "@/lib/stripe";
+import type Stripe from "stripe";
 
 type ActiveTeamStripeCustomer = {
     workspaceId: string;
@@ -25,6 +26,38 @@ function deriveCustomerName(user: { email?: string | null; user_metadata?: Recor
     if (fromMeta) return fromMeta;
     const emailLocal = user.email?.split("@")[0]?.trim();
     return emailLocal || undefined;
+}
+
+function isMissingStripeCustomerError(error: unknown): boolean {
+    if (!error || typeof error !== "object") return false;
+
+    const candidate = error as {
+        code?: string;
+        param?: string;
+        message?: string;
+        raw?: { code?: string; param?: string; message?: string };
+    };
+
+    const code = String(candidate.code ?? candidate.raw?.code ?? "");
+    const param = String(candidate.param ?? candidate.raw?.param ?? "");
+    const message = String(candidate.message ?? candidate.raw?.message ?? "");
+
+    return (
+        code === "resource_missing" &&
+        (param === "customer" || param === "id" || message.includes("No such customer"))
+    );
+}
+
+async function upsertWorkspaceStripeCustomer(workspaceId: string, customerId: string) {
+    const admin = createAdminClient();
+    const { error: upsertError } = await admin
+        .from("wallets")
+        .upsert(
+            { workspace_id: workspaceId, stripe_customer_id: customerId },
+            { onConflict: "workspace_id", ignoreDuplicates: false }
+        );
+
+    if (upsertError) throw upsertError;
 }
 
 async function findOrCreateStripeCustomer(args: {
@@ -74,6 +107,69 @@ async function findOrCreateStripeCustomer(args: {
     return customerId;
 }
 
+async function resolveWorkspaceStripeCustomer(args: {
+    workspaceId: string;
+    userId: string;
+    email?: string | null;
+    name?: string;
+    storedCustomerId?: string | null;
+    createIfMissing?: boolean;
+}): Promise<string | null> {
+    const storedCustomerId = args.storedCustomerId?.trim() ?? "";
+    const stripe = getStripe();
+
+    if (storedCustomerId) {
+        try {
+            const customer = await stripe.customers.retrieve(storedCustomerId);
+            if ("deleted" in customer && customer.deleted) {
+                console.warn("[stripe-customer] Stored customer is deleted; repairing binding", {
+                    workspaceId: args.workspaceId,
+                    customerId: storedCustomerId,
+                });
+            } else {
+                const boundWorkspaceId =
+                    typeof customer.metadata?.workspace_id === "string"
+                        ? customer.metadata.workspace_id.trim()
+                        : "";
+
+                if (!boundWorkspaceId || boundWorkspaceId === args.workspaceId) {
+                    return storedCustomerId;
+                }
+
+                console.warn("[stripe-customer] Stored customer belongs to another workspace; repairing binding", {
+                    workspaceId: args.workspaceId,
+                    customerId: storedCustomerId,
+                    boundWorkspaceId,
+                });
+            }
+        } catch (error) {
+            if (!isMissingStripeCustomerError(error)) {
+                throw error;
+            }
+
+            console.warn("[stripe-customer] Stored customer missing in current Stripe account; repairing binding", {
+                workspaceId: args.workspaceId,
+                customerId: storedCustomerId,
+            });
+        }
+    } else if (!args.createIfMissing) {
+        return null;
+    }
+
+    const customerId = await findOrCreateStripeCustomer({
+        workspaceId: args.workspaceId,
+        userId: args.userId,
+        email: args.email ?? undefined,
+        name: args.name,
+    });
+
+    if (customerId !== storedCustomerId) {
+        await upsertWorkspaceStripeCustomer(args.workspaceId, customerId);
+    }
+
+    return customerId;
+}
+
 export async function requireActiveTeamStripeCustomer(
     options: RequireActiveTeamStripeCustomerOptions = {}
 ): Promise<ActiveTeamStripeCustomer> {
@@ -111,44 +207,22 @@ export async function requireActiveTeamStripeCustomer(
         .maybeSingle();
 
     if (walletErr) throw walletErr;
-    if (!wallet?.stripe_customer_id && !options.createIfMissing) {
-        throw new Error("missing_stripe_customer");
-    }
+    const customerId = await resolveWorkspaceStripeCustomer({
+        workspaceId,
+        userId: user.id,
+        email: user.email ?? undefined,
+        name: deriveCustomerName(user),
+        storedCustomerId: wallet?.stripe_customer_id ?? null,
+        createIfMissing: options.createIfMissing ?? false,
+    });
 
-    if (!wallet?.stripe_customer_id && options.createIfMissing) {
-        const customerId = await findOrCreateStripeCustomer({
-            workspaceId,
-            userId: user.id,
-            email: user.email ?? undefined,
-            name: deriveCustomerName(user),
-        });
-
-        const admin = createAdminClient();
-        const { error: upsertError } = await admin
-            .from("wallets")
-            .upsert(
-                { workspace_id: workspaceId, stripe_customer_id: customerId },
-                { onConflict: "workspace_id", ignoreDuplicates: false }
-            );
-
-        if (upsertError) throw upsertError;
-
-        return {
-            workspaceId,
-            customerId,
-            userId: user.id,
-            userEmail: user.email ?? null,
-            userDisplayName: deriveCustomerName(user) ?? null,
-        };
-    }
-
-    if (!wallet?.workspace_id || !wallet?.stripe_customer_id) {
+    if (!wallet?.workspace_id || !customerId) {
         throw new Error("missing_stripe_customer");
     }
 
     return {
         workspaceId: String(wallet.workspace_id),
-        customerId: String(wallet.stripe_customer_id),
+        customerId,
         userId: user.id,
         userEmail: user.email ?? null,
         userDisplayName: deriveCustomerName(user) ?? null,
@@ -162,21 +236,16 @@ export async function ensureWorkspaceStripeWallet(args?: {
     name?: string;
 }) {
     if (args?.workspaceId && args?.userId) {
-        const customerId = await findOrCreateStripeCustomer({
+        const customerId = await resolveWorkspaceStripeCustomer({
             workspaceId: args.workspaceId,
             userId: args.userId,
             email: args.email ?? undefined,
             name: args.name,
+            createIfMissing: true,
         });
-
-        const admin = createAdminClient();
-        const { error } = await admin
-            .from("wallets")
-            .upsert(
-                { workspace_id: args.workspaceId, stripe_customer_id: customerId },
-                { onConflict: "workspace_id", ignoreDuplicates: false }
-            );
-        if (error) throw error;
+        if (!customerId) {
+            throw new Error("missing_stripe_customer");
+        }
 
         return {
             workspaceId: args.workspaceId,

--- a/apps/web/src/lib/server/createStripeCheckoutResponse.ts
+++ b/apps/web/src/lib/server/createStripeCheckoutResponse.ts
@@ -1,0 +1,272 @@
+import { NextResponse } from "next/server";
+import {
+	deriveFirstName,
+	sendCheckoutStartedEvent,
+	type ResendCheckoutStartedPayload,
+} from "@/lib/automations/resend-events";
+import { sendBillingDiscordWebhook } from "@/lib/automations/billingDiscord";
+import { buildStripeCheckoutRedirectUrls } from "@/lib/stripeCheckoutRedirects";
+import { getStripe } from "@/lib/stripe";
+import { requireActiveWorkspaceStripeCustomer } from "@/lib/server/activeTeamStripe";
+
+type CheckoutKind = "oneoff" | "pay_and_save" | "save_only";
+type CheckoutStartedNotificationKind =
+	ResendCheckoutStartedPayload["checkoutKind"];
+
+type CreateStripeCheckoutResponseArgs = {
+	amountPence?: number;
+	currency?: string;
+	kind: CheckoutKind;
+	notificationCheckoutKind?: CheckoutStartedNotificationKind;
+	originHeader: string | null;
+	refererHeader: string | null;
+	requestedWorkspaceId?: string;
+};
+
+function isPositiveCheckoutAmount(value: number | undefined): value is number {
+	return typeof value === "number" && Number.isFinite(value) && value >= 500;
+}
+
+async function sendCheckoutStartedNotifications(args: {
+	checkoutSessionId: string;
+	payload: ResendCheckoutStartedPayload;
+	userEmail: string | null;
+	logContext: Record<string, unknown>;
+}) {
+	if (args.userEmail) {
+		try {
+			await sendCheckoutStartedEvent({
+				email: args.userEmail,
+				payload: args.payload,
+			});
+		} catch (error) {
+			// eslint-disable-next-line no-console
+			console.error("Failed sending checkout.started event", {
+				...args.logContext,
+				checkoutSessionId: args.checkoutSessionId,
+				error: error instanceof Error ? error.message : String(error),
+			});
+		}
+	}
+
+	try {
+		await sendBillingDiscordWebhook({
+			event: "checkout_started",
+			email: args.userEmail,
+			payload: args.payload,
+		});
+	} catch (error) {
+		// eslint-disable-next-line no-console
+		console.error("Failed sending billing Discord webhook", {
+			...args.logContext,
+			checkoutSessionId: args.checkoutSessionId,
+			error: error instanceof Error ? error.message : String(error),
+		});
+	}
+}
+
+export async function createStripeCheckoutResponse(
+	args: CreateStripeCheckoutResponseArgs,
+): Promise<NextResponse> {
+	const {
+		amountPence,
+		currency = "usd",
+		kind,
+		notificationCheckoutKind,
+		originHeader,
+		refererHeader,
+		requestedWorkspaceId,
+	} = args;
+	const {
+		workspaceId,
+		customerId,
+		userId,
+		userEmail,
+		userDisplayName,
+	} = await requireActiveWorkspaceStripeCustomer({
+		createIfMissing: true,
+	});
+	const firstName = deriveFirstName(userDisplayName);
+
+	if (requestedWorkspaceId && requestedWorkspaceId !== workspaceId) {
+		return NextResponse.json({ error: "Workspace mismatch" }, { status: 403 });
+	}
+
+	const { successUrl, cancelUrl } = buildStripeCheckoutRedirectUrls({
+		configuredBaseUrl: process.env.NEXT_PUBLIC_BASE_URL,
+		originHeader,
+		refererHeader,
+		kind,
+	});
+
+	const stripe = getStripe();
+
+	if (kind === "oneoff") {
+		if (!isPositiveCheckoutAmount(amountPence)) {
+			return NextResponse.json({ error: "Invalid amount" }, { status: 400 });
+		}
+
+		const paymentAttempt = Date.now();
+		const { successUrl: paymentSuccessUrl } = buildStripeCheckoutRedirectUrls({
+			configuredBaseUrl: process.env.NEXT_PUBLIC_BASE_URL,
+			originHeader,
+			refererHeader,
+			kind,
+			paymentAttempt,
+		});
+
+		const session = await stripe.checkout.sessions.create({
+			mode: "payment",
+			payment_method_types: ["card", "link"],
+			payment_method_options: {
+				card: {
+					request_three_d_secure: "automatic",
+				},
+			},
+			customer: customerId,
+			line_items: [
+				{
+					quantity: 1,
+					price_data: {
+						currency,
+						unit_amount: amountPence,
+						product_data: { name: "AI Credits top-up (one-off)" },
+					},
+				},
+			],
+			payment_intent_data: {
+				metadata: {
+					purpose: "top_up_one_off",
+					...(workspaceId ? { workspace_id: workspaceId } : {}),
+				},
+			},
+			success_url: paymentSuccessUrl,
+			cancel_url: cancelUrl,
+			allow_promotion_codes: false,
+			billing_address_collection: "auto",
+			metadata: {
+				purpose: "top_up_one_off",
+				...(workspaceId ? { workspace_id: workspaceId } : {}),
+			},
+		});
+
+		const startedAtIso = new Date().toISOString();
+		const checkoutKindForNotifications =
+			notificationCheckoutKind ?? "oneoff";
+		const checkoutStartedPayload: ResendCheckoutStartedPayload = {
+			workspaceId,
+			userId,
+			firstName,
+			checkoutSessionId: session.id,
+			checkoutKind: checkoutKindForNotifications,
+			currency,
+			amountPence,
+			startedAtIso,
+		};
+
+		await sendCheckoutStartedNotifications({
+			checkoutSessionId: session.id,
+			payload: checkoutStartedPayload,
+			userEmail,
+			logContext: {
+				workspaceId,
+				userId,
+				checkoutKind: checkoutKindForNotifications,
+			},
+		});
+
+		return NextResponse.json({ url: session.url });
+	}
+
+	if (kind === "pay_and_save") {
+		if (!isPositiveCheckoutAmount(amountPence)) {
+			return NextResponse.json({ error: "Invalid amount" }, { status: 400 });
+		}
+
+		const paymentAttempt = Date.now();
+		const { successUrl: paymentSuccessUrl } = buildStripeCheckoutRedirectUrls({
+			configuredBaseUrl: process.env.NEXT_PUBLIC_BASE_URL,
+			originHeader,
+			refererHeader,
+			kind,
+			paymentAttempt,
+		});
+
+		const session = await stripe.checkout.sessions.create({
+			mode: "payment",
+			payment_method_types: ["card", "link"],
+			payment_method_options: {
+				card: { request_three_d_secure: "automatic" },
+			},
+			customer: customerId,
+			line_items: [
+				{
+					quantity: 1,
+					price_data: {
+						currency,
+						unit_amount: amountPence,
+						product_data: { name: "AI Credits top-up (save card)" },
+					},
+				},
+			],
+			payment_intent_data: {
+				setup_future_usage: "off_session",
+				metadata: {
+					purpose: "top_up",
+					...(workspaceId ? { workspace_id: workspaceId } : {}),
+				},
+			},
+			success_url: paymentSuccessUrl,
+			cancel_url: cancelUrl,
+		});
+
+		const startedAtIso = new Date().toISOString();
+		const checkoutKindForNotifications =
+			notificationCheckoutKind ?? "pay_and_save";
+		const checkoutStartedPayload: ResendCheckoutStartedPayload = {
+			workspaceId,
+			userId,
+			firstName,
+			checkoutSessionId: session.id,
+			checkoutKind: checkoutKindForNotifications,
+			currency,
+			amountPence,
+			startedAtIso,
+		};
+
+		await sendCheckoutStartedNotifications({
+			checkoutSessionId: session.id,
+			payload: checkoutStartedPayload,
+			userEmail,
+			logContext: {
+				workspaceId,
+				userId,
+				checkoutKind: checkoutKindForNotifications,
+			},
+		});
+
+		return NextResponse.json({ url: session.url });
+	}
+
+	if (kind === "save_only") {
+		// eslint-disable-next-line no-console
+		console.log(`creating setup session (save_only) customerId=${customerId}`);
+		const session = await stripe.checkout.sessions.create({
+			mode: "setup",
+			payment_method_types: ["card", "link"],
+			customer: customerId,
+			success_url: successUrl,
+			cancel_url: cancelUrl,
+			setup_intent_data: {
+				metadata: {
+					purpose: "auto_topup_setup",
+					...(workspaceId ? { workspace_id: workspaceId } : {}),
+				},
+			},
+		});
+
+		return NextResponse.json({ url: session.url });
+	}
+
+	return NextResponse.json({ error: "Unknown kind" }, { status: 400 });
+}

--- a/apps/web/src/lib/stripeCheckoutRedirects.test.ts
+++ b/apps/web/src/lib/stripeCheckoutRedirects.test.ts
@@ -1,0 +1,50 @@
+import {
+	buildStripeCheckoutRedirectUrls,
+	resolveStripeCheckoutBaseUrl,
+} from "./stripeCheckoutRedirects";
+
+describe("stripe checkout redirects", () => {
+	it("uses the configured base URL when present", () => {
+		const baseUrl = resolveStripeCheckoutBaseUrl({
+			configuredBaseUrl: "https://billing.example.com",
+			originHeader: "https://ignored.example.com",
+			refererHeader: "https://ignored.example.com/settings/credits",
+		});
+
+		expect(baseUrl).toBe("https://billing.example.com");
+	});
+
+	it("falls back to the referer origin instead of using the full referer URL", () => {
+		const redirects = buildStripeCheckoutRedirectUrls({
+			refererHeader: "https://app.example.com/settings/credits?dialog=top-up",
+			kind: "pay_and_save",
+			paymentAttempt: 123456,
+		});
+
+		expect(redirects.baseUrl).toBe("https://app.example.com");
+		expect(redirects.settingsCreditsUrl).toBe(
+			"https://app.example.com/settings/credits",
+		);
+		expect(redirects.successUrl).toBe(
+			"https://app.example.com/settings/credits?checkout=success&kind=pay_and_save&payment_attempt=123456",
+		);
+		expect(redirects.cancelUrl).toBe(
+			"https://app.example.com/settings/credits?checkout=cancelled",
+		);
+	});
+
+	it("falls back to localhost when no valid origin information is available", () => {
+		const redirects = buildStripeCheckoutRedirectUrls({
+			originHeader: "not-a-url",
+			refererHeader: "",
+			kind: "save_only",
+		});
+
+		expect(redirects.successUrl).toBe(
+			"http://localhost:3000/settings/credits?checkout=success&kind=save_only",
+		);
+		expect(redirects.cancelUrl).toBe(
+			"http://localhost:3000/settings/credits?checkout=cancelled",
+		);
+	});
+});

--- a/apps/web/src/lib/stripeCheckoutRedirects.ts
+++ b/apps/web/src/lib/stripeCheckoutRedirects.ts
@@ -1,0 +1,68 @@
+function normalizeHttpOrigin(candidate: string | null | undefined): string | null {
+	if (typeof candidate !== "string") return null;
+
+	const trimmed = candidate.trim();
+	if (!trimmed) return null;
+
+	try {
+		const parsed = new URL(trimmed);
+		if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+			return null;
+		}
+		return parsed.origin;
+	} catch {
+		return null;
+	}
+}
+
+export function resolveStripeCheckoutBaseUrl(args: {
+	configuredBaseUrl?: string | null;
+	originHeader?: string | null;
+	refererHeader?: string | null;
+	fallbackBaseUrl?: string;
+}): string {
+	const fallbackBaseUrl = args.fallbackBaseUrl ?? "http://localhost:3000";
+
+	return (
+		normalizeHttpOrigin(args.configuredBaseUrl) ??
+		normalizeHttpOrigin(args.originHeader) ??
+		normalizeHttpOrigin(args.refererHeader) ??
+		normalizeHttpOrigin(fallbackBaseUrl) ??
+		"http://localhost:3000"
+	);
+}
+
+export function buildStripeCheckoutRedirectUrls(args: {
+	configuredBaseUrl?: string | null;
+	originHeader?: string | null;
+	refererHeader?: string | null;
+	kind?: string | null;
+	paymentAttempt?: number | string | null;
+}): {
+	baseUrl: string;
+	settingsCreditsUrl: string;
+	successUrl: string;
+	cancelUrl: string;
+} {
+	const baseUrl = resolveStripeCheckoutBaseUrl(args);
+	const settingsCreditsUrl = new URL("/settings/credits", baseUrl);
+	const successUrl = new URL(settingsCreditsUrl);
+	const cancelUrl = new URL(settingsCreditsUrl);
+
+	successUrl.searchParams.set("checkout", "success");
+	if (typeof args.kind === "string" && args.kind.trim()) {
+		successUrl.searchParams.set("kind", args.kind.trim());
+	}
+	if (args.paymentAttempt !== null && args.paymentAttempt !== undefined) {
+		successUrl.searchParams.set("payment_attempt", String(args.paymentAttempt));
+	}
+
+	cancelUrl.searchParams.set("checkout", "cancelled");
+
+	return {
+		baseUrl,
+		settingsCreditsUrl: settingsCreditsUrl.toString(),
+		successUrl: successUrl.toString(),
+		cancelUrl: cancelUrl.toString(),
+	};
+}

--- a/supabase/migrations/20260606093227_stripe_workspace_webhook_repairs.sql
+++ b/supabase/migrations/20260606093227_stripe_workspace_webhook_repairs.sql
@@ -1,0 +1,155 @@
+-- Repair Stripe wallet/payment-intent RPCs for workspace-era schemas.
+-- The web webhook now calls these functions with workspace_id columns/args.
+
+drop function if exists public.wallet_apply_delta(uuid, bigint);
+drop function if exists public.stripe_apply_payment_intent_credit(uuid, text, text, bigint, timestamptz);
+
+create or replace function public.wallet_apply_delta(
+    p_workspace_id uuid,
+    p_delta_nanos bigint
+)
+returns table(before_balance_nanos bigint, after_balance_nanos bigint)
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+    v_before bigint;
+    v_after bigint;
+begin
+    if p_workspace_id is null then
+        raise exception 'missing_workspace_id';
+    end if;
+
+    update public.wallets
+    set balance_nanos = balance_nanos + p_delta_nanos,
+        updated_at = now()
+    where workspace_id = p_workspace_id
+    returning balance_nanos - p_delta_nanos, balance_nanos
+    into v_before, v_after;
+
+    if not found then
+        raise exception 'wallet_not_found';
+    end if;
+
+    return query select v_before, v_after;
+end;
+$$;
+
+create or replace function public.stripe_apply_payment_intent_credit(
+    p_workspace_id uuid,
+    p_payment_intent_id text,
+    p_kind text,
+    p_amount_nanos bigint,
+    p_event_time timestamptz default now()
+)
+returns table(
+    applied boolean,
+    before_balance_nanos bigint,
+    after_balance_nanos bigint,
+    status text
+)
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+    v_existing public.credit_ledger%rowtype;
+    v_before bigint;
+    v_after bigint;
+    v_kind text;
+begin
+    if p_workspace_id is null then
+        raise exception 'missing_workspace_id';
+    end if;
+
+    if coalesce(trim(p_payment_intent_id), '') = '' then
+        raise exception 'missing_payment_intent_id';
+    end if;
+
+    if p_amount_nanos is null or p_amount_nanos <= 0 then
+        raise exception 'invalid_amount_nanos';
+    end if;
+
+    v_kind := case lower(coalesce(trim(p_kind), ''))
+        when 'top_up_one_off' then 'top_up_one_off'
+        when 'auto_top_up' then 'auto_top_up'
+        else 'top_up'
+    end;
+
+    select *
+    into v_existing
+    from public.credit_ledger
+    where ref_type = 'Stripe_Payment_Intent'
+      and ref_id = p_payment_intent_id
+    for update;
+
+    if found and v_existing.workspace_id is not null and v_existing.workspace_id <> p_workspace_id then
+        raise exception 'payment_intent_workspace_mismatch';
+    end if;
+
+    if found and lower(coalesce(v_existing.status, '')) in ('paid', 'succeeded') then
+        return query
+        select
+            false,
+            coalesce(v_existing.before_balance_nanos, 0)::bigint,
+            coalesce(v_existing.after_balance_nanos, 0)::bigint,
+            coalesce(v_existing.status, 'Paid');
+        return;
+    end if;
+
+    if not found then
+        insert into public.credit_ledger (
+            workspace_id,
+            kind,
+            amount_nanos,
+            before_balance_nanos,
+            after_balance_nanos,
+            ref_type,
+            ref_id,
+            status,
+            event_time
+        ) values (
+            p_workspace_id,
+            v_kind,
+            0,
+            0,
+            0,
+            'Stripe_Payment_Intent',
+            p_payment_intent_id,
+            'Applying',
+            coalesce(p_event_time, now())
+        );
+    end if;
+
+    update public.wallets
+    set balance_nanos = balance_nanos + p_amount_nanos,
+        updated_at = now()
+    where workspace_id = p_workspace_id
+    returning balance_nanos - p_amount_nanos, balance_nanos
+    into v_before, v_after;
+
+    if not found then
+        raise exception 'wallet_not_found';
+    end if;
+
+    update public.credit_ledger
+    set workspace_id = p_workspace_id,
+        kind = v_kind,
+        amount_nanos = p_amount_nanos,
+        before_balance_nanos = v_before,
+        after_balance_nanos = v_after,
+        status = 'Paid',
+        event_time = coalesce(p_event_time, now())
+    where ref_type = 'Stripe_Payment_Intent'
+      and ref_id = p_payment_intent_id;
+
+    return query
+    select true, v_before, v_after, 'Paid';
+end;
+$$;
+
+revoke all on function public.wallet_apply_delta(uuid, bigint) from public;
+grant execute on function public.wallet_apply_delta(uuid, bigint) to service_role;
+revoke all on function public.stripe_apply_payment_intent_credit(uuid, text, text, bigint, timestamptz) from public;
+grant execute on function public.stripe_apply_payment_intent_credit(uuid, text, text, bigint, timestamptz) to service_role;


### PR DESCRIPTION
## What changed
- repaired Stripe customer binding so workspaces recover when a stored customer ID belongs to the wrong Stripe account or no longer exists
- centralized checkout session creation into a shared helper used by both checkout routes
- fixed Stripe redirect URL construction so referer fallback uses the referer origin instead of the full referer URL
- added Discord billing notifications for `checkout_started` and `credits_purchased`
- updated the Stripe webhook path to resolve wallets safely in workspace-era schemas and send purchase notifications after crediting
- added the SQL migration needed for the workspace-based webhook RPCs

## Why
The Stripe flow had two real failure modes:
1. stale or cross-mode customer IDs could break checkout creation when a workspace was linked to a customer from the wrong Stripe environment
2. webhook crediting still depended on older team-era database assumptions, which broke wallet resolution and payment intent credit application

This PR also adds Discord billing visibility so checkout starts and completed purchases show up alongside the other account lifecycle notifications.

## Validation
- `pnpm --filter @ai-stats/web test -- src/lib/automations/billingDiscord.test.ts src/lib/server/activeTeamStripe.test.ts src/lib/stripeCheckoutRedirects.test.ts`
- `pnpm --filter @ai-stats/web exec tsc --noEmit`
- manual local Stripe test against `http://localhost:3100` with test keys:
  - signed in with a new account
  - created a real `cs_test_...` checkout session
  - completed Stripe Checkout with `4242 4242 4242 4242`
  - observed webhook `200` responses for `payment_intent.created`, `payment_intent.succeeded`, and `checkout.session.completed`
  - verified redirect back to credits success state and wallet balance increase from `$0` to `$25`

## Notes
- `DISCORD_BILLING_WEBHOOK_URL` should be configured in the runtime environment where billing notifications are expected to fire.
