### PR TITLE
Improve chat playground errors and prompts

### DIFF
--- a/apps/web/src/components/(chat)/ChatConversation.tsx
+++ b/apps/web/src/components/(chat)/ChatConversation.tsx
@@ -516,6 +516,7 @@ export function ChatConversation({
 				onWebSearchEnabledChange={onWebSearchEnabledChange}
 				apiServerToolsEnabled={apiServerToolsEnabled}
 				onApiServerToolsEnabledChange={onApiServerToolsEnabledChange}
+				showEvaluationPrompts={(activeThread?.messages.length ?? 0) === 0}
 				reasoningEnabled={reasoningEnabled}
 				reasoningPickerOpen={reasoningPickerOpen}
 				onReasoningPickerOpenChange={setReasoningPickerOpen}

--- a/apps/web/src/components/(chat)/ChatConversation.tsx
+++ b/apps/web/src/components/(chat)/ChatConversation.tsx
@@ -5,6 +5,7 @@ import type { ChangeEvent } from "react";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { ChatConversationComposer } from "@/components/(chat)/ChatConversationComposer";
 import { ChatConversationMessages } from "@/components/(chat)/ChatConversationMessages";
+import type { ChatRequestErrorDetails } from "@/components/(chat)/ChatRequestErrorNotice";
 import type { ChatSettings, ChatThread } from "@/lib/indexeddb/chats";
 import { Square } from "lucide-react";
 import {
@@ -54,6 +55,8 @@ type ChatConversationProps = {
 	selectedModelsHint?: string;
 	onOpenModelPicker: () => void;
 	onAudioAttachmentRequirementChange?: (requiresAudioInput: boolean) => void;
+	requestError?: ChatRequestErrorDetails | null;
+	onDismissRequestError?: () => void;
 };
 
 type SendGateType = "auth";
@@ -89,6 +92,8 @@ export function ChatConversation({
 	selectedModelsHint,
 	onOpenModelPicker,
 	onAudioAttachmentRequirementChange,
+	requestError = null,
+	onDismissRequestError,
 }: ChatConversationProps) {
 	const isUnified = mode === "unified";
 	const [composer, setComposer] = useState("");
@@ -397,6 +402,13 @@ export function ChatConversation({
 		[onReasoningEffortChange, onReasoningEnabledChange],
 	);
 
+	const handleSelectEvaluationPrompt = useCallback((prompt: string) => {
+		setComposer(prompt);
+		requestAnimationFrame(() => {
+			textareaRef.current?.focus();
+		});
+	}, []);
+
 	const handleSubmit = () => {
 		if (isSending) return;
 		const text = composer.trim();
@@ -484,6 +496,8 @@ export function ChatConversation({
 						onBranchAssistant={onBranchAssistant}
 						onSelectVariant={onSelectVariant}
 						onCopy={handleCopy}
+						requestError={requestError}
+						onDismissRequestError={onDismissRequestError}
 					/>
 				</div>
 			</ScrollArea>
@@ -519,6 +533,7 @@ export function ChatConversation({
 				onToggleRecording={toggleRecording}
 				onOpenModelPicker={onOpenModelPicker}
 				onSubmit={handleSubmit}
+				onSelectEvaluationPrompt={handleSelectEvaluationPrompt}
 				onComposerChange={setComposer}
 				onRemoveAttachment={(index) =>
 					setAttachments((prev) => prev.filter((_, i) => i !== index))

--- a/apps/web/src/components/(chat)/ChatConversationComposer.tsx
+++ b/apps/web/src/components/(chat)/ChatConversationComposer.tsx
@@ -156,6 +156,7 @@ interface ChatConversationComposerProps {
 	onWebSearchEnabledChange?: (enabled: boolean) => void;
 	apiServerToolsEnabled: boolean;
 	onApiServerToolsEnabledChange?: (enabled: boolean) => void;
+	showEvaluationPrompts: boolean;
 	reasoningEnabled: boolean;
 	reasoningPickerOpen: boolean;
 	onReasoningPickerOpenChange: (open: boolean) => void;
@@ -195,6 +196,7 @@ export function ChatConversationComposer(props: ChatConversationComposerProps) {
 		isUnified,
 		apiServerToolsEnabled,
 		onApiServerToolsEnabledChange,
+		showEvaluationPrompts,
 		reasoningEnabled,
 		reasoningPickerOpen,
 		onReasoningPickerOpenChange,
@@ -293,39 +295,43 @@ export function ChatConversationComposer(props: ChatConversationComposerProps) {
 						</div>
 					</div>
 				) : null}
-				<ScrollArea
-					ref={promptScrollAreaRef}
-					className="-mx-4 w-[calc(100%+2rem)] whitespace-nowrap px-4 md:-mx-8 md:w-[calc(100%+4rem)] md:px-8"
-					aria-label="Prompt presets"
-				>
-					<div className="flex w-max gap-3 py-1">
-						{PROMPT_SCROLL_COPIES.map((copyIndex) => (
-							<div
-								key={copyIndex}
-								className="flex shrink-0 gap-3"
-								aria-hidden={copyIndex !== 1}
-							>
-								{EVALUATION_PROMPTS.map((item) => (
-									<button
-										key={`${item.title}-${copyIndex}`}
-										type="button"
-										className="group/card flex h-16 w-56 shrink-0 flex-col justify-center overflow-hidden rounded-xl bg-card px-4 text-left text-foreground shadow-sm ring-1 ring-border/40 transition-colors hover:bg-muted/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring sm:w-60"
-										onClick={() => onSelectEvaluationPrompt(item.prompt)}
-										tabIndex={copyIndex === 1 ? 0 : -1}
-									>
-										<span className="w-full truncate text-[13px] font-medium transition-colors group-hover/card:text-foreground sm:text-sm">
-											{item.title}
-										</span>
-										<span className="mt-1 w-full truncate text-xs text-muted-foreground">
-											{item.description}
-										</span>
-									</button>
-								))}
-							</div>
-						))}
-					</div>
-					<ScrollBar className="hidden" orientation="horizontal" />
-				</ScrollArea>
+				{showEvaluationPrompts ? (
+					<ScrollArea
+						ref={promptScrollAreaRef}
+						className="-mx-4 w-[calc(100%+2rem)] whitespace-nowrap px-4 md:-mx-8 md:w-[calc(100%+4rem)] md:px-8"
+						aria-label="Prompt presets"
+					>
+						<div className="flex w-max gap-3 py-1">
+							{PROMPT_SCROLL_COPIES.map((copyIndex) => (
+								<div
+									key={copyIndex}
+									className="flex shrink-0 gap-3"
+									aria-hidden={copyIndex !== 1}
+								>
+									{EVALUATION_PROMPTS.map((item) => (
+										<button
+											key={`${item.title}-${copyIndex}`}
+											type="button"
+											className="group/card flex h-16 w-56 shrink-0 flex-col justify-center overflow-hidden rounded-xl bg-card px-4 text-left text-foreground shadow-sm ring-1 ring-border/40 transition-colors hover:bg-muted/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring sm:w-60"
+											onClick={() =>
+												onSelectEvaluationPrompt(item.prompt)
+											}
+											tabIndex={copyIndex === 1 ? 0 : -1}
+										>
+											<span className="w-full truncate text-[13px] font-medium transition-colors group-hover/card:text-foreground sm:text-sm">
+												{item.title}
+											</span>
+											<span className="mt-1 w-full truncate text-xs text-muted-foreground">
+												{item.description}
+											</span>
+										</button>
+									))}
+								</div>
+							))}
+						</div>
+						<ScrollBar className="hidden" orientation="horizontal" />
+					</ScrollArea>
+				) : null}
 				<div className="rounded-2xl border border-border bg-card px-3 py-2 shadow-sm">
 					<input
 						ref={fileInputRef}

--- a/apps/web/src/components/(chat)/ChatConversationComposer.tsx
+++ b/apps/web/src/components/(chat)/ChatConversationComposer.tsx
@@ -267,7 +267,7 @@ export function ChatConversationComposer(props: ChatConversationComposerProps) {
 			viewport.removeEventListener("scroll", handleScroll);
 			window.removeEventListener("resize", moveToMiddle);
 		};
-	}, []);
+	}, [showEvaluationPrompts]);
 
 	return (
 		<div className="border-t border-border bg-background px-4 py-4 md:px-8">

--- a/apps/web/src/components/(chat)/ChatConversationComposer.tsx
+++ b/apps/web/src/components/(chat)/ChatConversationComposer.tsx
@@ -1,6 +1,11 @@
 "use client";
 
-import type { ChangeEvent, RefObject } from "react";
+import {
+	useEffect,
+	useRef,
+	type ChangeEvent,
+	type RefObject,
+} from "react";
 import Link from "next/link";
 import {
 	Brain,
@@ -22,6 +27,10 @@ import {
 	PopoverContent,
 	PopoverTrigger,
 } from "@/components/ui/popover";
+import {
+	ScrollArea,
+	ScrollBar,
+} from "@/components/ui/scroll-area";
 import { Spinner } from "@/components/ui/spinner";
 import { Textarea } from "@/components/ui/textarea";
 import {
@@ -37,6 +46,100 @@ type ReasoningOption = {
 	value: NonNullable<ChatSettings["reasoningEffort"]>;
 	label: string;
 };
+
+const EVALUATION_PROMPTS = [
+	{
+		title: "Palindrome Quest",
+		description: "Find the next palindrome",
+		prompt:
+			"Find the smallest palindrome number greater than 12932. Explain your reasoning briefly.",
+	},
+	{
+		title: "Car Wash Test",
+		description: "Should you walk or drive?",
+		prompt:
+			"A person needs to go through a car wash. Should they walk through it or drive through it? Explain the safest and most sensible answer.",
+	},
+	{
+		title: "Personal Finance",
+		description: "Draft a portfolio proposal",
+		prompt:
+			"Draft a practical portfolio management proposal for a 35-year-old with moderate risk tolerance, a 20-year time horizon, and a preference for low-fee diversified funds.",
+	},
+	{
+		title: "9.9 vs 9.11",
+		description: "Which one is larger?",
+		prompt: "Which is bigger, 9.11 or 9.9? Explain your answer briefly.",
+	},
+	{
+		title: "The Missing Dollar",
+		description: "Classic money logic puzzle",
+		prompt:
+			"Three guests pay $30 for a room. The manager realizes it should cost $25 and gives $5 to the bellhop to return. The bellhop keeps $2 and gives $1 back to each guest. Each guest paid $9, totaling $27, plus the bellhop's $2 makes $29. Where is the missing dollar?",
+	},
+	{
+		title: "Career Development",
+		description: "Build a growth roadmap",
+		prompt:
+			"Create a 90-day professional growth roadmap for a mid-level software engineer who wants to become a technical lead.",
+	},
+	{
+		title: "Strawberry Test",
+		description: "How many r's are in the word?",
+		prompt:
+			"How many times does the letter r appear in the word strawberry? Think carefully and answer with one sentence.",
+	},
+	{
+		title: "Small Business Strategy",
+		description: "Plan an expansion",
+		prompt:
+			"Develop a concise expansion plan for a small local coffee shop that wants to add online ordering and corporate catering.",
+	},
+	{
+		title: "Poem Riddle",
+		description: "Compose a 13-line poem",
+		prompt:
+			"Compose a 13-line poem where the first letter of each line spells REASONINGTEST.",
+	},
+	{
+		title: "Alphabet Series",
+		description: "Find the next letter",
+		prompt:
+			"What is the next letter in this sequence: A, C, F, J, O, ? Explain the pattern briefly.",
+	},
+	{
+		title: "Healthy Lifestyle",
+		description: "Diet and exercise plan",
+		prompt:
+			"Design a balanced weekly diet and exercise regimen for a busy office worker with beginner fitness experience.",
+	},
+	{
+		title: "Anagram Challenge",
+		description: "Unscramble the letters",
+		prompt:
+			"Unscramble the letters 'TCAOR' into a common English word. If there is more than one possibility, list them and explain which is most likely.",
+	},
+	{
+		title: "Educational Advancement",
+		description: "Plan higher education",
+		prompt:
+			"Create a decision plan for someone choosing between a part-time master's degree, a professional certificate, and self-study.",
+	},
+	{
+		title: "Word Transformation",
+		description: "Change one letter at a time",
+		prompt:
+			"Transform COLD into WARM by changing one letter at a time, with every intermediate step being a valid English word.",
+	},
+	{
+		title: "JSON Only",
+		description: "Return a strict object",
+		prompt:
+			"Return only valid JSON with keys answer, confidence, and reasoning. The question is: which is larger, 9.11 or 9.9?",
+	},
+];
+
+const PROMPT_SCROLL_COPIES = [0, 1, 2];
 
 interface ChatConversationComposerProps {
 	sendGateType: SendGateType;
@@ -72,6 +175,7 @@ interface ChatConversationComposerProps {
 	onToggleRecording: () => void;
 	onOpenModelPicker: () => void;
 	onSubmit: () => void;
+	onSelectEvaluationPrompt: (prompt: string) => void;
 	onComposerChange: (value: string) => void;
 	onRemoveAttachment: (index: number) => void;
 	onFileSelect: (event: ChangeEvent<HTMLInputElement>) => void;
@@ -108,13 +212,63 @@ export function ChatConversationComposer(props: ChatConversationComposerProps) {
 		onToggleRecording,
 		onOpenModelPicker,
 		onSubmit,
+		onSelectEvaluationPrompt,
 		onComposerChange,
 		onRemoveAttachment,
 		onFileSelect,
 	} = props;
+	const promptScrollAreaRef = useRef<HTMLDivElement | null>(null);
+
+	useEffect(() => {
+		const root = promptScrollAreaRef.current;
+		const viewport = root?.querySelector(
+			"[data-radix-scroll-area-viewport]",
+		) as HTMLDivElement | null;
+		if (!viewport) return;
+
+		let isAdjusting = false;
+		let rafId = 0;
+		const getSegmentWidth = () => viewport.scrollWidth / PROMPT_SCROLL_COPIES.length;
+		const moveToMiddle = () => {
+			const segmentWidth = getSegmentWidth();
+			if (segmentWidth > 0) {
+				viewport.scrollLeft = segmentWidth;
+			}
+		};
+		const unlockAdjustment = () => {
+			isAdjusting = false;
+		};
+		const handleScroll = () => {
+			if (isAdjusting) return;
+			const segmentWidth = getSegmentWidth();
+			if (segmentWidth <= 0) return;
+			const left = viewport.scrollLeft;
+			if (left < segmentWidth * 0.35) {
+				isAdjusting = true;
+				viewport.scrollLeft = left + segmentWidth;
+				rafId = requestAnimationFrame(unlockAdjustment);
+				return;
+			}
+			if (left > segmentWidth * 1.65) {
+				isAdjusting = true;
+				viewport.scrollLeft = left - segmentWidth;
+				rafId = requestAnimationFrame(unlockAdjustment);
+			}
+		};
+
+		rafId = requestAnimationFrame(moveToMiddle);
+		viewport.addEventListener("scroll", handleScroll, { passive: true });
+		window.addEventListener("resize", moveToMiddle);
+
+		return () => {
+			cancelAnimationFrame(rafId);
+			viewport.removeEventListener("scroll", handleScroll);
+			window.removeEventListener("resize", moveToMiddle);
+		};
+	}, []);
 
 	return (
-		<div className="border-t border-border px-4 py-4 md:px-8">
+		<div className="border-t border-border bg-background px-4 py-4 md:px-8">
 			<div className="mx-auto flex w-full max-w-3xl flex-col gap-3">
 				{sendGateType === "auth" ? (
 					<div className="flex flex-wrap items-center justify-between gap-3 rounded-xl border border-amber-300/70 bg-amber-50 px-3 py-2 text-amber-900 dark:border-amber-700/70 dark:bg-amber-950/30 dark:text-amber-100">
@@ -139,7 +293,40 @@ export function ChatConversationComposer(props: ChatConversationComposerProps) {
 						</div>
 					</div>
 				) : null}
-				<div className="rounded-2xl border border-border bg-background px-3 py-2">
+				<ScrollArea
+					ref={promptScrollAreaRef}
+					className="-mx-4 w-[calc(100%+2rem)] whitespace-nowrap px-4 md:-mx-8 md:w-[calc(100%+4rem)] md:px-8"
+					aria-label="Prompt presets"
+				>
+					<div className="flex w-max gap-3 py-1">
+						{PROMPT_SCROLL_COPIES.map((copyIndex) => (
+							<div
+								key={copyIndex}
+								className="flex shrink-0 gap-3"
+								aria-hidden={copyIndex !== 1}
+							>
+								{EVALUATION_PROMPTS.map((item) => (
+									<button
+										key={`${item.title}-${copyIndex}`}
+										type="button"
+										className="group/card flex h-16 w-56 shrink-0 flex-col justify-center overflow-hidden rounded-xl bg-card px-4 text-left text-foreground shadow-sm ring-1 ring-border/40 transition-colors hover:bg-muted/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring sm:w-60"
+										onClick={() => onSelectEvaluationPrompt(item.prompt)}
+										tabIndex={copyIndex === 1 ? 0 : -1}
+									>
+										<span className="w-full truncate text-[13px] font-medium transition-colors group-hover/card:text-foreground sm:text-sm">
+											{item.title}
+										</span>
+										<span className="mt-1 w-full truncate text-xs text-muted-foreground">
+											{item.description}
+										</span>
+									</button>
+								))}
+							</div>
+						))}
+					</div>
+					<ScrollBar className="hidden" orientation="horizontal" />
+				</ScrollArea>
+				<div className="rounded-2xl border border-border bg-card px-3 py-2 shadow-sm">
 					<input
 						ref={fileInputRef}
 						type="file"
@@ -167,7 +354,7 @@ export function ChatConversationComposer(props: ChatConversationComposerProps) {
 						}}
 						rows={2}
 						placeholder={placeholder}
-						className="min-h-[56px] resize-none border-0 bg-transparent px-1 py-2 shadow-none focus-visible:ring-0"
+						className="min-h-[56px] resize-none border-0 !bg-transparent px-1 py-2 shadow-none focus-visible:ring-0 dark:!bg-transparent"
 					/>
 					{attachments.length > 0 ? (
 						<div className="flex flex-wrap gap-1 pb-1">

--- a/apps/web/src/components/(chat)/ChatConversationMessages.tsx
+++ b/apps/web/src/components/(chat)/ChatConversationMessages.tsx
@@ -12,6 +12,10 @@ import {
 import { Shimmer } from "@/components/ai-elements/shimmer";
 import { Button } from "@/components/ui/button";
 import {
+	ChatRequestErrorNotice,
+	type ChatRequestErrorDetails,
+} from "@/components/(chat)/ChatRequestErrorNotice";
+import {
 	Popover,
 	PopoverContent,
 	PopoverTrigger,
@@ -102,6 +106,8 @@ type ChatConversationMessagesProps = {
 	onBranchAssistant: (messageId: string) => void;
 	onSelectVariant: (messageId: string, variantIndex: number) => void;
 	onCopy: (text: string) => boolean | Promise<boolean>;
+	requestError?: ChatRequestErrorDetails | null;
+	onDismissRequestError?: () => void;
 };
 
 export function ChatConversationMessages({
@@ -124,8 +130,13 @@ export function ChatConversationMessages({
 	onBranchAssistant,
 	onSelectVariant,
 	onCopy,
+	requestError = null,
+	onDismissRequestError,
 }: ChatConversationMessagesProps) {
 	const [copiedMessageKey, setCopiedMessageKey] = useState<string | null>(null);
+	const [dismissedErrorMessageIds, setDismissedErrorMessageIds] = useState<
+		Set<string>
+	>(() => new Set());
 	const copiedResetTimeoutRef = useRef<number | null>(null);
 
 	useEffect(() => {
@@ -266,6 +277,26 @@ export function ChatConversationMessages({
 				(activeVariant?.meta as Record<string, unknown> | null) ??
 				(message.meta as Record<string, unknown> | null) ??
 				null;
+			let messageRequestError: ChatRequestErrorDetails | null = null;
+			if (!isUser) {
+				if (
+					activeMeta?.chat_request_error &&
+					typeof activeMeta.chat_request_error === "object" &&
+					!Array.isArray(activeMeta.chat_request_error)
+				) {
+					messageRequestError =
+						activeMeta.chat_request_error as ChatRequestErrorDetails;
+				} else if (
+					requestError &&
+					lastMessageId === message.id &&
+					!dismissedErrorMessageIds.has(message.id)
+				) {
+					messageRequestError = requestError;
+				}
+			}
+			const showRequestError =
+				Boolean(messageRequestError) &&
+				!dismissedErrorMessageIds.has(message.id);
 			const videoUrl = isUser
 				? null
 				: sanitizeHttpMediaUrl(extractGeneratedVideoUrl(content));
@@ -320,16 +351,21 @@ export function ChatConversationMessages({
 				(displayModelId ? modelLinkById[displayModelId] : undefined) ??
 				buildModelLink(displayModelId);
 			const hasModelLink = Boolean(displayModelId && modelLink !== "#");
-			const responseProviderId =
+			const routingSelectedProvider =
+				(activeMeta?.routing as any)?.selected_provider;
+			let responseProviderId = message.providerId?.trim() || null;
+			if (
+				typeof routingSelectedProvider === "string" &&
+				routingSelectedProvider.trim().length > 0
+			) {
+				responseProviderId = routingSelectedProvider.trim();
+			}
+			if (
 				typeof activeMeta?.provider === "string" &&
 				activeMeta.provider.trim().length > 0
-					? activeMeta.provider.trim()
-					: typeof (activeMeta?.routing as any)?.selected_provider ===
-							  "string" &&
-						  (activeMeta?.routing as any).selected_provider.trim()
-								.length > 0
-						? (activeMeta?.routing as any).selected_provider.trim()
-						: message.providerId?.trim() || null;
+			) {
+				responseProviderId = activeMeta.provider.trim();
+			}
 			const responseProviderLabel =
 				message.providerName?.trim() || responseProviderId || null;
 			const isEditing = editingId === message.id;
@@ -546,8 +582,21 @@ export function ChatConversationMessages({
 									) : null}
 								</div>
 							)
-						) : isSending &&
-						  (!content || content === "Generating...") ? (
+						) : showRequestError && messageRequestError ? (
+							<ChatRequestErrorNotice
+								error={messageRequestError}
+								threadTitle={activeThread.title}
+								className="not-prose"
+								onDismiss={() => {
+									setDismissedErrorMessageIds((current) => {
+										const next = new Set(current);
+										next.add(message.id);
+										return next;
+									});
+									onDismissRequestError?.();
+								}}
+							/>
+						) : isSending && (!content || content === "Generating...") ? (
 							<div className="flex min-h-7 items-center">
 								<Shimmer className="text-sm text-muted-foreground">
 									Generating...
@@ -923,6 +972,9 @@ export function ChatConversationMessages({
 		modelLinkById,
 		accentColor,
 		onCopy,
+		requestError,
+		onDismissRequestError,
+		dismissedErrorMessageIds,
 		handleCopyForMessage,
 		copiedMessageKey,
 		onEditingValueChange,

--- a/apps/web/src/components/(chat)/ChatConversationMessages.tsx
+++ b/apps/web/src/components/(chat)/ChatConversationMessages.tsx
@@ -359,8 +359,7 @@ export function ChatConversationMessages({
 				activeMeta.provider.trim().length > 0
 			) {
 				responseProviderId = activeMeta.provider.trim();
-			}
-			if (
+			} else if (
 				typeof routingSelectedProvider === "string" &&
 				routingSelectedProvider.trim().length > 0
 			) {
@@ -582,20 +581,6 @@ export function ChatConversationMessages({
 									) : null}
 								</div>
 							)
-						) : showRequestError && messageRequestError ? (
-							<ChatRequestErrorNotice
-								error={messageRequestError}
-								threadTitle={activeThread.title}
-								className="not-prose"
-								onDismiss={() => {
-									setDismissedErrorMessageIds((current) => {
-										const next = new Set(current);
-										next.add(message.id);
-										return next;
-									});
-									onDismissRequestError?.();
-								}}
-							/>
 						) : isSending && (!content || content === "Generating...") ? (
 							<div className="flex min-h-7 items-center">
 								<Shimmer className="text-sm text-muted-foreground">
@@ -613,9 +598,29 @@ export function ChatConversationMessages({
 									>
 										<ReasoningTrigger />
 										<ReasoningContent>
-											{reasoningText}
-										</ReasoningContent>
+										{reasoningText}
+									</ReasoningContent>
 									</Reasoning>
+								) : null}
+								{showRequestError && messageRequestError ? (
+									<ChatRequestErrorNotice
+										error={messageRequestError}
+										threadTitle={activeThread.title}
+										className="not-prose"
+										onDismiss={() => {
+											setDismissedErrorMessageIds((current) => {
+												const next = new Set(current);
+												next.add(message.id);
+												return next;
+											});
+											onDismissRequestError?.();
+										}}
+									/>
+								) : !contentWithoutMediaLinks &&
+									messageRequestError ? (
+									<p className="not-prose text-sm text-muted-foreground">
+										Request failed. Use Retry to run this message again.
+									</p>
 								) : null}
 								{contentWithoutMediaLinks ? (
 									<Streamdown>{contentWithoutMediaLinks}</Streamdown>

--- a/apps/web/src/components/(chat)/ChatConversationMessages.tsx
+++ b/apps/web/src/components/(chat)/ChatConversationMessages.tsx
@@ -355,16 +355,16 @@ export function ChatConversationMessages({
 				(activeMeta?.routing as any)?.selected_provider;
 			let responseProviderId = message.providerId?.trim() || null;
 			if (
-				typeof routingSelectedProvider === "string" &&
-				routingSelectedProvider.trim().length > 0
-			) {
-				responseProviderId = routingSelectedProvider.trim();
-			}
-			if (
 				typeof activeMeta?.provider === "string" &&
 				activeMeta.provider.trim().length > 0
 			) {
 				responseProviderId = activeMeta.provider.trim();
+			}
+			if (
+				typeof routingSelectedProvider === "string" &&
+				routingSelectedProvider.trim().length > 0
+			) {
+				responseProviderId = routingSelectedProvider.trim();
 			}
 			const responseProviderLabel =
 				message.providerName?.trim() || responseProviderId || null;

--- a/apps/web/src/components/(chat)/ChatConversationMessages.tsx
+++ b/apps/web/src/components/(chat)/ChatConversationMessages.tsx
@@ -622,7 +622,7 @@ export function ChatConversationMessages({
 										Request failed. Use Retry to run this message again.
 									</p>
 								) : null}
-								{contentWithoutMediaLinks ? (
+								{!showRequestError && contentWithoutMediaLinks ? (
 									<Streamdown>{contentWithoutMediaLinks}</Streamdown>
 								) : null}
 								{imageUrl ? (

--- a/apps/web/src/components/(chat)/ChatPlayground.tsx
+++ b/apps/web/src/components/(chat)/ChatPlayground.tsx
@@ -2186,7 +2186,7 @@ function ChatPlaygroundContent({
 							latestThread,
 							streamingMessageId,
 							variantIndex,
-							"",
+							message,
 							undefined,
 							errorMeta,
 						);
@@ -2195,7 +2195,7 @@ function ChatPlaygroundContent({
 						const errorMessage: ChatMessage = {
 							id: generateId(),
 							role: "assistant",
-							content: "",
+							content: message,
 							createdAt: nowIso(),
 							modelId: selectedModelId,
 							providerId: latestThread.settings.providerId,
@@ -2204,7 +2204,7 @@ function ChatPlaygroundContent({
 							variants: [
 								{
 									id: generateId(),
-									content: "",
+									content: message,
 									createdAt: nowIso(),
 									meta: errorMeta,
 								},

--- a/apps/web/src/components/(chat)/ChatPlayground.tsx
+++ b/apps/web/src/components/(chat)/ChatPlayground.tsx
@@ -28,7 +28,6 @@ import {
 import { ChatHeader } from "@/components/(chat)/ChatHeader";
 import { ModelSettingsDialog } from "@/components/(chat)/ModelSettingsDialog";
 import {
-	ChatRequestErrorNotice,
 	type ChatRequestErrorDetails,
 } from "@/components/(chat)/ChatRequestErrorNotice";
 import { ChatSearchDialog } from "@/components/(chat)/ChatSearchDialog";
@@ -1416,6 +1415,7 @@ function ChatPlaygroundContent({
 					latestThread = result.nextThread;
 					variantIndex = result.variantIndex;
 					assistantContent = initialVariant.content;
+					streamingMessageId = targetAssistantId;
 					placeholderReady = true;
 					await updateThreadState(latestThread, false);
 				} else {
@@ -2145,8 +2145,6 @@ function ChatPlaygroundContent({
 					typeof structuredError?.code === "string"
 						? structuredError.code
 						: "";
-				const isGatewayUnavailable =
-					errorCode === "gateway_unreachable";
 				setError(message);
 				const nextRequestError: ChatRequestErrorDetails = {
 					status:
@@ -2175,32 +2173,11 @@ function ChatPlaygroundContent({
 					timestamp: nowIso(),
 				};
 				setRequestError(nextRequestError);
-				const isGatewayError =
-					message.includes('"description":"all_candidates_failed"') ||
-					message.includes('"errorCode":"upstream_error"') ||
-					message.includes("all_candidates_failed");
-				const summary =
-					nextRequestError.description ||
-					nextRequestError.details[0]?.message ||
-					message;
-				const errorContent = isGatewayError
-					? `All Providers Failed\n${summary}${
-							nextRequestError.requestId
-								? `\nRequest ID: ${nextRequestError.requestId}`
-								: ""
-						}`
-					: isGatewayUnavailable
-						? message
-						: `Request failed${
-								nextRequestError.status
-									? ` (${nextRequestError.status})`
-									: ""
-							}\n${summary}${
-								nextRequestError.requestId
-									? `\nRequest ID: ${nextRequestError.requestId}`
-									: ""
-							}`;
 				if (latestThread) {
+					const errorMeta = {
+						...(compareMeta ?? {}),
+						chat_request_error: nextRequestError,
+					};
 					const existingMessage = latestThread.messages.find(
 						(m) => m.id === streamingMessageId
 					);
@@ -2209,16 +2186,16 @@ function ChatPlaygroundContent({
 							latestThread,
 							streamingMessageId,
 							variantIndex,
-							errorContent,
+							"",
 							undefined,
-							compareMeta ?? undefined,
+							errorMeta,
 						);
 					} else {
 						const orgId = getOrgId(selectedModelId);
 						const errorMessage: ChatMessage = {
 							id: generateId(),
 							role: "assistant",
-							content: errorContent,
+							content: "",
 							createdAt: nowIso(),
 							modelId: selectedModelId,
 							providerId: latestThread.settings.providerId,
@@ -2227,13 +2204,13 @@ function ChatPlaygroundContent({
 							variants: [
 								{
 									id: generateId(),
-									content: errorContent,
+									content: "",
 									createdAt: nowIso(),
-									meta: compareMeta ?? undefined,
+									meta: errorMeta,
 								},
 							],
 							activeVariantIndex: 0,
-							meta: compareMeta ?? undefined,
+							meta: errorMeta,
 						};
 						latestThread = {
 							...latestThread,
@@ -3627,18 +3604,6 @@ function ChatPlaygroundContent({
 				<SidebarRail />
 			</Sidebar>
 			<SidebarInset className="flex h-full min-w-0 min-h-0 flex-1 flex-col overflow-hidden bg-background">
-				{requestError ? (
-					<div className="px-4 pt-4 md:px-8">
-						<ChatRequestErrorNotice
-							error={requestError}
-							threadTitle={activeThread?.title ?? null}
-							onDismiss={() => {
-								setRequestError(null);
-								setError(null);
-							}}
-						/>
-					</div>
-				) : null}
 				<ChatHeader
 					activeThread={activeThread}
 					modelOptions={modelOptions}
@@ -3725,6 +3690,11 @@ function ChatPlaygroundContent({
 					onAudioAttachmentRequirementChange={(requiresAudioInput) =>
 						setComposerRequiresAudioInput(requiresAudioInput)
 					}
+					requestError={requestError}
+					onDismissRequestError={() => {
+						setRequestError(null);
+						setError(null);
+					}}
 				/>
 			</SidebarInset>
 			<ModelSettingsDialog

--- a/apps/web/src/components/(chat)/ChatPlayground.tsx
+++ b/apps/web/src/components/(chat)/ChatPlayground.tsx
@@ -3582,6 +3582,10 @@ function ChatPlaygroundContent({
 		temporaryMode,
 		updateThreadState,
 	]);
+	const handleDismissRequestError = useCallback(() => {
+		setRequestError(null);
+		setError(null);
+	}, []);
 
 	return (
 		<div className="flex h-full min-h-0 w-full overflow-hidden bg-background text-foreground">
@@ -3691,10 +3695,7 @@ function ChatPlaygroundContent({
 						setComposerRequiresAudioInput(requiresAudioInput)
 					}
 					requestError={requestError}
-					onDismissRequestError={() => {
-						setRequestError(null);
-						setError(null);
-					}}
+					onDismissRequestError={handleDismissRequestError}
 				/>
 			</SidebarInset>
 			<ModelSettingsDialog

--- a/apps/web/src/components/(chat)/ChatRequestErrorNotice.tsx
+++ b/apps/web/src/components/(chat)/ChatRequestErrorNotice.tsx
@@ -4,6 +4,7 @@ import { useMemo, useState } from "react";
 import { AlertTriangle, Bug, ClipboardCopy, ExternalLink, X } from "lucide-react";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
 import {
 	Dialog,
 	DialogContent,
@@ -37,6 +38,7 @@ type ChatRequestErrorNoticeProps = {
 	error: ChatRequestErrorDetails;
 	threadTitle?: string | null;
 	onDismiss: () => void;
+	className?: string;
 };
 
 function buildSummary(error: ChatRequestErrorDetails): string {
@@ -76,6 +78,7 @@ export function ChatRequestErrorNotice({
 	error,
 	threadTitle,
 	onDismiss,
+	className,
 }: ChatRequestErrorNoticeProps) {
 	const [open, setOpen] = useState(false);
 	const [notes, setNotes] = useState("");
@@ -136,7 +139,12 @@ export function ChatRequestErrorNotice({
 
 	return (
 		<>
-			<div className="mx-auto mb-4 flex w-full max-w-5xl items-start gap-3 rounded-2xl border border-red-200 bg-red-50 px-4 py-3 text-red-950 dark:border-red-900/70 dark:bg-red-950/30 dark:text-red-100">
+			<div
+				className={cn(
+					"mx-auto mb-4 flex w-full max-w-5xl items-start gap-3 rounded-2xl border border-red-200 bg-red-50 px-4 py-3 text-red-950 dark:border-red-900/70 dark:bg-red-950/30 dark:text-red-100",
+					className,
+				)}
+			>
 				<AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" />
 				<div className="min-w-0 flex-1">
 					<p className="text-sm font-medium">


### PR DESCRIPTION
﻿## Summary
- Render chat request failures inline in the conversation instead of above the model selector.
- Preserve the existing request error actions while attaching structured error metadata to failed assistant messages.
- Add manual infinite-style prompt preset scrolling in the chat composer using the ShadCN ScrollArea pattern.
- Add prompt preset cards for common model evaluation and productivity prompts, with click-to-fill composer behavior.
- Flatten the composer textarea styling so the input no longer appears two-tone.

## Validation
- pnpm --filter @ai-stats/web typecheck
- pnpm --filter @ai-stats/web test -- Chat
- pnpm --filter @ai-stats/web exec eslint --quiet 'src/components/(chat)/ChatConversation.tsx' 'src/components/(chat)/ChatConversationComposer.tsx' 'src/components/(chat)/ChatConversationMessages.tsx' 'src/components/(chat)/ChatPlayground.tsx' 'src/components/(chat)/ChatRequestErrorNotice.tsx'

## Notes
- Prepared on a clean worktree from origin/main so unrelated API/cache/schema changes from the current local branch are not included.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ai-stats/ai-stats/pull/691" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Conversation UI now surfaces request-level errors inline with a dismiss option.
  * Composer includes selectable evaluation prompts that auto-fill the message field and focus the input.
  * Prompts are presented in a horizontally scrollable, auto-centering selector.
  * Error notice supports an optional styling class for layout flexibility.

* **Bug Fixes**
  * Failures now attach to the correct assistant message and can be dismissed per-message.
  * More accurate provider attribution for assistant responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->