### PR TITLE
Improve public SEO metadata and methodology pages

### DIFF
--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -23,6 +23,15 @@ const nextConfig = {
   experimental: {
     turbopackFileSystemCacheForDev: true,
   },
+  async redirects() {
+    return [
+      {
+        source: "/providers",
+        destination: "/api-providers",
+        permanent: true,
+      },
+    ];
+  },
   async headers() {
     return [
       {

--- a/apps/web/public/llms.txt
+++ b/apps/web/public/llms.txt
@@ -1,0 +1,29 @@
+# AI Stats
+
+> AI Stats is an open-source AI gateway and model intelligence database for comparing AI models, providers, pricing, benchmarks, latency, throughput, and gateway support.
+
+## Core product pages
+
+- [Models](https://ai-stats.phaseo.app/models): Browse AI models by provider, capability, modality, pricing, and gateway status.
+- [API Providers](https://ai-stats.phaseo.app/api-providers): Compare providers by model coverage, modality support, and usage signals.
+- [Rankings](https://ai-stats.phaseo.app/rankings): Usage, latency, throughput, and cost rankings across tracked models.
+- [Pricing](https://ai-stats.phaseo.app/pricing): Gateway pricing, credit fees, and cost guidance.
+- [Docs](https://docs.ai-stats.phaseo.app/v1): Developer documentation for the gateway and API.
+- [Docs LLM index](https://docs.ai-stats.phaseo.app/llms.txt): Documentation index for AI tools and answer engines.
+
+## Data and methodology
+
+- [Pricing calculator](https://ai-stats.phaseo.app/tools/pricing-calculator)
+- [Model database](https://ai-stats.phaseo.app/models)
+- [Provider database](https://ai-stats.phaseo.app/api-providers)
+- [Benchmarks](https://ai-stats.phaseo.app/benchmarks)
+- [Methodology hub](https://ai-stats.phaseo.app/methodology)
+- [How AI Stats calculates model pricing](https://ai-stats.phaseo.app/how-ai-stats-calculates-model-pricing)
+- [How AI Stats measures latency and throughput](https://ai-stats.phaseo.app/how-ai-stats-measures-latency-throughput)
+- [How AI Stats normalises AI benchmarks](https://ai-stats.phaseo.app/how-ai-stats-normalises-ai-benchmarks)
+- [How AI Stats tracks provider availability](https://ai-stats.phaseo.app/how-ai-stats-tracks-provider-availability)
+
+## API
+
+- [Quickstart](https://docs.ai-stats.phaseo.app/v1/quickstart)
+- [API reference](https://docs.ai-stats.phaseo.app/v1/api-reference/introduction)

--- a/apps/web/src/app/(dashboard)/api-providers/[apiProvider]/page.tsx
+++ b/apps/web/src/app/(dashboard)/api-providers/[apiProvider]/page.tsx
@@ -58,7 +58,7 @@ export async function generateMetadata(props: {
 		.join(" ");
 
 	return buildMetadata({
-		title: `${providerName} - API performance, Latency & Usage analytics`,
+		title: `${providerName} API Models, Latency & Usage Analytics`,
 		description,
 		path: `/api-providers/${apiProvider}`,
 		keywords: [
@@ -209,6 +209,14 @@ export default async function Page({
 			)}
 			<APIProviderDetailShell apiProviderId={apiProvider}>
 				<div className="flex flex-col gap-10 w-full">
+					<section className="space-y-3">
+						<p className="max-w-4xl text-sm leading-6 text-muted-foreground sm:text-base">
+							Track how {header?.api_provider_name ?? "this provider"} performs on
+							the AI Stats Gateway, including latency, throughput, token usage, and
+							the models driving current traffic. Use this page as a provider-level
+							companion to the broader model and pricing database.
+						</p>
+					</section>
 					<section className="space-y-2">
 						<h3 className="text-xl font-semibold">Performance</h3>
 						<PerformanceCards params={params} />

--- a/apps/web/src/app/(dashboard)/api-providers/page.tsx
+++ b/apps/web/src/app/(dashboard)/api-providers/page.tsx
@@ -4,7 +4,8 @@ import { getAllAPIProvidersCached } from "@/lib/fetchers/api-providers/getAllAPI
 import type { APIProviderCard } from "@/lib/fetchers/api-providers/getAllAPIProviders";
 import APIProvidersDisplay from "@/components/(data)/api-providers/APIProvidersDisplay";
 import { Skeleton } from "@/components/ui/skeleton";
-import { buildMetadata } from "@/lib/seo";
+import { absoluteUrl, buildMetadata } from "@/lib/seo";
+import Script from "next/script";
 
 export const metadata: Metadata = buildMetadata({
 	title: "AI API Providers: Pricing, Models & Performance",
@@ -23,8 +24,89 @@ export const metadata: Metadata = buildMetadata({
 async function APIProvidersSection() {
 	const apiProviders =
 		(await getAllAPIProvidersCached()) as APIProviderCard[];
+	const topByModels = [...apiProviders]
+		.sort((a, b) => b.total_models - a.total_models)
+		.slice(0, 6)
+		.map((provider) => provider.api_provider_name);
+	const totalModels = apiProviders.reduce(
+		(sum, provider) => sum + Math.max(0, Number(provider.total_models ?? 0)),
+		0,
+	);
+	const totalFreeModels = apiProviders.reduce(
+		(sum, provider) => sum + Math.max(0, Number(provider.free_models ?? 0)),
+		0,
+	);
+	const dataCatalogSchema = {
+		"@context": "https://schema.org",
+		"@type": "DataCatalog",
+		name: "AI Stats API Provider Database",
+		description:
+			"Compare AI API providers by model coverage, modality support, gateway usage signals, and free model availability.",
+		url: absoluteUrl("/api-providers"),
+		keywords: [
+			"AI API providers",
+			"LLM providers",
+			"provider coverage",
+			"free models",
+			"gateway providers",
+		],
+		includesObject: topByModels.map((name) => ({
+			"@type": "Dataset",
+			name,
+		})),
+	};
+	const breadcrumbSchema = {
+		"@context": "https://schema.org",
+		"@type": "BreadcrumbList",
+		itemListElement: [
+			{
+				"@type": "ListItem",
+				position: 1,
+				name: "Home",
+				item: absoluteUrl("/"),
+			},
+			{
+				"@type": "ListItem",
+				position: 2,
+				name: "API Providers",
+				item: absoluteUrl("/api-providers"),
+			},
+		],
+	};
 
-	return <APIProvidersDisplay providers={apiProviders} />;
+	return (
+		<>
+			<Script
+				id="api-providers-data-catalog-schema"
+				type="application/ld+json"
+				dangerouslySetInnerHTML={{ __html: JSON.stringify(dataCatalogSchema) }}
+			/>
+			<Script
+				id="api-providers-breadcrumb-schema"
+				type="application/ld+json"
+				dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbSchema) }}
+			/>
+			<div className="space-y-3">
+				<h1 className="text-3xl font-bold tracking-tight">
+					Compare AI API providers by model coverage, usage, and modality support
+				</h1>
+				<p className="max-w-4xl text-sm leading-6 text-muted-foreground sm:text-base">
+					AI Stats tracks {apiProviders.length.toLocaleString()} API providers with{" "}
+					{totalModels.toLocaleString()} listed provider-model combinations and{" "}
+					{totalFreeModels.toLocaleString()} free-model entries. Use this index to
+					compare provider breadth, gateway usage, and modality support before you
+					choose where to route traffic.
+				</p>
+				{topByModels.length > 0 ? (
+					<p className="max-w-4xl text-sm leading-6 text-muted-foreground">
+						High-coverage providers in the current index include{" "}
+						{topByModels.join(", ")}.
+					</p>
+				) : null}
+			</div>
+			<APIProvidersDisplay providers={apiProviders} showPrimaryHeader={false} />
+		</>
+	);
 }
 
 function APIProvidersFallback() {

--- a/apps/web/src/app/(dashboard)/apps/page.tsx
+++ b/apps/web/src/app/(dashboard)/apps/page.tsx
@@ -6,6 +6,7 @@ import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import TopAppsLeaderboardTable from "@/components/(data)/apps/TopAppsLeaderboardTable";
 import { getPublicAppIdsCached } from "@/lib/fetchers/apps/getAppDetails";
 import {
+	getAppsIndexabilitySnapshot,
 	getAppImageUrlsByIds,
 	getTopApps,
 	getTrendingApps,
@@ -38,19 +39,26 @@ type TrendingPublicApp = {
 	imageUrl?: string | null;
 };
 
-export const metadata: Metadata = buildMetadata({
-	title: "AI App Rankings: Usage Trends & Top Apps",
-	description:
-		"See the most popular and fastest-growing AI apps on AI Stats Gateway, with leaderboard and token-usage trends.",
-	path: "/apps",
-	keywords: [
-		"AI apps",
-		"AI app rankings",
-		"app leaderboard",
-		"app usage trends",
-		"app trends",
-	],
-});
+export async function generateMetadata(): Promise<Metadata> {
+	const indexability = await getAppsIndexabilitySnapshot();
+
+	return buildMetadata({
+		title: "AI App Rankings: Usage Trends & Top Apps",
+		description:
+			"See the most popular and fastest-growing AI apps on AI Stats Gateway, with leaderboard and token-usage trends.",
+		path: "/apps",
+		keywords: [
+			"AI apps",
+			"AI app rankings",
+			"app leaderboard",
+			"app usage trends",
+			"app trends",
+		],
+		robots: indexability.shouldIndex
+			? { index: true, follow: true }
+			: { index: false, follow: true },
+	});
+}
 
 function formatCompactNumber(value: number): string {
 	if (!Number.isFinite(value)) return "0";

--- a/apps/web/src/app/(dashboard)/how-ai-stats-calculates-model-pricing/page.tsx
+++ b/apps/web/src/app/(dashboard)/how-ai-stats-calculates-model-pricing/page.tsx
@@ -1,0 +1,22 @@
+import type { Metadata } from "next";
+import { MethodologyArticlePage } from "@/components/methodology/MethodologyArticlePage";
+import {
+	METHODOLOGY_ENTRY_BY_SLUG,
+	type MethodologyEntry,
+} from "@/lib/content/methodology";
+import { buildMetadata } from "@/lib/seo";
+
+const entry = METHODOLOGY_ENTRY_BY_SLUG[
+	"how-ai-stats-calculates-model-pricing"
+] as MethodologyEntry;
+
+export const metadata: Metadata = buildMetadata({
+	title: entry.title,
+	description: entry.description,
+	path: entry.path,
+	keywords: entry.keywords,
+});
+
+export default function ModelPricingMethodologyPage() {
+	return <MethodologyArticlePage entry={entry} />;
+}

--- a/apps/web/src/app/(dashboard)/how-ai-stats-measures-latency-throughput/page.tsx
+++ b/apps/web/src/app/(dashboard)/how-ai-stats-measures-latency-throughput/page.tsx
@@ -1,0 +1,22 @@
+import type { Metadata } from "next";
+import { MethodologyArticlePage } from "@/components/methodology/MethodologyArticlePage";
+import {
+	METHODOLOGY_ENTRY_BY_SLUG,
+	type MethodologyEntry,
+} from "@/lib/content/methodology";
+import { buildMetadata } from "@/lib/seo";
+
+const entry = METHODOLOGY_ENTRY_BY_SLUG[
+	"how-ai-stats-measures-latency-throughput"
+] as MethodologyEntry;
+
+export const metadata: Metadata = buildMetadata({
+	title: entry.title,
+	description: entry.description,
+	path: entry.path,
+	keywords: entry.keywords,
+});
+
+export default function LatencyThroughputMethodologyPage() {
+	return <MethodologyArticlePage entry={entry} />;
+}

--- a/apps/web/src/app/(dashboard)/how-ai-stats-normalises-ai-benchmarks/page.tsx
+++ b/apps/web/src/app/(dashboard)/how-ai-stats-normalises-ai-benchmarks/page.tsx
@@ -1,0 +1,22 @@
+import type { Metadata } from "next";
+import { MethodologyArticlePage } from "@/components/methodology/MethodologyArticlePage";
+import {
+	METHODOLOGY_ENTRY_BY_SLUG,
+	type MethodologyEntry,
+} from "@/lib/content/methodology";
+import { buildMetadata } from "@/lib/seo";
+
+const entry = METHODOLOGY_ENTRY_BY_SLUG[
+	"how-ai-stats-normalises-ai-benchmarks"
+] as MethodologyEntry;
+
+export const metadata: Metadata = buildMetadata({
+	title: entry.title,
+	description: entry.description,
+	path: entry.path,
+	keywords: entry.keywords,
+});
+
+export default function BenchmarkMethodologyPage() {
+	return <MethodologyArticlePage entry={entry} />;
+}

--- a/apps/web/src/app/(dashboard)/how-ai-stats-tracks-provider-availability/page.tsx
+++ b/apps/web/src/app/(dashboard)/how-ai-stats-tracks-provider-availability/page.tsx
@@ -1,0 +1,22 @@
+import type { Metadata } from "next";
+import { MethodologyArticlePage } from "@/components/methodology/MethodologyArticlePage";
+import {
+	METHODOLOGY_ENTRY_BY_SLUG,
+	type MethodologyEntry,
+} from "@/lib/content/methodology";
+import { buildMetadata } from "@/lib/seo";
+
+const entry = METHODOLOGY_ENTRY_BY_SLUG[
+	"how-ai-stats-tracks-provider-availability"
+] as MethodologyEntry;
+
+export const metadata: Metadata = buildMetadata({
+	title: entry.title,
+	description: entry.description,
+	path: entry.path,
+	keywords: entry.keywords,
+});
+
+export default function ProviderAvailabilityMethodologyPage() {
+	return <MethodologyArticlePage entry={entry} />;
+}

--- a/apps/web/src/app/(dashboard)/internal/data/actions.ts
+++ b/apps/web/src/app/(dashboard)/internal/data/actions.ts
@@ -8,6 +8,11 @@ import {
 	revalidateModelDataOnlyTags,
 	revalidateModelDataTags,
 } from "@/lib/cache/revalidateDataTags";
+import {
+	getIndexNowModelUrls,
+	getIndexNowProviderUrls,
+	submitIndexNowUrls,
+} from "@/lib/indexnow";
 import { updateModel } from "@/app/(dashboard)/models/actions";
 import { normalizeProviderPromptTrainingPolicy } from "@/lib/providers/promptTrainingPolicy";
 import {
@@ -406,6 +411,10 @@ export async function createAPIProviderAction(formData: FormData) {
 	if (error) throw new Error(error.message);
 
 	revalidateModelDataTags();
+	await submitIndexNowUrls(
+		getIndexNowProviderUrls(apiProviderId),
+		`create provider ${apiProviderId}`,
+	);
 	revalidatePath("/internal/data/api-providers");
 }
 
@@ -430,6 +439,10 @@ export async function updateAPIProviderAction(apiProviderId: string, formData: F
 	if (error) throw new Error(error.message);
 
 	revalidateModelDataTags();
+	await submitIndexNowUrls(
+		getIndexNowProviderUrls(apiProviderId),
+		`update provider ${apiProviderId}`,
+	);
 	revalidatePath("/internal/data/api-providers");
 }
 
@@ -442,6 +455,10 @@ export async function deleteAPIProviderAction(apiProviderId: string) {
 	if (error) throw new Error(error.message);
 
 	revalidateModelDataTags();
+	await submitIndexNowUrls(
+		getIndexNowProviderUrls(apiProviderId),
+		`delete provider ${apiProviderId}`,
+	);
 	revalidatePath("/internal/data/api-providers");
 }
 
@@ -913,6 +930,10 @@ export async function createModelAction(formData: FormData) {
 		modelId,
 		organisationIds: [organisationId],
 	});
+	await submitIndexNowUrls(
+		getIndexNowModelUrls(modelId),
+		`create model ${modelId}`,
+	);
 	revalidatePath("/internal/data/models");
 }
 
@@ -955,6 +976,10 @@ export async function updateModelAction(modelId: string, formData: FormData) {
 	if (error) throw new Error(error.message);
 
 	revalidateModelDataTags({ modelId, organisationIds: [organisationId] });
+	await submitIndexNowUrls(
+		getIndexNowModelUrls(modelId),
+		`update model ${modelId}`,
+	);
 	revalidatePath("/internal/data/models");
 }
 
@@ -964,6 +989,10 @@ export async function deleteModelAction(modelId: string) {
 	await deleteModelGraph(supabase, modelId);
 
 	revalidateModelDataTags({ modelId, organisationIds });
+	await submitIndexNowUrls(
+		getIndexNowModelUrls(modelId),
+		`delete model ${modelId}`,
+	);
 	revalidatePath("/internal/data/models");
 }
 

--- a/apps/web/src/app/(dashboard)/methodology/page.tsx
+++ b/apps/web/src/app/(dashboard)/methodology/page.tsx
@@ -1,0 +1,71 @@
+import Link from "next/link";
+import type { Metadata } from "next";
+import { ArrowRight } from "lucide-react";
+import { buildMetadata } from "@/lib/seo";
+import { METHODOLOGY_ENTRIES } from "@/lib/content/methodology";
+import { Separator } from "@/components/ui/separator";
+
+export const metadata: Metadata = buildMetadata({
+	title: "AI Stats Methodology",
+	description:
+		"Source-of-truth methodology pages covering how AI Stats calculates pricing, measures latency and throughput, normalises benchmarks, and tracks provider availability.",
+	path: "/methodology",
+	keywords: [
+		"AI Stats methodology",
+		"AI model pricing methodology",
+		"AI benchmark methodology",
+		"provider availability methodology",
+	],
+});
+
+export default function MethodologyIndexPage() {
+	return (
+		<div className="container mx-auto max-w-4xl space-y-10 px-4 py-10 sm:px-6 lg:px-8">
+			<header className="space-y-3">
+				<div className="text-sm text-muted-foreground">
+					Methodology
+				</div>
+				<h1 className="max-w-3xl text-3xl font-semibold tracking-tight text-foreground sm:text-4xl">
+					How AI Stats measures what it publishes
+				</h1>
+				<p className="max-w-2xl text-sm leading-7 text-muted-foreground sm:text-base">
+					Four reference pages covering how pricing, performance, benchmarks,
+					and provider coverage are defined across the public catalog.
+				</p>
+			</header>
+
+			<Separator className="bg-zinc-200/70 dark:bg-zinc-800/70" />
+
+			<section className="divide-y divide-zinc-200/70 dark:divide-zinc-800/70">
+				{METHODOLOGY_ENTRIES.map((entry) => (
+					<article
+						key={entry.slug}
+						className="grid gap-4 py-6 md:grid-cols-[minmax(0,1fr)_auto] md:items-start"
+					>
+						<div className="space-y-3">
+							<p className="text-sm text-muted-foreground">{entry.shortTitle}</p>
+							<h2 className="text-xl font-semibold tracking-tight text-foreground">
+								{entry.title}
+							</h2>
+							<p className="text-sm leading-6 text-muted-foreground">
+								{entry.description}
+							</p>
+							<p className="text-xs text-zinc-500 dark:text-zinc-400">
+								Last updated {entry.lastUpdated}
+							</p>
+						</div>
+						<div className="md:self-start">
+							<Link
+								href={entry.path}
+								className="inline-flex items-center gap-1 text-sm font-medium text-foreground transition-colors hover:text-muted-foreground"
+							>
+								Read page
+								<ArrowRight className="h-4 w-4" />
+							</Link>
+						</div>
+					</article>
+				))}
+			</section>
+		</div>
+	);
+}

--- a/apps/web/src/app/(dashboard)/models/[organisationId]/[modelId]/page.tsx
+++ b/apps/web/src/app/(dashboard)/models/[organisationId]/[modelId]/page.tsx
@@ -6,7 +6,7 @@ import ModelOverviewSections, {
 } from "@/components/(data)/model/overview/ModelOverviewSections";
 import ModelDetailShell from "@/components/(data)/model/ModelDetailShell";
 import type { Metadata } from "next";
-import { buildMetadata } from "@/lib/seo";
+import { absoluteUrl, buildMetadata } from "@/lib/seo";
 import {
 	getModelPath,
 	getModelMetadataIdentity,
@@ -23,6 +23,7 @@ import {
 	type QuickstartRequestContext,
 	type QuickstartSearchParams,
 } from "@/components/(data)/model/quickstart/requestContext";
+import Script from "next/script";
 
 async function ModelOverviewSectionsContent({
 	modelId,
@@ -82,12 +83,12 @@ export async function generateMetadata(props: {
 	const imagePath = `/og/models/${modelId}`;
 
 	return buildMetadata({
-		title: `${modelName} - Benchmarks, Pricing & API Access`,
+		title: `${modelName} Pricing, Benchmarks, Latency & Providers`,
 		description: buildModelPageMetadataDescription({
 			modelDescription,
 			suffix:
-				"Browse benchmarks, providers, pricing, deployment options, and compatibility details on AI Stats.",
-			fallback: `Browse benchmarks, providers, pricing, deployment options, and compatibility details for ${modelName} on AI Stats.`,
+				"Compare pricing, benchmarks, providers, latency signals, and compatibility details on AI Stats.",
+			fallback: `Compare pricing, benchmarks, providers, latency signals, and compatibility details for ${modelName} on AI Stats.`,
 		}),
 		path,
 		keywords: [
@@ -132,24 +133,86 @@ export default async function Page({
 		);
 	}
 	const modelPromise = getModelOverviewCached(modelId, includeHidden);
+	const modelOverview = await modelPromise;
+	const modelName = modelOverview?.name ?? modelId.split("/").slice(-1)[0] ?? modelId;
+	const organisationName =
+		modelOverview?.organisation?.name ?? routeParams.organisationId;
+	const datasetSchema = {
+		"@context": "https://schema.org",
+		"@type": "Dataset",
+		name: `${organisationName} ${modelName}`.trim(),
+		description: `AI Stats profile for ${modelName} with pricing, benchmarks, providers, latency signals, and gateway compatibility details.`,
+		url: absoluteUrl(getModelPath(modelId)),
+		creator: {
+			"@type": "Organization",
+			name: organisationName,
+		},
+		keywords: [
+			modelName,
+			`${modelName} pricing`,
+			`${modelName} benchmarks`,
+			`${modelName} providers`,
+		],
+		dateModified:
+			modelOverview?.updated_at ??
+			modelOverview?.release_date ??
+			modelOverview?.announcement_date ??
+			undefined,
+	};
+	const breadcrumbSchema = {
+		"@context": "https://schema.org",
+		"@type": "BreadcrumbList",
+		itemListElement: [
+			{
+				"@type": "ListItem",
+				position: 1,
+				name: "Home",
+				item: absoluteUrl("/"),
+			},
+			{
+				"@type": "ListItem",
+				position: 2,
+				name: "Models",
+				item: absoluteUrl("/models"),
+			},
+			{
+				"@type": "ListItem",
+				position: 3,
+				name: modelName,
+				item: absoluteUrl(getModelPath(modelId)),
+			},
+		],
+	};
 
 	return (
-		<ModelDetailShell modelId={modelId} tab="overview" includeHidden={includeHidden}>
-			<Suspense fallback={<ModelOverviewSectionsSkeleton />}>
-				<ModelOverviewSectionsContent
-					modelId={modelId}
-					includeHidden={includeHidden}
-					modelPromise={modelPromise}
-					quickstartRequestContext={quickstartRequestContext}
-				/>
-			</Suspense>
-			<Suspense fallback={<ModelCreatorModelsSkeleton />}>
-				<ModelCreatorModelsSectionContent
-					modelId={modelId}
-					includeHidden={includeHidden}
-					modelPromise={modelPromise}
-				/>
-			</Suspense>
-		</ModelDetailShell>
+		<>
+			<Script
+				id="model-dataset-schema"
+				type="application/ld+json"
+				dangerouslySetInnerHTML={{ __html: JSON.stringify(datasetSchema) }}
+			/>
+			<Script
+				id="model-breadcrumb-schema"
+				type="application/ld+json"
+				dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbSchema) }}
+			/>
+			<ModelDetailShell modelId={modelId} tab="overview" includeHidden={includeHidden}>
+				<Suspense fallback={<ModelOverviewSectionsSkeleton />}>
+					<ModelOverviewSectionsContent
+						modelId={modelId}
+						includeHidden={includeHidden}
+						modelPromise={modelPromise}
+						quickstartRequestContext={quickstartRequestContext}
+					/>
+				</Suspense>
+				<Suspense fallback={<ModelCreatorModelsSkeleton />}>
+					<ModelCreatorModelsSectionContent
+						modelId={modelId}
+						includeHidden={includeHidden}
+						modelPromise={modelPromise}
+					/>
+				</Suspense>
+			</ModelDetailShell>
+		</>
 	);
 }

--- a/apps/web/src/app/(dashboard)/models/actions.ts
+++ b/apps/web/src/app/(dashboard)/models/actions.ts
@@ -9,6 +9,11 @@ import {
   revalidateModelDataTags,
 } from "@/lib/cache/revalidateDataTags"
 import {
+  getIndexNowModelUrls,
+  getIndexNowProviderUrls,
+  submitIndexNowUrls,
+} from "@/lib/indexnow"
+import {
   MODEL_MODALITY_OPTIONS,
   normalizeCapabilityStatus,
   normalizeModelStatus,
@@ -1025,6 +1030,13 @@ export async function updateModel(payload: ModelUpdatePayload) {
   const benchmarkIds = Array.from(
     new Set([...previousBenchmarkIds, ...incomingBenchmarkIds])
   )
+  const providerIdsForIndexNow = Array.from(
+    new Set([
+      ...(provider_models ?? []).map((row) => row.provider_id?.trim() || ""),
+      ...(provider_capabilities ?? []).map((row) => row.provider_id?.trim() || ""),
+      ...(pricing_rules ?? []).map((row) => row.provider_id?.trim() || ""),
+    ].filter(Boolean))
+  )
   revalidateModelDataTags({
     modelId,
     organisationIds: [previousOrganisationId, nextOrganisationId],
@@ -1035,6 +1047,15 @@ export async function updateModel(payload: ModelUpdatePayload) {
   }
   revalidatePath(`/models/**`)
   revalidatePath("/models")
+  await submitIndexNowUrls(
+    [
+      ...getIndexNowModelUrls(modelId),
+      ...providerIdsForIndexNow.flatMap((providerId) =>
+        getIndexNowProviderUrls(providerId)
+      ),
+    ],
+    `update model graph ${modelId}`
+  )
 
   return { ok: true }
 }

--- a/apps/web/src/app/(dashboard)/models/page.tsx
+++ b/apps/web/src/app/(dashboard)/models/page.tsx
@@ -8,7 +8,7 @@ import {
 import { getFreeRouterOverview } from "@/lib/fetchers/models/getFreeRouterOverview";
 import { getMonitorModels } from "@/lib/fetchers/models/table-view/getMonitorModels";
 import type { Metadata } from "next";
-import { buildMetadata } from "@/lib/seo";
+import { absoluteUrl, buildMetadata } from "@/lib/seo";
 import { featureOrder } from "@/lib/config/featureLabels";
 import {
 	FREE_ROUTER_DESCRIPTION,
@@ -20,6 +20,7 @@ import {
 } from "@/lib/models/freeRouter";
 import { normalizeOrganisationDisplayName } from "@/lib/models/organisationDisplay";
 import { resolveProviderDisplayName } from "@/lib/providers/providerOffers";
+import Script from "next/script";
 import type {
 	GatewayStatusFilter,
 	ModelsFilterFacets,
@@ -1137,6 +1138,43 @@ function buildFreeRouterModelsPageEntry(
 	};
 }
 
+function summarizeModelsPage(models: ModelsPageModel[]) {
+	const creators = new Set<string>();
+	const providers = new Set<string>();
+	let activeModels = 0;
+
+	for (const model of models) {
+		const creator = normalizeOrganisationDisplayName(
+			model.organisation_name,
+			model.organisation_id,
+		);
+		if (creator) creators.add(creator);
+
+		for (const provider of model.gateway_provider_names ?? []) {
+			const normalized = String(provider ?? "").trim();
+			if (normalized) providers.add(normalized);
+		}
+
+		if (model.gateway_status === "active") {
+			activeModels += 1;
+		}
+	}
+
+	const featuredModels = models
+		.filter((model) => model.model_id !== FREE_ROUTER_MODEL_ID)
+		.slice(0, 8)
+		.map((model) => model.name)
+		.filter(Boolean);
+
+	return {
+		totalModels: models.length,
+		activeModels,
+		creators: creators.size,
+		providers: providers.size,
+		featuredModels,
+	};
+}
+
 async function ModelsPageDataSection() {
 	const includeHidden = false;
 	const [monitorResult, allModels, freeRouterOverview] = await Promise.all([
@@ -1151,8 +1189,83 @@ async function ModelsPageDataSection() {
 		...models.filter((model) => model.model_id !== FREE_ROUTER_MODEL_ID),
 	];
 	const facets = buildModelsFilterFacets(modelsWithFreeRouter);
+	const summary = summarizeModelsPage(modelsWithFreeRouter);
+	const dataCatalogSchema = {
+		"@context": "https://schema.org",
+		"@type": "DataCatalog",
+		name: "AI Stats Model Database",
+		description:
+			"Compare AI models by pricing, benchmarks, context window, modalities, providers, and gateway availability.",
+		url: absoluteUrl("/models"),
+		keywords: [
+			"AI models",
+			"model pricing",
+			"AI benchmarks",
+			"context window",
+			"gateway providers",
+		],
+		includesObject: summary.featuredModels.map((name) => ({
+			"@type": "Dataset",
+			name,
+		})),
+	};
+	const breadcrumbSchema = {
+		"@context": "https://schema.org",
+		"@type": "BreadcrumbList",
+		itemListElement: [
+			{
+				"@type": "ListItem",
+				position: 1,
+				name: "Home",
+				item: absoluteUrl("/"),
+			},
+			{
+				"@type": "ListItem",
+				position: 2,
+				name: "Models",
+				item: absoluteUrl("/models"),
+			},
+		],
+	};
 
-	return <ModelsDisplay models={modelsWithFreeRouter} facets={facets} />;
+	return (
+		<>
+			<Script
+				id="models-data-catalog-schema"
+				type="application/ld+json"
+				dangerouslySetInnerHTML={{ __html: JSON.stringify(dataCatalogSchema) }}
+			/>
+			<Script
+				id="models-breadcrumb-schema"
+				type="application/ld+json"
+				dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbSchema) }}
+			/>
+			<div className="mb-8 space-y-3">
+				<h1 className="text-3xl font-bold tracking-tight">
+					Compare AI models by pricing, benchmarks, providers, and context
+				</h1>
+				<p className="max-w-4xl text-sm leading-6 text-muted-foreground sm:text-base">
+					AI Stats tracks {summary.totalModels.toLocaleString()} models from{" "}
+					{summary.creators.toLocaleString()} model creators and{" "}
+					{summary.providers.toLocaleString()} gateway providers. Use this index
+					to compare pricing, modality support, context length, active gateway
+					coverage, throughput, latency, and benchmark results.
+				</p>
+				{summary.featuredModels.length > 0 ? (
+					<p className="max-w-4xl text-sm leading-6 text-muted-foreground">
+						Popular entries in this index include{" "}
+						{summary.featuredModels.join(", ")}. {summary.activeModels.toLocaleString()}{" "}
+						models currently have active gateway coverage.
+					</p>
+				) : null}
+			</div>
+			<ModelsDisplay
+				models={modelsWithFreeRouter}
+				facets={facets}
+				showPrimaryHeader={false}
+			/>
+		</>
+	);
 }
 
 export default function ModelsPage() {

--- a/apps/web/src/app/(dashboard)/page.tsx
+++ b/apps/web/src/app/(dashboard)/page.tsx
@@ -8,7 +8,7 @@ import {
 	type LucideIcon,
 } from "lucide-react";
 import type { Metadata } from "next";
-import { buildMetadata } from "@/lib/seo";
+import { absoluteUrl, buildMetadata } from "@/lib/seo";
 import { getGatewayHeroVariant } from "@/lib/flags/gatewayHero";
 import { GATEWAY_TIERS } from "@/components/(gateway)/credits/tiers";
 import DatabaseStats from "@/components/landingPage/DatabaseStatistics";
@@ -26,6 +26,12 @@ import PartnerLogos from "@/components/landingPage/PartnerLogos/PartnerLogos";
 import { Logo } from "@/components/Logo";
 import { HomepageModelContext } from "@/components/agents/HomepageModelContext";
 import { Button } from "@/components/ui/button";
+import Script from "next/script";
+import {
+	PREFERRED_SITE_NAME,
+	SITE_ALTERNATE_NAME,
+	SITE_NAME,
+} from "@/lib/seo";
 
 export const metadata: Metadata = buildMetadata({
 	title: "AI Models, Benchmarks & Gateway API",
@@ -326,8 +332,41 @@ function LandingPage({ isBeta }: { isBeta: boolean }) {
 
 export default async function Page() {
 	const heroVariant = await getGatewayHeroVariant();
+	const softwareApplicationSchema = {
+		"@context": "https://schema.org",
+		"@type": "SoftwareApplication",
+		name: SITE_NAME,
+		alternateName: PREFERRED_SITE_NAME,
+		applicationCategory: "DeveloperApplication",
+		operatingSystem: "Web",
+		url: absoluteUrl("/"),
+		description:
+			"Open-source AI gateway and model intelligence database for comparing AI models, providers, pricing, benchmarks, and reliability.",
+	};
+	const websiteSchema = {
+		"@context": "https://schema.org",
+		"@type": "WebSite",
+		name: PREFERRED_SITE_NAME,
+		alternateName: SITE_ALTERNATE_NAME,
+		url: absoluteUrl("/"),
+		description:
+			"Compare AI models, providers, pricing, benchmarks, and gateway reliability data.",
+	};
+
 	return (
 		<>
+			<Script
+				id="homepage-software-application-schema"
+				type="application/ld+json"
+				dangerouslySetInnerHTML={{
+					__html: JSON.stringify(softwareApplicationSchema),
+				}}
+			/>
+			<Script
+				id="homepage-website-schema"
+				type="application/ld+json"
+				dangerouslySetInnerHTML={{ __html: JSON.stringify(websiteSchema) }}
+			/>
 			<HomepageModelContext />
 			<LandingPage isBeta={heroVariant === "experimental"} />
 		</>

--- a/apps/web/src/app/(dashboard)/pricing/page.tsx
+++ b/apps/web/src/app/(dashboard)/pricing/page.tsx
@@ -503,6 +503,13 @@ export default function PricingPage() {
 						<Link className="underline underline-offset-4" href="/tools/pricing-calculator">
 							Pricing Calculator
 						</Link>
+						{" "}and review{" "}
+						<Link
+							className="underline underline-offset-4"
+							href="/how-ai-stats-calculates-model-pricing"
+						>
+							how AI Stats calculates model pricing
+						</Link>
 						.
 					</p>
 					<div className="flex flex-col gap-3 sm:flex-row sm:flex-wrap sm:items-center">

--- a/apps/web/src/app/(dashboard)/rankings/page.tsx
+++ b/apps/web/src/app/(dashboard)/rankings/page.tsx
@@ -6,6 +6,7 @@
 import { Suspense } from "react";
 import { Metadata } from "next";
 import { buildMetadata } from "@/lib/seo";
+import Link from "next/link";
 import { PerformanceLandscapePanel } from "@/components/(rankings)/PerformanceLandscapePanel";
 import { PerformanceLeaderboard } from "@/components/(rankings)/PerformanceLeaderboard";
 import { MarketShareStackedBar } from "@/components/(rankings)/MarketShareStackedBar";
@@ -35,26 +36,34 @@ import {
     getTopApps,
     getOrganisationLogoIdsByNames,
     getAppImageUrlsByIds,
+    getRankingsIndexabilitySnapshot,
 } from "@/lib/fetchers/rankings/getRankingsData";
 
-export const metadata: Metadata = buildMetadata({
-	title: "AI Model Rankings: Usage, Cost, Latency & Throughput",
-	description:
-		"Track live AI model rankings using AI Stats gateway data, with cost, latency, throughput and provider breakdowns.",
-	path: "/rankings",
-	keywords: [
-		"AI model rankings",
-		"LLM rankings",
-		"model latency",
-		"model throughput",
-		"AI usage statistics",
-	],
-	openGraph: {
-		title: "AI Model Rankings: Live Usage Statistics",
+export async function generateMetadata(): Promise<Metadata> {
+	const indexability = await getRankingsIndexabilitySnapshot();
+
+	return buildMetadata({
+		title: "AI Model Rankings: Usage, Cost, Latency & Throughput",
 		description:
-			"Compare AI models by usage, cost, latency, and throughput with live gateway data and provider breakdowns.",
-	},
-});
+			"Track live AI model rankings using AI Stats gateway data, with cost, latency, throughput and provider breakdowns.",
+		path: "/rankings",
+		keywords: [
+			"AI model rankings",
+			"LLM rankings",
+			"model latency",
+			"model throughput",
+			"AI usage statistics",
+		],
+		openGraph: {
+			title: "AI Model Rankings: Live Usage Statistics",
+			description:
+				"Compare AI models by usage, cost, latency, and throughput with live gateway data and provider breakdowns.",
+		},
+		robots: indexability.shouldIndex
+			? { index: true, follow: true }
+			: { index: false, follow: true },
+	});
+}
 
 export default async function RankingsPage() {
     return (
@@ -69,6 +78,30 @@ export default async function RankingsPage() {
                         </h1>
                         <p className="text-sm text-muted-foreground">
                             Based on real usage data from across AI Stats.
+                        </p>
+                        <p className="text-sm text-muted-foreground">
+                            Methodology:{" "}
+                            <Link
+                                href="/how-ai-stats-measures-latency-throughput"
+                                className="underline underline-offset-4"
+                            >
+                                latency and throughput
+                            </Link>
+                            ,{" "}
+                            <Link
+                                href="/how-ai-stats-normalises-ai-benchmarks"
+                                className="underline underline-offset-4"
+                            >
+                                benchmark normalization
+                            </Link>
+                            , and{" "}
+                            <Link
+                                href="/how-ai-stats-tracks-provider-availability"
+                                className="underline underline-offset-4"
+                            >
+                                provider availability
+                            </Link>
+                            .
                         </p>
                     </div>
                     <Suspense fallback={<ChartSkeleton />}>

--- a/apps/web/src/app/indexnow-key.txt/route.ts
+++ b/apps/web/src/app/indexnow-key.txt/route.ts
@@ -1,0 +1,15 @@
+import { INDEXNOW_KEY } from "@/lib/indexnow";
+
+export async function GET() {
+	if (!INDEXNOW_KEY) {
+		return new Response("Not found", { status: 404 });
+	}
+
+	return new Response(INDEXNOW_KEY, {
+		status: 200,
+		headers: {
+			"Content-Type": "text/plain; charset=utf-8",
+			"Cache-Control": "public, max-age=0, s-maxage=86400",
+		},
+	});
+}

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -8,7 +8,12 @@ import { Montserrat } from "next/font/google";
 import { cn } from "@/lib/utils";
 import { TailwindIndicator } from "@/components/tailwind-indicator";
 import { Metadata } from "next";
-import { METADATA_BASE, absoluteUrl } from "@/lib/seo";
+import {
+	METADATA_BASE,
+	PREFERRED_SITE_NAME,
+	SITE_NAME,
+	absoluteUrl,
+} from "@/lib/seo";
 import { GA_MEASUREMENT_ID } from "@/lib/analytics";
 import { CookieConsentManager } from "@/components/analytics/CookieConsentManager";
 import { DeferredVercelAnalytics } from "@/components/analytics/DeferredVercelAnalytics";
@@ -20,19 +25,20 @@ const montserrat = Montserrat({ subsets: ["latin"] });
 
 export const metadata: Metadata = {
 	title: {
-		default: "AI Stats",
-		template: "%s | AI Stats",
+		default: PREFERRED_SITE_NAME,
+		template: `%s | ${SITE_NAME}`,
 	},
 	description:
 		"Discover and compare the world's most comprehensive AI model database and gateway. Browse benchmarks, features, pricing, and access state-of-the-art AI models.",
-	authors: [{ name: "AI Stats" }],
+	applicationName: PREFERRED_SITE_NAME,
+	authors: [{ name: SITE_NAME }],
 	metadataBase: METADATA_BASE,
 	openGraph: {
 		type: "website",
 		locale: "en_GB",
-		siteName: "AI Stats",
+		siteName: PREFERRED_SITE_NAME,
 		url: absoluteUrl("/"),
-		title: "AI Stats",
+		title: PREFERRED_SITE_NAME,
 		description:
 			"Browse and compare state-of-the-art AI models, benchmarks, features, and pricing.",
 		images: [
@@ -48,7 +54,7 @@ export const metadata: Metadata = {
 		card: "summary_large_image",
 		site: "@phaseoapp",
 		creator: "@DanielButler001",
-		title: "AI Stats",
+		title: PREFERRED_SITE_NAME,
 		description:
 			"Browse and compare state-of-the-art AI models, benchmarks, features, and pricing.",
 		images: [absoluteUrl("/og.png")],

--- a/apps/web/src/app/not-found.tsx
+++ b/apps/web/src/app/not-found.tsx
@@ -36,7 +36,7 @@ const suggestions = [
 		icon: BookOpen,
 	},
 	{
-		href: "/providers",
+		href: "/api-providers",
 		label: "Explore providers",
 		description:
 			"Browse supported providers and see where coverage is available today.",

--- a/apps/web/src/app/robots.txt/route.ts
+++ b/apps/web/src/app/robots.txt/route.ts
@@ -2,18 +2,31 @@ import { CONTENT_SIGNAL_VALUE } from "@/lib/agent-discovery";
 import { PUBLIC_CDN_CACHE_CONTROL } from "@/lib/cache/publicCacheHeaders";
 import { SITE_URL } from "@/lib/seo";
 
+const DISALLOW_PATHS = [
+	"/api/",
+	"/auth/",
+	"/sign-in",
+	"/sign-up",
+	"/settings/",
+	"/internal/",
+	"/gateway/usage",
+] as const;
+
+function buildRobotBlock(userAgent: string): string[] {
+	return [
+		`User-agent: ${userAgent}`,
+		`Content-Signal: ${CONTENT_SIGNAL_VALUE}`,
+		"Allow: /",
+		...DISALLOW_PATHS.map((path) => `Disallow: ${path}`),
+		"",
+	];
+}
+
 const ROBOTS_BODY = [
-	"User-agent: *",
-	`Content-Signal: ${CONTENT_SIGNAL_VALUE}`,
-	"Allow: /",
-	"Disallow: /api/",
-	"Disallow: /auth/",
-	"Disallow: /sign-in",
-	"Disallow: /sign-up",
-	"Disallow: /settings/",
-	"Disallow: /internal/",
-	"Disallow: /gateway/usage",
-	"",
+	...buildRobotBlock("*"),
+	...buildRobotBlock("OAI-SearchBot"),
+	...buildRobotBlock("ChatGPT-User"),
+	...buildRobotBlock("GPTBot"),
 	`Sitemap: ${SITE_URL}/sitemap.xml`,
 	`Host: ${SITE_URL}`,
 	"",

--- a/apps/web/src/app/sitemap.ts
+++ b/apps/web/src/app/sitemap.ts
@@ -36,6 +36,9 @@ type RouteSuffix = {
 
 type ModelSitemapSource = {
 	model_id?: string | null;
+	updated_at?: string | null;
+	primary_date?: string | null;
+	announcement_date?: string | null;
 };
 
 type PresetSitemapSource = {
@@ -60,6 +63,11 @@ const staticRoutes: Array<{
         { path: "/families", changeFrequency: "weekly", priority: 0.75 },
         { path: "/subscription-plans", changeFrequency: "weekly", priority: 0.75 },
         { path: "/pricing", changeFrequency: "weekly", priority: 0.75 },
+        { path: "/methodology", changeFrequency: "monthly", priority: 0.68 },
+        { path: "/how-ai-stats-calculates-model-pricing", changeFrequency: "monthly", priority: 0.65 },
+        { path: "/how-ai-stats-measures-latency-throughput", changeFrequency: "monthly", priority: 0.65 },
+        { path: "/how-ai-stats-normalises-ai-benchmarks", changeFrequency: "monthly", priority: 0.65 },
+        { path: "/how-ai-stats-tracks-provider-availability", changeFrequency: "monthly", priority: 0.65 },
         { path: "/faq", changeFrequency: "monthly", priority: 0.6 },
 		{ path: "/compare", changeFrequency: "weekly", priority: 0.7 },
 		{ path: "/migrate", changeFrequency: "weekly", priority: 0.7 },
@@ -279,6 +287,53 @@ function applySuffixes(
     return items;
 }
 
+function resolveLastModified(
+	...candidates: Array<string | null | undefined>
+): string | null {
+	let latest: string | null = null;
+	let latestMs = Number.NEGATIVE_INFINITY;
+
+	for (const candidate of candidates) {
+		if (!candidate) continue;
+		const parsed = Date.parse(candidate);
+		if (!Number.isFinite(parsed) || parsed <= latestMs) continue;
+		latestMs = parsed;
+		latest = candidate;
+	}
+
+	return latest;
+}
+
+function applySuffixesWithEntries<T extends { slug: string; lastModified?: string | null }>(
+	prefix: string,
+	entries: T[],
+	suffixes: RouteSuffix[],
+	fallbackLastModified: string,
+): SitemapItem[] {
+	if (!entries.length) {
+		return [];
+	}
+
+	const items: SitemapItem[] = [];
+	for (const entry of entries) {
+		for (const suffix of suffixes) {
+			const route = suffix.suffix
+				? `${prefix}/${entry.slug}${suffix.suffix}`
+				: `${prefix}/${entry.slug}`;
+			items.push(
+				createItem(
+					route,
+					suffix.changeFrequency,
+					suffix.priority,
+					entry.lastModified ?? fallbackLastModified,
+				),
+			);
+		}
+	}
+
+	return items;
+}
+
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
 	const lastModified =
 		process.env.NEXT_PUBLIC_DEPLOY_TIME ?? new Date().toISOString();
@@ -310,15 +365,43 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
 		getHelpArticleParams(),
 	]);
 
-	const modelSlugs = normalizeModelRouteSlugs(
-		fromSettled(modelsResult, "models for sitemap", [])
+	const modelsForSitemap = fromSettled(modelsResult, "models for sitemap", []);
+	const modelSlugs = normalizeModelRouteSlugs(modelsForSitemap);
+	const modelEntries = modelSlugs.map((slug) => {
+		const source = modelsForSitemap.find(
+			(model) => String(model.model_id ?? "").trim() === slug,
+		);
+		return {
+			slug,
+			lastModified:
+				resolveLastModified(
+					source?.updated_at,
+					source?.primary_date,
+					source?.announcement_date,
+				) ?? lastModified,
+		};
+	});
+	const providersForSitemap = fromSettled(
+		apiProvidersResult,
+		"api providers for sitemap",
+		[],
 	);
 	const providerSlugs = normalizeSingleSegmentSlugs(
-		fromSettled(apiProvidersResult, "api providers for sitemap", []).map(
-			(provider) => String(provider.api_provider_id ?? "").trim()
+		providersForSitemap.map((provider) =>
+			String(provider.api_provider_id ?? "").trim()
 		),
 		"api provider",
 	);
+	const providerEntries = providerSlugs.map((slug) => {
+		const source = providersForSitemap.find(
+			(provider) => String(provider.api_provider_id ?? "").trim() === slug,
+		);
+		return {
+			slug,
+			lastModified:
+				resolveLastModified(source?.last_updated_at) ?? lastModified,
+		};
+	});
 	const organisationSlugs = normalizeSingleSegmentSlugs(
 		fromSettled(organisationsResult, "organisations for sitemap", []).map(
 			(organisation) => String(organisation.organisation_id ?? "").trim()
@@ -354,10 +437,15 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
 	);
 
 	const dynamicItems = [
-		...applySuffixes("/models", modelSlugs, MODEL_SUFFIXES, lastModified),
-		...applySuffixes(
+		...applySuffixesWithEntries(
+			"/models",
+			modelEntries,
+			MODEL_SUFFIXES,
+			lastModified,
+		),
+		...applySuffixesWithEntries(
 			"/api-providers",
-			providerSlugs,
+			providerEntries,
 			PROVIDER_SUFFIXES,
 			lastModified
 		),

--- a/apps/web/src/components/(data)/api-providers/APIProvidersDisplay.tsx
+++ b/apps/web/src/components/(data)/api-providers/APIProvidersDisplay.tsx
@@ -16,6 +16,7 @@ import type { APIProviderCard as APIProviderCardType } from "@/lib/fetchers/api-
 
 interface APIProvidersDisplayProps {
 	providers: APIProviderCardType[];
+	showPrimaryHeader?: boolean;
 }
 
 type ProviderSortOption =
@@ -40,6 +41,7 @@ function normalizeSortOption(
 
 export default function APIProvidersDisplay({
 	providers,
+	showPrimaryHeader = true,
 }: APIProvidersDisplayProps) {
 	const [search, setSearch] = useQueryState("search", {
 		defaultValue: "",
@@ -92,7 +94,11 @@ export default function APIProvidersDisplay({
 	return (
 		<>
 			<div className="mb-5 flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
-				<h1 className="text-xl font-bold">API Providers</h1>
+				{showPrimaryHeader ? (
+					<h1 className="text-xl font-bold">API Providers</h1>
+				) : (
+					<div />
+				)}
 				<div className="flex w-full flex-col gap-2 sm:flex-row sm:items-center lg:w-auto">
 					<div className="flex items-center gap-2 text-sm text-muted-foreground">
 						<ArrowUpDown className="h-4 w-4" />

--- a/apps/web/src/components/footer.tsx
+++ b/apps/web/src/components/footer.tsx
@@ -63,6 +63,11 @@ const developerLinks = [
 		external: true,
 	},
 	{
+		href: "/methodology",
+		label: "Methodology",
+		icon: FileText,
+	},
+	{
 		href: "https://ai-stats.instatus.com/",
 		label: "Status",
 		icon: Activity,
@@ -239,7 +244,8 @@ export default function Footer() {
 							/>
 						</Link>
 						<p className="max-w-xs text-sm leading-6 text-zinc-600 dark:text-zinc-400">
-							Unified model, provider, and gateway data for teams building with AI APIs.
+							AI Stats by Phaseo brings together model, provider, and gateway
+							data for teams building with AI APIs.
 						</p>
 						<div className="grid gap-2 sm:max-w-none sm:grid-cols-3 xl:max-w-sm xl:grid-cols-1">
 							{featuredLinks.map((link) => (

--- a/apps/web/src/components/landingPage/Auth/SupportedModelsStats.tsx
+++ b/apps/web/src/components/landingPage/Auth/SupportedModelsStats.tsx
@@ -39,7 +39,7 @@ export default async function SupportedModelsStats() {
 		{
 			label: "Organisations",
 			raw: orgsCount,
-			route: "/providers",
+			route: "/api-providers",
 		},
 		{
 			label: "API Models",

--- a/apps/web/src/components/methodology/MethodologyArticlePage.tsx
+++ b/apps/web/src/components/methodology/MethodologyArticlePage.tsx
@@ -1,0 +1,94 @@
+import Link from "next/link";
+import Script from "next/script";
+import { ArrowRight } from "lucide-react";
+import { absoluteUrl, SITE_NAME } from "@/lib/seo";
+import type { MethodologyEntry } from "@/lib/content/methodology";
+import { Separator } from "@/components/ui/separator";
+
+export function MethodologyArticlePage({ entry }: { entry: MethodologyEntry }) {
+	const articleSchema = {
+		"@context": "https://schema.org",
+		"@type": "Article",
+		headline: entry.title,
+		description: entry.description,
+		datePublished: entry.lastUpdated,
+		dateModified: entry.lastUpdated,
+		mainEntityOfPage: absoluteUrl(entry.path),
+		author: {
+			"@type": "Organization",
+			name: SITE_NAME,
+		},
+		publisher: {
+			"@type": "Organization",
+			name: SITE_NAME,
+		},
+	};
+
+	return (
+		<>
+			<Script
+				id={`methodology-schema-${entry.slug}`}
+				type="application/ld+json"
+				dangerouslySetInnerHTML={{ __html: JSON.stringify(articleSchema) }}
+			/>
+			<div className="container mx-auto max-w-3xl space-y-10 px-4 py-10 sm:px-6 lg:px-8">
+				<header className="space-y-4">
+					<div className="text-sm text-muted-foreground">
+						Methodology
+					</div>
+					<div className="space-y-3">
+						<h1 className="max-w-3xl text-3xl font-semibold tracking-tight text-foreground sm:text-4xl">
+							{entry.title}
+						</h1>
+						<p className="max-w-3xl text-sm leading-7 text-muted-foreground sm:text-base">
+							{entry.intro}
+						</p>
+					</div>
+					<p className="text-sm text-zinc-500 dark:text-zinc-400">
+						Last updated: {entry.lastUpdated}
+					</p>
+				</header>
+
+				<Separator className="bg-zinc-200/70 dark:bg-zinc-800/70" />
+
+				<article className="space-y-8">
+					{entry.sections.map((section) => (
+						<section
+							key={section.heading}
+							className="space-y-3 border-t border-zinc-200/70 pt-6 first:border-t-0 first:pt-0 dark:border-zinc-800/70"
+						>
+							<h2 className="text-xl font-semibold tracking-tight text-foreground sm:text-2xl">
+								{section.heading}
+							</h2>
+							<div className="space-y-4 text-base leading-7 text-zinc-700 dark:text-zinc-300">
+								{section.paragraphs.map((paragraph) => (
+									<p key={paragraph}>{paragraph}</p>
+								))}
+							</div>
+						</section>
+					))}
+				</article>
+
+				<Separator className="bg-zinc-200/70 dark:bg-zinc-800/70" />
+
+				<section className="space-y-4">
+					<h2 className="text-sm text-muted-foreground">
+						Related pages
+					</h2>
+					<div className="flex flex-col gap-3">
+						{entry.relatedLinks.map((link) => (
+							<Link
+								key={link.href}
+								href={link.href}
+								className="inline-flex items-center gap-1 text-sm font-medium text-foreground transition-colors hover:text-muted-foreground"
+							>
+								{link.label}
+								<ArrowRight className="h-4 w-4" />
+							</Link>
+						))}
+					</div>
+				</section>
+			</div>
+		</>
+	);
+}

--- a/apps/web/src/lib/content/methodology.ts
+++ b/apps/web/src/lib/content/methodology.ts
@@ -1,0 +1,265 @@
+export type MethodologySection = {
+	heading: string;
+	paragraphs: string[];
+};
+
+export type MethodologyEntry = {
+	path: string;
+	slug: string;
+	shortTitle: string;
+	title: string;
+	description: string;
+	intro: string;
+	lastUpdated: string;
+	keywords: string[];
+	sections: MethodologySection[];
+	relatedLinks: Array<{
+		href: string;
+		label: string;
+	}>;
+};
+
+const LAST_UPDATED = "2026-06-07";
+
+export const METHODOLOGY_ENTRIES: MethodologyEntry[] = [
+	{
+		path: "/how-ai-stats-calculates-model-pricing",
+		slug: "how-ai-stats-calculates-model-pricing",
+		shortTitle: "Model pricing",
+		title: "How AI Stats calculates model pricing",
+		description:
+			"How AI Stats maps provider price sheets, meters, and routing rules into the public model pricing shown across the catalog.",
+		intro:
+			"This page explains how AI Stats turns provider pricing sources into the public pricing values shown on model and provider pages.",
+		lastUpdated: LAST_UPDATED,
+		keywords: [
+			"AI model pricing methodology",
+			"API pricing methodology",
+			"token pricing",
+			"AI Stats pricing",
+		],
+		sections: [
+			{
+				heading: "What we are measuring",
+				paragraphs: [
+					"AI Stats tracks the public execution price for a model-provider combination, including the meter type, unit size, currency, and plan context used by the upstream provider or gateway configuration.",
+					"We separate database pricing visibility from gateway top-up fees. Public model pricing focuses on what a request costs to execute, while the pricing page explains any platform-level credit purchase fees.",
+				],
+			},
+			{
+				heading: "Primary inputs",
+				paragraphs: [
+					"Pricing values are sourced from structured provider pricing rules, provider-model capability mappings, and model metadata stored in the catalog.",
+					"When a provider exposes multiple meters for a model, AI Stats keeps the capability-level pricing so the visible page can distinguish text generation, embeddings, image generation, or other billable surfaces where applicable.",
+				],
+			},
+			{
+				heading: "How prices are normalised",
+				paragraphs: [
+					"Provider price sheets arrive in different units such as per token, per 1M tokens, per image, per second, or per request. AI Stats stores the raw unit and unit size, then calculates consistent display values for the catalog and calculator.",
+					"Currency is preserved as published. Where a provider exposes separate input and output rates, those are shown separately rather than collapsed into a blended estimate.",
+				],
+			},
+			{
+				heading: "Effective dates and change handling",
+				paragraphs: [
+					"Pricing rules can carry effective start and end dates. When multiple rules exist for the same capability, AI Stats prefers the active rule with the strongest match and the highest operational priority.",
+					"When a provider updates a model price, the older rule is retained only as historical context where the data model supports it; the public catalog is meant to reflect the current active price.",
+				],
+			},
+			{
+				heading: "Caveats",
+				paragraphs: [
+					"Some providers publish incomplete or delayed public pricing for preview models, region-specific SKUs, or enterprise-only offerings. In those cases AI Stats may show partial pricing or omit a comparison until the rule can be verified.",
+					"Displayed prices are an operational reference, not a billing contract. Always confirm production billing terms with the provider or your AI Stats commercial plan where necessary.",
+				],
+			},
+		],
+		relatedLinks: [
+			{ href: "/pricing", label: "Gateway pricing" },
+			{ href: "/tools/pricing-calculator", label: "Pricing calculator" },
+			{ href: "/models", label: "Model database" },
+		],
+	},
+	{
+		path: "/how-ai-stats-measures-latency-throughput",
+		slug: "how-ai-stats-measures-latency-throughput",
+		shortTitle: "Latency and throughput",
+		title: "How AI Stats measures latency and throughput",
+		description:
+			"How AI Stats defines the latency, throughput, and request-performance metrics shown in rankings and model or provider performance pages.",
+		intro:
+			"This page explains what AI Stats counts as latency and throughput, how those metrics are aggregated, and why results can vary by route and timeframe.",
+		lastUpdated: LAST_UPDATED,
+		keywords: [
+			"AI model latency methodology",
+			"AI throughput methodology",
+			"LLM latency",
+			"AI Stats performance",
+		],
+		sections: [
+			{
+				heading: "What we are measuring",
+				paragraphs: [
+					"Latency represents the elapsed request time recorded by the gateway for a routed completion, subject to the instrumentation available for that request type.",
+					"Throughput represents the output rate observed for successful requests, typically normalized to tokens per second for text-generation style workloads.",
+				],
+			},
+			{
+				heading: "Aggregation windows",
+				paragraphs: [
+					"Public performance views use rolling windows such as the last 24 hours for detailed performance and longer periods for leaderboard and trend summaries.",
+					"Median values are preferred over averages for public displays because a small number of slow outliers can distort means and produce misleading rankings.",
+				],
+			},
+			{
+				heading: "Filtering and eligibility",
+				paragraphs: [
+					"AI Stats excludes obviously invalid records, unknown identifiers, and rows without enough usable request volume to support a meaningful comparison.",
+					"Performance pages and leaderboards only rank rows with finite, positive throughput or latency values once the relevant thresholds are met.",
+				],
+			},
+			{
+				heading: "Why values can move",
+				paragraphs: [
+					"Latency and throughput are operational measurements, not intrinsic constants of a model. They can move because of provider routing, regional load, model updates, queueing behavior, prompt length, output length, and transport conditions.",
+					"A model may therefore rank differently across providers, across time windows, or across the gateway and the provider's own direct benchmarks.",
+				],
+			},
+			{
+				heading: "Caveats",
+				paragraphs: [
+					"Public performance charts are designed for directional comparison. They are not a substitute for your own workload-specific benchmarking under your own prompt mix, concurrency, and latency budget.",
+					"If a page has insufficient current data, AI Stats may show an empty state and treat that route as a weak search candidate until enough public volume exists.",
+				],
+			},
+		],
+		relatedLinks: [
+			{ href: "/rankings", label: "Rankings" },
+			{ href: "/models", label: "Models" },
+			{ href: "/api-providers", label: "Providers" },
+		],
+	},
+	{
+		path: "/how-ai-stats-normalises-ai-benchmarks",
+		slug: "how-ai-stats-normalises-ai-benchmarks",
+		shortTitle: "Benchmark normalisation",
+		title: "How AI Stats normalises AI benchmarks",
+		description:
+			"How AI Stats stores benchmark scores, variants, and sort direction while keeping benchmark displays aligned across different sources.",
+		intro:
+			"This page explains how AI Stats treats benchmark data from different sources without pretending that every benchmark is directly comparable.",
+		lastUpdated: LAST_UPDATED,
+		keywords: [
+			"AI benchmark methodology",
+			"benchmark normalization",
+			"LLM benchmark scores",
+			"AI Stats benchmarks",
+		],
+		sections: [
+			{
+				heading: "What we store",
+				paragraphs: [
+					"Each benchmark result is stored with a benchmark identifier, a score, optional variant metadata, source links, and self-reported flags where relevant.",
+					"Benchmarks also carry category and sort-direction metadata so AI Stats can distinguish measures where higher is better from measures where lower is better.",
+				],
+			},
+			{
+				heading: "What normalisation means here",
+				paragraphs: [
+					"Normalisation in AI Stats does not mean converting all benchmarks into one universal score. It means preserving enough context to present each benchmark consistently and sort it correctly.",
+					"When benchmarks use different variants, prompts, or evaluation protocols, AI Stats keeps those differences visible instead of flattening them into a single synthetic ranking.",
+				],
+			},
+			{
+				heading: "Ranking logic",
+				paragraphs: [
+					"For benchmark tables, AI Stats respects the benchmark's declared ordering direction. A lower score can therefore rank above a higher one when the benchmark measures error rate, latency, or another lower-is-better quantity.",
+					"If a score cannot be verified or lacks enough context, it may still be stored with source notes but should not be interpreted as equal to a fully verified leaderboard row.",
+				],
+			},
+			{
+				heading: "Source quality and disclosure",
+				paragraphs: [
+					"Benchmark results may come from provider disclosures, benchmark organizers, or other public sources. AI Stats retains source links so readers can inspect the origin of a result.",
+					"Self-reported scores are flagged as such where the source format supports it. That flag is a transparency signal, not an automatic rejection of the score.",
+				],
+			},
+			{
+				heading: "Caveats",
+				paragraphs: [
+					"Benchmark scores are one input to model selection, not the full answer. Real production fit also depends on cost, latency, reliability, modality support, and tooling constraints.",
+					"Two models with similar benchmark numbers may still behave very differently in your own tasks, especially when prompt style or context length changes.",
+				],
+			},
+		],
+		relatedLinks: [
+			{ href: "/benchmarks", label: "Benchmarks" },
+			{ href: "/models", label: "Models" },
+			{ href: "/compare", label: "Compare models" },
+		],
+	},
+	{
+		path: "/how-ai-stats-tracks-provider-availability",
+		slug: "how-ai-stats-tracks-provider-availability",
+		shortTitle: "Provider availability",
+		title: "How AI Stats tracks provider availability",
+		description:
+			"How AI Stats maps models to providers, tracks gateway availability, and interprets provider-specific coverage on public catalog pages.",
+		intro:
+			"This page explains how AI Stats decides whether a model is available on a provider and what the public provider coverage views are intended to mean.",
+		lastUpdated: LAST_UPDATED,
+		keywords: [
+			"provider availability methodology",
+			"API provider coverage",
+			"model availability",
+			"AI Stats providers",
+		],
+		sections: [
+			{
+				heading: "What availability means on AI Stats",
+				paragraphs: [
+					"Provider availability means AI Stats has a model-provider mapping for a specific API route, capability surface, or gateway-executable pairing.",
+					"It does not guarantee perpetual uptime, universal account access, or identical commercial terms across every region and customer tier.",
+				],
+			},
+			{
+				heading: "How mappings are stored",
+				paragraphs: [
+					"AI Stats stores canonical model identifiers separately from provider-specific model identifiers so one model can be tracked across multiple providers without losing provider-specific details.",
+					"Provider model rows can also carry capability metadata, prompt-training policy overrides, active-gateway state, modality information, and effective date windows.",
+				],
+			},
+			{
+				heading: "Gateway-active versus catalog-visible",
+				paragraphs: [
+					"A provider-model mapping can exist in the catalog before it is fully active on the public gateway. The catalog is meant to show coverage and operational context, while gateway state signals whether that route is available for execution.",
+					"That distinction matters because some models appear in provider documentation before they are broadly enabled, stable, or routable through a common interface.",
+				],
+			},
+			{
+				heading: "When provider pages change",
+				paragraphs: [
+					"Provider pages change when model mappings, capability rules, pricing rules, or provider metadata are updated. AI Stats revalidates those pages and can notify external discovery systems such as IndexNow when public URLs materially change.",
+					"Because provider coverage is operational data, totals can move as routes are added, disabled, renamed, or recategorized.",
+				],
+			},
+			{
+				heading: "Caveats",
+				paragraphs: [
+					"Availability on AI Stats should be read as a current catalog signal, not a contractual promise. Enterprise allowlists, region locks, quotas, or staged rollouts can still affect whether a route works for a given account.",
+					"If a provider page has too little public data to stand on its own, AI Stats may prefer reduced indexing until the page contains enough verified coverage information.",
+				],
+			},
+		],
+		relatedLinks: [
+			{ href: "/api-providers", label: "Provider database" },
+			{ href: "/models", label: "Models" },
+			{ href: "/rankings", label: "Rankings" },
+		],
+	},
+];
+
+export const METHODOLOGY_ENTRY_BY_SLUG = Object.fromEntries(
+	METHODOLOGY_ENTRIES.map((entry) => [entry.slug, entry]),
+) as Record<string, MethodologyEntry>;

--- a/apps/web/src/lib/fetchers/api-providers/getAllAPIProviders.ts
+++ b/apps/web/src/lib/fetchers/api-providers/getAllAPIProviders.ts
@@ -143,6 +143,21 @@ function chunkValues<T>(values: readonly T[], size: number): T[][] {
 	return chunks;
 }
 
+function pickLatestIsoDate(
+	current: string | null | undefined,
+	candidate: string | null | undefined,
+): string | null {
+	const currentMs = current ? Date.parse(current) : Number.NEGATIVE_INFINITY;
+	const candidateMs = candidate ? Date.parse(candidate) : Number.NEGATIVE_INFINITY;
+	if (!Number.isFinite(candidateMs)) {
+		return current ?? null;
+	}
+	if (!Number.isFinite(currentMs) || candidateMs > currentMs) {
+		return candidate ?? null;
+	}
+	return current ?? null;
+}
+
 export async function getAllAPIProviders(): Promise<APIProviderCard[]> {
     let supabase: ReturnType<typeof createAdminClient> | null = null;
     try {
@@ -223,6 +238,7 @@ export async function getAllAPIProviders(): Promise<APIProviderCard[]> {
     const totalModelsByProvider = new Map<string, Set<string>>();
     const activeModelsByProvider = new Map<string, Set<string>>();
     const freeModelsByProvider = new Map<string, Set<string>>();
+    const lastUpdatedAtByProvider = new Map<string, string | null>();
     const inputModalityModelSetsByProvider = new Map<
         string,
         Record<ProviderModalityKey, Set<string>>
@@ -239,6 +255,14 @@ export async function getAllAPIProviders(): Promise<APIProviderCard[]> {
             String(row.api_model_id ?? "").trim() ||
             String(row.provider_api_model_id ?? "").trim();
         if (!modelKey) continue;
+
+        lastUpdatedAtByProvider.set(
+            providerId,
+            pickLatestIsoDate(
+                lastUpdatedAtByProvider.get(providerId) ?? null,
+                row.effective_from ?? row.effective_to ?? null,
+            ),
+        );
 
         const totalSet = totalModelsByProvider.get(providerId) ?? new Set<string>();
         totalSet.add(modelKey);
@@ -339,6 +363,13 @@ export async function getAllAPIProviders(): Promise<APIProviderCard[]> {
             providerId,
             (monthlyTokensByProvider.get(providerId) ?? 0) + tokens,
         );
+        lastUpdatedAtByProvider.set(
+            providerId,
+            pickLatestIsoDate(
+                lastUpdatedAtByProvider.get(providerId) ?? null,
+                row.created_at ?? null,
+            ),
+        );
 
         if (!Number.isFinite(createdAtMs) || createdAtMs < dayStartMs) continue;
 
@@ -388,6 +419,8 @@ export async function getAllAPIProviders(): Promise<APIProviderCard[]> {
                     total_daily_tokens: dailyTokensByProvider.get(providerId) ?? 0,
                     total_monthly_tokens:
                         monthlyTokensByProvider.get(providerId) ?? 0,
+                    last_updated_at:
+                        lastUpdatedAtByProvider.get(providerId) ?? null,
                     modality_model_ids: Object.fromEntries(
                         MODALITY_KEYS.map((key) => [
                             key,

--- a/apps/web/src/lib/fetchers/api-providers/providerIndexGrouping.ts
+++ b/apps/web/src/lib/fetchers/api-providers/providerIndexGrouping.ts
@@ -25,6 +25,7 @@ export interface APIProviderCard {
 	api_provider_name: string;
 	colour?: string | null;
 	country_code: string;
+	last_updated_at?: string | null;
 	total_models: number;
 	active_models: number;
 	free_models: number;
@@ -48,6 +49,7 @@ export interface APIProviderIndexVariant {
 	total_daily_requests: number;
 	total_daily_tokens: number;
 	total_monthly_tokens: number;
+	last_updated_at?: string | null;
 	modality_model_ids: Record<
 		ProviderModalityKey,
 		{
@@ -76,6 +78,21 @@ function uniqueStrings(values: Iterable<string>): string[] {
 				.filter(Boolean),
 		),
 	);
+}
+
+function pickLatestIsoDate(values: Array<string | null | undefined>): string | null {
+	let latest: string | null = null;
+	let latestMs = Number.NEGATIVE_INFINITY;
+
+	for (const value of values) {
+		if (!value) continue;
+		const parsed = Date.parse(value);
+		if (!Number.isFinite(parsed) || parsed <= latestMs) continue;
+		latestMs = parsed;
+		latest = value;
+	}
+
+	return latest;
 }
 
 function getRegionalParentProviderId(
@@ -226,6 +243,9 @@ export function groupProviderIndexCards(
 				(sum, variant) =>
 					sum + Math.max(0, Number(variant.total_monthly_tokens ?? 0)),
 				0,
+			),
+			last_updated_at: pickLatestIsoDate(
+				group.map((variant) => variant.last_updated_at ?? null),
 			),
 			daily_share_pct:
 				totalDailyRequests > 0

--- a/apps/web/src/lib/fetchers/models/getAllModels.ts
+++ b/apps/web/src/lib/fetchers/models/getAllModels.ts
@@ -14,6 +14,7 @@ export interface ModelCard {
     hidden?: boolean;
     release_date?: string | null;
     announcement_date?: string | null;
+    updated_at?: string | null;
     input_types?: string[];
     output_types?: string[];
     // Backward-compatibility alias used in some legacy call sites
@@ -136,6 +137,7 @@ export function mapRawToModelCard(
         hidden: Boolean(raw.hidden),
         release_date: raw.release_date ?? null,
         announcement_date: raw.announcement_date ?? null,
+        updated_at: raw.updated_at ?? null,
         input_types: inputTypes,
         output_types: outputTypes,
         input_modalities: inputTypes,
@@ -203,6 +205,7 @@ async function fetchModelsFromDb(filters: GetModelsFilter): Promise<any[]> {
             hidden,
             release_date,
             announcement_date,
+            updated_at,
             input_types,
             output_types,
             organisation: data_organisations (name, colour)

--- a/apps/web/src/lib/fetchers/rankings/getRankingsData.ts
+++ b/apps/web/src/lib/fetchers/rankings/getRankingsData.ts
@@ -174,6 +174,20 @@ export type DailyAppRollup = {
     success_rate: number | null;
 };
 
+export type RankingsIndexabilitySnapshot = {
+	hasLeaderboardData: boolean;
+	hasPerformanceData: boolean;
+	hasUsageData: boolean;
+	hasAppsData: boolean;
+	shouldIndex: boolean;
+};
+
+export type AppsIndexabilitySnapshot = {
+	hasLeaderboardData: boolean;
+	hasTrendingData: boolean;
+	shouldIndex: boolean;
+};
+
 function getDefaultWeeklySinceIso(): string {
     const now = new Date();
     const since = new Date(
@@ -991,7 +1005,49 @@ export async function getTopApps(
                 fallbackTitlesById.get(row.app_id) ??
                 row.app_id,
         })),
-    };
+	};
+}
+
+export async function getRankingsIndexabilitySnapshot(): Promise<RankingsIndexabilitySnapshot> {
+	const [rankingsResult, performanceResult, usageResult, appsResult] =
+		await Promise.all([
+			getRankings("week", "tokens", 1),
+			getPerformanceData(24),
+			getTimeseriesData("year", "week", 1),
+			getTopApps("week", 1),
+		]);
+
+	const hasLeaderboardData = rankingsResult.rankings.some(
+		(row) =>
+			Boolean(row.model_id) &&
+			row.model_id.toLowerCase() !== "unknown" &&
+			row.model_id.toLowerCase() !== "other" &&
+			Number(row.total_tokens ?? 0) > 0,
+	);
+	const hasPerformanceData = performanceResult.data.some(
+		(row) =>
+			Boolean(row.model_id) &&
+			Boolean(row.provider) &&
+			Number.isFinite(Number(row.median_throughput ?? 0)) &&
+			Number(row.median_throughput ?? 0) > 0,
+	);
+	const hasUsageData = usageResult.data.some(
+		(row) =>
+			Boolean(row.model_id) &&
+			row.model_id.toLowerCase() !== "unknown" &&
+			row.model_id.toLowerCase() !== "other" &&
+			Number(row.tokens ?? 0) > 0,
+	);
+	const hasAppsData = appsResult.data.some((row) => Number(row.tokens ?? 0) > 0);
+
+	return {
+		hasLeaderboardData,
+		hasPerformanceData,
+		hasUsageData,
+		hasAppsData,
+		shouldIndex:
+			hasLeaderboardData || hasPerformanceData || hasUsageData || hasAppsData,
+	};
 }
 
 /**
@@ -1079,7 +1135,27 @@ export async function getTrendingApps(
                 fallbackTitlesById.get(row.app_id) ??
                 row.app_id,
         })),
-    };
+	};
+}
+
+export async function getAppsIndexabilitySnapshot(): Promise<AppsIndexabilitySnapshot> {
+	const [topAppsResult, trendingAppsResult] = await Promise.all([
+		getTopApps("4w", 1),
+		getTrendingApps(1),
+	]);
+
+	const hasLeaderboardData = topAppsResult.data.some(
+		(row) => Number(row.tokens ?? 0) > 0,
+	);
+	const hasTrendingData = trendingAppsResult.data.some(
+		(row) => Number(row.growth_tokens ?? 0) > 0,
+	);
+
+	return {
+		hasLeaderboardData,
+		hasTrendingData,
+		shouldIndex: hasLeaderboardData || hasTrendingData,
+	};
 }
 
 export async function getWeeklyModelProviderTokens(): Promise<{

--- a/apps/web/src/lib/fetchers/rankings/getRankingsData.ts
+++ b/apps/web/src/lib/fetchers/rankings/getRankingsData.ts
@@ -6,6 +6,7 @@
 "use cache";
 import { cacheLife, cacheTag } from "next/cache";
 import { createAdminClient } from "@/utils/supabase/admin";
+import { getPublicAppIdsCached } from "@/lib/fetchers/apps/getAppDetails";
 import {
 	fetchPublicGatewayRequestRows,
 } from "@/lib/fetchers/gateway/fetchPublicGatewayRequests";
@@ -187,6 +188,8 @@ export type AppsIndexabilitySnapshot = {
 	hasTrendingData: boolean;
 	shouldIndex: boolean;
 };
+
+const APPS_INDEXABILITY_QUERY_LIMIT = 300;
 
 function getDefaultWeeklySinceIso(): string {
     const now = new Date();
@@ -1139,16 +1142,22 @@ export async function getTrendingApps(
 }
 
 export async function getAppsIndexabilitySnapshot(): Promise<AppsIndexabilitySnapshot> {
-	const [topAppsResult, trendingAppsResult] = await Promise.all([
-		getTopApps("4w", 1),
-		getTrendingApps(1),
+	const [publicAppIds, topAppsResult, trendingAppsResult] = await Promise.all([
+		getPublicAppIdsCached(),
+		getTopApps("4w", APPS_INDEXABILITY_QUERY_LIMIT),
+		getTrendingApps(APPS_INDEXABILITY_QUERY_LIMIT),
 	]);
+	const publicAppIdSet = new Set(publicAppIds);
 
 	const hasLeaderboardData = topAppsResult.data.some(
-		(row) => Number(row.tokens ?? 0) > 0,
+		(row) =>
+			publicAppIdSet.has(String(row.app_id ?? "").trim()) &&
+			Number(row.tokens ?? 0) > 0,
 	);
 	const hasTrendingData = trendingAppsResult.data.some(
-		(row) => Number(row.growth_tokens ?? 0) > 0,
+		(row) =>
+			publicAppIdSet.has(String(row.app_id ?? "").trim()) &&
+			Number(row.growth_tokens ?? 0) > 0,
 	);
 
 	return {

--- a/apps/web/src/lib/indexnow.ts
+++ b/apps/web/src/lib/indexnow.ts
@@ -1,0 +1,107 @@
+import { absoluteUrl, SITE_URL } from "@/lib/seo";
+
+const INDEXNOW_ENDPOINT = "https://api.indexnow.org/IndexNow";
+const INDEXNOW_KEY_PATH = "/indexnow-key.txt";
+const MODEL_INDEXNOW_SUFFIXES = [
+	"",
+	"/quickstart",
+	"/benchmarks",
+	"/providers",
+	"/family",
+	"/performance",
+] as const;
+const PROVIDER_INDEXNOW_SUFFIXES = ["", "/models"] as const;
+
+export const INDEXNOW_KEY = String(process.env.INDEXNOW_KEY ?? "").trim();
+
+function isPublicHttpsSite(url: string): boolean {
+	try {
+		const parsed = new URL(url);
+		if (parsed.protocol !== "https:") return false;
+
+		const hostname = parsed.hostname.toLowerCase();
+		return !(
+			hostname === "localhost" ||
+			hostname === "127.0.0.1" ||
+			hostname === "0.0.0.0"
+		);
+	} catch {
+		return false;
+	}
+}
+
+export function isIndexNowEnabled(): boolean {
+	return Boolean(INDEXNOW_KEY) && isPublicHttpsSite(SITE_URL);
+}
+
+export function getIndexNowKeyLocation(): string {
+	return absoluteUrl(INDEXNOW_KEY_PATH);
+}
+
+export function getIndexNowModelUrls(modelId: string): string[] {
+	const trimmedModelId = modelId.trim().replace(/^\/+|\/+$/g, "");
+	if (!trimmedModelId) return [];
+
+	return MODEL_INDEXNOW_SUFFIXES.map((suffix) =>
+		absoluteUrl(`/models/${trimmedModelId}${suffix}`),
+	);
+}
+
+export function getIndexNowProviderUrls(providerId: string): string[] {
+	const trimmedProviderId = providerId.trim().replace(/^\/+|\/+$/g, "");
+	if (!trimmedProviderId) return [];
+
+	return PROVIDER_INDEXNOW_SUFFIXES.map((suffix) =>
+		absoluteUrl(`/api-providers/${trimmedProviderId}${suffix}`),
+	);
+}
+
+export async function submitIndexNowUrls(
+	urls: string[],
+	context: string,
+): Promise<void> {
+	if (!isIndexNowEnabled()) {
+		return;
+	}
+
+	const uniqueUrls = Array.from(
+		new Set(
+			urls
+				.map((url) => String(url).trim())
+				.filter((url) => url.startsWith("https://")),
+		),
+	);
+	if (!uniqueUrls.length) {
+		return;
+	}
+
+	const host = new URL(SITE_URL).host;
+
+	try {
+		const response = await fetch(INDEXNOW_ENDPOINT, {
+			method: "POST",
+			headers: {
+				"Content-Type": "application/json; charset=utf-8",
+			},
+			body: JSON.stringify({
+				host,
+				key: INDEXNOW_KEY,
+				keyLocation: getIndexNowKeyLocation(),
+				urlList: uniqueUrls,
+			}),
+		});
+
+		if (!response.ok) {
+			console.warn("[indexnow] submission failed", {
+				context,
+				status: response.status,
+				statusText: response.statusText,
+			});
+		}
+	} catch (error) {
+		console.warn("[indexnow] submission error", {
+			context,
+			error: error instanceof Error ? error.message : String(error),
+		});
+	}
+}

--- a/apps/web/src/lib/seo.ts
+++ b/apps/web/src/lib/seo.ts
@@ -11,6 +11,9 @@ if (process.env.NODE_ENV === "production" && !configuredSiteUrl) {
 
 const DEFAULT_SITE_URL = configuredSiteUrl ?? "http://localhost:3000";
 
+export const SITE_NAME = "AI Stats";
+export const PREFERRED_SITE_NAME = "AI Stats by Phaseo";
+export const SITE_ALTERNATE_NAME = SITE_NAME;
 export const SITE_URL = DEFAULT_SITE_URL.replace(/\/+$/, "");
 export const METADATA_BASE = new URL(SITE_URL);
 
@@ -55,13 +58,14 @@ export function buildMetadata({
 	return {
 		title,
 		description,
+		applicationName: PREFERRED_SITE_NAME,
 		metadataBase: METADATA_BASE,
 		keywords,
 		alternates: {
 			canonical,
 		},
 		openGraph: {
-			siteName: "AI Stats",
+			siteName: PREFERRED_SITE_NAME,
 			title,
 			description,
 			type,


### PR DESCRIPTION
## Summary
- improve crawlability and canonical routing for public SEO surfaces
- add structured methodology content and cleaner methodology page styling
- expand metadata, schema, sitemap, robots, and llms.txt coverage for models and providers
- add thin-page indexing guards and IndexNow plumbing for public URL updates

## What changed
- added a permanent `/providers` -> `/api-providers` redirect
- added static `apps/web/public/llms.txt`
- expanded `robots.txt` with `OAI-SearchBot`, `ChatGPT-User`, and `GPTBot` sections
- improved sitemap `lastModified` handling for model and provider URLs
- added homepage, models, providers, model detail, and provider detail metadata/schema improvements
- added a methodology hub and four methodology pages
- refined methodology page styling to match the existing site language more closely
- added soft site-name disambiguation with `AI Stats by Phaseo`
- added conditional `noindex` handling for thin `rankings` and `apps` states
- added IndexNow key route and submission helpers for changed public URLs
- fixed remaining public links that still pointed at `/providers`

## Validation
- `pnpm --filter @ai-stats/web typecheck`
- `pnpm --filter @ai-stats/web exec next build`
- verified locally in browser on:
  - `/methodology`
  - `/how-ai-stats-calculates-model-pricing`
  - `/llms.txt`
  - `/robots.txt`
  - `/sitemap.xml`

## Notes
- local canonical output depends on local `SITE_URL`
- full repo lint was not used here because the checkout already has unrelated lint noise; validation was done with typecheck, build, and direct page checks
- local build logs still show existing data/table warnings for unrelated missing local sources, but the web build completes successfully
