### PR TITLE
Add Gemini 3.5 Live Translate pricing

### DIFF
--- a/packages/data/catalog/src/data/api_providers/google-ai-studio/models.json
+++ b/packages/data/catalog/src/data/api_providers/google-ai-studio/models.json
@@ -3282,12 +3282,12 @@
         "output_modalities":  "audio,text",
         "context_length":  null,
         "max_output_tokens":  null,
-        "effective_from":  "2026-05-19T00:00:00",
+        "effective_from":  "2026-06-09T00:00:00",
         "effective_to":  null,
         "capabilities":  [
                              {
                                  "capability_id":  "audio.translations",
-                                 "status":  "coming_soon",
+                                 "status":  "active",
                                  "params":  [
 
                                             ]

--- a/packages/data/catalog/src/data/api_providers/google-ai-studio/models.json
+++ b/packages/data/catalog/src/data/api_providers/google-ai-studio/models.json
@@ -3287,7 +3287,7 @@
         "capabilities":  [
                              {
                                  "capability_id":  "audio.translations",
-                                 "status":  "active",
+                                 "status":  "coming_soon",
                                  "params":  [
 
                                             ]

--- a/packages/data/catalog/src/data/models/google/gemini-3.5-live-translate-preview/model.json
+++ b/packages/data/catalog/src/data/models/google/gemini-3.5-live-translate-preview/model.json
@@ -20,13 +20,13 @@
     },
     {
       "platform": "guide",
-      "url": "https://ai.google.dev/gemini-api/docs/live"
+      "url": "https://ai.google.dev/gemini-api/docs/live-api/live-translate"
     }
   ],
   "details": [
     {
       "name": "catalog_note",
-      "value": "AI Stats inferred this preview model's modality metadata from its public name and the documented Gemini Live API family because a dedicated model page was not yet publicly indexed when this entry was added."
+      "value": "Official Gemini docs list this preview model as a Live API speech-to-speech translation model with audio input and translated audio plus transcript output."
     }
   ],
   "benchmarks": []

--- a/packages/data/catalog/src/data/pricing/google-ai-studio/google-gemini-3.5-live-translate-preview/audio.translations/pricing.json
+++ b/packages/data/catalog/src/data/pricing/google-ai-studio/google-gemini-3.5-live-translate-preview/audio.translations/pricing.json
@@ -1,0 +1,33 @@
+{
+  "key": "google-ai-studio:google/gemini-3.5-live-translate-preview:audio.translations",
+  "api_provider_id": "google-ai-studio",
+  "provider_slug": "google-ai-studio",
+  "api_model_id": "google/gemini-3.5-live-translate-preview",
+  "capability_id": "audio.translations",
+  "rules": [
+    {
+      "meter": "input_audio_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 3.5,
+      "currency": "USD",
+      "pricing_plan": "standard",
+      "note": null,
+      "match": [],
+      "priority": 100,
+      "effective_from": "2026-06-09T00:00:00Z"
+    },
+    {
+      "meter": "output_audio_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 21,
+      "currency": "USD",
+      "pricing_plan": "standard",
+      "note": null,
+      "match": [],
+      "priority": 100,
+      "effective_from": "2026-06-09T00:00:00Z"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add Google AI Studio pricing for `google/gemini-3.5-live-translate-preview`
- mark the Google AI Studio provider capability as active effective `2026-06-09`
- update the model metadata to point to the dedicated Live Translate guide and replace the earlier inferred-note wording
- leave `google-vertex` unchanged because the official Google Cloud model and pricing docs do not list this model yet

## Validation
- `pnpm validate:data`
- `pnpm validate:gateway`
