### PR TITLE
Add Moonshot K2.7 Code support

### DIFF
--- a/.changeset/moonshot-k27-code-gateway-api.md
+++ b/.changeset/moonshot-k27-code-gateway-api.md
@@ -1,0 +1,5 @@
+---
+"@ai-stats/gateway-api": patch
+---
+
+Add Moonshot `kimi-k2.7-code` to the catalog and gateway, including direct-provider pricing, subscription-plan coverage, and Moonshot request normalization for the model's stricter thinking, sampling, and tool-choice rules.

--- a/apps/api/src/executors/_shared/text-generate/openai-compat/providers/moonshot-ai/quirks.ts
+++ b/apps/api/src/executors/_shared/text-generate/openai-compat/providers/moonshot-ai/quirks.ts
@@ -5,8 +5,67 @@
 import type { ProviderQuirks } from "../../quirks/types";
 import { applyJsonSchemaFallback } from "../../quirks/structured";
 
+const MOONSHOT_PROVIDER_IDS = new Set([
+	"moonshot-ai",
+	"moonshotai",
+	"moonshot-ai-turbo",
+	"moonshotai-turbo",
+]);
+
+const K2_7_CODE_MODELS = new Set([
+	"kimi-k2.7-code",
+	"moonshotai/kimi-k2.7-code",
+]);
+
 const isMoonshot = (providerId?: string) =>
-	providerId === "moonshot-ai" || providerId === "moonshot-ai-turbo";
+	MOONSHOT_PROVIDER_IDS.has(String(providerId ?? "").trim().toLowerCase());
+
+function isK27CodeModel(model: unknown): boolean {
+	return K2_7_CODE_MODELS.has(String(model ?? "").trim().toLowerCase());
+}
+
+function normalizeK27CodeRequest(request: Record<string, any>) {
+	if (!isK27CodeModel(request?.model)) return;
+
+	// K2.7 Code rejects disabled thinking. Omit or enable it instead.
+	if (request.thinking && typeof request.thinking === "object") {
+		if (request.thinking.type === "disabled") {
+			request.thinking = { ...request.thinking, type: "enabled" };
+		}
+	}
+
+	// K2.7 Code only accepts the documented fixed/default sampling values.
+	if (typeof request.temperature === "number" && request.temperature !== 1) {
+		delete request.temperature;
+	}
+	if (typeof request.top_p === "number" && request.top_p !== 0.95) {
+		delete request.top_p;
+	}
+	if (
+		typeof request.frequency_penalty === "number" &&
+		request.frequency_penalty !== 0
+	) {
+		delete request.frequency_penalty;
+	}
+	if (
+		typeof request.presence_penalty === "number" &&
+		request.presence_penalty !== 0
+	) {
+		delete request.presence_penalty;
+	}
+
+	// Tool choice is restricted to auto/none for this model.
+	const hasTools = Array.isArray(request.tools) && request.tools.length > 0;
+	if (request.tool_choice !== undefined) {
+		const normalizedToolChoice =
+			typeof request.tool_choice === "string"
+				? request.tool_choice.trim().toLowerCase()
+				: null;
+		if (normalizedToolChoice !== "auto" && normalizedToolChoice !== "none") {
+			request.tool_choice = hasTools ? "auto" : "none";
+		}
+	}
+}
 
 export const moonshotQuirks: ProviderQuirks = {
 	transformRequest: ({ request }) => {
@@ -22,6 +81,8 @@ export const moonshotQuirks: ProviderQuirks = {
 					: msg,
 			);
 		}
+
+		normalizeK27CodeRequest(request);
 	},
 };
 

--- a/apps/api/src/executors/_shared/text-generate/openai-compat/quirks/__tests__/moonshot.test.ts
+++ b/apps/api/src/executors/_shared/text-generate/openai-compat/quirks/__tests__/moonshot.test.ts
@@ -30,4 +30,36 @@ describe("Moonshot quirks", () => {
 		expect(request.response_format).toEqual({ type: "json_object" });
 		expect(String(request.messages[0].content)).toContain("The JSON must match this schema");
 	});
