### PR TITLE
[codex] Keep header full width

### DIFF
--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -279,23 +279,6 @@
 	}
 }
 
-@supports (view-transition-name: none) {
-	::view-transition-old(site-header-shell),
-	::view-transition-new(site-header-shell) {
-		animation-duration: 280ms;
-		animation-timing-function: cubic-bezier(0.22, 1, 0.36, 1);
-	}
-}
-
-@media (prefers-reduced-motion: reduce) {
-	@supports (view-transition-name: none) {
-		::view-transition-old(site-header-shell),
-		::view-transition-new(site-header-shell) {
-			animation-duration: 1ms;
-		}
-	}
-}
-
 @layer base {
 	button:not(:disabled),
 	[role="button"]:not(:disabled) {

--- a/apps/web/src/components/header/HeaderShell.tsx
+++ b/apps/web/src/components/header/HeaderShell.tsx
@@ -1,5 +1,3 @@
-"use client";
-
 import type { CSSProperties, ReactNode } from "react";
 
 type HeaderShellProps = {

--- a/apps/web/src/components/header/HeaderShell.tsx
+++ b/apps/web/src/components/header/HeaderShell.tsx
@@ -1,74 +1,29 @@
 "use client";
 
-import { usePathname } from "next/navigation";
 import type { CSSProperties, ReactNode } from "react";
-import { cn } from "@/lib/utils";
 
 type HeaderShellProps = {
 	children: ReactNode;
 };
 
 export default function HeaderShell({ children }: HeaderShellProps) {
-	const pathname = usePathname() ?? "";
-	const isExperimentsCouncilRoute =
-		pathname === "/experiments/council" ||
-		pathname.startsWith("/experiments/council/");
-	const isModelsListRoute =
-		pathname === "/models" ||
-		pathname.startsWith("/models/table") ||
-		pathname.startsWith("/models/collections");
-	const isModelDetailRoute =
-		pathname.startsWith("/models/") && !isModelsListRoute;
-	const isWideOnlyRoute =
-		pathname.startsWith("/settings") || isModelsListRoute;
-	const variant: "default" | "wide" | "compact" = isExperimentsCouncilRoute
-		? "compact"
-		: isWideOnlyRoute
-			? "wide"
-			: "default";
-	const isWideRoute =
-		pathname.startsWith("/settings") ||
-		isExperimentsCouncilRoute ||
-		isModelsListRoute ||
-		isModelDetailRoute;
-	const headerVars: CSSProperties & Record<string, string> =
-		variant === "compact"
-			? {
-					"--site-header-height": "3.375rem",
-					"--site-header-gap": "2rem",
-					"--site-header-left-gap": "1.25rem",
-					"--site-header-logo-height": "1.9rem",
-					"--site-header-divider-height": "1.25rem",
-					"--site-header-control-h": "2.125rem",
-					"--site-header-nav-px": "0.5rem",
-					"--site-header-search-width": "10.5rem",
-					"--site-header-search-width-xl": "11.5rem",
-				}
-			: {
-					"--site-header-height": "3.75rem",
-					"--site-header-gap": "1.5rem",
-					"--site-header-left-gap": "1.25rem",
-					"--site-header-logo-height": "2.3rem",
-					"--site-header-divider-height": "1.5rem",
-					"--site-header-control-h": "2.25rem",
-					"--site-header-nav-px": "0.5rem",
-					"--site-header-search-width": "10.75rem",
-					"--site-header-search-width-xl": "12rem",
-				};
+	const headerVars: CSSProperties & Record<string, string> = {
+		"--site-header-height": "3.75rem",
+		"--site-header-gap": "1.5rem",
+		"--site-header-left-gap": "1.25rem",
+		"--site-header-logo-height": "2.3rem",
+		"--site-header-divider-height": "1.5rem",
+		"--site-header-control-h": "2.25rem",
+		"--site-header-nav-px": "0.5rem",
+		"--site-header-search-width": "10.75rem",
+		"--site-header-search-width-xl": "12rem",
+	};
 
 	return (
 		<div
-			className={cn(
-				"mx-auto w-full [view-transition-name:site-header-shell]",
-				"transition-[max-width,padding-inline] duration-300 ease-[cubic-bezier(0.22,1,0.36,1)] motion-reduce:transition-none",
-				variant === "compact"
-					? "max-w-full px-3 sm:px-4 lg:px-5"
-					: isWideRoute
-					? "max-w-full px-4 lg:px-5 xl:px-6"
-					: "max-w-full px-4 sm:max-w-[640px] md:max-w-[768px] lg:max-w-[1024px] xl:max-w-[1280px] 2xl:max-w-[1536px]",
-			)}
+			className="w-full max-w-full px-4 lg:px-5 xl:px-6"
 			style={headerVars}
-			data-variant={variant}
+			data-variant="full-width"
 		>
 			{children}
 		</div>

--- a/apps/web/src/components/header/LegalHeaderShell.tsx
+++ b/apps/web/src/components/header/LegalHeaderShell.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import type { ReactNode } from "react";
-import { cn } from "@/lib/utils";
 
 type LegalHeaderShellProps = {
 	children: ReactNode;
@@ -10,10 +9,7 @@ type LegalHeaderShellProps = {
 export default function LegalHeaderShell({ children }: LegalHeaderShellProps) {
 	return (
 		<div
-			className={cn(
-				"mx-auto h-10 w-full max-w-full px-4",
-				"sm:max-w-[640px] md:max-w-[768px] lg:max-w-[1024px] xl:max-w-[1280px] 2xl:max-w-[1536px]",
-			)}
+			className="h-10 w-full max-w-full px-4 lg:px-5 xl:px-6"
 			data-variant="legal-compact"
 		>
 			<div className="flex h-full items-center">{children}</div>

--- a/apps/web/src/components/header/header.tsx
+++ b/apps/web/src/components/header/header.tsx
@@ -112,7 +112,7 @@ export default function Header() {
 		>
 			<Suspense
 				fallback={
-					<div className="mx-auto w-full max-w-full px-4 [view-transition-name:site-header-shell] sm:max-w-[640px] md:max-w-[768px] lg:max-w-[1024px] xl:max-w-[1280px] 2xl:max-w-[1536px]">
+					<div className="w-full max-w-full px-4 lg:px-5 xl:px-6">
 						{headerContent}
 					</div>
 				}


### PR DESCRIPTION
﻿## Summary
- keep the shared site header full-width on every route instead of switching between centered, wide, and compact variants
- remove the named `site-header-shell` view-transition styling
- align the header Suspense fallback and legal header shell with the full-width behavior

## Validation
- `pnpm --filter @ai-stats/web exec eslint src/components/header/HeaderShell.tsx src/components/header/header.tsx src/components/header/LegalHeaderShell.tsx`
- Browser check on `http://localhost:3200/pricing`: header reported `variant: full-width`, `left: 0`, `max-width: 100%`, and `viewTransitionName: none`

## Notes
- Full `pnpm --filter @ai-stats/web lint` was not used as the gating result because the current repo has unrelated pre-existing lint failures across many files.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Removed header view-transition animations
  * Updated header to display full-width during page loading states

* **Refactor**
  * Simplified header component styling for consistent behavior across all pages

<!-- end of auto-generated comment: release notes by coderabbit.ai -->