### PR TITLE
Add GLM 5.2 reasoning effort support

### DIFF
--- a/apps/api/src/executors/_shared/text-generate/openai-compat/__tests__/transform-chat.test.ts
+++ b/apps/api/src/executors/_shared/text-generate/openai-compat/__tests__/transform-chat.test.ts
@@ -801,6 +801,47 @@ describe("irToOpenAIChat", () => {
 		expect(request.reasoning.summary).toBe("auto");
 	});
 
+	it("maps Z.AI GLM-5.2 reasoning effort to thinking and reasoning_effort", () => {
+		const request = irToOpenAIChat({
+			model: "z-ai/glm-5.2",
+			messages: [{
+				role: "user",
+				content: [{ type: "text", text: "hi" }],
+			}],
+			stream: false,
+			reasoning: {
+				effort: "max",
+			},
+		} as any, "glm-5.2", "z-ai");
+
+		expect(request.thinking).toEqual({
+			type: "enabled",
+			clear_thinking: false,
+		});
+		expect(request.reasoning_effort).toBe("max");
+		expect(request.reasoning).toBeUndefined();
+	});
+
+	it("maps Z.AI disabled reasoning to thinking disabled", () => {
+		const request = irToOpenAIChat({
+			model: "z-ai/glm-5.2",
+			messages: [{
+				role: "user",
+				content: [{ type: "text", text: "hi" }],
+			}],
+			stream: false,
+			reasoning: {
+				effort: "none",
+			},
+		} as any, "glm-5.2", "zai");
+
+		expect(request.thinking).toEqual({
+			type: "disabled",
+			clear_thinking: false,
+		});
+		expect(request.reasoning_effort).toBeUndefined();
+	});
+
 	it("maps Arcee reasoning configuration to reasoning_effort", () => {
 		const request = irToOpenAIChat({
 			model: "arcee-ai/coder-large",

--- a/apps/api/src/executors/_shared/text-generate/openai-compat/providers/z-ai/quirks.ts
+++ b/apps/api/src/executors/_shared/text-generate/openai-compat/providers/z-ai/quirks.ts
@@ -52,7 +52,7 @@ export const zaiQuirks: ProviderQuirks = {
 			};
 		}
 
-		if (request.reasoning_effort == null) {
+		if (request.reasoning_effort == null && reasoningEnabled !== false) {
 			const effort = mapReasoningEffortToZai(ir.reasoning?.effort);
 			if (effort) {
 				request.reasoning_effort = effort;

--- a/apps/api/src/executors/_shared/text-generate/openai-compat/providers/z-ai/quirks.ts
+++ b/apps/api/src/executors/_shared/text-generate/openai-compat/providers/z-ai/quirks.ts
@@ -7,6 +7,21 @@
 
 import type { ProviderQuirks } from "../../quirks/types";
 
+function mapReasoningEffortToZai(value?: string): "high" | "max" | undefined {
+	switch (value) {
+		case "max":
+		case "xhigh":
+			return "max";
+		case "minimal":
+		case "low":
+		case "medium":
+		case "high":
+			return "high";
+		default:
+			return undefined;
+	}
+}
+
 export const zaiQuirks: ProviderQuirks = {
 	transformRequest: ({ request, ir }) => {
 		// Z.AI chat compatibility docs do not define a "developer" role.
@@ -35,6 +50,15 @@ export const zaiQuirks: ProviderQuirks = {
 				type: "disabled",
 				clear_thinking: false,
 			};
+		}
+
+		if (request.reasoning_effort == null) {
+			const effort = mapReasoningEffortToZai(ir.reasoning?.effort);
+			if (effort) {
+				request.reasoning_effort = effort;
+			} else if (ir.reasoning?.enabled === true) {
+				request.reasoning_effort = "high";
+			}
 		}
 	},
 

--- a/apps/api/src/executors/_shared/text-generate/openai-compat/quirks/__tests__/zai.test.ts
+++ b/apps/api/src/executors/_shared/text-generate/openai-compat/quirks/__tests__/zai.test.ts
@@ -43,7 +43,7 @@ describe("Z.AI Quirks", () => {
 			const request: Record<string, any> = {};
 			zaiQuirks.transformRequest!({
 				request,
-				ir: { reasoning: { enabled: false } } as any,
+				ir: { reasoning: { enabled: false, effort: "medium" } } as any,
 			});
 			expect(request.thinking).toEqual({
 				type: "disabled",

--- a/apps/api/src/executors/_shared/text-generate/openai-compat/quirks/__tests__/zai.test.ts
+++ b/apps/api/src/executors/_shared/text-generate/openai-compat/quirks/__tests__/zai.test.ts
@@ -36,6 +36,7 @@ describe("Z.AI Quirks", () => {
 				type: "enabled",
 				clear_thinking: false,
 			});
+			expect(request.reasoning_effort).toBe("high");
 		});
 
 		it("disables thinking when reasoning.enabled=false", () => {
@@ -48,6 +49,43 @@ describe("Z.AI Quirks", () => {
 				type: "disabled",
 				clear_thinking: false,
 			});
+			expect(request.reasoning_effort).toBeUndefined();
+		});
+
+		it("maps GLM-5.2 reasoning efforts to Z.AI supported levels", () => {
+			const highRequest: Record<string, any> = {};
+			zaiQuirks.transformRequest!({
+				request: highRequest,
+				ir: { reasoning: { effort: "high" } } as any,
+			});
+			expect(highRequest.thinking).toEqual({
+				type: "enabled",
+				clear_thinking: false,
+			});
+			expect(highRequest.reasoning_effort).toBe("high");
+
+			const maxRequest: Record<string, any> = {};
+			zaiQuirks.transformRequest!({
+				request: maxRequest,
+				ir: { reasoning: { effort: "max" } } as any,
+			});
+			expect(maxRequest.reasoning_effort).toBe("max");
+
+			const xhighRequest: Record<string, any> = {};
+			zaiQuirks.transformRequest!({
+				request: xhighRequest,
+				ir: { reasoning: { effort: "xhigh" } } as any,
+			});
+			expect(xhighRequest.reasoning_effort).toBe("max");
+		});
+
+		it("maps lower generic reasoning efforts to Z.AI high effort", () => {
+			const request: Record<string, any> = {};
+			zaiQuirks.transformRequest!({
+				request,
+				ir: { reasoning: { effort: "medium" } } as any,
+			});
+			expect(request.reasoning_effort).toBe("high");
 		});
 	});
 

--- a/packages/data/catalog/src/data/api_providers/z-ai/models.json
+++ b/packages/data/catalog/src/data/api_providers/z-ai/models.json
@@ -945,14 +945,64 @@
     "input_modalities": "text",
     "output_modalities": "text",
     "context_length": 1000000,
-    "max_output_tokens": null,
+    "max_output_tokens": 128000,
     "effective_from": "2026-06-16T00:00:00",
     "effective_to": null,
     "capabilities": [
       {
         "capability_id": "text.generate",
         "status": "active",
-        "params": []
+        "params": [
+          {
+            "param_id": "max_tokens",
+            "provider_min": null,
+            "provider_max": 128000,
+            "provider_default": null,
+            "notes": null
+          },
+          {
+            "param_id": "reasoning",
+            "provider_min": null,
+            "provider_max": null,
+            "provider_default": "high",
+            "notes": "Z.AI GLM-5.2 supports reasoning_effort high and max; gateway maps generic lower efforts to high and xhigh/max to max."
+          },
+          {
+            "param_id": "response_format",
+            "provider_min": null,
+            "provider_max": null,
+            "provider_default": null,
+            "notes": null
+          },
+          {
+            "param_id": "temperature",
+            "provider_min": null,
+            "provider_max": null,
+            "provider_default": null,
+            "notes": null
+          },
+          {
+            "param_id": "tool_choice",
+            "provider_min": null,
+            "provider_max": null,
+            "provider_default": null,
+            "notes": null
+          },
+          {
+            "param_id": "tools",
+            "provider_min": null,
+            "provider_max": null,
+            "provider_default": null,
+            "notes": null
+          },
+          {
+            "param_id": "top_p",
+            "provider_min": null,
+            "provider_max": null,
+            "provider_default": null,
+            "notes": null
+          }
+        ]
       }
     ]
   },

--- a/packages/data/catalog/src/data/api_providers/z-ai/models.json
+++ b/packages/data/catalog/src/data/api_providers/z-ai/models.json
@@ -982,6 +982,13 @@
             "notes": null
           },
           {
+            "param_id": "stop",
+            "provider_min": null,
+            "provider_max": null,
+            "provider_default": null,
+            "notes": null
+          },
+          {
             "param_id": "tool_choice",
             "provider_min": null,
             "provider_max": null,

--- a/packages/data/catalog/src/data/manifest.json
+++ b/packages/data/catalog/src/data/manifest.json
@@ -2660,6 +2660,7 @@
     "z-ai:text.generate:z-ai-glm-5",
     "z-ai:text.generate:z-ai-glm-5-code",
     "z-ai:text.generate:z-ai-glm-5-turbo",
+    "z-ai:text.generate:z-ai-glm-5.2",
     "z-ai:text.generate:z-ai-glm-5v-turbo"
   ]
 }

--- a/packages/data/catalog/src/data/models/z-ai/glm-5.2/model.json
+++ b/packages/data/catalog/src/data/models/z-ai/glm-5.2/model.json
@@ -4,49 +4,53 @@
   "name": "GLM 5.2",
   "status": "Available",
   "previous_model_id": "z-ai/glm-5.1",
-  "description": "GLM 5.2 is Z.AI's latest flagship coding model, now documented for both the GLM Coding Plan and Z.AI's general OpenAI-compatible API configuration flows.",
-  "announced_date": null,
-  "release_date": null,
+  "description": "GLM 5.2 is Z.AI's frontier open-weights model for coding and long-horizon agentic tasks, with a 1M context window and high/max reasoning effort controls.",
+  "announced_date": "2026-06-16",
+  "release_date": "2026-06-16",
   "deprecation_date": null,
   "retirement_date": null,
-  "license": null,
-  "input_types": null,
-  "output_types": null,
+  "license": "MIT",
+  "input_types": "text",
+  "output_types": "text",
   "api_model_id": "z-ai/glm-5.2",
-  "page_notice": {
-    "tone": "info",
-    "markdown": "Z.AI now documents `glm-5.2` on the general OpenAI-compatible API path in addition to the GLM Coding Plan materials, but the public pricing table still does not publish a dedicated `GLM-5.2` token-pricing row and the release-notes page still stops at `GLM-5.1`."
-  },
   "links": [
     {
       "platform": "docs",
-      "url": "https://docs.z.ai/devpack/overview"
+      "url": "https://docs.z.ai/guides/llm/glm-5.2"
     },
     {
       "platform": "docs",
-      "url": "https://docs.z.ai/devpack/quick-start"
+      "url": "https://docs.z.ai/guides/overview/pricing"
     },
     {
       "platform": "docs",
-      "url": "https://docs.z.ai/devpack/latest-model"
+      "url": "https://docs.z.ai/guides/capabilities/thinking-mode"
     },
     {
-      "platform": "docs",
-      "url": "https://docs.z.ai/devpack/tool/droid"
+      "platform": "announcement",
+      "url": "https://x.com/Zai_org/status/2066938937344495629"
     }
   ],
   "details": [
     {
       "name": "availability",
-      "value": "Public Z.AI docs now show GLM-5.2 in both Coding Plan materials and general OpenAI-compatible setup guidance, including the general API endpoint for standard-plan users."
+      "value": "Z.AI publicly announced GLM-5.2 on 2026-06-16 and documents it for the standard OpenAI-compatible API as model glm-5.2."
     },
     {
       "name": "context_length",
-      "value": "Z.AI's setup guides document a 1M context configuration for glm-5.2 in supported coding-tool integrations."
+      "value": "1,000,000 tokens"
     },
     {
-      "name": "pricing_status",
-      "value": "The current public Z.AI pricing page still does not publish a dedicated standard API token-pricing row for GLM-5.2."
+      "name": "max_output_tokens",
+      "value": "128,000 tokens"
+    },
+    {
+      "name": "reasoning_effort",
+      "value": "Supports high and max reasoning efforts via Z.AI's reasoning_effort request parameter; thinking is enabled with the thinking.type field."
+    },
+    {
+      "name": "pricing",
+      "value": "Same standard API pricing as GLM-5.1: $1.40 per 1M input tokens, $0.26 per 1M cached input tokens, and $4.40 per 1M output tokens."
     }
   ],
   "benchmarks": []


### PR DESCRIPTION
## Summary
- Add Z.AI GLM-5.2 reasoning effort request mapping for the OpenAI-compatible gateway path.
- Map Z.AI reasoning to `thinking: { type, clear_thinking: false }` plus top-level `reasoning_effort` (`high` or `max`).
- Update GLM-5.2 catalog metadata, max output tokens, provider params, and manifest route for the existing Z.AI pricing file.

## Evidence
- Z.AI GLM-5.2 docs: https://docs.z.ai/guides/llm/glm-5.2
  - Documents `glm-5.2`, 1M context, 128K max output, `thinking.type`, and `reasoning_effort: max` examples.
- Z.AI pricing: https://docs.z.ai/guides/overview/pricing
  - Lists GLM-5.2 at the same standard API prices as GLM-5.1: $1.40/M input, $0.26/M cached input, $4.40/M output.
- Z.AI announcement: https://x.com/Zai_org/status/2066938937344495629
  - Announces GLM-5.2 on 2026-06-16 with high/max reasoning effort levels and MIT-licensed open weights.

## Validation
- `pnpm validate:data`
- `pnpm validate:pricing`
- `pnpm validate:gateway`
- `pnpm --filter @ai-stats/gateway-api test -- src/executors/_shared/text-generate/openai-compat/quirks/__tests__/zai.test.ts src/executors/_shared/text-generate/openai-compat/__tests__/transform-chat.test.ts`

## Notes
- The first gateway test attempt failed before dependency install because the clean worktree had no `node_modules`.
- `pnpm install` completed with non-blocking Supabase bin warnings, then the targeted tests passed.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ai-stats/ai-stats/pull/769" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Z.AI GLM-5.2 model with advanced reasoning capabilities, including configurable reasoning effort levels (`high`, `max`, `xhigh`).
  * Model now declares 128,000 maximum output tokens and supports additional text generation parameters: `response_format`, `temperature`, `tool_choice`, `tools`, and `top_p`.
  * Updated model metadata with current release information and comprehensive documentation links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->