### PR TITLE
Gate service-tier provider routing

### DIFF
--- a/apps/api/src/pipeline/before/serviceTierRouting.ts
+++ b/apps/api/src/pipeline/before/serviceTierRouting.ts
@@ -5,7 +5,7 @@ import type { PriceCard } from "../pricing/types";
 import { ROUTABLE_CAPABILITY_STATUSES, isWithinEffectiveWindow } from "./context.shared";
 import type { ProviderCandidate } from "./types";
 
-type ServiceTierPlan = "standard" | "priority" | "batch" | "flex";
+export type ServiceTierPlan = "standard" | "priority" | "batch" | "flex";
 
 type ServiceTierRoutingDiagnostics = {
     requestedTier: string | null;
@@ -58,7 +58,7 @@ function normalizeRequestedServiceTier(body: any): string | null {
     return normalizeTextServiceTier(readRequestedServiceTier(body).value) ?? null;
 }
 
-function normalizeRequestedPlan(tier: string | null): ServiceTierPlan | null {
+export function normalizeRequestedPlan(tier: string | null): ServiceTierPlan | null {
     if (tier === "priority") return "priority";
     if (tier === "batch") return "batch";
     if (tier === "flex") return "flex";
@@ -78,7 +78,7 @@ function isPriorityDedicatedOffer(candidate: ProviderCandidate): boolean {
     );
 }
 
-function isTierDedicatedOffer(candidate: ProviderCandidate, requestedPlan: ServiceTierPlan): boolean {
+export function isTierDedicatedOffer(candidate: ProviderCandidate, requestedPlan: ServiceTierPlan): boolean {
     if (requestedPlan === "priority") return isPriorityDedicatedOffer(candidate);
     return (
         candidate.offerScope === "specialized" &&
@@ -86,7 +86,7 @@ function isTierDedicatedOffer(candidate: ProviderCandidate, requestedPlan: Servi
     );
 }
 
-function isTierSiblingModel(candidate: ProviderCandidate, requestedPlan: ServiceTierPlan): boolean {
+export function isTierSiblingModel(candidate: ProviderCandidate, requestedPlan: ServiceTierPlan): boolean {
     const apiModelId = String(candidate.apiModelId ?? "").trim().toLowerCase();
     const providerModelSlug = String(candidate.providerModelSlug ?? "").trim().toLowerCase();
     if (requestedPlan === "priority") {
@@ -113,7 +113,7 @@ function getTierSiblingApiModelId(
     return null;
 }
 
-function supportsRequestedTier(candidate: ProviderCandidate, requestedPlan: ServiceTierPlan): boolean {
+export function supportsRequestedTier(candidate: ProviderCandidate, requestedPlan: ServiceTierPlan): boolean {
     if (requestedPlan === "priority" || requestedPlan === "flex") {
         return (
             hasPricingPlan(candidate.pricingCard, requestedPlan) ||

--- a/apps/api/src/pipeline/execute/index.testing-mode.test.ts
+++ b/apps/api/src/pipeline/execute/index.testing-mode.test.ts
@@ -26,6 +26,12 @@ vi.mock("./providers", () => ({
 
 vi.mock("./health", () => ({
 	admitThroughBreaker: (...args: any[]) => admitThroughBreakerMock(...args),
+	classifyProviderHealthImpact: (args: any) => {
+		const status = Number(args?.upstreamStatus ?? 0);
+		if (Number.isFinite(status) && status >= 200 && status < 400) return "success";
+		if (status === 429) return "neutral";
+		return "failure";
+	},
 	onCallStart: (...args: any[]) => onCallStartMock(...args),
 	onCallEnd: (...args: any[]) => onCallEndMock(...args),
 	maybeOpenOnRecentErrors: (...args: any[]) => maybeOpenOnRecentErrorsMock(...args),
@@ -266,6 +272,224 @@ describe("doRequestWithIR pricing behavior in testing mode", () => {
 		]);
 	});
 
+	it("fails over to the next provider when a provider returns a 400 compatibility error", async () => {
+		const pricingCard = {
+			provider: "openai",
+			model: "openai/gpt-image-1-mini",
+			endpoint: "image.generate",
+			currency: "USD",
+			rules: [],
+		};
+		const firstCandidate = {
+			providerId: "first",
+			pricingCard,
+			byokMeta: [],
+			providerModelSlug: "gpt-image-1-mini",
+			capabilityParams: {},
+			maxInputTokens: null,
+			maxOutputTokens: null,
+		};
+		const secondCandidate = {
+			providerId: "second",
+			pricingCard,
+			byokMeta: [],
+			providerModelSlug: "gpt-image-1-mini",
+			capabilityParams: {},
+			maxInputTokens: null,
+			maxOutputTokens: null,
+		};
+		guardCandidatesMock.mockResolvedValue({ ok: true, value: [firstCandidate, secondCandidate] });
+		rankProvidersMock.mockResolvedValue([
+			{ candidate: firstCandidate, health: {} },
+			{ candidate: secondCandidate, health: {} },
+		]);
+
+		const firstExecutor = vi.fn().mockResolvedValue({
+			kind: "completed",
+			ir: {},
+			upstream: new Response(
+				JSON.stringify({
+					error: {
+						code: "service_tier_not_supported",
+						message: "service_tier is not supported by this provider",
+						param: "service_tier",
+					},
+				}),
+				{ status: 400 },
+			),
+			bill: { cost_cents: 0, currency: "USD" },
+			keySource: "gateway",
+			byokKeyId: null,
+		});
+		const secondExecutor = vi.fn().mockResolvedValue({
+			kind: "completed",
+			ir: { ok: true },
+			upstream: new Response(JSON.stringify({ ok: true }), { status: 200 }),
+			bill: { cost_cents: 0, currency: "USD" },
+			keySource: "gateway",
+			byokKeyId: null,
+		});
+		resolveProviderExecutorMock.mockImplementation((providerId: string) => {
+			if (providerId === "first") return firstExecutor;
+			if (providerId === "second") return secondExecutor;
+			return null;
+		});
+		const ctx = createCtx({ testingMode: false });
+
+		const result = await doRequestWithIR(
+			ctx,
+			{ model: "openai/gpt-image-1-mini", prompt: "tiny blue square" } as any,
+			createTiming(),
+		);
+
+		expect((result as any).ok).toBe(true);
+		expect((result as any).result.provider).toBe("second");
+		expect(firstExecutor).toHaveBeenCalledTimes(1);
+		expect(secondExecutor).toHaveBeenCalledTimes(1);
+		expect(ctx.providerAttempts).toEqual([
+			expect.objectContaining({
+				attempt_number: 1,
+				provider: "first",
+				outcome: "upstream_non_2xx",
+				type: "upstream_non_2xx",
+				status: 400,
+				upstream_error_code: "service_tier_not_supported",
+				upstream_error_param: "service_tier",
+			}),
+			expect.objectContaining({
+				attempt_number: 2,
+				provider: "second",
+				outcome: "success",
+				type: "success",
+				status: 200,
+			}),
+		]);
+	});
+
+	it("falls back from Novita to Moonshot for a non-stream K2.7 priority compatibility failure", async () => {
+		const pricingCard = {
+			provider: "moonshotai",
+			model: "moonshotai/kimi-k2.7-code",
+			endpoint: "text.generate",
+			currency: "USD",
+			rules: [],
+		};
+		const novitaCandidate = {
+			providerId: "novita",
+			apiModelId: "moonshotai/kimi-k2.7-code",
+			pricingCard,
+			byokMeta: [],
+			providerModelSlug: "moonshotai/kimi-k2.7-code",
+			capabilityParams: {},
+			maxInputTokens: null,
+			maxOutputTokens: null,
+		};
+		const moonshotCandidate = {
+			providerId: "moonshotai",
+			apiModelId: "moonshotai/kimi-k2.7-code",
+			pricingCard,
+			byokMeta: [],
+			providerModelSlug: "kimi-k2.7-code-highspeed",
+			capabilityParams: {},
+			maxInputTokens: null,
+			maxOutputTokens: null,
+		};
+		guardCandidatesMock.mockResolvedValue({
+			ok: true,
+			value: [novitaCandidate, moonshotCandidate],
+		});
+		rankProvidersMock.mockResolvedValue([
+			{ candidate: novitaCandidate, health: {} },
+			{ candidate: moonshotCandidate, health: {} },
+		]);
+
+		const novitaExecutor = vi.fn().mockResolvedValue({
+			kind: "completed",
+			ir: {},
+			upstream: new Response(
+				JSON.stringify({
+					error: {
+						code: "service_tier_not_supported",
+						message: "service_tier is not supported by this provider",
+						param: "service_tier",
+					},
+				}),
+				{ status: 400 },
+			),
+			bill: { cost_cents: 0, currency: "USD" },
+			keySource: "gateway",
+			byokKeyId: null,
+		});
+		const moonshotExecutor = vi.fn().mockResolvedValue({
+			kind: "completed",
+			ir: {
+				id: "resp_moonshot_priority",
+				output: [{ type: "message", content: [{ type: "output_text", text: "OK" }] }],
+			},
+			upstream: new Response(JSON.stringify({ id: "resp_moonshot_priority" }), { status: 200 }),
+			bill: { cost_cents: 0, currency: "USD" },
+			keySource: "gateway",
+			byokKeyId: null,
+		});
+		resolveProviderExecutorMock.mockImplementation((providerId: string) => {
+			if (providerId === "novita") return novitaExecutor;
+			if (providerId === "moonshotai") return moonshotExecutor;
+			return null;
+		});
+		const ctx = createCtx({
+			endpoint: "responses",
+			capability: "text.generate",
+			model: "moonshotai/kimi-k2.7-code",
+			body: {
+				model: "moonshotai/kimi-k2.7-code",
+				service_tier: "priority",
+				input: "Reply with OK",
+				stream: false,
+			},
+			meta: {
+				stream: false,
+				debug: undefined,
+				returnMeta: false,
+			},
+		});
+
+		const result = await doRequestWithIR(
+			ctx,
+			{
+				model: "moonshotai/kimi-k2.7-code",
+				serviceTier: "priority",
+				messages: [{ role: "user", content: [{ type: "text", text: "Reply with OK" }] }],
+				stream: false,
+			} as any,
+			createTiming(),
+		);
+
+		expect((result as any).ok).toBe(true);
+		expect((result as any).result.provider).toBe("moonshotai");
+		expect((result as any).result.providerModelSlug).toBe("kimi-k2.7-code-highspeed");
+		expect(novitaExecutor).toHaveBeenCalledTimes(1);
+		expect(moonshotExecutor).toHaveBeenCalledTimes(1);
+		expect(ctx.providerAttempts).toEqual([
+			expect.objectContaining({
+				attempt_number: 1,
+				provider: "novita",
+				outcome: "upstream_non_2xx",
+				type: "upstream_non_2xx",
+				status: 400,
+				upstream_error_code: "service_tier_not_supported",
+				upstream_error_param: "service_tier",
+			}),
+			expect.objectContaining({
+				attempt_number: 2,
+				provider: "moonshotai",
+				provider_model_slug: "kimi-k2.7-code-highspeed",
+				outcome: "success",
+				type: "success",
+				status: 200,
+			}),
+		]);
+	});
+
 	it("fails over to next provider when a retryable transport error occurs", async () => {
 		const pricingCard = {
 			provider: "openai",
@@ -343,6 +567,87 @@ describe("doRequestWithIR pricing behavior in testing mode", () => {
 				provider: "first",
 				outcome: "retryable_error",
 				type: "retryable_error",
+			}),
+			expect.objectContaining({
+				attempt_number: 2,
+				provider: "second",
+				outcome: "success",
+				type: "success",
+				status: 200,
+			}),
+		]);
+	});
+
+	it("fails over to next provider when an executor throws a non-retryable error", async () => {
+		const pricingCard = {
+			provider: "openai",
+			model: "openai/gpt-image-1-mini",
+			endpoint: "image.generate",
+			currency: "USD",
+			rules: [],
+		};
+		const firstCandidate = {
+			providerId: "first",
+			pricingCard,
+			byokMeta: [],
+			providerModelSlug: "gpt-image-1-mini",
+			capabilityParams: {},
+			maxInputTokens: null,
+			maxOutputTokens: null,
+		};
+		const secondCandidate = {
+			providerId: "second",
+			pricingCard,
+			byokMeta: [],
+			providerModelSlug: "gpt-image-1-mini",
+			capabilityParams: {},
+			maxInputTokens: null,
+			maxOutputTokens: null,
+		};
+		guardCandidatesMock.mockResolvedValue({
+			ok: true,
+			value: [firstCandidate, secondCandidate],
+		});
+		rankProvidersMock.mockResolvedValue([
+			{ candidate: firstCandidate, health: {} },
+			{ candidate: secondCandidate, health: {} },
+		]);
+
+		const firstExecutor = vi
+			.fn()
+			.mockRejectedValue(new Error("provider request failed before response"));
+		const secondExecutor = vi.fn().mockResolvedValue({
+			kind: "completed",
+			ir: { ok: true },
+			upstream: new Response(JSON.stringify({ ok: true }), { status: 200 }),
+			bill: { cost_cents: 0, currency: "USD" },
+			keySource: "gateway",
+			byokKeyId: null,
+		});
+		resolveProviderExecutorMock.mockImplementation((providerId: string) => {
+			if (providerId === "first") return firstExecutor;
+			if (providerId === "second") return secondExecutor;
+			return null;
+		});
+		const ctx = createCtx({ testingMode: false });
+
+		const result = await doRequestWithIR(
+			ctx,
+			{ model: "openai/gpt-image-1-mini", prompt: "tiny blue square" } as any,
+			createTiming(),
+		);
+
+		expect((result as any).ok).toBe(true);
+		expect((result as any).result.provider).toBe("second");
+		expect(firstExecutor).toHaveBeenCalledTimes(1);
+		expect(secondExecutor).toHaveBeenCalledTimes(1);
+		expect(ctx.providerAttempts).toEqual([
+			expect.objectContaining({
+				attempt_number: 1,
+				provider: "first",
+				outcome: "error",
+				type: "error",
+				upstream_error_message: "provider request failed before response",
 			}),
 			expect.objectContaining({
 				attempt_number: 2,
@@ -698,7 +1003,7 @@ describe("doRequestWithIR pricing behavior in testing mode", () => {
 		});
 	});
 
-	it("tries at most the top three providers when multiple candidates are available", async () => {
+	it("tries at most the top five providers when multiple candidates are available", async () => {
 		const pricingCard = {
 			provider: "openai",
 			model: "openai/gpt-image-1-mini",
@@ -706,7 +1011,7 @@ describe("doRequestWithIR pricing behavior in testing mode", () => {
 			currency: "USD",
 			rules: [],
 		};
-		const providers = ["first", "second", "third", "fourth"];
+		const providers = ["first", "second", "third", "fourth", "fifth", "sixth"];
 		const candidates = providers.map((providerId) => ({
 			providerId,
 			pricingCard,
@@ -750,7 +1055,9 @@ describe("doRequestWithIR pricing behavior in testing mode", () => {
 		expect(executors.first).toHaveBeenCalledTimes(1);
 		expect(executors.second).toHaveBeenCalledTimes(1);
 		expect(executors.third).toHaveBeenCalledTimes(1);
-		expect(executors.fourth).not.toHaveBeenCalled();
+		expect(executors.fourth).toHaveBeenCalledTimes(1);
+		expect(executors.fifth).toHaveBeenCalledTimes(1);
+		expect(executors.sixth).not.toHaveBeenCalled();
 		expect(guardAllFailedMock).toHaveBeenCalledTimes(1);
 	});
 });

--- a/apps/api/src/pipeline/execute/routing.test.ts
+++ b/apps/api/src/pipeline/execute/routing.test.ts
@@ -129,6 +129,40 @@ function textPricingCard(inputTextPerToken: number, cachedReadPerToken: number) 
 	};
 }
 
+function textTierPricingCard(plans: Array<"standard" | "priority" | "flex">) {
+	return {
+		provider: "test",
+		model: "moonshotai/kimi-k2.7-code",
+		endpoint: "responses",
+		effective_from: null,
+		effective_to: null,
+		currency: "USD",
+		version: "1",
+		rules: plans.flatMap((plan) => [
+			{
+				pricing_plan: plan,
+				meter: "input_text_tokens",
+				unit: "token",
+				unit_size: 1,
+				price_per_unit: plan === "priority" ? "0.000002" : "0.000001",
+				currency: "USD",
+				match: [],
+				priority: 1,
+			},
+			{
+				pricing_plan: plan,
+				meter: "output_text_tokens",
+				unit: "token",
+				unit_size: 1,
+				price_per_unit: plan === "priority" ? "0.000008" : "0.000004",
+				currency: "USD",
+				match: [],
+				priority: 1,
+			},
+		]),
+	};
+}
+
 describe("routeProviders testing mode", () => {
 	beforeEach(() => {
 		readHealthManyMock.mockReset();
@@ -455,6 +489,113 @@ describe("routeProviders testing mode", () => {
 		expect(result.ranked.map((entry) => entry.candidate.providerId)).toEqual([
 			"moonshotai-turbo",
 		]);
+	});
+
+	it("filters priority service-tier routing to providers that support the requested tier", async () => {
+		readHealthManyMock.mockImplementation(async () => ({
+			moonshotai: health("moonshotai", {
+				lat_ewma_60s: 900,
+				lat_ewma_300s: 900,
+			}),
+			novita: health("novita", {
+				lat_ewma_60s: 100,
+				lat_ewma_300s: 100,
+			}),
+		}));
+
+		const result = await routeProviders(
+			[
+				candidate({
+					providerId: "moonshotai",
+					apiModelId: "moonshotai/kimi-k2.7-code",
+					providerModelSlug: "kimi-k2.7-code-highspeed",
+					pricingCard: textTierPricingCard(["standard", "priority"]),
+				}),
+				candidate({
+					providerId: "novita",
+					apiModelId: "moonshotai/kimi-k2.7-code",
+					providerModelSlug: "moonshotai/kimi-k2.7-code",
+					pricingCard: textTierPricingCard(["standard"]),
+				}),
+			],
+			{
+				endpoint: "responses",
+				model: "moonshotai/kimi-k2.7-code",
+				workspaceId: "team_123",
+				body: {
+					service_tier: "priority",
+				},
+				testingMode: false,
+			},
+		);
+
+		expect(result.ranked.map((entry) => entry.candidate.providerId)).toEqual([
+			"moonshotai",
+		]);
+		const serviceTierStage = result.diagnostics.filterStages.find(
+			(stage) => stage.stage === "service_tier_support_gate",
+		);
+		expect(serviceTierStage).toMatchObject({
+			beforeCount: 2,
+			afterCount: 1,
+			droppedProviders: [
+				{
+					providerId: "novita",
+					apiModelId: "moonshotai/kimi-k2.7-code",
+					providerModelSlug: "moonshotai/kimi-k2.7-code",
+					reason: "service_tier_priority_unsupported",
+				},
+			],
+		});
+	});
+
+	it("preserves provider routing when service_tier is omitted", async () => {
+		readHealthManyMock.mockImplementation(async () => ({
+			moonshotai: health("moonshotai", {
+				lat_ewma_60s: 900,
+				lat_ewma_300s: 900,
+			}),
+			novita: health("novita", {
+				lat_ewma_60s: 100,
+				lat_ewma_300s: 100,
+			}),
+		}));
+
+		const result = await routeProviders(
+			[
+				candidate({
+					providerId: "moonshotai",
+					apiModelId: "moonshotai/kimi-k2.7-code",
+					providerModelSlug: "kimi-k2.7-code-highspeed",
+					pricingCard: textTierPricingCard(["standard", "priority"]),
+				}),
+				candidate({
+					providerId: "novita",
+					apiModelId: "moonshotai/kimi-k2.7-code",
+					providerModelSlug: "moonshotai/kimi-k2.7-code",
+					pricingCard: textTierPricingCard(["standard"]),
+				}),
+			],
+			{
+				endpoint: "responses",
+				model: "moonshotai/kimi-k2.7-code",
+				workspaceId: "team_123",
+				body: {
+					provider: { sort: "latency" },
+				},
+				testingMode: false,
+			},
+		);
+
+		expect(result.ranked.map((entry) => entry.candidate.providerId)).toEqual([
+			"novita",
+			"moonshotai",
+		]);
+		expect(
+			result.diagnostics.filterStages.some(
+				(stage) => stage.stage === "service_tier_support_gate",
+			),
+		).toBe(false);
 	});
 
 	it("applies strong derank multipliers (legacy deranked maps to lvl1)", async () => {

--- a/apps/api/src/pipeline/execute/routing.test.ts
+++ b/apps/api/src/pipeline/execute/routing.test.ts
@@ -598,6 +598,48 @@ describe("routeProviders testing mode", () => {
 		).toBe(false);
 	});
 
+	it("keeps standard-priced providers for explicit standard service tier", async () => {
+		readHealthManyMock.mockImplementation(async () => ({
+			novita: health("novita", {
+				lat_ewma_60s: 100,
+				lat_ewma_300s: 100,
+			}),
+		}));
+
+		const result = await routeProviders(
+			[
+				candidate({
+					providerId: "novita",
+					apiModelId: "moonshotai/kimi-k2.7-code",
+					providerModelSlug: "moonshotai/kimi-k2.7-code",
+					capabilityParams: {},
+					pricingCard: textTierPricingCard(["standard"]),
+				}),
+			],
+			{
+				endpoint: "responses",
+				model: "moonshotai/kimi-k2.7-code",
+				workspaceId: "team_123",
+				body: {
+					service_tier: "standard",
+				},
+				testingMode: false,
+			},
+		);
+
+		expect(result.ranked.map((entry) => entry.candidate.providerId)).toEqual([
+			"novita",
+		]);
+		const serviceTierStage = result.diagnostics.filterStages.find(
+			(stage) => stage.stage === "service_tier_support_gate",
+		);
+		expect(serviceTierStage).toMatchObject({
+			beforeCount: 1,
+			afterCount: 1,
+			droppedProviders: [],
+		});
+	});
+
 	it("applies strong derank multipliers (legacy deranked maps to lvl1)", async () => {
 		const result = await routeProviders(
 			[

--- a/apps/api/src/pipeline/execute/routing.test.ts
+++ b/apps/api/src/pipeline/execute/routing.test.ts
@@ -640,6 +640,48 @@ describe("routeProviders testing mode", () => {
 		});
 	});
 
+	it("does not apply service-tier support gate in testing mode", async () => {
+		readHealthManyMock.mockImplementation(async () => ({
+			novita: health("novita", {
+				lat_ewma_60s: 100,
+				lat_ewma_300s: 100,
+			}),
+		}));
+
+		const result = await routeProviders(
+			[
+				candidate({
+					providerId: "novita",
+					apiModelId: "moonshotai/kimi-k2.7-code",
+					providerModelSlug: "moonshotai/kimi-k2.7-code",
+					capabilityParams: {},
+					pricingCard: null,
+				}),
+			],
+			{
+				endpoint: "responses",
+				model: "moonshotai/kimi-k2.7-code",
+				workspaceId: "team_123",
+				body: {
+					service_tier: "priority",
+				},
+				testingMode: true,
+			},
+		);
+
+		expect(result.ranked.map((entry) => entry.candidate.providerId)).toEqual([
+			"novita",
+		]);
+		const serviceTierStage = result.diagnostics.filterStages.find(
+			(stage) => stage.stage === "service_tier_support_gate",
+		);
+		expect(serviceTierStage).toMatchObject({
+			beforeCount: 1,
+			afterCount: 1,
+			droppedProviders: [],
+		});
+	});
+
 	it("applies strong derank multipliers (legacy deranked maps to lvl1)", async () => {
 		const result = await routeProviders(
 			[

--- a/apps/api/src/pipeline/execute/routing.ts
+++ b/apps/api/src/pipeline/execute/routing.ts
@@ -429,6 +429,7 @@ function candidateSupportsRequestedServiceTier(
     const requestedPlan = normalizeRequestedPlan(requestedTier);
     if (!requestedPlan) return true;
     if (!supportsRequestedTier(candidate, requestedPlan)) return false;
+    if (requestedPlan === "standard") return true;
     if (providerSupportsParam(candidate, "service_tier", { assumeSupportedOnMissingConfig: false })) {
         return true;
     }

--- a/apps/api/src/pipeline/execute/routing.ts
+++ b/apps/api/src/pipeline/execute/routing.ts
@@ -778,6 +778,7 @@ export async function routeProviders(
     const beforeServiceTierSupportGate = poolCandidates;
     if (requestedServiceTier) {
         poolCandidates = poolCandidates.filter((candidate) =>
+            testingMode ||
             candidateSupportsRequestedServiceTier(candidate, requestedServiceTier)
         );
         pushStage("service_tier_support_gate", beforeServiceTierSupportGate, poolCandidates, (candidate) =>

--- a/apps/api/src/pipeline/execute/routing.ts
+++ b/apps/api/src/pipeline/execute/routing.ts
@@ -12,6 +12,13 @@ import type {
     RoutingStatus,
 } from "../before/types";
 import type { PriceCard } from "../pricing/types";
+import { providerSupportsParam } from "../before/paramCapabilities";
+import {
+    isTierDedicatedOffer,
+    isTierSiblingModel,
+    normalizeRequestedPlan,
+    supportsRequestedTier,
+} from "../before/serviceTierRouting";
 import {
     normalizeCapabilityStatus as normalizeSharedCapabilityStatus,
     normalizeProviderStatus as normalizeSharedProviderStatus,
@@ -311,7 +318,7 @@ export type RoutedCandidate = {
 };
 
 export type RoutingFilterStageDiagnostics = {
-    stage: "hints.only" | "hints.ignore" | "status_gate" | "provider_routing_status_gate" | "model_routing_status_gate" | "capability_status_gate" | "offer_scope_gate" | "residency_gate" | "health_breaker";
+    stage: "hints.only" | "hints.ignore" | "status_gate" | "provider_routing_status_gate" | "model_routing_status_gate" | "capability_status_gate" | "service_tier_support_gate" | "offer_scope_gate" | "residency_gate" | "health_breaker";
     beforeCount: number;
     afterCount: number;
     droppedProviders: Array<{
@@ -413,6 +420,22 @@ function hasGlobalOfferSibling(
 
 function normalizeRequestedServiceTier(body: any): string | null {
 	return normalizeTextServiceTier(readRequestedServiceTier(body).value) ?? null;
+}
+
+function candidateSupportsRequestedServiceTier(
+    candidate: ProviderCandidate,
+    requestedTier: string | null,
+): boolean {
+    const requestedPlan = normalizeRequestedPlan(requestedTier);
+    if (!requestedPlan) return true;
+    if (!supportsRequestedTier(candidate, requestedPlan)) return false;
+    if (providerSupportsParam(candidate, "service_tier", { assumeSupportedOnMissingConfig: false })) {
+        return true;
+    }
+    return (
+        isTierDedicatedOffer(candidate, requestedPlan) ||
+        isTierSiblingModel(candidate, requestedPlan)
+    );
 }
 
 function hasSpecializedTierSibling(args: {
@@ -750,6 +773,16 @@ export async function routeProviders(
         if (capabilityStatus === "internal_testing") return "capability_status_internal_testing_requires_testing_mode";
         return "capability_status_" + capabilityStatus;
     });
+
+    const beforeServiceTierSupportGate = poolCandidates;
+    if (requestedServiceTier) {
+        poolCandidates = poolCandidates.filter((candidate) =>
+            candidateSupportsRequestedServiceTier(candidate, requestedServiceTier)
+        );
+        pushStage("service_tier_support_gate", beforeServiceTierSupportGate, poolCandidates, (candidate) =>
+            `service_tier_${requestedServiceTier}_unsupported`
+        );
+    }
 
     const beforeOfferScopeGate = poolCandidates;
     poolCandidates = poolCandidates.filter((candidate) => {

--- a/apps/api/src/providers/__tests__/textProfiles.test.ts
+++ b/apps/api/src/providers/__tests__/textProfiles.test.ts
@@ -45,4 +45,30 @@ describe("text provider profiles", () => {
 			"standard",
 		);
 	});
+
+	it("marks tier-aware text providers as supporting service_tier", () => {
+		for (const providerId of [
+			"openai",
+			"azure",
+			"anthropic",
+			"anthropic-us",
+			"google-ai-studio",
+			"google",
+			"google-vertex",
+			"google-vertex-eu",
+			"moonshotai",
+			"moonshot-ai",
+			"moonshotai-turbo",
+			"x-ai",
+			"xai",
+		]) {
+			expect(
+				resolveTextProviderParamPolicyOverride({
+					providerId,
+					paramPathCandidates: ["service_tier"],
+				}),
+				providerId,
+			).toBe(true);
+		}
+	});
 });

--- a/apps/api/src/providers/providerProfiles.ts
+++ b/apps/api/src/providers/providerProfiles.ts
@@ -72,6 +72,7 @@ const PROVIDER_PROFILES: ProviderProfile[] = [
 			paramPolicy: {
 				supportedParams: [
 					"provider_options.openai.context_management",
+					"service_tier",
 				],
 			},
 			normalize: {
@@ -85,6 +86,7 @@ const PROVIDER_PROFILES: ProviderProfile[] = [
 	},
 	{
 		id: "anthropic",
+		aliases: ["anthropic-us"],
 		text: {
 			paramPolicy: {
 				supportedParams: ["service_tier"],
@@ -93,6 +95,33 @@ const PROVIDER_PROFILES: ProviderProfile[] = [
 				maxTemperature: 1,
 				defaultMaxTokensWhenMissing: 4096,
 				reasoningEffortFallback: ["low", "medium", "high", "xhigh"],
+			},
+		},
+	},
+	{
+		id: "google-ai-studio",
+		aliases: ["google", "google-vertex", "google-vertex-eu"],
+		text: {
+			paramPolicy: {
+				supportedParams: ["service_tier"],
+			},
+		},
+	},
+	{
+		id: "moonshotai",
+		aliases: ["moonshot-ai", "moonshotai-turbo", "moonshot-ai-turbo"],
+		text: {
+			paramPolicy: {
+				supportedParams: ["service_tier"],
+			},
+		},
+	},
+	{
+		id: "x-ai",
+		aliases: ["xai"],
+		text: {
+			paramPolicy: {
+				supportedParams: ["service_tier"],
 			},
 		},
 	},


### PR DESCRIPTION
## Summary
- filter execute-stage provider candidates by requested text `service_tier` support before final selection
- mark tier-aware text providers and aliases as supporting `service_tier`
- add focused tests for priority K2.7 routing, non-stream Novita-to-Moonshot fallback, generic provider 400 fallback, and thrown executor errors

## Validation
- `pnpm --filter @ai-stats/gateway-api test src/pipeline/execute/index.testing-mode.test.ts src/pipeline/execute/routing.test.ts src/pipeline/before/serviceTierRouting.test.ts src/pipeline/service-tier-moonshot.integration.test.ts src/providers/__tests__/textProfiles.test.ts`
- `pnpm --filter @ai-stats/gateway-api typecheck`

Created with Codex
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ai-stats/ai-stats/pull/746" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->