### PR TITLE
[codex] Prepare Z.AI GLM 5.2 coding-plan API rollout

### DIFF
--- a/packages/data/catalog/src/data/api_providers/z-ai/models.json
+++ b/packages/data/catalog/src/data/api_providers/z-ai/models.json
@@ -936,6 +936,27 @@
     ]
   },
   {
+    "api_model_id": "z-ai/glm-5.2",
+    "provider_api_model_id": "z-ai:z-ai/glm-5.2",
+    "provider_model_slug": "glm-5.2",
+    "internal_model_id": "z-ai/glm-5.2",
+    "is_active_gateway": false,
+    "quantization_scheme": null,
+    "input_modalities": "text",
+    "output_modalities": "text",
+    "context_length": 1000000,
+    "max_output_tokens": null,
+    "effective_from": null,
+    "effective_to": null,
+    "capabilities": [
+      {
+        "capability_id": "text.generate",
+        "status": "active",
+        "params": []
+      }
+    ]
+  },
+  {
     "api_model_id": "z-ai/glm-5v-turbo",
     "provider_api_model_id": "z-ai:z-ai/glm-5v-turbo",
     "provider_model_slug": "glm-5v-turbo",

--- a/packages/data/catalog/src/data/manifest.json
+++ b/packages/data/catalog/src/data/manifest.json
@@ -1087,6 +1087,7 @@
       "z-ai/glm-5-code",
       "z-ai/glm-5-turbo",
       "z-ai/glm-5.1",
+      "z-ai/glm-5.2",
       "z-ai/glm-5v-turbo",
       "z-ai/glm-image"
     ]

--- a/packages/data/catalog/src/data/models/z-ai/glm-5.2/model.json
+++ b/packages/data/catalog/src/data/models/z-ai/glm-5.2/model.json
@@ -2,9 +2,9 @@
   "model_id": "z-ai/glm-5.2",
   "organisation_id": "z-ai",
   "name": "GLM 5.2",
-  "status": "Rumoured",
+  "status": "Available",
   "previous_model_id": "z-ai/glm-5.1",
-  "description": "GLM 5.2 is a rumoured Z.AI flagship model tracked as the likely successor to GLM 5.1. The current record is based on leaked private-testing references and early public sightings rather than a formal Z.AI release.",
+  "description": "GLM 5.2 is Z.AI's latest flagship coding model documented across the GLM Coding Plan materials, with premium-tier positioning for complex coding and agent workflows.",
   "announced_date": null,
   "release_date": null,
   "deprecation_date": null,
@@ -15,13 +15,34 @@
   "api_model_id": "z-ai/glm-5.2",
   "page_notice": {
     "tone": "warning",
-    "markdown": "GLM 5.2 is a rumoured model and is not publicly released. This page exists because leaked private-testing references and public sightings suggest Z.AI is evaluating a `glm-5.2` line. Specs, pricing, provider availability, and release timing are unconfirmed and may change or disappear without notice."
+    "markdown": "Z.AI now documents `glm-5.2` for the dedicated GLM Coding Plan endpoint and tooling, but the current public general-pricing and release-notes pages still stop short of listing broader standard API rollout details."
   },
-  "links": [],
+  "links": [
+    {
+      "platform": "docs",
+      "url": "https://docs.z.ai/devpack/overview"
+    },
+    {
+      "platform": "docs",
+      "url": "https://docs.z.ai/devpack/latest-model"
+    },
+    {
+      "platform": "docs",
+      "url": "https://docs.z.ai/devpack/tool/others"
+    }
+  ],
   "details": [
     {
       "name": "availability",
-      "value": "Tracked from private-testing leaks and public sightings only. No public Z.AI announcement, provider launch, or final model card is available yet."
+      "value": "Public Z.AI Coding Plan documentation lists GLM-5.2 as a supported model for all plan tiers and supported coding-tool integrations."
+    },
+    {
+      "name": "context_length",
+      "value": "The Coding Plan tool guides document a 1M context configuration for glm-5.2 in supported coding-tool setups."
+    },
+    {
+      "name": "pricing_status",
+      "value": "The current public Z.AI pricing page does not yet publish standard API token pricing for GLM-5.2."
     }
   ],
   "benchmarks": []

--- a/packages/data/catalog/src/data/subscription_plans/z-ai-glm-coding-lite/plan.json
+++ b/packages/data/catalog/src/data/subscription_plans/z-ai-glm-coding-lite/plan.json
@@ -63,7 +63,7 @@
   ],
   "models": [
     {
-      "model_id": "z-ai/glm-5.1",
+      "model_id": "z-ai/glm-5.2",
       "model_info": null,
       "rate_limit": null,
       "other_info": null

--- a/packages/data/catalog/src/data/subscription_plans/z-ai-glm-coding-max/plan.json
+++ b/packages/data/catalog/src/data/subscription_plans/z-ai-glm-coding-max/plan.json
@@ -69,7 +69,7 @@
   ],
   "models": [
     {
-      "model_id": "z-ai/glm-5.1",
+      "model_id": "z-ai/glm-5.2",
       "model_info": null,
       "rate_limit": null,
       "other_info": null

--- a/packages/data/catalog/src/data/subscription_plans/z-ai-glm-coding-pro/plan.json
+++ b/packages/data/catalog/src/data/subscription_plans/z-ai-glm-coding-pro/plan.json
@@ -69,7 +69,7 @@
   ],
   "models": [
     {
-      "model_id": "z-ai/glm-5.1",
+      "model_id": "z-ai/glm-5.2",
       "model_info": null,
       "rate_limit": null,
       "other_info": null


### PR DESCRIPTION
## Summary
- update the `z-ai/glm-5.2` catalog record from rumoured-only to documented Coding Plan availability
- add a non-active Z.AI provider catalog entry for `glm-5.2` with 1M context so the standard API launch can be flipped on cleanly later
- switch the Z.AI GLM Coding Plan Lite/Pro/Max plan entries from `glm-5.1` to `glm-5.2`
- add `z-ai/glm-5.2` to the manifest model list

## Why
Z.AI's public docs now describe `GLM-5.2` as supported in the GLM Coding Plan and OpenAI-compatible coding-tool integrations, but the public release-notes and pricing pages still stop short of listing a broader standard API rollout. This PR aligns the catalog with that documented split state without falsely advertising live general gateway support yet.

## Notes
- `packages/data/catalog/src/data/api_providers/z-ai/models.json` keeps `glm-5.2` as `is_active_gateway: false`
- no Z.AI `glm-5.2` pricing was added because the public pricing page still does not publish standard API token pricing for it
- the next launch-week follow-up should be to flip gateway activation and add pricing once Z.AI publishes the standard API details

## Validation
- `pnpm exec tsx packages/data/catalog/src/data/validate.ts --sections modelFiles,apiProviderModels,modelReferences,plans`
- `pnpm validate:gateway`

## Sources
- `https://docs.z.ai/devpack/overview`
- `https://docs.z.ai/devpack/latest-model`
- `https://docs.z.ai/devpack/tool/others`
- `https://docs.z.ai/devpack/tool/claude`
- `https://docs.z.ai/release-notes/new-released`
- `https://docs.z.ai/guides/overview/pricing`
