### PR TITLE
Activate Venice pricing for Claude Fable 5

### DIFF
--- a/packages/data/catalog/src/data/api_providers/venice/models.json
+++ b/packages/data/catalog/src/data/api_providers/venice/models.json
@@ -1771,7 +1771,7 @@
     "output_modalities": "text",
     "context_length": 1000000,
     "max_output_tokens": 128000,
-    "effective_from": null,
+    "effective_from": "2026-06-09T00:00:00",
     "effective_to": null,
     "capabilities": [
       {
@@ -1818,7 +1818,7 @@
     "capabilities": [
       {
         "capability_id": "text.generate",
-        "status": "coming_soon",
+        "status": "active",
         "params": []
       }
     ]

--- a/packages/data/catalog/src/data/pricing/venice/anthropic-claude-fable-5/text.generate/pricing.json
+++ b/packages/data/catalog/src/data/pricing/venice/anthropic-claude-fable-5/text.generate/pricing.json
@@ -12,7 +12,7 @@
       "price_per_unit": 12,
       "currency": "USD",
       "pricing_plan": "standard",
-      "note": "Provisional scaffold from a $10 per million input and $50 per million output baseline, with current Venice standard, priority, and cache multipliers applied pending provider confirmation.",
+      "note": "Venice published pricing as of 2026-06-09.",
       "match": [],
       "priority": 100,
       "effective_from": "2026-06-09T00:00:00Z"
@@ -24,7 +24,7 @@
       "price_per_unit": 24,
       "currency": "USD",
       "pricing_plan": "priority",
-      "note": "Provisional scaffold from a $10 per million input and $50 per million output baseline, with current Venice standard, priority, and cache multipliers applied pending provider confirmation.",
+      "note": "Derived from the current Venice priority multiplier convention on 2026-06-09; Venice's public pricing page publishes the standard schedule only.",
       "match": [],
       "priority": 100,
       "effective_from": "2026-06-09T00:00:00Z"
@@ -36,7 +36,7 @@
       "price_per_unit": 1.2,
       "currency": "USD",
       "pricing_plan": "standard",
-      "note": "Provisional scaffold from a $10 per million input and $50 per million output baseline, with current Venice standard, priority, and cache multipliers applied pending provider confirmation.",
+      "note": "Venice published pricing as of 2026-06-09.",
       "match": [],
       "priority": 100,
       "effective_from": "2026-06-09T00:00:00Z"
@@ -48,7 +48,7 @@
       "price_per_unit": 2.4,
       "currency": "USD",
       "pricing_plan": "priority",
-      "note": "Provisional scaffold from a $10 per million input and $50 per million output baseline, with current Venice standard, priority, and cache multipliers applied pending provider confirmation.",
+      "note": "Derived from the current Venice priority multiplier convention on 2026-06-09; Venice's public pricing page publishes the standard schedule only.",
       "match": [],
       "priority": 100,
       "effective_from": "2026-06-09T00:00:00Z"
@@ -60,7 +60,7 @@
       "price_per_unit": 15,
       "currency": "USD",
       "pricing_plan": "standard",
-      "note": "Provisional scaffold from a $10 per million input and $50 per million output baseline, with current Venice standard, priority, and cache multipliers applied pending provider confirmation.",
+      "note": "Venice published pricing as of 2026-06-09.",
       "match": [],
       "priority": 100,
       "effective_from": "2026-06-09T00:00:00Z"
@@ -72,7 +72,7 @@
       "price_per_unit": 30,
       "currency": "USD",
       "pricing_plan": "priority",
-      "note": "Provisional scaffold from a $10 per million input and $50 per million output baseline, with current Venice standard, priority, and cache multipliers applied pending provider confirmation.",
+      "note": "Derived from the current Venice priority multiplier convention on 2026-06-09; Venice's public pricing page publishes the standard schedule only.",
       "match": [],
       "priority": 100,
       "effective_from": "2026-06-09T00:00:00Z"
@@ -84,7 +84,7 @@
       "price_per_unit": 60,
       "currency": "USD",
       "pricing_plan": "standard",
-      "note": "Provisional scaffold from a $10 per million input and $50 per million output baseline, with current Venice standard, priority, and cache multipliers applied pending provider confirmation.",
+      "note": "Venice published pricing as of 2026-06-09.",
       "match": [],
       "priority": 100,
       "effective_from": "2026-06-09T00:00:00Z"
@@ -96,7 +96,7 @@
       "price_per_unit": 120,
       "currency": "USD",
       "pricing_plan": "priority",
-      "note": "Provisional scaffold from a $10 per million input and $50 per million output baseline, with current Venice standard, priority, and cache multipliers applied pending provider confirmation.",
+      "note": "Derived from the current Venice priority multiplier convention on 2026-06-09; Venice's public pricing page publishes the standard schedule only.",
       "match": [],
       "priority": 100,
       "effective_from": "2026-06-09T00:00:00Z"


### PR DESCRIPTION
## Summary
This PR finalizes Venice coverage for Claude Fable 5 by moving the provider entry from coming soon to active and replacing the provisional pricing copy with confirmed pricing metadata.

## What changed
- marks `anthropic/claude-fable-5` as active for the `venice` provider from 2026-06-09
- updates the Venice Claude Fable 5 pricing notes so the standard schedule reflects the confirmed public pricing page
- keeps the existing Venice priority-tier convention explicit as derived catalog logic rather than presenting it as provider-confirmed published pricing

## Source of truth
Confirmed against Venice's public pricing page on June 9, 2026:
- input: $12.00 / 1M
- output: $60.00 / 1M
- cache read: $1.20 / 1M
- cache write: $15.00 / 1M

Reference: https://docs.venice.ai/overview/pricing

## Validation
Ran successfully:
- `pnpm validate:pricing`
- `pnpm validate:data`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Claude Fable 5 text generation capability is now active.

* **Updates**
  * Official pricing information published for Claude Fable 5.
  * Claude Opus 4.7 Fast scheduled to become effective June 9, 2026.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->