### PR TITLE
Disable Groq qwen3.6 gateway route

### DIFF
--- a/packages/data/catalog/src/data/api_providers/groq/models.json
+++ b/packages/data/catalog/src/data/api_providers/groq/models.json
@@ -214,7 +214,7 @@
     "provider_api_model_id": "groq:qwen/qwen3.6-27b",
     "provider_model_slug": "qwen/qwen3.6-27b",
     "internal_model_id": "qwen/qwen3.6-27b",
-    "is_active_gateway": true,
+    "is_active_gateway": false,
     "quantization_scheme": null,
     "input_modalities": "text",
     "output_modalities": "text",


### PR DESCRIPTION
## Summary
- mark Groq `qwen/qwen3.6-27b` as non-gateway while Groq has not published public token pricing for it

## Why
The upstream-discovery follow-up PR added the Groq provider mapping for `qwen/qwen3.6-27b`, but did not add a matching pricing entry. That left the model active on gateway with no pricing and triggered the automated missing-pricing audit.

Groq's public pricing page currently lists `qwen/qwen3-32b`, but not `qwen/qwen3.6-27b`. Until Groq publishes public pricing for `qwen/qwen3.6-27b`, the safer catalog state is to keep the provider mapping and disable gateway routing for that row.

## Validation
- `pnpm --filter @ai-stats/web run audit:missing-pricing -- --provider=groq`
- `pnpm run validate:data`
- `pnpm run validate:pricing`

## Issues
- Follow-up to #755 and #757

Created with Codex

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ai-stats/ai-stats/pull/759" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated model gateway availability: The Qwen 3.6-27B model is no longer available as an active gateway option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->