### PR TITLE
Add current Fireworks serverless model support

### DIFF
--- a/packages/data/catalog/src/data/api_providers/fireworks/models.json
+++ b/packages/data/catalog/src/data/api_providers/fireworks/models.json
@@ -409,6 +409,27 @@
     ]
   },
   {
+    "api_model_id": "minimax/minimax-m3",
+    "provider_api_model_id": "fireworks:minimax/minimax-m3",
+    "provider_model_slug": "accounts/fireworks/models/minimax-m3",
+    "internal_model_id": "minimax/minimax-m3",
+    "is_active_gateway": true,
+    "quantization_scheme": null,
+    "input_modalities": "text,image",
+    "output_modalities": "text",
+    "context_length": 512000,
+    "max_output_tokens": null,
+    "effective_from": "2026-06-11T00:00:00",
+    "effective_to": null,
+    "capabilities": [
+      {
+        "capability_id": "text.generate",
+        "status": "active",
+        "params": []
+      }
+    ]
+  },
+  {
     "api_model_id": "openai/gpt-oss-120b",
     "provider_api_model_id": "fireworks:openai/gpt-oss-120b",
     "provider_model_slug": "accounts/fireworks/models/gpt-oss-120b",
@@ -550,6 +571,27 @@
     "capabilities": [
       {
         "capability_id": "text.rerank",
+        "status": "active",
+        "params": []
+      }
+    ]
+  },
+  {
+    "api_model_id": "qwen/qwen3.7-plus",
+    "provider_api_model_id": "fireworks:qwen/qwen3.7-plus",
+    "provider_model_slug": "accounts/fireworks/models/qwen3p7-plus",
+    "internal_model_id": "qwen/qwen3.7-plus",
+    "is_active_gateway": true,
+    "quantization_scheme": null,
+    "input_modalities": "text,image",
+    "output_modalities": "text",
+    "context_length": 262000,
+    "max_output_tokens": null,
+    "effective_from": "2026-06-07T00:00:00",
+    "effective_to": null,
+    "capabilities": [
+      {
+        "capability_id": "text.generate",
         "status": "active",
         "params": []
       }

--- a/packages/data/catalog/src/data/pricing/fireworks/minimax-minimax-m3/text.generate/pricing.json
+++ b/packages/data/catalog/src/data/pricing/fireworks/minimax-minimax-m3/text.generate/pricing.json
@@ -1,0 +1,45 @@
+{
+  "key": "fireworks:minimax/minimax-m3:text.generate",
+  "api_provider_id": "fireworks",
+  "provider_slug": "fireworks",
+  "api_model_id": "minimax/minimax-m3",
+  "capability_id": "text.generate",
+  "rules": [
+    {
+      "meter": "input_text_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 0.3,
+      "currency": "USD",
+      "pricing_plan": "standard",
+      "note": "From Fireworks model page.",
+      "match": [],
+      "priority": 100,
+      "effective_from": "2026-06-11T00:00:00Z"
+    },
+    {
+      "meter": "cached_read_text_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 0.06,
+      "currency": "USD",
+      "pricing_plan": "standard",
+      "note": "From Fireworks model page.",
+      "match": [],
+      "priority": 100,
+      "effective_from": "2026-06-11T00:00:00Z"
+    },
+    {
+      "meter": "output_text_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 1.2,
+      "currency": "USD",
+      "pricing_plan": "standard",
+      "note": "From Fireworks model page.",
+      "match": [],
+      "priority": 100,
+      "effective_from": "2026-06-11T00:00:00Z"
+    }
+  ]
+}

--- a/packages/data/catalog/src/data/pricing/fireworks/qwen-qwen3.7-plus/text.generate/pricing.json
+++ b/packages/data/catalog/src/data/pricing/fireworks/qwen-qwen3.7-plus/text.generate/pricing.json
@@ -1,0 +1,45 @@
+{
+  "key": "fireworks:qwen/qwen3.7-plus:text.generate",
+  "api_provider_id": "fireworks",
+  "provider_slug": "fireworks",
+  "api_model_id": "qwen/qwen3.7-plus",
+  "capability_id": "text.generate",
+  "rules": [
+    {
+      "meter": "input_text_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 0.4,
+      "currency": "USD",
+      "pricing_plan": "standard",
+      "note": "From Fireworks model page.",
+      "match": [],
+      "priority": 100,
+      "effective_from": "2026-06-07T00:00:00Z"
+    },
+    {
+      "meter": "cached_read_text_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 0.08,
+      "currency": "USD",
+      "pricing_plan": "standard",
+      "note": "From Fireworks model page.",
+      "match": [],
+      "priority": 100,
+      "effective_from": "2026-06-07T00:00:00Z"
+    },
+    {
+      "meter": "output_text_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 1.6,
+      "currency": "USD",
+      "pricing_plan": "standard",
+      "note": "From Fireworks model page.",
+      "match": [],
+      "priority": 100,
+      "effective_from": "2026-06-07T00:00:00Z"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add current Fireworks serverless catalog entries for `minimax/minimax-m3`
- add current Fireworks serverless catalog entries for `qwen/qwen3.7-plus`
- document the reviewed Fireworks drift separately from the transient `factory-ai` shield-model churn

## Validation
- `pnpm validate:data`

## Review notes
- Skipped the Fable 5 deletion issues as requested.
- Reviewed open upstream-discovery issues for Fireworks, GMICloud, and CrofAI.
- The Fireworks `accounts/factory-ai/models/shield-grounded-*` add/delete pair looks like transient upstream churn and not the actual public serverless surface.
- The real Fireworks serverless support gap in the catalog was `minimax-m3` and `qwen3.7-plus`, which this PR adds.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ai-stats/ai-stats/pull/721" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**New Features**
* Added support for Fireworks models `minimax/minimax-m3` and `qwen/qwen3.7-plus` with multimodal input (text and images) for text generation
* Pricing tiers configured for both models with separate rate structures for input tokens, cached input tokens, and output tokens

<!-- end of auto-generated comment: release notes by coderabbit.ai -->