### PR TITLE
Add Cloudflare Workers AI hosted models

### DIFF
--- a/packages/data/catalog/src/data/api_providers/cloudflare/models.json
+++ b/packages/data/catalog/src/data/api_providers/cloudflare/models.json
@@ -854,6 +854,20 @@
             "provider_max": null,
             "provider_default": null,
             "notes": null
+          },
+          {
+            "param_id": "tool_choice",
+            "provider_min": null,
+            "provider_max": null,
+            "provider_default": null,
+            "notes": null
+          },
+          {
+            "param_id": "tools",
+            "provider_min": null,
+            "provider_max": null,
+            "provider_default": null,
+            "notes": null
           }
         ]
       }
@@ -1022,6 +1036,20 @@
           },
           {
             "param_id": "top_p",
+            "provider_min": null,
+            "provider_max": null,
+            "provider_default": null,
+            "notes": null
+          },
+          {
+            "param_id": "tool_choice",
+            "provider_min": null,
+            "provider_max": null,
+            "provider_default": null,
+            "notes": null
+          },
+          {
+            "param_id": "tools",
             "provider_min": null,
             "provider_max": null,
             "provider_default": null,

--- a/packages/data/catalog/src/data/api_providers/cloudflare/models.json
+++ b/packages/data/catalog/src/data/api_providers/cloudflare/models.json
@@ -949,7 +949,7 @@
     "api_model_id": "moonshotai/kimi-k2.6",
     "provider_api_model_id": "cloudflare:@cf/moonshotai/kimi-k2.6",
     "provider_model_slug": "@cf/moonshotai/kimi-k2.6",
-    "internal_model_id": "",
+    "internal_model_id": "moonshotai/kimi-k2.6",
     "is_active_gateway": false,
     "quantization_scheme": null,
     "input_modalities": "text",

--- a/packages/data/catalog/src/data/api_providers/cloudflare/models.json
+++ b/packages/data/catalog/src/data/api_providers/cloudflare/models.json
@@ -817,6 +817,49 @@
     ]
   },
   {
+    "api_model_id": "zai-org/glm-5.2",
+    "provider_api_model_id": "cloudflare:@cf/zai-org/glm-5.2",
+    "provider_model_slug": "@cf/zai-org/glm-5.2",
+    "internal_model_id": "z-ai/glm-5.2",
+    "is_active_gateway": false,
+    "quantization_scheme": null,
+    "input_modalities": "text",
+    "output_modalities": "text",
+    "context_length": 262144,
+    "max_output_tokens": null,
+    "effective_from": "2026-06-16T00:00:00",
+    "effective_to": null,
+    "capabilities": [
+      {
+        "capability_id": "text.generate",
+        "status": "active",
+        "params": [
+          {
+            "param_id": "max_tokens",
+            "provider_min": null,
+            "provider_max": null,
+            "provider_default": null,
+            "notes": null
+          },
+          {
+            "param_id": "temperature",
+            "provider_min": null,
+            "provider_max": null,
+            "provider_default": null,
+            "notes": null
+          },
+          {
+            "param_id": "top_p",
+            "provider_min": null,
+            "provider_max": null,
+            "provider_default": null,
+            "notes": null
+          }
+        ]
+      }
+    ]
+  },
+  {
     "api_model_id": "nvidia/nemotron-3-120b-a12b",
     "provider_api_model_id": "cloudflare:@cf/nvidia/nemotron-3-120b-a12b",
     "provider_model_slug": "@cf/nvidia/nemotron-3-120b-a12b",
@@ -914,6 +957,49 @@
     "context_length": null,
     "max_output_tokens": null,
     "effective_from": "2026-04-28T00:00:00",
+    "effective_to": null,
+    "capabilities": [
+      {
+        "capability_id": "text.generate",
+        "status": "active",
+        "params": [
+          {
+            "param_id": "max_tokens",
+            "provider_min": null,
+            "provider_max": null,
+            "provider_default": null,
+            "notes": null
+          },
+          {
+            "param_id": "temperature",
+            "provider_min": null,
+            "provider_max": null,
+            "provider_default": null,
+            "notes": null
+          },
+          {
+            "param_id": "top_p",
+            "provider_min": null,
+            "provider_max": null,
+            "provider_default": null,
+            "notes": null
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "api_model_id": "moonshotai/kimi-k2.7-code",
+    "provider_api_model_id": "cloudflare:@cf/moonshotai/kimi-k2.7-code",
+    "provider_model_slug": "@cf/moonshotai/kimi-k2.7-code",
+    "internal_model_id": "moonshotai/kimi-k2.7-code",
+    "is_active_gateway": false,
+    "quantization_scheme": null,
+    "input_modalities": "text,image",
+    "output_modalities": "text",
+    "context_length": 262144,
+    "max_output_tokens": null,
+    "effective_from": "2026-06-16T00:00:00",
     "effective_to": null,
     "capabilities": [
       {

--- a/packages/data/catalog/src/data/pricing/cloudflare/moonshotai-kimi-k2.7-code/text.generate/pricing.json
+++ b/packages/data/catalog/src/data/pricing/cloudflare/moonshotai-kimi-k2.7-code/text.generate/pricing.json
@@ -1,0 +1,42 @@
+{
+  "key": "cloudflare:moonshotai/kimi-k2.7-code:text.generate",
+  "api_provider_id": "cloudflare",
+  "provider_slug": "cloudflare",
+  "api_model_id": "moonshotai/kimi-k2.7-code",
+  "capability_id": "text.generate",
+  "rules": [
+    {
+      "meter": "input_text_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 0.95,
+      "currency": "USD",
+      "pricing_plan": "standard",
+      "note": "From Cloudflare Workers AI pricing on 2026-06-16.",
+      "match": [],
+      "priority": 100
+    },
+    {
+      "meter": "cached_read_text_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 0.19,
+      "currency": "USD",
+      "pricing_plan": "standard",
+      "note": "From Cloudflare Workers AI pricing on 2026-06-16.",
+      "match": [],
+      "priority": 100
+    },
+    {
+      "meter": "output_text_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 4,
+      "currency": "USD",
+      "pricing_plan": "standard",
+      "note": "From Cloudflare Workers AI pricing on 2026-06-16.",
+      "match": [],
+      "priority": 100
+    }
+  ]
+}

--- a/packages/data/catalog/src/data/pricing/cloudflare/zai-org-glm-5.2/text.generate/pricing.json
+++ b/packages/data/catalog/src/data/pricing/cloudflare/zai-org-glm-5.2/text.generate/pricing.json
@@ -1,0 +1,42 @@
+{
+  "key": "cloudflare:zai-org/glm-5.2:text.generate",
+  "api_provider_id": "cloudflare",
+  "provider_slug": "cloudflare",
+  "api_model_id": "zai-org/glm-5.2",
+  "capability_id": "text.generate",
+  "rules": [
+    {
+      "meter": "input_text_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 1.4,
+      "currency": "USD",
+      "pricing_plan": "standard",
+      "note": "From Cloudflare Workers AI pricing on 2026-06-16.",
+      "match": [],
+      "priority": 100
+    },
+    {
+      "meter": "cached_read_text_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 0.26,
+      "currency": "USD",
+      "pricing_plan": "standard",
+      "note": "From Cloudflare Workers AI pricing on 2026-06-16.",
+      "match": [],
+      "priority": 100
+    },
+    {
+      "meter": "output_text_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 4.4,
+      "currency": "USD",
+      "pricing_plan": "standard",
+      "note": "From Cloudflare Workers AI pricing on 2026-06-16.",
+      "match": [],
+      "priority": 100
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add Cloudflare Workers AI hosted rows for GLM-5.2 and Kimi K2.7 Code
- add Cloudflare-hosted pricing for input, cached input, and output tokens
- expose advertised `tools` and `tool_choice` support for the new function-calling rows
- map the existing Cloudflare Kimi K2.6 row to its canonical local model
- audit the filtered Cloudflare-hosted model catalog for newer LLM rows that already exist locally

## Evidence
- Filtered Cloudflare AI catalog for Cloudflare-hosted models and target authors: https://developers.cloudflare.com/ai/models/?authors=google&authors=ibm-granite&authors=meta-llama&authors=mistralai&authors=moonshotai&authors=nvidia&authors=openai&authors=qwen&authors=xai&authors=zai-org&providers=cloudflare-hosted
- Workers AI model catalog: https://developers.cloudflare.com/workers-ai/models/
- GLM-5.2 model page lists `@cf/zai-org/glm-5.2`, 262,144 token context, function calling, reasoning, and $1.40 input / $0.26 cached input / $4.40 output per 1M: https://developers.cloudflare.com/workers-ai/models/glm-5.2/
- Kimi K2.7 Code model page lists `@cf/moonshotai/kimi-k2.7-code`, 262,144 token context, function calling, reasoning, vision, and $0.95 input / $0.19 cached input / $4.00 output per 1M: https://developers.cloudflare.com/workers-ai/models/kimi-k2.7-code/
- Kimi K2.6 model page lists `@cf/moonshotai/kimi-k2.6`, 262,144 token context, reasoning, vision, and $0.95 input / $0.16 cached input / $4.00 output per 1M: https://developers.cloudflare.com/workers-ai/models/kimi-k2.6/
- Workers AI pricing page lists the same per-model token rates with dateModified 2026-06-16: https://developers.cloudflare.com/workers-ai/platform/pricing/

## Filtered Catalog Coverage
- Added in this PR: `@cf/zai-org/glm-5.2`, `@cf/moonshotai/kimi-k2.7-code`
- Fixed existing mapping: `@cf/moonshotai/kimi-k2.6`
- Already present with provider rows and pricing: `@cf/moonshotai/kimi-k2.5`, `@cf/zai-org/glm-4.7-flash`, `@cf/openai/gpt-oss-120b`, `@cf/openai/gpt-oss-20b`, `@cf/nvidia/nemotron-3-120b-a12b`, `@cf/google/gemma-4-26b-a4b-it`, `@cf/qwen/qwen3-30b-a3b-fp8`, `@cf/qwen/qwq-32b`, `@cf/qwen/qwen2.5-coder-32b-instruct`, `@cf/meta/llama-4-scout-17b-16e-instruct`, `@cf/ibm-granite/granite-4.0-h-micro`, `@cf/mistralai/mistral-small-3.1-24b-instruct`
- Intentionally not added: third-party models, older hosted rows, non-LLM rows, and rows without a clear existing canonical local model

## Validation
- `pnpm validate:data`
- `pnpm validate:pricing`

## Notes
- Gateway activation is deferred: new rows use `is_active_gateway: false`.
- This is scoped to Cloudflare-hosted Workers AI rows only.

Created with Codex
