### PR TITLE
Show monitor links and status dates

### DIFF
--- a/apps/web/src/components/monitor/MonitorHistoryClient.tsx
+++ b/apps/web/src/components/monitor/MonitorHistoryClient.tsx
@@ -140,7 +140,12 @@ const PROVIDER_STATUS_META: Record<
 };
 
 type BadgeKind = "added" | "removed";
-type DisplayRowKind = "benchmark" | "description" | "pricing" | "status";
+type DisplayRowKind =
+	| "benchmark"
+	| "description"
+	| "link"
+	| "pricing"
+	| "status";
 type ChangeFilter = "all" | DisplayRowKind;
 
 const CHANGE_FILTER_OPTIONS: Array<{ label: string; value: ChangeFilter }> = [
@@ -148,6 +153,7 @@ const CHANGE_FILTER_OPTIONS: Array<{ label: string; value: ChangeFilter }> = [
 	{ label: "Status", value: "status" },
 	{ label: "Pricing", value: "pricing" },
 	{ label: "Description", value: "description" },
+	{ label: "Links", value: "link" },
 	{ label: "Benchmark results", value: "benchmark" },
 ];
 
@@ -364,6 +370,24 @@ function formatGenericValue(value: unknown): string {
 	return String(value);
 }
 
+function isDateOnlyMonitorField(field: string) {
+	return field === "deprecation_date" || field === "retirement_date";
+}
+
+function formatMonitorDateValue(value: unknown): string {
+	if (value == null) return "None";
+	const text = String(value).trim();
+	if (!text) return "None";
+	const parsed = new Date(text);
+	if (Number.isNaN(parsed.getTime())) return text;
+	return new Intl.DateTimeFormat("en-US", {
+		day: "numeric",
+		month: "short",
+		timeZone: "UTC",
+		year: "numeric",
+	}).format(parsed);
+}
+
 function normalizeProviderStatusValue(value: unknown): string {
 	const normalized = String(value ?? "")
 		.trim()
@@ -460,7 +484,10 @@ function isTrackedChange(change: ChangeHistory) {
 	if (change.entityType === "model" && !change.field) return true;
 	if (change.field === "description") return true;
 	if (change.field === "status") return true;
+	if (change.field === "deprecation_date") return true;
+	if (change.field === "retirement_date") return true;
 	if (change.field.startsWith("benchmarks.")) return true;
+	if (change.field.startsWith("links.")) return true;
 	if (change.field.startsWith("pricing.")) return true;
 	return false;
 }
@@ -753,9 +780,22 @@ function getPricingLabelParts(field: string): { label: string; labelDetail?: str
 
 function getRowKind(change: ChangeHistory): DisplayRowKind {
 	if (change.field === "description") return "description";
-	if (change.field === "status" || !change.field) return "status";
+	if (
+		change.field === "status" ||
+		change.field === "deprecation_date" ||
+		change.field === "retirement_date" ||
+		!change.field
+	)
+		return "status";
 	if (change.field.startsWith("benchmarks.")) return "benchmark";
+	if (change.field.startsWith("links.")) return "link";
 	return "pricing";
+}
+
+function getLinkLabel(field: string) {
+	const match = field.match(/^links\.([^.[]+)(?:\[[^\]]+\])?\.url$/);
+	const platform = match?.[1] ?? "";
+	return { label: `${humanizeSlug(platform || "link")} link` };
 }
 
 function getRowLabel(change: ChangeHistory) {
@@ -773,9 +813,12 @@ function getRowLabel(change: ChangeHistory) {
 	}
 	if (change.field === "description") return { label: "Description" };
 	if (change.field === "status") return { label: "Status" };
+	if (change.field === "deprecation_date") return { label: "Deprecation date" };
+	if (change.field === "retirement_date") return { label: "Retirement date" };
 	if (change.field.startsWith("benchmarks.")) {
 		return { label: getBenchmarkLabel(change.field) };
 	}
+	if (change.field.startsWith("links.")) return getLinkLabel(change.field);
 	if (change.field.startsWith("pricing.")) return getPricingLabelParts(change.field);
 	return { label: humanizeSlug(change.field || "change") };
 }
@@ -833,9 +876,10 @@ function shouldHideRowForCard(card: MonitorCard, row: DisplayRow) {
 function getRowWeight(row: DisplayRow) {
 	if (row.kind === "status") return 0;
 	if (row.kind === "pricing") return 1;
-	if (row.kind === "description") return 2;
-	if (row.kind === "benchmark") return 3;
-	return 4;
+	if (row.kind === "link") return 2;
+	if (row.kind === "description") return 3;
+	if (row.kind === "benchmark") return 4;
+	return 5;
 }
 
 function getStatusRowPriority(row: DisplayRow) {
@@ -1083,7 +1127,9 @@ function renderValueTransition(row: DisplayRow) {
 	const formatValue =
 		row.kind === "pricing"
 			? formatPriceValue
-			: formatGenericValue;
+			: isDateOnlyMonitorField(row.field)
+				? formatMonitorDateValue
+				: formatGenericValue;
 	if (row.oldValue == null && row.newValue != null) {
 		return (
 			<div className="flex min-w-0 flex-wrap items-center gap-2 text-sm">

--- a/scripts/update-monitor-history.test.ts
+++ b/scripts/update-monitor-history.test.ts
@@ -2,6 +2,20 @@ import assert from "node:assert/strict";
 import { testingExports } from "./update-monitor-history";
 
 function main() {
+  assert.equal(testingExports.assertSafeGitRef("HEAD"), "HEAD");
+  assert.equal(
+    testingExports.assertSafeGitRef("origin/main", "head ref"),
+    "origin/main"
+  );
+  assert.throws(
+    () => testingExports.assertSafeGitRef("HEAD; curl attacker", "head ref"),
+    /invalid characters|unsafe git revision pattern/
+  );
+  assert.throws(
+    () => testingExports.assertSafeGitRef("../main", "head ref"),
+    /unsafe git revision pattern/
+  );
+
   const before = [
     {
       benchmark_id: "aider-polyglot",
@@ -36,6 +50,63 @@ function main() {
   ]);
 
   assert.deepEqual(testingExports.diffBenchmarks(before, before, "benchmarks"), []);
+
+  assert.equal(
+    testingExports.shouldTrackDiff(
+      {
+        provider: "model",
+        model: "minimax/minimax-m3",
+        endpoint: null,
+        entityType: "model",
+        entityId: "minimax/minimax-m3",
+        orgId: "minimax",
+      },
+      {
+        field: "links.weights.url",
+        before: null,
+        after: "https://huggingface.co/MiniMaxAI/MiniMax-M3",
+      }
+    ),
+    true
+  );
+
+  assert.equal(
+    testingExports.shouldTrackDiff(
+      {
+        provider: "model",
+        model: "xiaomi/mimo-v2-flash",
+        endpoint: null,
+        entityType: "model",
+        entityId: "xiaomi/mimo-v2-flash",
+        orgId: "xiaomi",
+      },
+      {
+        field: "deprecation_date",
+        before: null,
+        after: "2026-06-12T00:00:00",
+      }
+    ),
+    true
+  );
+
+  assert.equal(
+    testingExports.shouldTrackDiff(
+      {
+        provider: "model",
+        model: "xiaomi/mimo-v2-flash",
+        endpoint: null,
+        entityType: "model",
+        entityId: "xiaomi/mimo-v2-flash",
+        orgId: "xiaomi",
+      },
+      {
+        field: "retirement_date",
+        before: null,
+        after: "2026-06-18T00:00:00",
+      }
+    ),
+    true
+  );
 
   const providerModelDiffs = testingExports.diffModelList(
     [{ api_model_id: "cohere/command-a" }],

--- a/scripts/update-monitor-history.ts
+++ b/scripts/update-monitor-history.ts
@@ -1,4 +1,4 @@
-import { execSync } from "node:child_process";
+import { execFileSync, execSync } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -32,8 +32,27 @@ type Meta = {
   orgId: string | null;
 };
 
-function sh(cmd: string): string {
-  return execSync(cmd, { cwd: REPO_ROOT, encoding: "utf8" }).toString();
+function git(args: string[]): string {
+  return execFileSync("git", args, { cwd: REPO_ROOT, encoding: "utf8" }).toString();
+}
+
+export function assertSafeGitRef(ref: string, label = "git ref"): string {
+  const trimmed = String(ref ?? "").trim();
+  if (!trimmed) {
+    throw new Error(`${label} is required`);
+  }
+  if (!/^[A-Za-z0-9._/@-]+$/.test(trimmed)) {
+    throw new Error(`${label} contains invalid characters`);
+  }
+  if (
+    trimmed.startsWith("-") ||
+    trimmed.includes("..") ||
+    trimmed.includes("@{") ||
+    /[\\^:~?\[*\s]/.test(trimmed)
+  ) {
+    throw new Error(`${label} contains an unsafe git revision pattern`);
+  }
+  return trimmed;
 }
 
 const DATA_DIRS = new Set([
@@ -72,7 +91,8 @@ function isDataFile(filePath: string): boolean {
 }
 
 function getChangedFiles(commit: string): ChangeFile[] {
-  const output = sh(`git show --name-status --pretty="" ${commit} -- ${DATA_ROOT}`).trim();
+  const safeCommit = assertSafeGitRef(commit, "commit");
+  const output = git(["show", "--name-status", "--pretty=", safeCommit, "--", DATA_ROOT]).trim();
   if (!output) return [];
 
   const lines = output
@@ -154,7 +174,7 @@ function getBlobContents(refs: string[]): Map<string, string | null> {
 
 function getCommitDate(commit: string): string {
   try {
-    return sh(`git log -1 --format=%ci ${commit}`).trim();
+    return git(["log", "-1", "--format=%ci", assertSafeGitRef(commit, "commit")]).trim();
   } catch {
     return new Date().toISOString();
   }
@@ -162,7 +182,7 @@ function getCommitDate(commit: string): string {
 
 function getParentCommit(commit: string): string | null {
   try {
-    const out = sh(`git log -1 --format=%P ${commit}`).trim();
+    const out = git(["log", "-1", "--format=%P", assertSafeGitRef(commit, "commit")]).trim();
     if (!out) return null;
     return out.split(" ")[0] ?? null;
   } catch {
@@ -980,7 +1000,10 @@ function shouldTrackEntityAction(meta: Meta): boolean {
 function shouldTrackDiff(meta: Meta, diff: DiffItem): boolean {
   if (diff.field === "description") return meta.entityType === "model";
   if (diff.field === "status") return meta.entityType === "model";
+  if (diff.field === "deprecation_date") return meta.entityType === "model";
+  if (diff.field === "retirement_date") return meta.entityType === "model";
   if (diff.field.startsWith("benchmarks.")) return meta.entityType === "model";
+  if (diff.field.startsWith("links.")) return meta.entityType === "model";
   if (diff.field.startsWith("pricing.")) return meta.entityType === "pricing";
   return false;
 }
@@ -1238,8 +1261,6 @@ function processCommit(commit: string): HistoryEntry[] {
         (diff.field === "model_id" || diff.field === "key")
       )
         return false;
-      if (meta.entityType === "model" && diff.field.startsWith("links"))
-        return false;
       if (
         (meta.entityType === "organisation" || meta.entityType === "api-provider") &&
         diff.field.startsWith("models")
@@ -1272,7 +1293,9 @@ function processCommit(commit: string): HistoryEntry[] {
 }
 
 export function listCommitsInRange(base: string, head: string): string[] {
-  const out = sh(`git rev-list --reverse ${base}..${head}`).trim();
+  const safeBase = assertSafeGitRef(base, "base ref");
+  const safeHead = assertSafeGitRef(head, "head ref");
+  const out = git(["rev-list", "--reverse", `${safeBase}..${safeHead}`]).trim();
   if (!out) return [];
   return out.split("\n").map((s) => s.trim()).filter(Boolean);
 }
@@ -1454,8 +1477,10 @@ function isMainModule(): boolean {
 }
 
 export const testingExports = {
+  assertSafeGitRef,
   diffBenchmarks,
   diffModelList,
+  shouldTrackDiff,
   isProviderModelListingDiff,
   toProviderModelListingEntry,
   isProviderModelStatusDiff,


### PR DESCRIPTION
## Summary
- surface model link changes in monitor history, including Hugging Face weights links
- surface model deprecation and retirement dates alongside status changes
- keep monitor history git access on argument-based git calls and add focused tests for tracked fields

## Testing
- pnpm exec tsx scripts/update-monitor-history.test.ts
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ai-stats/ai-stats/pull/703" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Monitor history now tracks and displays deprecation dates and retirement dates for monitored items.
  * Added support for tracking link changes with improved filtering and display options.
  * Enhanced date formatting for better readability of date-related change entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->