### PR TITLE
Fix routing overrides and activate GLM-5.2 providers

### DIFF
--- a/apps/api/src/providers/__tests__/textProfiles.test.ts
+++ b/apps/api/src/providers/__tests__/textProfiles.test.ts
@@ -23,6 +23,33 @@ describe("text provider profiles", () => {
 		).toBe(false);
 	});
 
+	it("returns param policy overrides for provider-verified supported params", () => {
+		expect(
+			resolveTextProviderParamPolicyOverride({
+				providerId: "baseten",
+				paramPathCandidates: ["max_tokens"],
+			}),
+		).toBe(true);
+		expect(
+			resolveTextProviderParamPolicyOverride({
+				providerId: "deepinfra",
+				paramPathCandidates: ["max_tokens"],
+			}),
+		).toBe(true);
+		expect(
+			resolveTextProviderParamPolicyOverride({
+				providerId: "deepinfra",
+				paramPathCandidates: ["temperature"],
+			}),
+		).toBe(true);
+		expect(
+			resolveTextProviderParamPolicyOverride({
+				providerId: "deepinfra",
+				paramPathCandidates: ["service_tier"],
+			}),
+		).toBe(true);
+	});
+
 	it("provides normalize hints used by execute path", () => {
 		expect(getTextProviderTemperatureMax("anthropic")).toBe(1);
 		expect(getTextProviderDefaultMaxTokens("anthropic")).toBe(4096);

--- a/apps/api/src/providers/providerProfiles.ts
+++ b/apps/api/src/providers/providerProfiles.ts
@@ -152,6 +152,33 @@ const PROVIDER_PROFILES: ProviderProfile[] = [
 		},
 	},
 	{
+		id: "baseten",
+		text: {
+			paramPolicy: {
+				supportedParams: [
+					"max_tokens",
+					"temperature",
+					"top_p",
+					"stop",
+				],
+			},
+		},
+	},
+	{
+		id: "deepinfra",
+		text: {
+			paramPolicy: {
+				supportedParams: [
+					"service_tier",
+					"max_tokens",
+					"temperature",
+					"top_p",
+					"stop",
+				],
+			},
+		},
+	},
+	{
 		id: "arcee-ai",
 		aliases: ["arcee"],
 		textOnly: true,

--- a/apps/api/src/providers/providerProfiles.ts
+++ b/apps/api/src/providers/providerProfiles.ts
@@ -126,14 +126,6 @@ const PROVIDER_PROFILES: ProviderProfile[] = [
 		},
 	},
 	{
-		id: "deepinfra",
-		text: {
-			paramPolicy: {
-				supportedParams: ["service_tier"],
-			},
-		},
-	},
-	{
 		id: "cerebras",
 		text: {
 			paramPolicy: {

--- a/packages/data/catalog/src/data/api_providers/baseten/models.json
+++ b/packages/data/catalog/src/data/api_providers/baseten/models.json
@@ -391,5 +391,26 @@
         "params": []
       }
     ]
+  },
+  {
+    "api_model_id": "z-ai/glm-5.2",
+    "provider_api_model_id": "baseten:z-ai/glm-5.2",
+    "provider_model_slug": "zai-org/GLM-5.2",
+    "internal_model_id": "z-ai/glm-5.2",
+    "is_active_gateway": true,
+    "quantization_scheme": null,
+    "input_modalities": "text",
+    "output_modalities": "text",
+    "context_length": 1048576,
+    "max_output_tokens": null,
+    "effective_from": "2026-06-16T00:00:00",
+    "effective_to": null,
+    "capabilities": [
+      {
+        "capability_id": "text.generate",
+        "status": "active",
+        "params": []
+      }
+    ]
   }
 ]

--- a/packages/data/catalog/src/data/api_providers/deepinfra/models.json
+++ b/packages/data/catalog/src/data/api_providers/deepinfra/models.json
@@ -1426,5 +1426,26 @@
         "params": []
       }
     ]
+  },
+  {
+    "api_model_id": "z-ai/glm-5.2",
+    "provider_api_model_id": "deepinfra:z-ai/glm-5.2",
+    "provider_model_slug": "zai-org/GLM-5.2",
+    "internal_model_id": "z-ai/glm-5.2",
+    "is_active_gateway": true,
+    "quantization_scheme": "FP8",
+    "input_modalities": "text",
+    "output_modalities": "text",
+    "context_length": 1048576,
+    "max_output_tokens": null,
+    "effective_from": "2026-06-16T00:00:00",
+    "effective_to": null,
+    "capabilities": [
+      {
+        "capability_id": "text.generate",
+        "status": "active",
+        "params": []
+      }
+    ]
   }
 ]

