### PR TITLE
[codex] Add rumoured Z.AI GLM 5.2 model

### DIFF
--- a/apps/docs/v1/changelog.mdx
+++ b/apps/docs/v1/changelog.mdx
@@ -4,6 +4,14 @@ description: "Recent product updates, SDK changes, and model releases across AI 
 rss: true
 ---
 
+## June 11, 2026
+
+<p style={{ fontSize: "1rem", fontWeight: 600, marginTop: "1rem", marginBottom: "0.5rem" }}>New Models</p>
+
+- GLM 5.2 was added in `Rumoured` state with a notice that the entry is based on leaked private-testing references rather than a public Z.AI release.
+
+***
+
 ## June 9, 2026
 
 <p style={{ fontSize: "1rem", fontWeight: 600, marginTop: "1rem", marginBottom: "0.5rem" }}>New Models</p>

--- a/packages/data/catalog/src/data/models/z-ai/glm-5.2/model.json
+++ b/packages/data/catalog/src/data/models/z-ai/glm-5.2/model.json
@@ -1,0 +1,28 @@
+{
+  "model_id": "z-ai/glm-5.2",
+  "organisation_id": "z-ai",
+  "name": "GLM 5.2",
+  "status": "Rumoured",
+  "previous_model_id": "z-ai/glm-5.1",
+  "description": "GLM 5.2 is a rumoured Z.AI flagship model tracked as the likely successor to GLM 5.1. The current record is based on leaked private-testing references and early public sightings rather than a formal Z.AI release.",
+  "announced_date": null,
+  "release_date": null,
+  "deprecation_date": null,
+  "retirement_date": null,
+  "license": null,
+  "input_types": null,
+  "output_types": null,
+  "api_model_id": "z-ai/glm-5.2",
+  "page_notice": {
+    "tone": "warning",
+    "markdown": "GLM 5.2 is a rumoured model and is not publicly released. This page exists because leaked private-testing references and public sightings suggest Z.AI is evaluating a `glm-5.2` line. Specs, pricing, provider availability, and release timing are unconfirmed and may change or disappear without notice."
+  },
+  "links": [],
+  "details": [
+    {
+      "name": "availability",
+      "value": "Tracked from private-testing leaks and public sightings only. No public Z.AI announcement, provider launch, or final model card is available yet."
+    }
+  ],
+  "benchmarks": []
+}


### PR DESCRIPTION
## Summary
- add `z-ai/glm-5.2` as a `Rumoured` catalog entry
- add a model page warning that the entry is based on leaked private-testing references and public sightings, not a public Z.AI release
- add a June 11, 2026 changelog entry for the catalog update

## Why
The catalog did not yet have a tracked page for the rumoured GLM 5.2 line. This adds the entry while making the unofficial status explicit so users do not mistake it for a confirmed public launch.

## Impact
Users can now find the rumoured model in the catalog, and the page notice clarifies that specifications, pricing, availability, and release timing remain unconfirmed.

## Validation
- `pnpm validate:data`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added GLM 5.2 model to catalog (marked as Rumoured, based on private testing references)

* **Documentation**
  * Updated changelog for June 11, 2026 with new model entry

<!-- end of auto-generated comment: release notes by coderabbit.ai -->