### PR TITLE
Add MiniMax M3 Hugging Face link

### DIFF
--- a/packages/data/catalog/src/data/models/minimax/minimax-m3/model.json
+++ b/packages/data/catalog/src/data/models/minimax/minimax-m3/model.json
@@ -24,6 +24,10 @@
       "url": "https://platform.minimax.io/docs/guides/text-generation"
     },
     {
+      "platform": "weights",
+      "url": "https://huggingface.co/MiniMaxAI/MiniMax-M3"
+    },
+    {
       "platform": "website",
       "url": "https://www.minimax.io/models/text/m3"
     }


### PR DESCRIPTION
## Summary
- add the Hugging Face model page as a `weights` link for MiniMax M3

## Testing
- not run (metadata-only change)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ai-stats/ai-stats/pull/702" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->