--- a/packages/data/catalog/src/data/api_providers/fireworks/models.json
+++ b/packages/data/catalog/src/data/api_providers/fireworks/models.json
@@ -703,6 +703,27 @@
     ]
   },
   {
+    "api_model_id": "z-ai/glm-5.2",
+    "provider_api_model_id": "fireworks:z-ai/glm-5.2",
+    "provider_model_slug": "accounts/fireworks/models/glm-5p2",
+    "internal_model_id": "z-ai/glm-5.2",
+    "is_active_gateway": true,
+    "quantization_scheme": null,
+    "input_modalities": "text",
+    "output_modalities": "text",
+    "context_length": 1048576,
+    "max_output_tokens": null,
+    "effective_from": "2026-06-16T00:00:00",
+    "effective_to": null,
+    "capabilities": [
+      {
+        "capability_id": "text.generate",
+        "status": "active",
+        "params": []
+      }
+    ]
+  },
+  {
     "api_model_id": "qwen/qwen-3.6-plus",
     "provider_api_model_id": "fireworks:qwen/qwen-3.6-plus",
     "provider_model_slug": "accounts/fireworks/models/qwen3p6-plus",

--- a/packages/data/catalog/src/data/api_providers/gmicloud/models.json
+++ b/packages/data/catalog/src/data/api_providers/gmicloud/models.json
@@ -735,6 +735,27 @@
     ]
   },
   {
+    "api_model_id": "z-ai/glm-5.2",
+    "provider_api_model_id": "gmicloud:z-ai/glm-5.2",
+    "provider_model_slug": "zai-org/GLM-5.2-FP8",
+    "internal_model_id": "z-ai/glm-5.2",
+    "is_active_gateway": false,
+    "quantization_scheme": "FP8",
+    "input_modalities": "text",
+    "output_modalities": "text",
+    "context_length": 1048576,
+    "max_output_tokens": null,
+    "effective_from": "2026-06-16T00:00:00",
+    "effective_to": null,
+    "capabilities": [
+      {
+        "capability_id": "text.generate",
+        "status": "coming_soon",
+        "params": []
+      }
+    ]
+  },
+  {
     "api_model_id": "kwaipilot/kat-coder-pro-v2",
     "provider_api_model_id": "gmicloud:kwaipilot/kat-coder-pro-v2",
     "provider_model_slug": "kwaipilot/kat-coder-pro-v2",

--- a/packages/data/catalog/src/data/pricing/baseten/z-ai-glm-5.2/text.generate/pricing.json
+++ b/packages/data/catalog/src/data/pricing/baseten/z-ai-glm-5.2/text.generate/pricing.json
@@ -1,0 +1,45 @@
+{
+  "key": "baseten:z-ai/glm-5.2:text.generate",
+  "api_provider_id": "baseten",
+  "provider_slug": "baseten",
+  "api_model_id": "z-ai/glm-5.2",
+  "capability_id": "text.generate",
+  "rules": [
+    {
+      "meter": "input_text_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 1.5,
+      "currency": "USD",
+      "pricing_plan": "standard",
+      "note": null,
+      "match": [],
+      "priority": 100,
+      "effective_from": "2026-06-16T00:00:00Z"
+    },
+    {
+      "meter": "cached_read_text_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 0.3,
+      "currency": "USD",
+      "pricing_plan": "standard",
+      "note": null,
+      "match": [],
+      "priority": 100,
+      "effective_from": "2026-06-16T00:00:00Z"
+    },
+    {
+      "meter": "output_text_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 4.5,
+      "currency": "USD",
+      "pricing_plan": "standard",
+      "note": null,
+      "match": [],
+      "priority": 100,
+      "effective_from": "2026-06-16T00:00:00Z"
+    }
+  ]
+}

--- a/packages/data/catalog/src/data/pricing/deepinfra/z-ai-glm-5.2/text.generate/pricing.json
+++ b/packages/data/catalog/src/data/pricing/deepinfra/z-ai-glm-5.2/text.generate/pricing.json
@@ -1,0 +1,45 @@
+{
+  "key": "deepinfra:z-ai/glm-5.2:text.generate",
+  "api_provider_id": "deepinfra",
+  "provider_slug": "deepinfra",
+  "api_model_id": "z-ai/glm-5.2",
+  "capability_id": "text.generate",
+  "rules": [
+    {
+      "meter": "input_text_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 1.4,
+      "currency": "USD",
+      "pricing_plan": "standard",
+      "note": null,
+      "match": [],
+      "priority": 100,
+      "effective_from": "2026-06-16T00:00:00Z"
+    },
+    {
+      "meter": "cached_read_text_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 0.25,
+      "currency": "USD",
+      "pricing_plan": "standard",
+      "note": null,
+      "match": [],
+      "priority": 100,
+      "effective_from": "2026-06-16T00:00:00Z"
+    },
+    {
+      "meter": "output_text_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 4.4,
+      "currency": "USD",
+      "pricing_plan": "standard",
+      "note": null,
+      "match": [],
+      "priority": 100,
+      "effective_from": "2026-06-16T00:00:00Z"
+    }
+  ]
+}

--- a/packages/data/catalog/src/data/pricing/fireworks/z-ai-glm-5.2/text.generate/pricing.json
+++ b/packages/data/catalog/src/data/pricing/fireworks/z-ai-glm-5.2/text.generate/pricing.json
@@ -1,0 +1,45 @@
+{
+  "key": "fireworks:z-ai/glm-5.2:text.generate",
+  "api_provider_id": "fireworks",
+  "provider_slug": "fireworks",
+  "api_model_id": "z-ai/glm-5.2",
+  "capability_id": "text.generate",
+  "rules": [
+    {
+      "meter": "input_text_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 1.4,
+      "currency": "USD",
+      "pricing_plan": "standard",
+      "note": "From Fireworks model page.",
+      "match": [],
+      "priority": 100,
+      "effective_from": "2026-06-16T00:00:00Z"
+    },
+    {
+      "meter": "cached_read_text_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 0.26,
+      "currency": "USD",
+      "pricing_plan": "standard",
+      "note": "From Fireworks model page.",
+      "match": [],
+      "priority": 100,
+      "effective_from": "2026-06-16T00:00:00Z"
+    },
+    {
+      "meter": "output_text_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 4.4,
+      "currency": "USD",
+      "pricing_plan": "standard",
+      "note": "From Fireworks model page.",
+      "match": [],
+      "priority": 100,
+      "effective_from": "2026-06-16T00:00:00Z"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add provider profile param overrides for Baseten text models
- add provider profile param overrides for DeepInfra text models
- add GLM-5.2 provider rows and pricing for Baseten, DeepInfra, and Fireworks
- mark GMICloud GLM-5.2 FP8 as coming soon without gateway activation or pricing

## Related Issues
- Related to #761
- Related to #765

## Validation
- `pnpm --filter @ai-stats/gateway-api test -- src/providers/__tests__/textProfiles.test.ts src/pipeline/before/textParamPolicy.test.ts`
- live local gateway probe: `meta/llama-3.1-8b` with `max_tokens=8` selected `deepinfra` without dropping DeepInfra for param support
- live local gateway probe: `moonshotai/kimi-k2.6` with `max_tokens=8` selected `baseten` without dropping Baseten for param support
- `pnpm validate:data`
- `pnpm validate:pricing`

## Evidence
- Baseten pricing page on June 16, 2026 lists `GLM 5.2` at `$1.50` input, `$0.30` cached input, `$4.50` output per 1M: https://www.baseten.co/pricing/
- Baseten model page on June 16, 2026 lists `zai-org/GLM-5.2` and a 1M context window: https://www.baseten.co/library/glm-52/
- DeepInfra models index on June 16, 2026 lists `zai-org/GLM-5.2` at `$0.25` cached, `$1.40` input, `$4.40` output per 1M and `1024k` context: https://deepinfra.com/models
- DeepInfra model page payload on June 16, 2026 reports `max_tokens: 1048576` and `max_output_tokens: null`: https://deepinfra.com/zai-org/GLM-5.2
- Fireworks model page on June 16, 2026 lists `Available Serverless` pricing at `$1.40 / $0.26 / $4.40` per 1M input/cached input/output and `1040k tokens` context: https://fireworks.ai/models/fireworks/glm-5p2
- GMICloud `/v1/models` on June 16, 2026 lists `zai-org/GLM-5.2-FP8` with context `1048576` and quantization `fp8`; pricing is intentionally not added because the API-returned rates appear potentially discounted/account-scoped and are not yet confirmed as standard public pricing: https://api.gmi-serving.com/v1/models

## Notes
- Fireworks public evidence in this pass only exposed the standard serverless rate, so this PR adds standard pricing only for Fireworks GLM-5.2
- GMICloud is tracked as coming soon only: `is_active_gateway: false`, capability `status: coming_soon`, no pricing file
- no dedicated Fireworks/GMICloud tracking issue was open when I checked, so this PR keeps the existing Baseten/DeepInfra issue links

Created with Codex