### PR TITLE
[codex] refine footer monitor link placement

### DIFF
--- a/apps/web/src/components/footer.tsx
+++ b/apps/web/src/components/footer.tsx
@@ -15,6 +15,7 @@ import {
 	LifeBuoy,
 	MessageSquare,
 	Megaphone,
+	MonitorDot,
 	Scale,
 	Server,
 	ShieldCheck,
@@ -35,6 +36,7 @@ const productLinks = [
 	{ href: "/api-providers", label: "Providers", icon: Server },
 	{ href: "/apps", label: "Apps", icon: AppWindow },
 	{ href: "/rankings", label: "Rankings", icon: Trophy },
+	{ href: "/monitor", label: "Monitor", icon: MonitorDot },
 ];
 
 const developerLinks = [
@@ -66,12 +68,6 @@ const developerLinks = [
 		href: "/methodology",
 		label: "Methodology",
 		icon: FileText,
-	},
-	{
-		href: "https://ai-stats.instatus.com/",
-		label: "Status",
-		icon: Activity,
-		external: true,
 	},
 ];
 


### PR DESCRIPTION
## What changed
- add `Monitor` to the `Explore` footer column
- keep `Methodology` under `Build`
- remove the duplicate `Status` link from the `Build` footer column

## Why
`Monitor` reads as a product/data surface alongside models, providers, apps, and rankings. `Methodology` is explanatory/reference content, so it belongs under `Build`. This avoids having both `Status` and `Monitor` competing in the same nav area while preserving the `Check status` CTA button.

## Validation
- `pnpm exec eslint src/components/footer.tsx`
