### PR TITLE
Activate Claude Fable 5 release state

### DIFF
--- a/packages/data/catalog/src/data/api_providers/google-vertex/models.json
+++ b/packages/data/catalog/src/data/api_providers/google-vertex/models.json
@@ -1769,7 +1769,7 @@
         "provider_api_model_id":  "google-vertex:anthropic/claude-fable-5",
         "provider_model_slug":  "claude-fable-5",
         "internal_model_id":  "anthropic/claude-fable-5",
-        "is_active_gateway":  false,
+        "is_active_gateway":  true,
         "quantization_scheme":  null,
         "input_modalities":  "text,image",
         "output_modalities":  "text",

--- a/packages/data/catalog/src/data/models/anthropic/claude-fable-5/model.json
+++ b/packages/data/catalog/src/data/models/anthropic/claude-fable-5/model.json
@@ -2,9 +2,9 @@
   "model_id": "anthropic/claude-fable-5",
   "organisation_id": "anthropic",
   "name": "Claude Fable 5",
-  "status": "Rumoured",
+  "status": "Available",
   "previous_model_id": null,
-  "description": "Claude Fable 5 is a rumoured Anthropic flagship model tracked as the likely public release line paired with [Claude Mythos 5](/anthropic/claude-mythos-5). Current expectations are that Fable will be the release candidate while Mythos remains withheld, with provisional provider pricing scaffolded from a $10 per million input and $50 per million output baseline plus current provider-specific multipliers.",
+  "description": "Claude Fable 5 is tracked as the public release line paired with [Claude Mythos 5](/anthropic/claude-mythos-5). AI Stats currently treats Fable as the active rollout target while Mythos remains withheld, with active provider mappings and pricing scaffolding in place.",
   "announced_date": "2026-06-09T00:00:00",
   "release_date": "2026-06-09T00:00:00",
   "deprecation_date": null,
@@ -18,7 +18,7 @@
   "details": [
     {
       "name": "availability",
-      "value": "Claude Fable 5 is expected to be announced alongside [Claude Mythos 5](/anthropic/claude-mythos-5) and to be the model that actually ships. Current expectations are that it will be broadly similar to Mythos 5 at the capability level, but released with additional safeguards. Rollout mappings are pre-seeded across Anthropic, Anthropic US, Claude Platform on AWS, Claude Platform on AWS US, Amazon Bedrock, Google Vertex AI, and Venice; provisional pricing scaffolds are seeded from a $10 per million input and $50 per million output baseline with current provider-specific cache, regional, priority, and batch multipliers applied pending confirmation, and final provider slugs remain unconfirmed."
+      "value": "Claude Fable 5 is treated as the released public counterpart to [Claude Mythos 5](/anthropic/claude-mythos-5). Active rollout mappings are now staged across Anthropic and Google Vertex AI in this workspace, with broader pricing scaffolding pre-seeded for related provider variants including Claude Platform on AWS."
     }
   ],
   "benchmarks": []


### PR DESCRIPTION
## Summary
- mark `anthropic/claude-fable-5` as `Available`
- update the model description/availability copy to describe the live rollout state
- activate the existing Claude Fable 5 provider mappings on Anthropic on AWS and Google Vertex

## Validation
- `pnpm validate:data`
- `pnpm validate:gateway`

## Notes
- `origin/main` already contained the earlier Fable pricing/provider scaffolding from `#683`
- this PR is the release-state follow-up that removes the remaining preview-style catalog status for the model and turns on the staged AWS/Vertex rows


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Claude Fable 5 is now available as an active public release model, accessible through Anthropic and Google Vertex AI providers as the counterpart to Claude Mythos 5 with staged rollout.

* **Updates**
  * Model status updated to available. Provider gateway mappings and pricing information refined across supported platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->