### PR TITLE
Add Kimi K2.7 Code Hugging Face link

### DIFF
--- a/packages/data/catalog/src/data/models/moonshotai/kimi-k2.7-code/model.json
+++ b/packages/data/catalog/src/data/models/moonshotai/kimi-k2.7-code/model.json
@@ -20,6 +20,10 @@
       "url": "https://platform.kimi.ai/docs/guide/kimi-k2-7-code-quickstart"
     },
     {
+      "platform": "weights",
+      "url": "https://huggingface.co/moonshotai/Kimi-K2.7-Code"
+    },
+    {
       "platform": "pricing",
       "url": "https://platform.kimi.ai/docs/pricing/chat-k27-code"
     }


### PR DESCRIPTION
## Summary
- add the Hugging Face weights link for `moonshotai/kimi-k2.7-code`

## Testing
- not run

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ai-stats/ai-stats/pull/707" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added weights link for Kimi-K2.7-Code model to catalog, improving model accessibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->