### PR TITLE
chore(data): prep Anthropic Mythos and Fable release entries

### DIFF
--- a/packages/data/catalog/src/data/api_providers/amazon-bedrock/models.json
+++ b/packages/data/catalog/src/data/api_providers/amazon-bedrock/models.json
@@ -336,6 +336,27 @@
     ]
   },
   {
+    "api_model_id": "anthropic/claude-opus-4.8",
+    "provider_api_model_id": "amazon-bedrock:anthropic/claude-opus-4.8",
+    "provider_model_slug": "anthropic.claude-opus-4-8",
+    "internal_model_id": "anthropic/claude-opus-4.8",
+    "is_active_gateway": false,
+    "quantization_scheme": null,
+    "input_modalities": "text,image",
+    "output_modalities": "text",
+    "context_length": 1000000,
+    "max_output_tokens": 128000,
+    "effective_from": "2026-05-28T00:00:00",
+    "effective_to": null,
+    "capabilities": [
+      {
+        "capability_id": "text.generate",
+        "status": "active",
+        "params": []
+      }
+    ]
+  },
+  {
     "api_model_id": "anthropic/claude-sonnet-4",
     "provider_api_model_id": "amazon-bedrock:anthropic/claude-sonnet-4",
     "provider_model_slug": "anthropic.claude-sonnet-4-20250514-v1:0",
@@ -898,6 +919,27 @@
       {
         "capability_id": "text.generate",
         "status": "active",
+        "params": []
+      }
+    ]
+  },
+  {
+    "api_model_id": "anthropic/claude-fable-5",
+    "provider_api_model_id": "amazon-bedrock:anthropic/claude-fable-5",
+    "provider_model_slug": "anthropic.claude-fable-5-v1",
+    "internal_model_id": "anthropic/claude-fable-5",
+    "is_active_gateway": false,
+    "quantization_scheme": null,
+    "input_modalities": "text,image",
+    "output_modalities": "text",
+    "context_length": 1000000,
+    "max_output_tokens": null,
+    "effective_from": null,
+    "effective_to": null,
+    "capabilities": [
+      {
+        "capability_id": "text.generate",
+        "status": "coming_soon",
         "params": []
       }
     ]

--- a/packages/data/catalog/src/data/api_providers/anthropic-aws-us/models.json
+++ b/packages/data/catalog/src/data/api_providers/anthropic-aws-us/models.json
@@ -283,5 +283,28 @@
                                             ]
                              }
                          ]
+    },
+    {
+        "api_model_id":  "anthropic/claude-fable-5",
+        "provider_api_model_id":  "anthropic-aws-us:anthropic/claude-fable-5",
+        "provider_model_slug":  "claude-fable-5",
+        "internal_model_id":  "anthropic/claude-fable-5",
+        "is_active_gateway":  false,
+        "quantization_scheme":  null,
+        "input_modalities":  "text,image",
+        "output_modalities":  "text",
+        "context_length":  1000000,
+        "max_output_tokens":  128000,
+        "effective_from":  null,
+        "effective_to":  null,
+        "capabilities":  [
+                             {
+                                 "capability_id":  "text.generate",
+                                 "status":  "coming_soon",
+                                 "params":  [
+
+                                            ]
+                             }
+                         ]
     }
 ]

--- a/packages/data/catalog/src/data/api_providers/anthropic-aws/models.json
+++ b/packages/data/catalog/src/data/api_providers/anthropic-aws/models.json
@@ -1157,5 +1157,28 @@
                                             ]
                              }
                          ]
+    },
+    {
+        "api_model_id":  "anthropic/claude-fable-5",
+        "provider_api_model_id":  "anthropic-aws:anthropic/claude-fable-5",
+        "provider_model_slug":  "claude-fable-5",
+        "internal_model_id":  "anthropic/claude-fable-5",
+        "is_active_gateway":  false,
+        "quantization_scheme":  null,
+        "input_modalities":  "text,image",
+        "output_modalities":  "text",
+        "context_length":  1000000,
+        "max_output_tokens":  128000,
+        "effective_from":  null,
+        "effective_to":  null,
+        "capabilities":  [
+                             {
+                                 "capability_id":  "text.generate",
+                                 "status":  "coming_soon",
+                                 "params":  [
+
+                                            ]
+                             }
+                         ]
     }
 ]

