### PR TITLE
Add GPT-5.5 Cyber inferred pricing

### DIFF
--- a/packages/data/catalog/src/data/models/openai/gpt-5.5-cyber/model.json
+++ b/packages/data/catalog/src/data/models/openai/gpt-5.5-cyber/model.json
@@ -4,7 +4,7 @@
   "name": "GPT 5.5 Cyber",
   "status": "Withheld",
   "previous_model_id": "openai/gpt-5.4-cyber",
-  "description": "GPT 5.5 Cyber is OpenAI's high-quality speech-to-text model built on GPT-4o audio capabilities. It's priced per token (input and output), making it suitable for workflows that benefit from token-level billing transparency.",
+  "description": "GPT 5.5 Cyber is OpenAI's cyber-focused GPT-5.5 variant for trusted defenders in the Trusted Access for Cyber program.",
   "announced_date": "2026-04-30T00:00:00Z",
   "release_date": null,
   "deprecation_date": null,
@@ -14,6 +14,10 @@
   "output_types": "text",
   "api_model_id": "openai/gpt-5.5-cyber",
   "family_id": "openai/gpt-5.5",
+  "page_notice": {
+    "tone": "info",
+    "markdown": "AI Stats shows inferred standard short-context pricing for `gpt-5.5-cyber` based on the published [OpenAI Codex rate card](https://help.openai.com/en/articles/20001106-codex-rate-card). OpenAI's public [API pricing page](https://developers.openai.com/api/docs/pricing) does not currently publish a confirmed standard API price row for `gpt-5.5-cyber`, so these values are informational estimates derived from the Codex credit mapping."
+  },
   "links": [
     {
       "platform": "announcement",

--- a/packages/data/catalog/src/data/pricing/openai/openai-gpt-5.5-cyber/text.generate/pricing.json
+++ b/packages/data/catalog/src/data/pricing/openai/openai-gpt-5.5-cyber/text.generate/pricing.json
@@ -1,0 +1,70 @@
+{
+  "key": "openai:openai/gpt-5.5-cyber:text.generate",
+  "api_provider_id": "openai",
+  "provider_slug": "openai",
+  "model_id": "openai/gpt-5.5-cyber",
+  "api_model_id": "openai/gpt-5.5-cyber",
+  "capability_id": "text.generate",
+  "rules": [
+    {
+      "meter": "input_text_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 20,
+      "currency": "USD",
+      "pricing_plan": "standard",
+      "note": null,
+      "match": [
+        {
+          "path": "input_tokens",
+          "op": "lt",
+          "or_group": 1,
+          "and_index": 1,
+          "value": 272000
+        }
+      ],
+      "priority": 100,
+      "effective_from": "2026-04-30T00:00:00Z"
+    },
+    {
+      "meter": "cached_read_text_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 2,
+      "currency": "USD",
+      "pricing_plan": "standard",
+      "note": null,
+      "match": [
+        {
+          "path": "input_tokens",
+          "op": "lt",
+          "or_group": 1,
+          "and_index": 1,
+          "value": 272000
+        }
+      ],
+      "priority": 100,
+      "effective_from": "2026-04-30T00:00:00Z"
+    },
+    {
+      "meter": "output_text_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 120,
+      "currency": "USD",
+      "pricing_plan": "standard",
+      "note": null,
+      "match": [
+        {
+          "path": "input_tokens",
+          "op": "lt",
+          "or_group": 1,
+          "and_index": 1,
+          "value": 272000
+        }
+      ],
+      "priority": 100,
+      "effective_from": "2026-04-30T00:00:00Z"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add standard short-context pricing for `openai/gpt-5.5-cyber` at $20 input / $2 cached input / $120 output per 1M tokens
- add an info notice on the GPT 5.5 Cyber model page explaining that the pricing is inferred from the Codex rate card
- correct the GPT 5.5 Cyber model description to reflect the Trusted Access for Cyber positioning

## Why
The public OpenAI API pricing page does not currently publish a confirmed `gpt-5.5-cyber` pricing row, but the Codex rate card does publish token-based credits for GPT-5.5 Cyber. This PR records the inferred standard pricing with an explicit reader-facing notice so the data remains useful without overstating certainty.

## Validation
- `pnpm validate:pricing`
- `pnpm validate:data`

Created with Codex