+
+	it("normalizes K2.7 Code request fields to Moonshot's documented constraints", () => {
+		const request: Record<string, any> = {
+			model: "kimi-k2.7-code",
+			messages: [{ role: "user", content: "hi" }],
+			tools: [
+				{
+					type: "function",
+					function: {
+						name: "get_weather",
+						description: "Get weather",
+						parameters: { type: "object", properties: {} },
+					},
+				},
+			],
+			tool_choice: { type: "function", function: { name: "get_weather" } },
+			thinking: { type: "disabled" },
+			temperature: 0.2,
+			top_p: 0.5,
+			frequency_penalty: 0.3,
+			presence_penalty: -0.2,
+		};
+
+		moonshotQuirks.transformRequest?.({ request, ir: {} as any });
+
+		expect(request.thinking).toEqual({ type: "enabled" });
+		expect(request.temperature).toBeUndefined();
+		expect(request.top_p).toBeUndefined();
+		expect(request.frequency_penalty).toBeUndefined();
+		expect(request.presence_penalty).toBeUndefined();
+		expect(request.tool_choice).toBe("auto");
+	});
 });

--- a/apps/docs/openapi/v1/openapi.yaml
+++ b/apps/docs/openapi/v1/openapi.yaml
@@ -8452,6 +8452,7 @@ components:
         - moonshotai/kimi-k2.5
         - moonshotai/kimi-k2.5-lightning
         - moonshotai/kimi-k2.6
+        - moonshotai/kimi-k2.7-code
         - moonshotai/moonshot-v1-128k
         - moonshotai/moonshot-v1-128k-vision-preview
         - moonshotai/moonshot-v1-32k