--- a/packages/data/catalog/src/data/api_providers/anthropic-us/models.json
+++ b/packages/data/catalog/src/data/api_providers/anthropic-us/models.json
@@ -113,5 +113,26 @@
         ]
       }
     ]
+  },
+  {
+    "api_model_id": "anthropic/claude-fable-5",
+    "provider_api_model_id": "anthropic-us:anthropic/claude-fable-5",
+    "provider_model_slug": "claude-fable-5",
+    "internal_model_id": "anthropic/claude-fable-5",
+    "is_active_gateway": false,
+    "quantization_scheme": null,
+    "input_modalities": "text,image",
+    "output_modalities": "text",
+    "context_length": 1000000,
+    "max_output_tokens": 128000,
+    "effective_from": null,
+    "effective_to": null,
+    "capabilities": [
+      {
+        "capability_id": "text.generate",
+        "status": "coming_soon",
+        "params": []
+      }
+    ]
   }
 ]

--- a/packages/data/catalog/src/data/api_providers/anthropic/models.json
+++ b/packages/data/catalog/src/data/api_providers/anthropic/models.json
@@ -1172,5 +1172,26 @@
         "params": []
       }
     ]
+  },
+  {
+    "api_model_id": "anthropic/claude-fable-5",
+    "provider_api_model_id": "anthropic:anthropic/claude-fable-5",
+    "provider_model_slug": "claude-fable-5",
+    "internal_model_id": "anthropic/claude-fable-5",
+    "is_active_gateway": false,
+    "quantization_scheme": null,
+    "input_modalities": "text,image",
+    "output_modalities": "text",
+    "context_length": 1000000,
+    "max_output_tokens": 128000,
+    "effective_from": null,
+    "effective_to": null,
+    "capabilities": [
+      {
+        "capability_id": "text.generate",
+        "status": "coming_soon",
+        "params": []
+      }
+    ]
   }
 ]

--- a/packages/data/catalog/src/data/api_providers/google-vertex/models.json
+++ b/packages/data/catalog/src/data/api_providers/google-vertex/models.json
@@ -1763,5 +1763,28 @@
                                             ]
                              }
                          ]
+    },
+    {
+        "api_model_id":  "anthropic/claude-fable-5",
+        "provider_api_model_id":  "google-vertex:anthropic/claude-fable-5",
+        "provider_model_slug":  "claude-fable-5",
+        "internal_model_id":  "anthropic/claude-fable-5",
+        "is_active_gateway":  false,
+        "quantization_scheme":  null,
+        "input_modalities":  "text,image",
+        "output_modalities":  "text",
+        "context_length":  1000000,
+        "max_output_tokens":  128000,
+        "effective_from":  null,
+        "effective_to":  null,
+        "capabilities":  [
+                             {
+                                 "capability_id":  "text.generate",
+                                 "status":  "coming_soon",
+                                 "params":  [
+
+                                            ]
+                             }
+                         ]
     }
 ]

--- a/packages/data/catalog/src/data/api_providers/venice/models.json
+++ b/packages/data/catalog/src/data/api_providers/venice/models.json
@@ -1801,5 +1801,26 @@
         "params": []
       }
     ]
+  },
+  {
+    "api_model_id": "anthropic/claude-fable-5",
+    "provider_api_model_id": "venice:anthropic/claude-fable-5",
+    "provider_model_slug": "claude-fable-5",
+    "internal_model_id": "anthropic/claude-fable-5",
+    "is_active_gateway": false,
+    "quantization_scheme": null,
+    "input_modalities": "text,image",
+    "output_modalities": "text",
+    "context_length": 1000000,
+    "max_output_tokens": 128000,
+    "effective_from": null,
+    "effective_to": null,
+    "capabilities": [
+      {
+        "capability_id": "text.generate",
+        "status": "coming_soon",
+        "params": []
+      }
+    ]
   }
 ]

--- a/packages/data/catalog/src/data/families/anthropic-claude-fable/family.json
+++ b/packages/data/catalog/src/data/families/anthropic-claude-fable/family.json
@@ -1,0 +1,5 @@
+{
+  "family_id": "anthropic/claude-fable",
+  "family_name": "Claude Fable",
+  "organisation_id": "anthropic"
+}

