### PR TITLE
Route Moonshot K2.7 Code priority tier to HighSpeed

### DIFF
--- a/apps/api/src/executors/_shared/text-generate/openai-compat/__tests__/stream-protocol.test.ts
+++ b/apps/api/src/executors/_shared/text-generate/openai-compat/__tests__/stream-protocol.test.ts
@@ -283,6 +283,51 @@ describe("resolveStreamForProtocol", () => {
 		expect(output).toContain("\"arguments\":\"{\\\"city\\\":\\\"SF\\\"}\"");
 	});
 
+	it("keeps the public model id when converting responses streams back to chat chunks", async () => {
+		const upstream = makeSseResponse([
+			{
+				event: "response.created",
+				data: {
+					response: {
+						id: "resp_public_model_1",
+						created_at: 1710000010,
+						model: "kimi-k2.7-code-highspeed",
+					},
+				},
+			},
+			{
+				event: "response.output_text.delta",
+				data: {
+					output_index: 0,
+					delta: "pong",
+				},
+			},
+			"[DONE]",
+		]);
+
+		const stream = resolveStreamForProtocol(
+			upstream,
+			baseArgs({
+				ir: {
+					messages: [{ role: "user", content: [{ type: "text", text: "hello" }] }],
+					model: "moonshotai/kimi-k2.7-code",
+					stream: true,
+				},
+				providerId: "moonshotai",
+				providerModelSlug: "kimi-k2.7-code-highspeed",
+				endpoint: "chat.completions",
+				protocol: "openai.chat.completions",
+			}),
+			"responses",
+		);
+
+		const output = await readStreamText(stream);
+		const chunks = parseSseJsonFrames(output).filter((payload) => payload?.object === "chat.completion.chunk");
+		expect(chunks.length).toBeGreaterThan(0);
+		expect(chunks.every((payload) => payload?.model === "moonshotai/kimi-k2.7-code")).toBe(true);
+		expect(output).not.toContain("kimi-k2.7-code-highspeed");
+	});
+
 	it("emits output_item function-call events when transforming chat stream to responses", async () => {
 		const upstream = makeSseResponse([
 			{
@@ -346,6 +391,42 @@ describe("resolveStreamForProtocol", () => {
 		expect(output).toContain("event: response.function_call_arguments.delta");
 		expect(output).toContain("event: response.function_call_arguments.done");
 		expect(output).toContain("event: response.output_item.done");
+	});
+
+	it("keeps the public model id in responses stream metadata when upstream chat chunks use a hidden slug", async () => {
+		const upstream = makeSseResponse([
+			{
+				data: {
+					id: "chatcmpl_public_model_1",
+					object: "chat.completion.chunk",
+					created: 1710000011,
+					model: "kimi-k2.7-code-highspeed",
+					choices: [{ index: 0, delta: { content: "pong" }, finish_reason: "stop" }],
+					usage: { prompt_tokens: 2, completion_tokens: 1, total_tokens: 3 },
+				},
+			},
+			"[DONE]",
+		]);
+
+		const stream = resolveStreamForProtocol(
+			upstream,
+			baseArgs({
+				ir: {
+					messages: [{ role: "user", content: [{ type: "text", text: "hello" }] }],
+					model: "moonshotai/kimi-k2.7-code",
+					stream: true,
+				},
+				providerId: "moonshotai",
+				providerModelSlug: "kimi-k2.7-code-highspeed",
+				endpoint: "responses",
+				protocol: "openai.responses",
+			}),
+			"chat",
+		);
+
+		const output = await readStreamText(stream);
+		expect(output).toContain("\"model\":\"moonshotai/kimi-k2.7-code\"");
+		expect(output).not.toContain("kimi-k2.7-code-highspeed");
 	});
 
 	it("normalizes MiniMax XML interleaving into reasoning + function_call events", async () => {

--- a/apps/api/src/executors/_shared/text-generate/openai-compat/providers/moonshot-ai/quirks.ts
+++ b/apps/api/src/executors/_shared/text-generate/openai-compat/providers/moonshot-ai/quirks.ts
@@ -14,7 +14,9 @@ const MOONSHOT_PROVIDER_IDS = new Set([
 
 const K2_7_CODE_MODELS = new Set([
 	"kimi-k2.7-code",
+	"kimi-k2.7-code-highspeed",
 	"moonshotai/kimi-k2.7-code",
+	"moonshotai/kimi-k2.7-code-highspeed",
 ]);
 
 const isMoonshot = (providerId?: string) =>
@@ -24,7 +26,7 @@ function isK27CodeModel(model: unknown): boolean {
 	return K2_7_CODE_MODELS.has(String(model ?? "").trim().toLowerCase());
 }
 
-export function normalizeK27CodeRequest(request: Record<string, any>) {
+function normalizeK27CodeRequest(request: Record<string, any>) {
 	if (!isK27CodeModel(request?.model)) return;
 
 	// K2.7 Code rejects disabled thinking. Omit or enable it instead.

--- a/apps/api/src/executors/_shared/text-generate/openai-compat/providers/moonshot-ai/quirks.ts
+++ b/apps/api/src/executors/_shared/text-generate/openai-compat/providers/moonshot-ai/quirks.ts
@@ -26,7 +26,7 @@ function isK27CodeModel(model: unknown): boolean {
 	return K2_7_CODE_MODELS.has(String(model ?? "").trim().toLowerCase());
 }
 
-function normalizeK27CodeRequest(request: Record<string, any>) {
+export function normalizeK27CodeRequest(request: Record<string, any>) {
 	if (!isK27CodeModel(request?.model)) return;
 
 	// K2.7 Code rejects disabled thinking. Omit or enable it instead.

--- a/apps/api/src/executors/_shared/text-generate/openai-compat/quirks/__tests__/moonshot.test.ts
+++ b/apps/api/src/executors/_shared/text-generate/openai-compat/quirks/__tests__/moonshot.test.ts
@@ -31,35 +31,37 @@ describe("Moonshot quirks", () => {
 		expect(String(request.messages[0].content)).toContain("The JSON must match this schema");
 	});
 
-	it("normalizes K2.7 Code request fields to Moonshot's documented constraints", () => {
-		const request: Record<string, any> = {
-			model: "kimi-k2.7-code",
-			messages: [{ role: "user", content: "hi" }],
-			tools: [
-				{
-					type: "function",
-					function: {
-						name: "get_weather",
-						description: "Get weather",
-						parameters: { type: "object", properties: {} },
+	it("normalizes K2.7 Code request fields for both base and HighSpeed variants", () => {
+		for (const model of ["kimi-k2.7-code", "kimi-k2.7-code-highspeed"]) {
+			const request: Record<string, any> = {
+				model,
+				messages: [{ role: "user", content: "hi" }],
+				tools: [
+					{
+						type: "function",
+						function: {
+							name: "get_weather",
+							description: "Get weather",
+							parameters: { type: "object", properties: {} },
+						},
 					},
-				},
-			],
-			tool_choice: { type: "function", function: { name: "get_weather" } },
-			thinking: { type: "disabled" },
-			temperature: 0.2,
-			top_p: 0.5,
-			frequency_penalty: 0.3,
-			presence_penalty: -0.2,
-		};
+				],
+				tool_choice: { type: "function", function: { name: "get_weather" } },
+				thinking: { type: "disabled" },
+				temperature: 0.2,
+				top_p: 0.5,
+				frequency_penalty: 0.3,
+				presence_penalty: -0.2,
+			};
 
-		moonshotQuirks.transformRequest?.({ request, ir: {} as any });
+			moonshotQuirks.transformRequest?.({ request, ir: {} as any });
 
-		expect(request.thinking).toEqual({ type: "enabled" });
-		expect(request.temperature).toBeUndefined();
-		expect(request.top_p).toBeUndefined();
-		expect(request.frequency_penalty).toBeUndefined();
-		expect(request.presence_penalty).toBeUndefined();
-		expect(request.tool_choice).toBe("auto");
+			expect(request.thinking).toEqual({ type: "enabled" });
+			expect(request.temperature).toBeUndefined();
+			expect(request.top_p).toBeUndefined();
+			expect(request.frequency_penalty).toBeUndefined();
+			expect(request.presence_penalty).toBeUndefined();
+			expect(request.tool_choice).toBe("auto");
+		}
 	});
 });

--- a/apps/api/src/executors/_shared/text-generate/openai-compat/stream-transforms.ts
+++ b/apps/api/src/executors/_shared/text-generate/openai-compat/stream-transforms.ts
@@ -139,6 +139,14 @@ export function transformChatStream(
 							continue;
 						}
 
+						if (
+							(payload?.object === "chat.completion.chunk" || payload?.object === "chat.completion") &&
+							typeof args.ir.model === "string" &&
+							args.ir.model
+						) {
+							payload.model = args.ir.model;
+						}
+
 						applyStreamQuirks(payload, state, args.providerId);
 						controller.enqueue(encoder.encode(`data: ${JSON.stringify(payload)}\n\n`));
 					}
@@ -207,7 +215,7 @@ export function transformResponsesStreamToChat(
 			object: "chat.completion.chunk",
 			nativeResponseId,
 			created,
-			model: args.providerModelSlug ?? args.ir.model,
+			model: args.ir.model,
 			provider: args.providerId,
 			choices: [{
 				index,
@@ -241,6 +249,9 @@ export function transformResponsesStreamToChat(
 
 						// Some providers stream chat chunks even on /responses
 						if (payload?.object === "chat.completion.chunk" || payload?.object === "chat.completion") {
+							if (typeof args.ir.model === "string" && args.ir.model) {
+								payload.model = args.ir.model;
+							}
 							await emit(payload, controller);
 							continue;
 						}
@@ -412,7 +423,7 @@ export function transformChatStreamToResponses(
 	let createdAt = Math.floor(Date.now() / 1000);
 	let responseId: string | null = args.requestId ?? null;
 	let nativeResponseId: string | null = null;
-	let model = args.providerModelSlug ?? args.ir.model;
+	let model = args.ir.model;
 	let finalResponse: any = null;
 	let nextOutputIndex = 0;
 	const isMiniMaxToolInterop =
@@ -527,6 +538,20 @@ export function transformChatStreamToResponses(
 						}
 
 						if (mode === "responses" && !isChatPayload) {
+							if (payload?.response && typeof args.ir.model === "string" && args.ir.model) {
+								payload = {
+									...payload,
+									response: {
+										...payload.response,
+										model: args.ir.model,
+									},
+								};
+							} else if (typeof args.ir.model === "string" && args.ir.model && payload?.model) {
+								payload = {
+									...payload,
+									model: args.ir.model,
+								};
+							}
 							const normalized = normalizeResponsesEvent(event) ?? "response.event";
 							controller.enqueue(
 								encoder.encode(`event: ${normalized}\ndata: ${JSON.stringify(payload)}\n\n`)
@@ -542,14 +567,12 @@ export function transformChatStreamToResponses(
 						if (!createdEmitted) {
 							if (payload?.id) responseId = payload.id;
 							if (payload?.created) createdAt = payload.created;
-							if (payload?.model) model = payload.model;
 							await emitCreated(controller);
 							createdEmitted = true;
 						}
 
 						if (payload?.id) nativeResponseId = payload.id;
 						if (payload?.created) createdAt = payload.created;
-						if (payload?.model) model = payload.model;
 
 						finalResponse = accumulateChatCompletion(finalResponse, payload);
 

--- a/apps/api/src/pipeline/after/pricing.test.ts
+++ b/apps/api/src/pipeline/after/pricing.test.ts
@@ -186,6 +186,100 @@ describe("after/pricing calculatePricing", () => {
 		expect(result.totalNanos).toBe(12_000_000_000);
 	});
 
+	it("uses Moonshot K2.7 Code HighSpeed pricing for priority service tier", () => {
+		const moonshotCard: PriceCard = {
+			...TTS_CARD,
+			provider: "moonshotai",
+			model: "moonshotai/kimi-k2.7-code",
+			endpoint: "text.generate",
+			rules: [
+				{
+					meter: "input_text_tokens",
+					unit: "token",
+					unit_size: 1_000_000,
+					price_per_unit: "0.95",
+					currency: "USD",
+					pricing_plan: "standard",
+					note: null,
+					match: [],
+					priority: 100,
+				},
+				{
+					meter: "cached_read_text_tokens",
+					unit: "token",
+					unit_size: 1_000_000,
+					price_per_unit: "0.19",
+					currency: "USD",
+					pricing_plan: "standard",
+					note: null,
+					match: [],
+					priority: 100,
+				},
+				{
+					meter: "output_text_tokens",
+					unit: "token",
+					unit_size: 1_000_000,
+					price_per_unit: "4",
+					currency: "USD",
+					pricing_plan: "standard",
+					note: null,
+					match: [],
+					priority: 100,
+				},
+				{
+					meter: "input_text_tokens",
+					unit: "token",
+					unit_size: 1_000_000,
+					price_per_unit: "1.9",
+					currency: "USD",
+					pricing_plan: "priority",
+					note: null,
+					match: [],
+					priority: 100,
+				},
+				{
+					meter: "cached_read_text_tokens",
+					unit: "token",
+					unit_size: 1_000_000,
+					price_per_unit: "0.38",
+					currency: "USD",
+					pricing_plan: "priority",
+					note: null,
+					match: [],
+					priority: 100,
+				},
+				{
+					meter: "output_text_tokens",
+					unit: "token",
+					unit_size: 1_000_000,
+					price_per_unit: "8",
+					currency: "USD",
+					pricing_plan: "priority",
+					note: null,
+					match: [],
+					priority: 100,
+				},
+			],
+		};
+
+		const result = calculatePricing(
+			{
+				input_text_tokens: 1_000_000,
+				cached_read_text_tokens: 1_000_000,
+				output_text_tokens: 1_000_000,
+			},
+			moonshotCard,
+			{ service_tier: "priority" },
+		);
+
+		expect(result.totalNanos).toBe(10_280_000_000);
+		expect(result.pricedUsage?.pricing?.lines?.map((line: any) => line.unit_price_usd)).toEqual([
+			"1.900000000",
+			"0.380000000",
+			"8.000000000",
+		]);
+	});
+
 	it("uses standard pricing for explicit standard service tier", () => {
 		const priorityCard: PriceCard = {
 			...TTS_CARD,

--- a/apps/api/src/pipeline/before/serviceTierRouting.test.ts
+++ b/apps/api/src/pipeline/before/serviceTierRouting.test.ts
@@ -285,6 +285,68 @@ describe("applyServiceTierRouting", () => {
         ]);
     });
 
+    it("remaps Moonshot K2.7 Code priority requests to the hidden HighSpeed slug while keeping the public model stable", async () => {
+        queryState.providerRows = [
+            {
+                provider_id: "moonshotai",
+                api_model_id: "moonshotai/kimi-k2.7-code-highspeed",
+                provider_api_model_id: "moonshot-highspeed-pam",
+                provider_model_slug: "kimi-k2.7-code-highspeed",
+                is_active_gateway: false,
+                effective_from: "2026-06-12T00:00:00Z",
+                effective_to: null,
+            },
+        ];
+        queryState.capabilityRows = [
+            {
+                provider_api_model_id: "moonshot-highspeed-pam",
+                params: { thinking: true },
+                max_input_tokens: 262_144,
+                max_output_tokens: 65_536,
+                status: "active",
+                updated_at: "2026-06-12T00:00:00Z",
+                created_at: "2026-06-12T00:00:00Z",
+            },
+        ];
+
+        const result = await applyServiceTierRouting({
+            candidates: [
+                makeCandidate({
+                    providerId: "moonshotai",
+                    apiModelId: "moonshotai/kimi-k2.7-code",
+                    providerModelSlug: "kimi-k2.7-code",
+                    pricingCard: makeCard({
+                        provider: "moonshotai",
+                        model: "moonshotai/kimi-k2.7-code",
+                        plans: ["standard", "priority"],
+                    }),
+                }),
+            ],
+            body: { service_tier: "priority" },
+            capability: "text.generate",
+        });
+
+        expect(loadPriceCardMock).not.toHaveBeenCalled();
+        expect(result.candidates).toHaveLength(1);
+        expect(result.candidates[0]).toMatchObject({
+            providerId: "moonshotai",
+            apiModelId: "moonshotai/kimi-k2.7-code",
+            pricingKey: "moonshotai:moonshotai/kimi-k2.7-code",
+            providerModelSlug: "kimi-k2.7-code-highspeed",
+            maxInputTokens: 262_144,
+            maxOutputTokens: 65_536,
+            capabilityParams: { thinking: true },
+        });
+        expect(result.diagnostics.remappedProviders).toMatchObject([
+            {
+                providerId: "moonshotai",
+                fromApiModelId: "moonshotai/kimi-k2.7-code",
+                toApiModelId: "moonshotai/kimi-k2.7-code-highspeed",
+                reason: "priority_fast_sibling",
+            },
+        ]);
+    });
+
     it("remaps flex requests to the flex sibling model when pricing is exposed that way", async () => {
         queryState.providerRows = [
             {

--- a/apps/api/src/pipeline/before/serviceTierRouting.test.ts
+++ b/apps/api/src/pipeline/before/serviceTierRouting.test.ts
@@ -347,6 +347,35 @@ describe("applyServiceTierRouting", () => {
         ]);
     });
 
+    it("does not treat unrelated -highspeed models as priority siblings", async () => {
+        const result = await applyServiceTierRouting({
+            candidates: [
+                makeCandidate({
+                    providerId: "minimax",
+                    apiModelId: "minimax/minimax-m2.5-highspeed",
+                    providerModelSlug: "MiniMax-M2.5-highspeed",
+                    pricingCard: makeCard({
+                        provider: "minimax",
+                        model: "minimax/minimax-m2.5-highspeed",
+                        plans: ["standard"],
+                    }),
+                }),
+            ],
+            body: { service_tier: "priority" },
+            capability: "text.generate",
+        });
+
+        expect(result.candidates).toHaveLength(0);
+        expect(result.diagnostics.droppedProviders).toMatchObject([
+            {
+                providerId: "minimax",
+                apiModelId: "minimax/minimax-m2.5-highspeed",
+                reason: "service_tier_priority_unsupported",
+            },
+        ]);
+        expect(loadPriceCardMock).not.toHaveBeenCalled();
+    });
+
     it("remaps flex requests to the flex sibling model when pricing is exposed that way", async () => {
         queryState.providerRows = [
             {

--- a/apps/api/src/pipeline/before/serviceTierRouting.ts
+++ b/apps/api/src/pipeline/before/serviceTierRouting.ts
@@ -44,6 +44,10 @@ type TierSiblingCapabilityRow = {
     created_at: string | null;
 };
 
+const PRIORITY_SIBLING_API_MODEL_IDS = new Map<string, string>([
+    ["moonshotai/kimi-k2.7-code", "moonshotai/kimi-k2.7-code-highspeed"],
+]);
+
 function normalizeRequestedServiceTier(body: any): string | null {
     return normalizeTextServiceTier(readRequestedServiceTier(body).value) ?? null;
 }
@@ -80,7 +84,12 @@ function isTierSiblingModel(candidate: ProviderCandidate, requestedPlan: Service
     const apiModelId = String(candidate.apiModelId ?? "").trim().toLowerCase();
     const providerModelSlug = String(candidate.providerModelSlug ?? "").trim().toLowerCase();
     if (requestedPlan === "priority") {
-        return apiModelId.endsWith("-fast") || providerModelSlug.endsWith("-fast");
+        return (
+            apiModelId.endsWith("-fast") ||
+            apiModelId.endsWith("-highspeed") ||
+            providerModelSlug.endsWith("-fast") ||
+            providerModelSlug.endsWith("-highspeed")
+        );
     }
     if (requestedPlan === "flex") {
         return apiModelId.endsWith("-flex") || providerModelSlug.endsWith("-flex");
@@ -92,7 +101,9 @@ function getTierSiblingApiModelId(
     apiModelId: string,
     requestedPlan: ServiceTierPlan,
 ): string | null {
-    if (requestedPlan === "priority") return `${apiModelId}-fast`;
+    if (requestedPlan === "priority") {
+        return PRIORITY_SIBLING_API_MODEL_IDS.get(apiModelId.trim().toLowerCase()) ?? `${apiModelId}-fast`;
+    }
     if (requestedPlan === "flex") return `${apiModelId}-flex`;
     return null;
 }

--- a/apps/api/src/pipeline/before/serviceTierRouting.ts
+++ b/apps/api/src/pipeline/before/serviceTierRouting.ts
@@ -48,6 +48,12 @@ const PRIORITY_SIBLING_API_MODEL_IDS = new Map<string, string>([
     ["moonshotai/kimi-k2.7-code", "moonshotai/kimi-k2.7-code-highspeed"],
 ]);
 
+const PRIORITY_SIBLING_VALUE_IDS = new Set(
+    Array.from(PRIORITY_SIBLING_API_MODEL_IDS.values(), (value) =>
+        value.trim().toLowerCase(),
+    ),
+);
+
 function normalizeRequestedServiceTier(body: any): string | null {
     return normalizeTextServiceTier(readRequestedServiceTier(body).value) ?? null;
 }
@@ -86,9 +92,8 @@ function isTierSiblingModel(candidate: ProviderCandidate, requestedPlan: Service
     if (requestedPlan === "priority") {
         return (
             apiModelId.endsWith("-fast") ||
-            apiModelId.endsWith("-highspeed") ||
             providerModelSlug.endsWith("-fast") ||
-            providerModelSlug.endsWith("-highspeed")
+            PRIORITY_SIBLING_VALUE_IDS.has(apiModelId)
         );
     }
     if (requestedPlan === "flex") {

--- a/apps/api/src/pipeline/service-tier-moonshot.integration.test.ts
+++ b/apps/api/src/pipeline/service-tier-moonshot.integration.test.ts
@@ -1,0 +1,216 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { PriceCard } from "./pricing/types";
+import { applyServiceTierRouting } from "./before/serviceTierRouting";
+import { calculatePricing } from "./after/pricing";
+
+const queryState = vi.hoisted(() => ({
+    providerRows: [] as any[],
+    capabilityRows: [] as any[],
+    providerFilters: {} as Record<string, unknown>,
+}));
+
+vi.mock("@/runtime/env", () => ({
+    getSupabaseAdmin: () => ({
+        from: (table: string) => {
+            if (table === "data_api_provider_models") {
+                return {
+                    select: () => {
+                        const builder: any = {
+                            eq: (_column: string, _value: unknown) => builder,
+                        };
+                        builder.eq = (column: string, value: unknown) => {
+                            queryState.providerFilters[column] = value;
+                            if (column === "is_active_gateway") {
+                                const rows = queryState.providerRows.filter((row) =>
+                                    Object.entries(queryState.providerFilters).every(
+                                        ([filterColumn, filterValue]) =>
+                                            row[filterColumn as keyof typeof row] === filterValue,
+                                    ),
+                                );
+                                return Promise.resolve({
+                                    data: rows,
+                                    error: null,
+                                });
+                            }
+                            return builder;
+                        };
+                        return builder;
+                    },
+                };
+            }
+
+            if (table === "data_api_provider_model_capabilities") {
+                return {
+                    select: () => {
+                        const builder: any = {
+                            eq: (_column: string, _value: unknown) => builder,
+                            in: (_column: string, _value: unknown) => builder,
+                        };
+                        builder.in = (column: string, _value: unknown) => {
+                            if (column === "provider_api_model_id") {
+                                return Promise.resolve({
+                                    data: queryState.capabilityRows,
+                                    error: null,
+                                });
+                            }
+                            return builder;
+                        };
+                        return builder;
+                    },
+                };
+            }
+
+            throw new Error(`Unexpected table: ${table}`);
+        },
+    }),
+}));
+
+function makeMoonshotPriorityCard(): PriceCard {
+    return {
+        provider: "moonshotai",
+        model: "moonshotai/kimi-k2.7-code",
+        endpoint: "text.generate",
+        effective_from: null,
+        effective_to: null,
+        currency: "USD",
+        version: null,
+        rules: [
+            {
+                pricing_plan: "standard",
+                meter: "input_text_tokens",
+                unit: "token",
+                unit_size: 1_000_000,
+                price_per_unit: "0.95",
+                currency: "USD",
+                match: [],
+                priority: 100,
+            },
+            {
+                pricing_plan: "standard",
+                meter: "cached_read_text_tokens",
+                unit: "token",
+                unit_size: 1_000_000,
+                price_per_unit: "0.19",
+                currency: "USD",
+                match: [],
+                priority: 100,
+            },
+            {
+                pricing_plan: "standard",
+                meter: "output_text_tokens",
+                unit: "token",
+                unit_size: 1_000_000,
+                price_per_unit: "4",
+                currency: "USD",
+                match: [],
+                priority: 100,
+            },
+            {
+                pricing_plan: "priority",
+                meter: "input_text_tokens",
+                unit: "token",
+                unit_size: 1_000_000,
+                price_per_unit: "1.9",
+                currency: "USD",
+                match: [],
+                priority: 100,
+            },
+            {
+                pricing_plan: "priority",
+                meter: "cached_read_text_tokens",
+                unit: "token",
+                unit_size: 1_000_000,
+                price_per_unit: "0.38",
+                currency: "USD",
+                match: [],
+                priority: 100,
+            },
+            {
+                pricing_plan: "priority",
+                meter: "output_text_tokens",
+                unit: "token",
+                unit_size: 1_000_000,
+                price_per_unit: "8",
+                currency: "USD",
+                match: [],
+                priority: 100,
+            },
+        ],
+    };
+}
+
+describe("Moonshot priority service tier validation", () => {
+    beforeEach(() => {
+        queryState.providerRows = [];
+        queryState.capabilityRows = [];
+        queryState.providerFilters = {};
+    });
+
+    it("routes K2.7 Code priority traffic to HighSpeed and bills with HighSpeed rates", async () => {
+        queryState.providerRows = [
+            {
+                provider_id: "moonshotai",
+                api_model_id: "moonshotai/kimi-k2.7-code-highspeed",
+                provider_api_model_id: "moonshot-highspeed-pam",
+                provider_model_slug: "kimi-k2.7-code-highspeed",
+                is_active_gateway: false,
+                effective_from: "2026-06-12T00:00:00Z",
+                effective_to: null,
+            },
+        ];
+        queryState.capabilityRows = [
+            {
+                provider_api_model_id: "moonshot-highspeed-pam",
+                params: { thinking: true },
+                max_input_tokens: 262_144,
+                max_output_tokens: 65_536,
+                status: "active",
+                updated_at: "2026-06-12T00:00:00Z",
+                created_at: "2026-06-12T00:00:00Z",
+            },
+        ];
+
+        const routing = await applyServiceTierRouting({
+            candidates: [
+                {
+                    providerId: "moonshotai",
+                    apiModelId: "moonshotai/kimi-k2.7-code",
+                    pricingKey: "moonshotai:moonshotai/kimi-k2.7-code",
+                    providerModelSlug: "kimi-k2.7-code",
+                    pricingCard: makeMoonshotPriorityCard(),
+                    offerScope: null,
+                    offerLabel: null,
+                    capabilityParams: {},
+                    maxInputTokens: null,
+                    maxOutputTokens: null,
+                } as any,
+            ],
+            body: { service_tier: "priority" },
+            capability: "text.generate",
+        });
+
+        expect(routing.candidates).toHaveLength(1);
+        expect(routing.candidates[0]).toMatchObject({
+            apiModelId: "moonshotai/kimi-k2.7-code",
+            pricingKey: "moonshotai:moonshotai/kimi-k2.7-code",
+            providerModelSlug: "kimi-k2.7-code-highspeed",
+        });
+
+        const priced = calculatePricing(
+            {
+                input_text_tokens: 1_000_000,
+                cached_read_text_tokens: 1_000_000,
+                output_text_tokens: 1_000_000,
+            },
+            routing.candidates[0].pricingCard,
+            { service_tier: "priority" },
+        );
+
+        expect(priced.totalNanos).toBe(10_280_000_000);
+        expect(priced.pricedUsage?.pricing?.lines?.map((line: any) => line.unit_price_usd)).toEqual([
+            "1.900000000",
+            "0.380000000",
+            "8.000000000",
+        ]);
+    });
+});

--- a/packages/data/catalog/src/data/api_providers/moonshotai/models.json
+++ b/packages/data/catalog/src/data/api_providers/moonshotai/models.json
@@ -126,6 +126,27 @@
     ]
   },
   {
+    "api_model_id": "moonshotai/kimi-k2.7-code-highspeed",
+    "provider_api_model_id": "moonshotai:moonshotai/kimi-k2.7-code-highspeed",
+    "provider_model_slug": "kimi-k2.7-code-highspeed",
+    "internal_model_id": "moonshotai/kimi-k2.7-code",
+    "is_active_gateway": false,
+    "quantization_scheme": null,
+    "input_modalities": "text,image,video",
+    "output_modalities": "text",
+    "context_length": 262144,
+    "max_output_tokens": null,
+    "effective_from": "2026-06-12T00:00:00",
+    "effective_to": null,
+    "capabilities": [
+      {
+        "capability_id": "text.generate",
+        "status": "active",
+        "params": []
+      }
+    ]
+  },
+  {
     "api_model_id": "moonshotai/moonshot-v1-8k",
     "provider_api_model_id": "moonshotai:moonshotai/moonshot-v1-8k",
     "provider_model_slug": "moonshot-v1-8k",

--- a/packages/data/catalog/src/data/pricing/moonshotai/moonshotai-kimi-k2.7-code/text.generate/pricing.json
+++ b/packages/data/catalog/src/data/pricing/moonshotai/moonshotai-kimi-k2.7-code/text.generate/pricing.json
@@ -18,6 +18,18 @@
       "effective_from": "2026-06-12T00:00:00Z"
     },
     {
+      "meter": "input_text_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 1.9,
+      "currency": "USD",
+      "pricing_plan": "priority",
+      "note": "Moonshot maps priority service tier for K2.7 Code to the HighSpeed variant.",
+      "match": [],
+      "priority": 100,
+      "effective_from": "2026-06-12T00:00:00Z"
+    },
+    {
       "meter": "cached_read_text_tokens",
       "unit": "token",
       "unit_size": 1000000,
@@ -30,6 +42,18 @@
       "effective_from": "2026-06-12T00:00:00Z"
     },
     {
+      "meter": "cached_read_text_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 0.38,
+      "currency": "USD",
+      "pricing_plan": "priority",
+      "note": "Moonshot maps priority service tier for K2.7 Code to the HighSpeed variant.",
+      "match": [],
+      "priority": 100,
+      "effective_from": "2026-06-12T00:00:00Z"
+    },
+    {
       "meter": "output_text_tokens",
       "unit": "token",
       "unit_size": 1000000,
@@ -37,6 +61,18 @@
       "currency": "USD",
       "pricing_plan": "standard",
       "note": null,
+      "match": [],
+      "priority": 100,
+      "effective_from": "2026-06-12T00:00:00Z"
+    },
+    {
+      "meter": "output_text_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 8,
+      "currency": "USD",
+      "pricing_plan": "priority",
+      "note": "Moonshot maps priority service tier for K2.7 Code to the HighSpeed variant.",
       "match": [],
       "priority": 100,
       "effective_from": "2026-06-12T00:00:00Z"


### PR DESCRIPTION
## Summary
- route `service_tier: "priority"` requests for `moonshotai/kimi-k2.7-code` to Moonshot's hidden `kimi-k2.7-code-highspeed` sibling while keeping the public model id stable
- add priority pricing rules for Moonshot K2.7 Code so billing matches the HighSpeed variant
- cover the routing and billing behavior with targeted tests, including an end-to-end pipeline integration test

## Validation
- `pnpm --filter @ai-stats/gateway-api exec vitest run src/executors/_shared/text-generate/openai-compat/quirks/__tests__/moonshot.test.ts src/pipeline/before/serviceTierRouting.test.ts src/pipeline/after/pricing.test.ts`
- `pnpm validate:data`
- `pnpm --filter @ai-stats/gateway-api exec vitest run src/pipeline/service-tier-moonshot.integration.test.ts src/executors/_shared/text-generate/openai-compat/quirks/__tests__/moonshot.test.ts src/pipeline/before/serviceTierRouting.test.ts src/pipeline/after/pricing.test.ts`
- local live smoke request against `POST /v1/chat/completions` with `model=moonshotai/kimi-k2.7-code`, `service_tier=priority`, and `provider.only=["moonshotai"]`; confirmed upstream `model` became `kimi-k2.7-code-highspeed` and pricing used the HighSpeed rates

Created with Codex

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ai-stats/ai-stats/pull/745" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->