### PR TITLE
Add CrofAI kimi-k2.7-code support

### DIFF
--- a/apps/api/src/executors/_shared/text-generate/openai-compat/providers/crofai/quirks.ts
+++ b/apps/api/src/executors/_shared/text-generate/openai-compat/providers/crofai/quirks.ts
@@ -3,8 +3,13 @@
 // How: Preserves reasoning_content and synthesizes reasoning_details during buffered and streaming normalization.
 
 import type { ProviderQuirks } from "../../quirks/types";
+import { normalizeK27CodeRequest } from "../moonshot-ai/quirks";
 
 export const crofAIQuirks: ProviderQuirks = {
+	transformRequest: ({ request }) => {
+		normalizeK27CodeRequest(request);
+	},
+
 	extractReasoning: ({ choice, rawContent }) => {
 		const reasoningContent = choice.message?.reasoning_content;
 

--- a/apps/api/src/executors/_shared/text-generate/openai-compat/providers/moonshot-ai/quirks.ts
+++ b/apps/api/src/executors/_shared/text-generate/openai-compat/providers/moonshot-ai/quirks.ts
@@ -24,7 +24,7 @@ function isK27CodeModel(model: unknown): boolean {
 	return K2_7_CODE_MODELS.has(String(model ?? "").trim().toLowerCase());
 }
 
-function normalizeK27CodeRequest(request: Record<string, any>) {
+export function normalizeK27CodeRequest(request: Record<string, any>) {
 	if (!isK27CodeModel(request?.model)) return;
 
 	// K2.7 Code rejects disabled thinking. Omit or enable it instead.

--- a/apps/api/src/executors/_shared/text-generate/openai-compat/quirks/__tests__/crofai.test.ts
+++ b/apps/api/src/executors/_shared/text-generate/openai-compat/quirks/__tests__/crofai.test.ts
@@ -2,6 +2,38 @@ import { describe, expect, it } from "vitest";
 import { crofAIQuirks } from "../../providers/crofai/quirks";
 
 describe("CrofAI quirks", () => {
+	it("normalizes K2.7 Code request fields to Moonshot-compatible constraints", () => {
+		const request: Record<string, any> = {
+			model: "moonshotai/kimi-k2.7-code",
+			messages: [{ role: "user", content: "hi" }],
+			tools: [
+				{
+					type: "function",
+					function: {
+						name: "get_weather",
+						description: "Get weather",
+						parameters: { type: "object", properties: {} },
+					},
+				},
+			],
+			tool_choice: { type: "function", function: { name: "get_weather" } },
+			thinking: { type: "disabled" },
+			temperature: 0.2,
+			top_p: 0.5,
+			frequency_penalty: 0.3,
+			presence_penalty: -0.2,
+		};
+
+		crofAIQuirks.transformRequest?.({ request, ir: {} as any });
+
+		expect(request.thinking).toEqual({ type: "enabled" });
+		expect(request.temperature).toBeUndefined();
+		expect(request.top_p).toBeUndefined();
+		expect(request.frequency_penalty).toBeUndefined();
+		expect(request.presence_penalty).toBeUndefined();
+		expect(request.tool_choice).toBe("auto");
+	});
+
 	it("extracts reasoning_content into reasoning blocks", () => {
 		const result = crofAIQuirks.extractReasoning?.({
 			choice: {

--- a/packages/data/catalog/src/data/api_providers/crofai/models.json
+++ b/packages/data/catalog/src/data/api_providers/crofai/models.json
@@ -441,6 +441,27 @@
     ]
   },
   {
+    "api_model_id": "moonshotai/kimi-k2.7-code",
+    "provider_api_model_id": "crofai:kimi-k2.7-code",
+    "provider_model_slug": "kimi-k2.7-code",
+    "internal_model_id": "moonshotai/kimi-k2.7-code",
+    "is_active_gateway": true,
+    "quantization_scheme": "int4",
+    "input_modalities": "text,image",
+    "output_modalities": "text",
+    "context_length": 262144,
+    "max_output_tokens": 262144,
+    "effective_from": "2026-06-13T00:00:00",
+    "effective_to": null,
+    "capabilities": [
+      {
+        "capability_id": "text.generate",
+        "status": "active",
+        "params": []
+      }
+    ]
+  },
+  {
     "api_model_id": "moonshotai/kimi-k2.5",
     "provider_api_model_id": "crofai:kimi-k2.5",
     "provider_model_slug": "kimi-k2.5",

--- a/packages/data/catalog/src/data/pricing/crofai/moonshotai-kimi-k2.7-code/text.generate/pricing.json
+++ b/packages/data/catalog/src/data/pricing/crofai/moonshotai-kimi-k2.7-code/text.generate/pricing.json
@@ -1,0 +1,45 @@
+{
+  "key": "crofai:moonshotai/kimi-k2.7-code:text.generate",
+  "api_provider_id": "crofai",
+  "provider_slug": "crofai",
+  "api_model_id": "moonshotai/kimi-k2.7-code",
+  "capability_id": "text.generate",
+  "rules": [
+    {
+      "meter": "input_text_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 0.55,
+      "currency": "USD",
+      "pricing_plan": "standard",
+      "note": "From CrofAI /v1/models.",
+      "match": [],
+      "priority": 100,
+      "effective_from": "2026-06-13T00:00:00Z"
+    },
+    {
+      "meter": "cached_read_text_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 0.05,
+      "currency": "USD",
+      "pricing_plan": "standard",
+      "note": "From CrofAI /v1/models.",
+      "match": [],
+      "priority": 100,
+      "effective_from": "2026-06-13T00:00:00Z"
+    },
+    {
+      "meter": "output_text_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 2.25,
+      "currency": "USD",
+      "pricing_plan": "standard",
+      "note": "From CrofAI /v1/models.",
+      "match": [],
+      "priority": 100,
+      "effective_from": "2026-06-13T00:00:00Z"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add CrofAI support for `moonshotai/kimi-k2.7-code`
- add CrofAI pricing for `moonshotai/kimi-k2.7-code` from the live CrofAI models API

## Validation
- `pnpm validate:data`
- `pnpm validate:pricing`

## Review notes
- Provider model metadata came from CrofAI's live `https://crof.ai/v1/models` response.
- Used the current CrofAI `kimi-k2.6` catalog shape as the structural pattern.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ai-stats/ai-stats/pull/722" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->