### PR TITLE
Fix homepage beta quickstart responsiveness

### DIFF
--- a/apps/web/src/components/landingPage/Home/HomeQuickstartSection.tsx
+++ b/apps/web/src/components/landingPage/Home/HomeQuickstartSection.tsx
@@ -736,7 +736,7 @@ function BetaDatabaseVisual() {
 						</div>
 					}
 				/>
-				<div className="grid grid-cols-[0.9fr_1fr_1.2fr] gap-4">
+				<div className="grid grid-cols-2 gap-4 xl:grid-cols-[0.9fr_1fr_1.2fr]">
 					<div>
 						<span className="text-[9px] font-medium text-zinc-500 dark:text-zinc-400">
 							Latency
@@ -759,7 +759,7 @@ function BetaDatabaseVisual() {
 							</span>
 						</p>
 					</div>
-					<div className="text-right">
+					<div className="hidden text-right xl:block">
 						<span className="text-[9px] font-medium text-zinc-500 dark:text-zinc-400">
 							Pricing
 						</span>
@@ -850,7 +850,7 @@ export default function HomeQuickstartSection({
 
 	return (
 		<div className="mx-auto mt-6 max-w-7xl">
-			<div className={`grid grid-cols-1 gap-5 ${variant === "beta" ? "md:grid-cols-3" : "md:grid-cols-2 xl:grid-cols-4"}`}>
+			<div className={`grid grid-cols-1 gap-5 ${variant === "beta" ? "md:grid-cols-2 lg:grid-cols-3" : "md:grid-cols-2 xl:grid-cols-4"}`}>
 				{benefits.map((benefit) => (
 					<Link
 						key={benefit.title}

--- a/apps/web/src/components/monitor/MonitorHistoryClient.tsx
+++ b/apps/web/src/components/monitor/MonitorHistoryClient.tsx
@@ -847,13 +847,13 @@ function getRowKind(change: ChangeHistory): DisplayRowKind {
 	return "pricing";
 }
 
-function getLinkLabel(field: string) {
+function getLinkLabel(field: string): { label: string; labelDetail?: string } {
 	const match = field.match(/^links\.([^.[]+)(?:\[[^\]]+\])?\.url$/);
 	const platform = match?.[1] ?? "";
 	return { label: `${humanizeSlug(platform || "link")} link` };
 }
 
-function getRowLabel(change: ChangeHistory) {
+function getRowLabel(change: ChangeHistory): { label: string; labelDetail?: string } {
 	if (change.entityType === "api-provider" && !change.field) {
 		return { label: "Provider listing" };
 	}


### PR DESCRIPTION
## Summary
- hide the pricing metric on the beta Open Model Intelligence card below `xl`
- keep beta homepage cards at 2 columns on medium screens and switch to 3 columns at `lg`
- preserve the 3-column desktop layout while preventing the smaller-screen card content from getting cut off

## Testing
- validated locally at `http://localhost:3100/`
- checked responsive behavior at medium and large widths in the in-app browser

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ai-stats/ai-stats/pull/706" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated beta database visual to use 2-column grid layout with responsive adjustments at larger breakpoints
  * Adjusted benefits cards grid responsiveness for improved display on medium and large screens
  * Pricing information now hidden on smaller screens, visible only on extra-large displays

<!-- end of auto-generated comment: release notes by coderabbit.ai -->