### PR TITLE
Add relative time details to model lifecycle cards

### DIFF
--- a/apps/web/src/components/(data)/model/overview/KeyDates.tsx
+++ b/apps/web/src/components/(data)/model/overview/KeyDates.tsx
@@ -1,11 +1,12 @@
 import { Megaphone, Rocket, Archive, Ban } from "lucide-react";
+import RelativeDateBadge from "./RelativeDateBadge";
+import { formatModelLifecycleDate } from "@/lib/dates/modelLifecycleDates";
 
 interface KeyDatesProps {
 	announced?: string;
 	released?: string;
 	deprecated?: string;
 	retired?: string;
-	formatDate: (dateStr?: string) => string;
 	showHeading?: boolean;
 }
 
@@ -14,7 +15,6 @@ export default function KeyDates({
 	released,
 	deprecated,
 	retired,
-	formatDate,
 	showHeading = true,
 }: KeyDatesProps) {
 	const entries = [
@@ -57,17 +57,22 @@ export default function KeyDates({
 	return (
 		<div className="space-y-2">
 			{showHeading ? <h3 className="text-base font-semibold">Key Dates</h3> : null}
-			<div className="flex flex-wrap gap-2">
+			<div className="grid gap-2 md:grid-cols-2">
 				{entries.map(({ key, label, value, Icon, className }) => (
 					<div
 						key={key}
-						className={`min-w-[12rem] flex-1 rounded-md border px-3 py-2 ${className}`}
+						className={`rounded-lg border px-3 py-3 ${className}`}
 					>
-						<div className="flex items-center gap-1.5 text-xs font-medium">
-							<Icon className="h-3.5 w-3.5" />
-							<span>{label}</span>
+						<div className="flex flex-wrap items-start justify-between gap-2">
+							<div className="flex items-center gap-1.5 text-xs font-medium">
+								<Icon className="h-3.5 w-3.5" />
+								<span>{label}</span>
+							</div>
+							{value ? <RelativeDateBadge date={value} /> : null}
 						</div>
-						<p className="mt-1 text-sm font-semibold">{formatDate(value)}</p>
+						<p className="mt-2 text-sm font-semibold">
+							{formatModelLifecycleDate(value)}
+						</p>
 					</div>
 				))}
 			</div>

--- a/apps/web/src/components/(data)/model/overview/ModelOverview.tsx
+++ b/apps/web/src/components/(data)/model/overview/ModelOverview.tsx
@@ -13,18 +13,6 @@ export interface ModelOverviewProps {
 }
 
 export default function ModelOverview({ model }: ModelOverviewProps) {
-	// Helper: format date as dd MMM yyyy
-	const formatDate = (dateStr?: string) => {
-		if (!dateStr) return "-";
-		const date = new Date(dateStr);
-		if (isNaN(date.getTime())) return "-";
-		return date.toLocaleDateString("en-GB", {
-			day: "2-digit",
-			month: "short",
-			year: "numeric",
-		});
-	};
-
 	// Modalities logic: always show Text, Image, Audio, Video
 	const parseTypes = (types: any) => {
 		const normalizeType = (raw: unknown): string => {
@@ -68,8 +56,6 @@ export default function ModelOverview({ model }: ModelOverviewProps) {
 	const inputTypes = parseTypes(model.input_types);
 	const outputTypes = parseTypes(model.output_types);
 
-	console.log("Model Status:", model.status);
-
 	return (
 		<div className="w-full mx-auto space-y-4">
 			{/* Status banner */}
@@ -89,7 +75,6 @@ export default function ModelOverview({ model }: ModelOverviewProps) {
 					released={model.release_date ?? undefined}
 					deprecated={model.deprecation_date ?? undefined}
 					retired={model.retirement_date ?? undefined}
-					formatDate={formatDate}
 				/>
 				<Performance details={model.model_details} />
 			</div>

--- a/apps/web/src/components/(data)/model/overview/ModelOverviewSections.tsx
+++ b/apps/web/src/components/(data)/model/overview/ModelOverviewSections.tsx
@@ -55,6 +55,7 @@ import {
 } from "@/components/ui/empty";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import ModelPendingApiReleaseBanner from "@/components/(data)/model/overview/ModelPendingApiReleaseBanner";
+import { formatModelLifecycleDate } from "@/lib/dates/modelLifecycleDates";
 import { cn } from "@/lib/utils";
 import { getModalityTone } from "@/lib/models/modalityStyles";
 
@@ -134,17 +135,6 @@ function parseTypes(types: unknown): string[] {
 		);
 	}
 	return [];
-}
-
-function formatDate(dateStr?: string | null): string {
-	if (!dateStr) return "-";
-	const date = new Date(dateStr);
-	if (Number.isNaN(date.getTime())) return "-";
-	return date.toLocaleDateString("en-GB", {
-		day: "2-digit",
-		month: "short",
-		year: "numeric",
-	});
 }
 
 function isProviderModelActiveNow(
@@ -670,7 +660,6 @@ export async function ModelAboutSection({
 				released={model.release_date ?? undefined}
 				deprecated={model.deprecation_date ?? undefined}
 				retired={model.retirement_date ?? undefined}
-				formatDate={formatDate}
 				showHeading={false}
 			/>
 			<OtherInfo details={model.model_details ?? undefined} showHeading={false} />
@@ -750,7 +739,7 @@ export async function ModelCreatorModelsSection({
 										</div>
 										<div className="mt-3">
 											<p className="text-xs text-muted-foreground">
-												{formatDate(creatorModel.primary_date)}
+												{formatModelLifecycleDate(creatorModel.primary_date)}
 											</p>
 										</div>
 									</Link>

--- a/apps/web/src/components/(data)/model/overview/RelativeDateBadge.tsx
+++ b/apps/web/src/components/(data)/model/overview/RelativeDateBadge.tsx
@@ -1,0 +1,79 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import {
+	describeDetailedRelativeCalendarDate,
+	type RelativeCalendarTone,
+} from "@/lib/dates/modelLifecycleDates";
+import {
+	HoverCard,
+	HoverCardContent,
+	HoverCardTrigger,
+} from "@/components/ui/hover-card";
+import { cn } from "@/lib/utils";
+
+const REFRESH_INTERVAL_MS = 60 * 60 * 1000;
+
+const toneClassNames: Record<RelativeCalendarTone, string> = {
+	past: "border-current/10 bg-white/70 dark:bg-black/10",
+	today: "border-current/20 bg-white/90 shadow-sm dark:bg-black/20",
+	future: "border-current/15 bg-white/85 dark:bg-black/15",
+};
+
+type RelativeDateBadgeProps = {
+	date: string;
+	className?: string;
+};
+
+export default function RelativeDateBadge({
+	date,
+	className,
+}: RelativeDateBadgeProps) {
+	const [now, setNow] = useState(() => new Date());
+
+	useEffect(() => {
+		const interval = window.setInterval(() => {
+			setNow(new Date());
+		}, REFRESH_INTERVAL_MS);
+
+		return () => window.clearInterval(interval);
+	}, []);
+
+	const relativeDate = describeDetailedRelativeCalendarDate(date, now);
+	if (!relativeDate) return null;
+
+	return (
+		<HoverCard openDelay={140} closeDelay={80}>
+			<HoverCardTrigger asChild>
+				<span
+					suppressHydrationWarning
+					tabIndex={0}
+					className={cn(
+						"inline-flex cursor-help items-center rounded-full border px-2 py-0.5 text-[11px] font-medium leading-4",
+						toneClassNames[relativeDate.tone],
+						className,
+					)}
+				>
+					{relativeDate.label}
+				</span>
+			</HoverCardTrigger>
+			<HoverCardContent align="end" className="w-72 p-3">
+				<div className="space-y-1">
+					<p className="text-xs font-medium text-muted-foreground">
+						Relative Time
+					</p>
+					<p className="text-sm font-semibold">{relativeDate.detailedLabel}</p>
+					<p className="text-xs text-muted-foreground">
+						{relativeDate.totalDays.toLocaleString()} total day
+						{relativeDate.totalDays === 1 ? "" : "s"}
+						{relativeDate.dayDifference < 0
+							? " elapsed"
+							: relativeDate.dayDifference > 0
+								? " remaining"
+								: ""}
+					</p>
+				</div>
+			</HoverCardContent>
+		</HoverCard>
+	);
+}

--- a/apps/web/src/lib/dates/modelLifecycleDates.test.ts
+++ b/apps/web/src/lib/dates/modelLifecycleDates.test.ts
@@ -1,0 +1,83 @@
+import {
+	describeDetailedRelativeCalendarDate,
+	describeRelativeCalendarDate,
+	formatModelLifecycleDate,
+} from "./modelLifecycleDates";
+
+describe("formatModelLifecycleDate", () => {
+	test("renders model dates using the canonical UTC calendar day", () => {
+		expect(formatModelLifecycleDate("2026-06-08")).toBe("08 Jun 2026");
+	});
+
+	test("returns a placeholder for missing or invalid dates", () => {
+		expect(formatModelLifecycleDate()).toBe("-");
+		expect(formatModelLifecycleDate("not-a-date")).toBe("-");
+	});
+});
+
+describe("describeRelativeCalendarDate", () => {
+	const now = new Date("2026-06-08T23:30:00-07:00");
+
+	test("treats date-only fields as UTC calendar dates", () => {
+		expect(describeRelativeCalendarDate("2026-06-09", now)).toEqual({
+			label: "Today",
+			tone: "today",
+			dayDifference: 0,
+		});
+	});
+
+	test("formats past lifecycle milestones", () => {
+		expect(describeRelativeCalendarDate("2026-03-08", now)).toEqual({
+			label: "3 months ago",
+			tone: "past",
+			dayDifference: -93,
+		});
+	});
+
+	test("formats upcoming lifecycle milestones", () => {
+		expect(describeRelativeCalendarDate("2026-07-10", now)).toEqual({
+			label: "In 1 month",
+			tone: "future",
+			dayDifference: 31,
+		});
+	});
+
+	test("handles adjacent days explicitly", () => {
+		expect(describeRelativeCalendarDate("2026-06-10", now)).toEqual({
+			label: "Tomorrow",
+			tone: "future",
+			dayDifference: 1,
+		});
+		expect(describeRelativeCalendarDate("2026-06-08", new Date("2026-06-09T09:00:00Z"))).toEqual({
+			label: "Yesterday",
+			tone: "past",
+			dayDifference: -1,
+		});
+	});
+});
+
+describe("describeDetailedRelativeCalendarDate", () => {
+	test("breaks past dates into calendar years, months, and days", () => {
+		expect(
+			describeDetailedRelativeCalendarDate(
+				"2023-08-22",
+				new Date("2026-06-08T09:00:00Z"),
+			),
+		).toMatchObject({
+			detailedLabel: "2 years, 9 months, 17 days ago",
+			totalDays: 1021,
+		});
+	});
+
+	test("breaks future dates into calendar months and days", () => {
+		expect(
+			describeDetailedRelativeCalendarDate(
+				"2026-09-28",
+				new Date("2026-06-08T09:00:00Z"),
+			),
+		).toMatchObject({
+			detailedLabel: "In 3 months, 20 days",
+			totalDays: 112,
+		});
+	});
+});

--- a/apps/web/src/lib/dates/modelLifecycleDates.ts
+++ b/apps/web/src/lib/dates/modelLifecycleDates.ts
@@ -1,0 +1,164 @@
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+export type RelativeCalendarTone = "past" | "today" | "future";
+
+export type RelativeCalendarDescriptor = {
+	label: string;
+	tone: RelativeCalendarTone;
+	dayDifference: number;
+};
+
+export type DetailedRelativeCalendarDescriptor = RelativeCalendarDescriptor & {
+	detailedLabel: string;
+	totalDays: number;
+};
+
+function toUtcDayTimestamp(value: string | Date): number | null {
+	const date = value instanceof Date ? value : new Date(value);
+	if (Number.isNaN(date.getTime())) return null;
+	return Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate());
+}
+
+function pluralize(value: number, unit: string): string {
+	return `${value} ${unit}${value === 1 ? "" : "s"}`;
+}
+
+function daysInUtcMonth(year: number, month: number): number {
+	return new Date(Date.UTC(year, month + 1, 0)).getUTCDate();
+}
+
+function addUtcMonths(date: Date, monthsToAdd: number): Date {
+	const year = date.getUTCFullYear();
+	const month = date.getUTCMonth();
+	const day = date.getUTCDate();
+	const totalMonths = month + monthsToAdd;
+	const nextYear = year + Math.floor(totalMonths / 12);
+	const nextMonth = ((totalMonths % 12) + 12) % 12;
+	const nextDay = Math.min(day, daysInUtcMonth(nextYear, nextMonth));
+	return new Date(Date.UTC(nextYear, nextMonth, nextDay));
+}
+
+function addUtcYears(date: Date, yearsToAdd: number): Date {
+	const year = date.getUTCFullYear() + yearsToAdd;
+	const month = date.getUTCMonth();
+	const day = Math.min(date.getUTCDate(), daysInUtcMonth(year, month));
+	return new Date(Date.UTC(year, month, day));
+}
+
+function decomposeCalendarDayDifference(start: Date, end: Date) {
+	let years = end.getUTCFullYear() - start.getUTCFullYear();
+	let cursor = addUtcYears(start, years);
+	if (cursor.getTime() > end.getTime()) {
+		years -= 1;
+		cursor = addUtcYears(start, years);
+	}
+
+	let months =
+		(end.getUTCFullYear() - cursor.getUTCFullYear()) * 12 +
+		(end.getUTCMonth() - cursor.getUTCMonth());
+	let monthCursor = addUtcMonths(cursor, months);
+	if (monthCursor.getTime() > end.getTime()) {
+		months -= 1;
+		monthCursor = addUtcMonths(cursor, months);
+	}
+
+	const days = Math.round((end.getTime() - monthCursor.getTime()) / DAY_MS);
+
+	return { years, months, days };
+}
+
+function formatDetailedRelativeDistance(absDays: number, start: Date, end: Date): string {
+	if (absDays === 0) return "0 days";
+
+	const { years, months, days } = decomposeCalendarDayDifference(start, end);
+	const parts = [
+		years > 0 ? pluralize(years, "year") : null,
+		months > 0 ? pluralize(months, "month") : null,
+		days > 0 ? pluralize(days, "day") : null,
+	].filter(Boolean);
+
+	return parts.length > 0 ? parts.join(", ") : pluralize(absDays, "day");
+}
+
+function formatRelativeDistance(absDays: number): string {
+	if (absDays < 14) return pluralize(absDays, "day");
+	if (absDays < 28) return pluralize(Math.round(absDays / 7), "week");
+	if (absDays < 730) return pluralize(Math.round(absDays / 30.4375), "month");
+	return pluralize(Math.round(absDays / 365.25), "year");
+}
+
+export function formatModelLifecycleDate(dateStr?: string | null): string {
+	if (!dateStr) return "-";
+	const date = new Date(dateStr);
+	if (Number.isNaN(date.getTime())) return "-";
+	return date.toLocaleDateString("en-GB", {
+		timeZone: "UTC",
+		day: "2-digit",
+		month: "short",
+		year: "numeric",
+	});
+}
+
+export function describeRelativeCalendarDate(
+	dateStr: string,
+	now = new Date(),
+): RelativeCalendarDescriptor | null {
+	const targetDay = toUtcDayTimestamp(dateStr);
+	const nowDay = toUtcDayTimestamp(now);
+	if (targetDay == null || nowDay == null) return null;
+
+	const dayDifference = Math.round((targetDay - nowDay) / DAY_MS);
+	if (dayDifference === 0) {
+		return { label: "Today", tone: "today", dayDifference };
+	}
+	if (dayDifference === 1) {
+		return { label: "Tomorrow", tone: "future", dayDifference };
+	}
+	if (dayDifference === -1) {
+		return { label: "Yesterday", tone: "past", dayDifference };
+	}
+
+	const distance = formatRelativeDistance(Math.abs(dayDifference));
+	if (dayDifference > 0) {
+		return {
+			label: `In ${distance}`,
+			tone: "future",
+			dayDifference,
+		};
+	}
+
+	return {
+		label: `${distance} ago`,
+		tone: "past",
+		dayDifference,
+	};
+}
+
+export function describeDetailedRelativeCalendarDate(
+	dateStr: string,
+	now = new Date(),
+): DetailedRelativeCalendarDescriptor | null {
+	const basic = describeRelativeCalendarDate(dateStr, now);
+	const targetDay = toUtcDayTimestamp(dateStr);
+	const nowDay = toUtcDayTimestamp(now);
+	if (!basic || targetDay == null || nowDay == null) return null;
+
+	const totalDays = Math.abs(basic.dayDifference);
+	const startTimestamp = Math.min(targetDay, nowDay);
+	const endTimestamp = Math.max(targetDay, nowDay);
+	const start = new Date(startTimestamp);
+	const end = new Date(endTimestamp);
+	const detailedDistance = formatDetailedRelativeDistance(totalDays, start, end);
+	const detailedLabel =
+		basic.dayDifference > 0
+			? `In ${detailedDistance}`
+			: basic.dayDifference < 0
+				? `${detailedDistance} ago`
+				: "Today";
+
+	return {
+		...basic,
+		detailedLabel,
+		totalDays,
+	};
+}


### PR DESCRIPTION
## Summary
This updates the model overview lifecycle cards to show both absolute dates and relative time context directly on the card surface.

The previous mockup only showed short relative badges such as `3 years ago`, and the wrapping flex layout could render the four lifecycle cards as a `3 + 1` stack instead of a stable `2 x 2` grid. That made the section feel inconsistent and left no room for more precise timing details.

## What changed
- replaced the wrapping lifecycle-card flex row with a two-column grid on desktop so the key dates render as a stable `2 x 2` block
- added a dedicated `RelativeDateBadge` component for announcement, release, deprecation, and retirement cards
- added UTC-safe lifecycle date helpers so date-only catalog fields do not drift across time zones
- added hover/focus detail for the relative badges so the compact label expands into a more exact calendar distance
- removed the leftover `console.log` and in-component duplicate date formatting now that lifecycle formatting is centralized

## Why this matters
Model pages are explicitly used for release, deprecation, and retirement tracking. The UI now gives readers two layers of timing information at once:
- the exact canonical date on the card
- a relative summary at a glance, with more detailed timing on hover/focus

That makes the lifecycle state easier to scan without losing precision.

## Validation
These checks were run against the same code in the source workspace before isolating the patch onto this clean PR branch:
- `pnpm --filter @ai-stats/web exec eslint "src/components/(data)/model/overview/KeyDates.tsx" "src/components/(data)/model/overview/RelativeDateBadge.tsx" "src/components/(data)/model/overview/ModelOverview.tsx" "src/components/(data)/model/overview/ModelOverviewSections.tsx" "src/lib/dates/modelLifecycleDates.ts" "src/lib/dates/modelLifecycleDates.test.ts"`
- `pnpm --filter @ai-stats/web test -- modelLifecycleDates.test.ts`

I also verified the UI against the local model pages for `openai/gpt-4.1` and `openai/babbage-002` in the browser while iterating on the card layout and relative-time treatment.
