### PR TITLE
revert(web): remove SEO copy from provider pages

### DIFF
--- a/apps/web/src/app/(dashboard)/api-providers/[apiProvider]/page.tsx
+++ b/apps/web/src/app/(dashboard)/api-providers/[apiProvider]/page.tsx
@@ -58,7 +58,7 @@ export async function generateMetadata(props: {
 		.join(" ");
 
 	return buildMetadata({
-		title: `${providerName} API Models, Latency & Usage Analytics`,
+		title: `${providerName} - API performance, Latency & Usage analytics`,
 		description,
 		path: `/api-providers/${apiProvider}`,
 		keywords: [
@@ -209,14 +209,6 @@ export default async function Page({
 			)}
 			<APIProviderDetailShell apiProviderId={apiProvider}>
 				<div className="flex flex-col gap-10 w-full">
-					<section className="space-y-3">
-						<p className="max-w-4xl text-sm leading-6 text-muted-foreground sm:text-base">
-							Track how {header?.api_provider_name ?? "this provider"} performs on
-							the AI Stats Gateway, including latency, throughput, token usage, and
-							the models driving current traffic. Use this page as a provider-level
-							companion to the broader model and pricing database.
-						</p>
-					</section>
 					<section className="space-y-2">
 						<h3 className="text-xl font-semibold">Performance</h3>
 						<PerformanceCards params={params} />

--- a/apps/web/src/app/(dashboard)/api-providers/page.tsx
+++ b/apps/web/src/app/(dashboard)/api-providers/page.tsx
@@ -4,8 +4,7 @@ import { getAllAPIProvidersCached } from "@/lib/fetchers/api-providers/getAllAPI
 import type { APIProviderCard } from "@/lib/fetchers/api-providers/getAllAPIProviders";
 import APIProvidersDisplay from "@/components/(data)/api-providers/APIProvidersDisplay";
 import { Skeleton } from "@/components/ui/skeleton";
-import { absoluteUrl, buildMetadata } from "@/lib/seo";
-import Script from "next/script";
+import { buildMetadata } from "@/lib/seo";
 
 export const metadata: Metadata = buildMetadata({
 	title: "AI API Providers: Pricing, Models & Performance",
@@ -24,89 +23,8 @@ export const metadata: Metadata = buildMetadata({
 async function APIProvidersSection() {
 	const apiProviders =
 		(await getAllAPIProvidersCached()) as APIProviderCard[];
-	const topByModels = [...apiProviders]
-		.sort((a, b) => b.total_models - a.total_models)
-		.slice(0, 6)
-		.map((provider) => provider.api_provider_name);
-	const totalModels = apiProviders.reduce(
-		(sum, provider) => sum + Math.max(0, Number(provider.total_models ?? 0)),
-		0,
-	);
-	const totalFreeModels = apiProviders.reduce(
-		(sum, provider) => sum + Math.max(0, Number(provider.free_models ?? 0)),
-		0,
-	);
-	const dataCatalogSchema = {
-		"@context": "https://schema.org",
-		"@type": "DataCatalog",
-		name: "AI Stats API Provider Database",
-		description:
-			"Compare AI API providers by model coverage, modality support, gateway usage signals, and free model availability.",
-		url: absoluteUrl("/api-providers"),
-		keywords: [
-			"AI API providers",
-			"LLM providers",
-			"provider coverage",
-			"free models",
-			"gateway providers",
-		],
-		includesObject: topByModels.map((name) => ({
-			"@type": "Dataset",
-			name,
-		})),
-	};
-	const breadcrumbSchema = {
-		"@context": "https://schema.org",
-		"@type": "BreadcrumbList",
-		itemListElement: [
-			{
-				"@type": "ListItem",
-				position: 1,
-				name: "Home",
-				item: absoluteUrl("/"),
-			},
-			{
-				"@type": "ListItem",
-				position: 2,
-				name: "API Providers",
-				item: absoluteUrl("/api-providers"),
-			},
-		],
-	};
 
-	return (
-		<>
-			<Script
-				id="api-providers-data-catalog-schema"
-				type="application/ld+json"
-				dangerouslySetInnerHTML={{ __html: JSON.stringify(dataCatalogSchema) }}
-			/>
-			<Script
-				id="api-providers-breadcrumb-schema"
-				type="application/ld+json"
-				dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbSchema) }}
-			/>
-			<div className="space-y-3">
-				<h1 className="text-3xl font-bold tracking-tight">
-					Compare AI API providers by model coverage, usage, and modality support
-				</h1>
-				<p className="max-w-4xl text-sm leading-6 text-muted-foreground sm:text-base">
-					AI Stats tracks {apiProviders.length.toLocaleString()} API providers with{" "}
-					{totalModels.toLocaleString()} listed provider-model combinations and{" "}
-					{totalFreeModels.toLocaleString()} free-model entries. Use this index to
-					compare provider breadth, gateway usage, and modality support before you
-					choose where to route traffic.
-				</p>
-				{topByModels.length > 0 ? (
-					<p className="max-w-4xl text-sm leading-6 text-muted-foreground">
-						High-coverage providers in the current index include{" "}
-						{topByModels.join(", ")}.
-					</p>
-				) : null}
-			</div>
-			<APIProvidersDisplay providers={apiProviders} showPrimaryHeader={false} />
-		</>
-	);
+	return <APIProvidersDisplay providers={apiProviders} />;
 }
 
 function APIProvidersFallback() {

--- a/apps/web/src/app/(dashboard)/rankings/page.tsx
+++ b/apps/web/src/app/(dashboard)/rankings/page.tsx
@@ -6,7 +6,6 @@
 import { Suspense } from "react";
 import { Metadata } from "next";
 import { buildMetadata } from "@/lib/seo";
-import Link from "next/link";
 import { PerformanceLandscapePanel } from "@/components/(rankings)/PerformanceLandscapePanel";
 import { PerformanceLeaderboard } from "@/components/(rankings)/PerformanceLeaderboard";
 import { MarketShareStackedBar } from "@/components/(rankings)/MarketShareStackedBar";
@@ -78,30 +77,6 @@ export default async function RankingsPage() {
                         </h1>
                         <p className="text-sm text-muted-foreground">
                             Based on real usage data from across AI Stats.
-                        </p>
-                        <p className="text-sm text-muted-foreground">
-                            Methodology:{" "}
-                            <Link
-                                href="/how-ai-stats-measures-latency-throughput"
-                                className="underline underline-offset-4"
-                            >
-                                latency and throughput
-                            </Link>
-                            ,{" "}
-                            <Link
-                                href="/how-ai-stats-normalises-ai-benchmarks"
-                                className="underline underline-offset-4"
-                            >
-                                benchmark normalization
-                            </Link>
-                            , and{" "}
-                            <Link
-                                href="/how-ai-stats-tracks-provider-availability"
-                                className="underline underline-offset-4"
-                            >
-                                provider availability
-                            </Link>
-                            .
                         </p>
                     </div>
                     <Suspense fallback={<ChartSkeleton />}>


### PR DESCRIPTION
## Summary
- revert the SEO intro/schema wrapper added to the API providers index page
- remove the added SEO intro copy and metadata title change from provider detail pages
- remove the methodology links paragraph under the rankings header
- keep the methodology pages themselves intact

## Verification
- Visual check against the running app on `http://localhost:3100` for `/api-providers`, `/api-providers/openai`, and `/rankings`
- `pnpm --filter @ai-stats/web typecheck` on the clean main-based worktree
  - currently fails on unrelated existing error: `apps/web/src/lib/fetchers/models/getModelPageNotice.test.ts(21,63)`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined API provider detail pages by removing introductory description sections, creating direct transitions to performance metrics
  * Removed methodology references section from rankings page for simplified navigation
  * Updated SEO metadata for API provider pages

<!-- end of auto-generated comment: release notes by coderabbit.ai -->