### PR TITLE
[codex] Add Anthropic suspension notice for Fable 5 and Mythos 5

### DIFF
--- a/apps/web/src/lib/fetchers/models/getModelPageNotice.test.ts
+++ b/apps/web/src/lib/fetchers/models/getModelPageNotice.test.ts
@@ -25,7 +25,6 @@ jest.mock("./visibility", () => ({
 }));
 
 import {
-	getBuiltinModelPageNotice,
 	parseModelPageNoticeRow,
 	resolveApiModelIdForModelPageUncached,
 } from "./getModelPageNotice";
@@ -128,31 +127,5 @@ describe("resolveApiModelIdForModelPageUncached", () => {
 			resolveApiModelIdForModelPageUncached("anthropic/claude-opus-4.1", false),
 		).resolves.toBe("anthropic/claude-opus-4.1");
 		expect(applyHiddenFilter).toHaveBeenCalledWith(internalModelsQuery, false);
-	});
-});
-
-describe("getBuiltinModelPageNotice", () => {
-	it("returns the export-control notice for Claude Fable 5", () => {
-		expect(getBuiltinModelPageNotice("anthropic/claude-fable-5")).toEqual({
-			apiModelId: "anthropic/claude-fable-5",
-			tone: "critical",
-			markdown: expect.stringContaining(
-				"Requests to this model are currently expected to fail.",
-			),
-		});
-	});
-
-	it("returns the export-control notice for Claude Mythos 5", () => {
-		expect(getBuiltinModelPageNotice("anthropic/claude-mythos-5")).toEqual({
-			apiModelId: "anthropic/claude-mythos-5",
-			tone: "critical",
-			markdown: expect.stringContaining(
-				"U.S. export control directive",
-			),
-		});
-	});
-
-	it("returns null for unaffected models", () => {
-		expect(getBuiltinModelPageNotice("anthropic/claude-opus-4.8")).toBeNull();
 	});
 });

--- a/apps/web/src/lib/fetchers/models/getModelPageNotice.test.ts
+++ b/apps/web/src/lib/fetchers/models/getModelPageNotice.test.ts
@@ -25,6 +25,7 @@ jest.mock("./visibility", () => ({
 }));
 
 import {
+	getBuiltinModelPageNotice,
 	parseModelPageNoticeRow,
 	resolveApiModelIdForModelPageUncached,
 } from "./getModelPageNotice";
@@ -127,5 +128,31 @@ describe("resolveApiModelIdForModelPageUncached", () => {
 			resolveApiModelIdForModelPageUncached("anthropic/claude-opus-4.1", false),
 		).resolves.toBe("anthropic/claude-opus-4.1");
 		expect(applyHiddenFilter).toHaveBeenCalledWith(internalModelsQuery, false);
+	});
+});
+
+describe("getBuiltinModelPageNotice", () => {
+	it("returns the export-control notice for Claude Fable 5", () => {
+		expect(getBuiltinModelPageNotice("anthropic/claude-fable-5")).toEqual({
+			apiModelId: "anthropic/claude-fable-5",
+			tone: "critical",
+			markdown: expect.stringContaining(
+				"Requests to this model are currently expected to fail.",
+			),
+		});
+	});
+
+	it("returns the export-control notice for Claude Mythos 5", () => {
+		expect(getBuiltinModelPageNotice("anthropic/claude-mythos-5")).toEqual({
+			apiModelId: "anthropic/claude-mythos-5",
+			tone: "critical",
+			markdown: expect.stringContaining(
+				"U.S. export control directive",
+			),
+		});
+	});
+
+	it("returns null for unaffected models", () => {
+		expect(getBuiltinModelPageNotice("anthropic/claude-opus-4.8")).toBeNull();
 	});
 });

--- a/apps/web/src/lib/fetchers/models/getModelPageNotice.ts
+++ b/apps/web/src/lib/fetchers/models/getModelPageNotice.ts
@@ -12,6 +12,22 @@ export type ModelPageNotice = {
 	markdown: string;
 };
 
