### PR TITLE
Update AkashML Kimi K2.7 catalog entries

### DIFF
--- a/packages/data/catalog/src/data/api_providers/akashml/models.json
+++ b/packages/data/catalog/src/data/api_providers/akashml/models.json
@@ -1,47 +1,5 @@
 [
   {
-    "api_model_id": "qwen/qwen3.6-35b-a3b",
-    "provider_api_model_id": "akashml:qwen/qwen3.6-35b-a3b",
-    "provider_model_slug": "Qwen/Qwen3.6-35B-A3B",
-    "internal_model_id": "qwen/qwen3.6-35b-a3b",
-    "is_active_gateway": true,
-    "quantization_scheme": null,
-    "input_modalities": "text,image",
-    "output_modalities": "text",
-    "context_length": 262144,
-    "max_output_tokens": null,
-    "effective_from": "2026-04-28T00:00:00",
-    "effective_to": null,
-    "capabilities": [
-      {
-        "capability_id": "text.generate",
-        "status": "active",
-        "params": []
-      }
-    ]
-  },
-  {
-    "api_model_id": "moonshotai/kimi-k2.6",
-    "provider_api_model_id": "akashml:moonshotai/kimi-k2.6",
-    "provider_model_slug": "moonshotai/Kimi-K2.6",
-    "internal_model_id": "moonshotai/kimi-k2.6",
-    "is_active_gateway": true,
-    "quantization_scheme": null,
-    "input_modalities": "text,image",
-    "output_modalities": "text",
-    "context_length": 256000,
-    "max_output_tokens": null,
-    "effective_from": "2026-04-28T00:00:00",
-    "effective_to": null,
-    "capabilities": [
-      {
-        "capability_id": "text.generate",
-        "status": "active",
-        "params": []
-      }
-    ]
-  },
-  {
     "api_model_id": "deepseek/deepseek-v4-flash",
     "provider_api_model_id": "akashml:deepseek/deepseek-v4-flash",
     "provider_model_slug": "deepseek-ai/DeepSeek-V4-Flash",
@@ -63,15 +21,15 @@
     ]
   },
   {
-    "api_model_id": "qwen/qwen3.5-35b-a3b",
-    "provider_api_model_id": "akashml:qwen/qwen3.5-35b-a3b",
-    "provider_model_slug": "Qwen/Qwen3.5-35B-A3B",
-    "internal_model_id": "qwen/qwen3.5-35b-a3b",
+    "api_model_id": "google/gemma-4-31b",
+    "provider_api_model_id": "akashml:google/gemma-4-31b",
+    "provider_model_slug": "google/gemma-4-31B-it",
+    "internal_model_id": "google/gemma-4-31b",
     "is_active_gateway": true,
     "quantization_scheme": null,
     "input_modalities": "text,image",
     "output_modalities": "text",
-    "context_length": 262144,
+    "context_length": 256000,
     "max_output_tokens": null,
     "effective_from": "2026-04-28T00:00:00",
     "effective_to": null,
@@ -126,15 +84,57 @@
     ]
   },
   {
-    "api_model_id": "google/gemma-4-31b",
-    "provider_api_model_id": "akashml:google/gemma-4-31b",
-    "provider_model_slug": "google/gemma-4-31B-it",
-    "internal_model_id": "google/gemma-4-31b",
+    "api_model_id": "moonshotai/kimi-k2.7-code",
+    "provider_api_model_id": "akashml:moonshotai/kimi-k2.7-code",
+    "provider_model_slug": "moonshotai/Kimi-K2.7-Code",
+    "internal_model_id": "moonshotai/kimi-k2.7-code",
     "is_active_gateway": true,
     "quantization_scheme": null,
     "input_modalities": "text,image",
     "output_modalities": "text",
     "context_length": 256000,
+    "max_output_tokens": null,
+    "effective_from": "2026-06-15T00:00:00",
+    "effective_to": null,
+    "capabilities": [
+      {
+        "capability_id": "text.generate",
+        "status": "active",
+        "params": []
+      }
+    ]
+  },
+  {
+    "api_model_id": "qwen/qwen3.5-35b-a3b",
+    "provider_api_model_id": "akashml:qwen/qwen3.5-35b-a3b",
+    "provider_model_slug": "Qwen/Qwen3.5-35B-A3B",
+    "internal_model_id": "qwen/qwen3.5-35b-a3b",
+    "is_active_gateway": true,
+    "quantization_scheme": null,
+    "input_modalities": "text,image",
+    "output_modalities": "text",
+    "context_length": 262144,
+    "max_output_tokens": null,
+    "effective_from": "2026-04-28T00:00:00",
+    "effective_to": null,
+    "capabilities": [
+      {
+        "capability_id": "text.generate",
+        "status": "active",
+        "params": []
+      }
+    ]
+  },
+  {
+    "api_model_id": "qwen/qwen3.6-35b-a3b",
+    "provider_api_model_id": "akashml:qwen/qwen3.6-35b-a3b",
+    "provider_model_slug": "Qwen/Qwen3.6-35B-A3B",
+    "internal_model_id": "qwen/qwen3.6-35b-a3b",
+    "is_active_gateway": true,
+    "quantization_scheme": null,
+    "input_modalities": "text,image",
+    "output_modalities": "text",
+    "context_length": 262144,
     "max_output_tokens": null,
     "effective_from": "2026-04-28T00:00:00",
     "effective_to": null,

--- a/packages/data/catalog/src/data/pricing/akashml/moonshotai-kimi-k2.7-code/text.generate/pricing.json
+++ b/packages/data/catalog/src/data/pricing/akashml/moonshotai-kimi-k2.7-code/text.generate/pricing.json
@@ -1,8 +1,8 @@
 {
-  "key": "akashml:moonshotai/kimi-k2.6:text.generate",
+  "key": "akashml:moonshotai/kimi-k2.7-code:text.generate",
   "api_provider_id": "akashml",
   "provider_slug": "akashml",
-  "api_model_id": "moonshotai/kimi-k2.6",
+  "api_model_id": "moonshotai/kimi-k2.7-code",
   "capability_id": "text.generate",
   "rules": [
     {


### PR DESCRIPTION
## Summary

- replace AkashML's stale `moonshotai/kimi-k2.6` provider-model entry with `moonshotai/kimi-k2.7-code`
- normalize `packages/data/catalog/src/data/api_providers/akashml/models.json` into canonical sorted order
- rename the AkashML pricing record to `moonshotai-kimi-k2.7-code` and update its key/model id while preserving the live `$0.95 / $4.00` token pricing

## Why

Model discovery detected that AkashML removed `moonshotai/Kimi-K2.6` and added `moonshotai/Kimi-K2.7-Code`.

This PR brings the provider catalog and AkashML-specific pricing record into line with the current AkashML listing.

Closes #712
Closes #744

## Validation

- `pnpm validate:data`
- `pnpm validate:pricing`

Created with Codex


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated AkashML model catalog with revised model configurations and mappings.
  * Updated pricing configuration identifiers for the Kimi K2.7 text generation model.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->