--- a/packages/data/catalog/src/data/models/anthropic/claude-fable-5/model.json
+++ b/packages/data/catalog/src/data/models/anthropic/claude-fable-5/model.json
@@ -1,0 +1,25 @@
+{
+  "model_id": "anthropic/claude-fable-5",
+  "organisation_id": "anthropic",
+  "name": "Claude Fable 5",
+  "status": "Rumoured",
+  "previous_model_id": null,
+  "description": "Claude Fable 5 is a rumoured Anthropic flagship model tracked as the likely public release line paired with [Claude Mythos 5](/anthropic/claude-mythos-5). Current expectations are that Fable will be the release candidate while Mythos remains withheld.",
+  "announced_date": null,
+  "release_date": null,
+  "deprecation_date": null,
+  "retirement_date": null,
+  "license": "Proprietary",
+  "input_types": null,
+  "output_types": null,
+  "api_model_id": "anthropic/claude-fable-5",
+  "family_id": "anthropic/claude-fable",
+  "links": [],
+  "details": [
+    {
+      "name": "availability",
+      "value": "Claude Fable 5 is expected to be announced alongside [Claude Mythos 5](/anthropic/claude-mythos-5) and to be the model that actually ships. Current expectations are that it will be broadly similar to Mythos 5 at the capability level, but released with additional safeguards. Rollout mappings are pre-seeded across Anthropic, Anthropic US, Claude Platform on AWS, Claude Platform on AWS US, Amazon Bedrock, Google Vertex AI, and Venice; pricing and final provider slugs remain unconfirmed."
+    }
+  ],
+  "benchmarks": []
+}

--- a/packages/data/catalog/src/data/models/anthropic/claude-mythos-5/model.json
+++ b/packages/data/catalog/src/data/models/anthropic/claude-mythos-5/model.json
@@ -2,9 +2,9 @@
   "model_id": "anthropic/claude-mythos-5",
   "organisation_id": "anthropic",
   "name": "Claude Mythos 5",
-  "status": "Rumoured",
+  "status": "Withheld",
   "previous_model_id": null,
-  "description": "Claude Mythos 5 is a leaked Anthropic API model ID tracked as a separate Mythos-line model alongside Claude Mythos Preview. This placeholder entry keeps the catalog ready in preparation for a wider release, ahead of formal pricing and fuller public capability documentation.",
+  "description": "Claude Mythos 5 is a withheld Anthropic API model ID tracked as part of the Mythos release track alongside Claude Mythos Preview. Current expectations are that it will be announced alongside [Claude Fable 5](/anthropic/claude-fable-5), with Mythos remaining withheld while Fable becomes the public release.",
   "announced_date": null,
   "release_date": null,
   "deprecation_date": null,
@@ -18,7 +18,7 @@
   "details": [
     {
       "name": "availability",
-      "value": "Observed as a leaked Anthropic API model ID; pricing and full public documentation are not yet confirmed."
+      "value": "Claude Mythos 5 is expected to be announced alongside [Claude Fable 5](/anthropic/claude-fable-5). Current expectations are that Mythos 5 will remain withheld rather than receive a public release, while Fable 5 ships as the public-facing counterpart with broadly similar capabilities and additional safeguards."
     }
   ],
   "benchmarks": []


### PR DESCRIPTION
## Summary
- mark `anthropic/claude-mythos-5` as withheld and add paired release notes linking it to `anthropic/claude-fable-5`
- add the new `anthropic/claude-fable` family and `anthropic/claude-fable-5` model entry
- pre-seed Fable rollout mappings across Anthropic, Anthropic US, Claude Platform on AWS, Claude Platform on AWS US, Amazon Bedrock, Google Vertex AI, and Venice with all provider statuses set to `coming_soon`
- add Amazon Bedrock support metadata for `anthropic/claude-opus-4.8`

## Validation
- `pnpm validate:data -- --preset structure`

## Notes
- pricing remains intentionally unset for `anthropic/claude-fable-5`
- Amazon Bedrock support for Opus 4.8 is based on current AWS and Anthropic docs


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Claude Opus 4.8 model, launching May 28, 2026, with extensive context support and text generation
  * Claude Fable 5 coming soon across multiple providers with text and image input capabilities
  * New Claude Fable family added to catalog
  * Updated Claude Mythos 5 model status and availability details

<!-- end of auto-generated comment: release notes by coderabbit.ai -->