+const ANTHROPIC_EXPORT_CONTROL_NOTICE_MARKDOWN =
+	"Anthropic said on June 12, 2026 that it had to disable Fable 5 and Mythos 5 for all customers to comply with a U.S. export control directive. Requests to this model are currently expected to fail. [Read Anthropic's statement](https://www.anthropic.com/news/fable-mythos-access).";
+
+const BUILTIN_MODEL_PAGE_NOTICES: Record<string, ModelPageNotice> = {
+	"anthropic/claude-fable-5": {
+		apiModelId: "anthropic/claude-fable-5",
+		tone: "critical",
+		markdown: ANTHROPIC_EXPORT_CONTROL_NOTICE_MARKDOWN,
+	},
+	"anthropic/claude-mythos-5": {
+		apiModelId: "anthropic/claude-mythos-5",
+		tone: "critical",
+		markdown: ANTHROPIC_EXPORT_CONTROL_NOTICE_MARKDOWN,
+	},
+};
+
 const modelPageNoticeSchema = z.object({
 	apiModelId: z.string().min(1),
 	tone: z.enum(["info", "warning", "critical"]),
@@ -54,6 +70,13 @@ export function parseModelPageNoticeRow(row: {
 	}
 
 	return parsed.data;
+}
+
+export function getBuiltinModelPageNotice(
+	apiModelId: string | null | undefined,
+): ModelPageNotice | null {
+	if (!apiModelId) return null;
+	return BUILTIN_MODEL_PAGE_NOTICES[apiModelId] ?? null;
 }
 
 export async function resolveApiModelIdForModelPageUncached(
@@ -128,6 +151,7 @@ async function getModelPageNoticeUncached(
 ): Promise<ModelPageNotice | null> {
 	const apiModelId = await resolveApiModelIdForModelPage(modelId, includeHidden);
 	if (!apiModelId) return null;
+	const builtinNotice = getBuiltinModelPageNotice(apiModelId);
 
 	const supabase = createAdminClient();
 	const { data, error } = await supabase
@@ -137,11 +161,11 @@ async function getModelPageNoticeUncached(
 		.maybeSingle();
 
 	if (error) {
-		if (isMissingRelationError(error)) return null;
+		if (isMissingRelationError(error)) return builtinNotice;
 		throw new Error(error.message || "Failed to fetch model page notice");
 	}
 
-	return parseModelPageNoticeRow(data);
+	return parseModelPageNoticeRow(data) ?? builtinNotice;
 }
 
 export async function getModelPageNotice(

--- a/apps/web/src/lib/fetchers/models/getModelPageNotice.ts
+++ b/apps/web/src/lib/fetchers/models/getModelPageNotice.ts
@@ -12,22 +12,6 @@ export type ModelPageNotice = {
 	markdown: string;
 };
 
-const ANTHROPIC_EXPORT_CONTROL_NOTICE_MARKDOWN =
-	"Anthropic said on June 12, 2026 that it had to disable Fable 5 and Mythos 5 for all customers to comply with a U.S. export control directive. Requests to this model are currently expected to fail. [Read Anthropic's statement](https://www.anthropic.com/news/fable-mythos-access).";
-
-const BUILTIN_MODEL_PAGE_NOTICES: Record<string, ModelPageNotice> = {
-	"anthropic/claude-fable-5": {
-		apiModelId: "anthropic/claude-fable-5",
-		tone: "critical",
-		markdown: ANTHROPIC_EXPORT_CONTROL_NOTICE_MARKDOWN,
-	},
-	"anthropic/claude-mythos-5": {
-		apiModelId: "anthropic/claude-mythos-5",
-		tone: "critical",
-		markdown: ANTHROPIC_EXPORT_CONTROL_NOTICE_MARKDOWN,
-	},
-};
-
 const modelPageNoticeSchema = z.object({
 	apiModelId: z.string().min(1),
 	tone: z.enum(["info", "warning", "critical"]),
@@ -71,14 +55,6 @@ export function parseModelPageNoticeRow(row: {
 
 	return parsed.data;
 }
-
-export function getBuiltinModelPageNotice(
-	apiModelId: string | null | undefined,
-): ModelPageNotice | null {
-	if (!apiModelId) return null;
-	return BUILTIN_MODEL_PAGE_NOTICES[apiModelId] ?? null;
-}
-
 export async function resolveApiModelIdForModelPageUncached(
 	modelId: string,
 	includeHidden: boolean,
@@ -151,7 +127,6 @@ async function getModelPageNoticeUncached(
 ): Promise<ModelPageNotice | null> {
 	const apiModelId = await resolveApiModelIdForModelPage(modelId, includeHidden);
 	if (!apiModelId) return null;
-	const builtinNotice = getBuiltinModelPageNotice(apiModelId);
 
 	const supabase = createAdminClient();
 	const { data, error } = await supabase
@@ -161,11 +136,11 @@ async function getModelPageNoticeUncached(
 		.maybeSingle();
 
 	if (error) {
-		if (isMissingRelationError(error)) return builtinNotice;
+		if (isMissingRelationError(error)) return null;
 		throw new Error(error.message || "Failed to fetch model page notice");
 	}
 
-	return parseModelPageNoticeRow(data) ?? builtinNotice;
+	return parseModelPageNoticeRow(data);
 }
 
 export async function getModelPageNotice(

--- a/packages/data/catalog/src/data/models/anthropic/claude-fable-5/model.json
+++ b/packages/data/catalog/src/data/models/anthropic/claude-fable-5/model.json
@@ -14,6 +14,10 @@
   "output_types": "text",
   "api_model_id": "anthropic/claude-fable-5",
   "family_id": "anthropic/claude-fable",
+  "page_notice": {
+    "tone": "critical",
+    "markdown": "Anthropic said on June 12, 2026 that it had to disable Fable 5 and Mythos 5 for all customers to comply with a U.S. export control directive. Requests to this model are currently expected to fail. [Read Anthropic's statement](https://www.anthropic.com/news/fable-mythos-access)."
+  },
   "links": [
     {
       "platform": "announcement",

--- a/packages/data/catalog/src/data/models/anthropic/claude-mythos-5/model.json
+++ b/packages/data/catalog/src/data/models/anthropic/claude-mythos-5/model.json
@@ -14,6 +14,10 @@
   "output_types": "text",
   "api_model_id": "anthropic/claude-mythos-5",
   "family_id": "anthropic/claude-mythos",
+  "page_notice": {
+    "tone": "critical",
+    "markdown": "Anthropic said on June 12, 2026 that it had to disable Fable 5 and Mythos 5 for all customers to comply with a U.S. export control directive. Requests to this model are currently expected to fail. [Read Anthropic's statement](https://www.anthropic.com/news/fable-mythos-access)."
+  },
   "links": [
     {
       "platform": "announcement",


### PR DESCRIPTION
## Summary
- add a data-backed critical `page_notice` to `anthropic/claude-fable-5` and `anthropic/claude-mythos-5`
- explain that requests are currently expected to fail after Anthropic's June 12, 2026 export-control suspension notice
- remove the earlier web-layer fallback so the notice source of truth stays in the catalog data

## Why
Anthropic's June 12, 2026 statement says it had to disable Fable 5 and Mythos 5 for all customers to comply with a U.S. export control directive. We need those model pages to warn users before they try the affected models, and that notice should live in model data.

## Validation
- `pnpm validate:data`
- `pnpm --filter @ai-stats/web test -- src/lib/fetchers/models/getModelPageNotice.test.ts`

## Source
- https://www.anthropic.com/news/fable-mythos-access

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Updates**
  * Added critical notices for Claude Fable 5 and Mythos 5 models indicating current unavailability
  * Users attempting to access these models will see a notification

* **Chores**
  * Minor code formatting adjustments

<!-- end of auto-generated comment: release notes by coderabbit.ai -->