### PR TITLE
[codex] Add Nebius GLM 5.2 pricing

### DIFF
--- a/packages/data/catalog/src/data/api_providers/nebius-token-factory/models.json
+++ b/packages/data/catalog/src/data/api_providers/nebius-token-factory/models.json
@@ -883,6 +883,27 @@
     ]
   },
   {
+    "api_model_id": "z-ai/glm-5.2",
+    "provider_api_model_id": "nebius-token-factory:z-ai/glm-5.2",
+    "provider_model_slug": "zai-org/GLM-5.2",
+    "internal_model_id": "z-ai/glm-5.2",
+    "is_active_gateway": true,
+    "quantization_scheme": "FP8",
+    "input_modalities": "text",
+    "output_modalities": "text",
+    "context_length": 131000,
+    "max_output_tokens": null,
+    "effective_from": "2026-06-15T00:00:00",
+    "effective_to": null,
+    "capabilities": [
+      {
+        "capability_id": "text.generate",
+        "status": "active",
+        "params": []
+      }
+    ]
+  },
+  {
     "api_model_id": "z-ai/glm-4.5",
     "provider_api_model_id": "nebius-token-factory:z-ai/glm-4.5",
     "provider_model_slug": "zai-org/GLM-4.5",

--- a/packages/data/catalog/src/data/pricing/nebius-token-factory/z-ai-glm-5.2/text.generate/pricing.json
+++ b/packages/data/catalog/src/data/pricing/nebius-token-factory/z-ai-glm-5.2/text.generate/pricing.json
@@ -1,0 +1,31 @@
+{
+  "key": "nebius-token-factory:z-ai/glm-5.2:text.generate",
+  "api_provider_id": "nebius-token-factory",
+  "provider_slug": "nebius-token-factory",
+  "api_model_id": "z-ai/glm-5.2",
+  "capability_id": "text.generate",
+  "rules": [
+    {
+      "meter": "input_text_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 1.4,
+      "currency": "USD",
+      "pricing_plan": "standard",
+      "note": "Nebius Token Factory public models_info API showed this pricing on 2026-06-16.",
+      "match": [],
+      "priority": 100
+    },
+    {
+      "meter": "output_text_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 4.4,
+      "currency": "USD",
+      "pricing_plan": "standard",
+      "note": "Nebius Token Factory public models_info API showed this pricing on 2026-06-16.",
+      "match": [],
+      "priority": 100
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Adds Nebius Token Factory provider availability and text-generation pricing for `z-ai/glm-5.2`.

Evidence: Nebius public models API at `https://api.tokenfactory.nebius.com/private/v1/models_info`, observed 2026-06-16T16:32:01Z, returned active `GLM-5.2` with `model_id: zai-org/GLM-5.2`, FP8 quantization, 131K context, input price `$1.40 / 1M tokens`, and output price `$4.40 / 1M tokens`.

## Changes

- Adds `nebius-token-factory:z-ai/glm-5.2` to the Nebius Token Factory provider model list.
- Adds Nebius text-generation pricing for `z-ai/glm-5.2`.
- Leaves cache pricing unset because Nebius did not expose cache-read/cache-write pricing in the public model record.

## Validation

- `pnpm validate:data`
- `pnpm validate:pricing`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features

* Added z-ai/glm-5.2 AI model with support for text generation, 131,000-token context length, and FP8 quantization. Available starting June 15, 2026.
* Established standard pricing structure with separate rates for input and output tokens, priced per 1 million tokens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->