### PR TITLE
[codex] Add GMICloud MiniMax M3 pricing

### DIFF
--- a/packages/data/catalog/src/data/api_providers/gmicloud/models.json
+++ b/packages/data/catalog/src/data/api_providers/gmicloud/models.json
@@ -210,6 +210,27 @@
     ]
   },
   {
+    "api_model_id": "minimax/minimax-m3",
+    "provider_api_model_id": "gmicloud:minimax/minimax-m3",
+    "provider_model_slug": "MiniMaxAI/MiniMax-M3",
+    "internal_model_id": "minimax/minimax-m3",
+    "is_active_gateway": true,
+    "quantization_scheme": "FP8",
+    "input_modalities": "text,image,video",
+    "output_modalities": "text",
+    "context_length": 1048576,
+    "max_output_tokens": null,
+    "effective_from": "2026-06-13T00:00:00",
+    "effective_to": null,
+    "capabilities": [
+      {
+        "capability_id": "text.generate",
+        "status": "active",
+        "params": []
+      }
+    ]
+  },
+  {
     "api_model_id": "openai/gpt-oss-120b",
     "provider_api_model_id": "gmicloud:openai/gpt-oss-120b",
     "provider_model_slug": "openai/gpt-oss-120b",

--- a/packages/data/catalog/src/data/pricing/gmicloud/minimax-minimax-m3/text.generate/pricing.json
+++ b/packages/data/catalog/src/data/pricing/gmicloud/minimax-minimax-m3/text.generate/pricing.json
@@ -1,0 +1,109 @@
+{
+  "key": "gmicloud:minimax/minimax-m3:text.generate",
+  "api_provider_id": "gmicloud",
+  "provider_slug": "gmicloud",
+  "api_model_id": "minimax/minimax-m3",
+  "capability_id": "text.generate",
+  "rules": [
+    {
+      "meter": "input_text_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 0.6,
+      "currency": "USD",
+      "pricing_plan": "standard",
+      "note": "From authenticated GMICloud console model page on 2026-06-13.",
+      "match": [
+        {
+          "path": "input_tokens",
+          "op": "lte",
+          "or_group": 1,
+          "and_index": 1,
+          "value": 512000
+        }
+      ],
+      "priority": 100,
+      "effective_from": "2026-06-13T00:00:00Z"
+    },
+    {
+      "meter": "output_text_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 2.4,
+      "currency": "USD",
+      "pricing_plan": "standard",
+      "note": "From authenticated GMICloud console model page on 2026-06-13.",
+      "match": [
+        {
+          "path": "input_tokens",
+          "op": "lte",
+          "or_group": 1,
+          "and_index": 1,
+          "value": 512000
+        }
+      ],
+      "priority": 100,
+      "effective_from": "2026-06-13T00:00:00Z"
+    },
+    {
+      "meter": "cached_read_text_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 0.12,
+      "currency": "USD",
+      "pricing_plan": "standard",
+      "note": "From authenticated GMICloud console model page on 2026-06-13.",
+      "match": [
+        {
+          "path": "input_tokens",
+          "op": "lte",
+          "or_group": 1,
+          "and_index": 1,
+          "value": 512000
+        }
+      ],
+      "priority": 100,
+      "effective_from": "2026-06-13T00:00:00Z"
+    },
+    {
+      "meter": "input_text_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 1.2,
+      "currency": "USD",
+      "pricing_plan": "standard",
+      "note": "From authenticated GMICloud console model page on 2026-06-13.",
+      "match": [
+        {
+          "path": "input_tokens",
+          "op": "gt",
+          "or_group": 1,
+          "and_index": 1,
+          "value": 512000
+        }
+      ],
+      "priority": 100,
+      "effective_from": "2026-06-13T00:00:00Z"
+    },
+    {
+      "meter": "output_text_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 4.8,
+      "currency": "USD",
+      "pricing_plan": "standard",
+      "note": "From authenticated GMICloud console model page on 2026-06-13.",
+      "match": [
+        {
+          "path": "input_tokens",
+          "op": "gt",
+          "or_group": 1,
+          "and_index": 1,
+          "value": 512000
+        }
+      ],
+      "priority": 100,
+      "effective_from": "2026-06-13T00:00:00Z"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add GMICloud support entry for `minimax/minimax-m3`
- add tiered GMICloud pricing for MiniMax M3 based on the authenticated console page
- capture the provider metadata exposed in the console page (`FP8`, `1,048,576` context, text/image/video input)

## Validation
- `pnpm validate:data`
- `pnpm validate:pricing`
- `pnpm validate:gateway`

## Notes
- pricing values were taken from the authenticated GMICloud console model page on 2026-06-13
- only the rates visible in the console were encoded; no extra cache-write or hidden tiers were inferred