--- a/packages/data/catalog/src/data/api_providers/moonshotai/models.json
+++ b/packages/data/catalog/src/data/api_providers/moonshotai/models.json
@@ -105,6 +105,27 @@
     ]
   },
   {
+    "api_model_id": "moonshotai/kimi-k2.7-code",
+    "provider_api_model_id": "moonshotai:moonshotai/kimi-k2.7-code",
+    "provider_model_slug": "kimi-k2.7-code",
+    "internal_model_id": "moonshotai/kimi-k2.7-code",
+    "is_active_gateway": true,
+    "quantization_scheme": null,
+    "input_modalities": "text,image,video",
+    "output_modalities": "text",
+    "context_length": 262144,
+    "max_output_tokens": null,
+    "effective_from": "2026-06-12T00:00:00",
+    "effective_to": null,
+    "capabilities": [
+      {
+        "capability_id": "text.generate",
+        "status": "active",
+        "params": []
+      }
+    ]
+  },
+  {
     "api_model_id": "moonshotai/moonshot-v1-8k",
     "provider_api_model_id": "moonshotai:moonshotai/moonshot-v1-8k",
     "provider_model_slug": "moonshot-v1-8k",

--- a/packages/data/catalog/src/data/models/moonshotai/kimi-k2.7-code/model.json
+++ b/packages/data/catalog/src/data/models/moonshotai/kimi-k2.7-code/model.json
@@ -1,0 +1,50 @@
+{
+  "model_id": "moonshotai/kimi-k2.7-code",
+  "organisation_id": "moonshotai",
+  "name": "Kimi K2.7 Code",
+  "status": "Available",
+  "previous_model_id": "moonshotai/kimi-k2.6",
+  "description": "Kimi K2.7 Code is Moonshot AI's strongest coding model, built for long-context software engineering and agent workflows with native text, image, and video input plus always-on long thinking.",
+  "announced_date": "2026-06-12T00:00:00",
+  "release_date": "2026-06-12T00:00:00",
+  "deprecation_date": null,
+  "retirement_date": null,
+  "license": "Modified MIT",
+  "input_types": "text,image,video",
+  "output_types": "text",
+  "api_model_id": "moonshotai/kimi-k2.7-code",
+  "family_id": "moonshotai/kimi-k2",
+  "links": [
+    {
+      "platform": "api_reference",
+      "url": "https://platform.kimi.ai/docs/guide/kimi-k2-7-code-quickstart"
+    },
+    {
+      "platform": "pricing",
+      "url": "https://platform.kimi.ai/docs/pricing/chat-k27-code"
+    }
+  ],
+  "details": [
+    {
+      "name": "input_context_length",
+      "value": 262144
+    },
+    {
+      "name": "supports_tools",
+      "value": true
+    },
+    {
+      "name": "supports_json_mode",
+      "value": true
+    },
+    {
+      "name": "supports_partial_mode",
+      "value": true
+    },
+    {
+      "name": "requires_thinking",
+      "value": true
+    }
+  ],
+  "benchmarks": []
+}

--- a/packages/data/catalog/src/data/pricing/moonshotai/moonshotai-kimi-k2.7-code/text.generate/pricing.json
+++ b/packages/data/catalog/src/data/pricing/moonshotai/moonshotai-kimi-k2.7-code/text.generate/pricing.json
@@ -1,0 +1,45 @@
+{
+  "key": "moonshotai:moonshotai/kimi-k2.7-code:text.generate",
+  "api_provider_id": "moonshotai",
+  "provider_slug": "moonshotai",
+  "api_model_id": "moonshotai/kimi-k2.7-code",
+  "capability_id": "text.generate",
+  "rules": [
+    {
+      "meter": "input_text_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 0.95,
+      "currency": "USD",
+      "pricing_plan": "standard",
+      "note": null,
+      "match": [],
+      "priority": 100,
+      "effective_from": "2026-06-12T00:00:00Z"
+    },
+    {
+      "meter": "cached_read_text_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 0.19,
+      "currency": "USD",
+      "pricing_plan": "standard",
+      "note": null,
+      "match": [],
+      "priority": 100,
+      "effective_from": "2026-06-12T00:00:00Z"
+    },
+    {
+      "meter": "output_text_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 4,
+      "currency": "USD",
+      "pricing_plan": "standard",
+      "note": null,
+      "match": [],
+      "priority": 100,
+      "effective_from": "2026-06-12T00:00:00Z"
+    }
+  ]
+}

--- a/packages/data/catalog/src/data/subscription_plans/moonshotai-kimi-tier0/plan.json
+++ b/packages/data/catalog/src/data/subscription_plans/moonshotai-kimi-tier0/plan.json
@@ -55,6 +55,12 @@
       "model_info": null,
       "rate_limit": null,
       "other_info": null
+    },
+    {
+      "model_id": "moonshotai/kimi-k2.7-code",
+      "model_info": null,
+      "rate_limit": null,
+      "other_info": null
     }
   ]
 }


### PR DESCRIPTION
## Summary
Closes #697

Adds support for `moonshotai/kimi-k2.7-code` across the catalog and gateway.

- adds the new Moonshot model record with release date, doc links, and durable model details
- adds provider pricing and Kimi tier plan coverage for the new model
- adds Moonshot gateway request normalization for K2.7 Code's documented parameter constraints
- adds a focused gateway test for the new normalization behavior

## Scope note
`moonshotai/kimi-latest` was intentionally not updated in this PR.

## Source links
- https://platform.kimi.ai/docs/guide/kimi-k2-7-code-quickstart
- https://platform.kimi.ai/docs/pricing/chat-k27-code

## Validation
- `pnpm validate:data`
- `pnpm --filter @ai-stats/gateway-api exec vitest run src/executors/_shared/text-generate/openai-compat/quirks/__tests__/moonshot.test.ts`

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ai-stats/ai-stats/pull/698" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the Moonshot kimi-k2.7-code model with text generation capability, including multimodal input support (text, image, video).
  * Configured direct-provider pricing and subscription plan coverage.
  * Optimized request handling for the model's specific operational requirements.

* **Tests**
  * Added test coverage verifying request normalization behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->