### PR TITLE
Remove GLM 5.2 page notice

### DIFF
--- a/apps/docs/v1/changelog.mdx
+++ b/apps/docs/v1/changelog.mdx
@@ -8,7 +8,7 @@ rss: true
 
 <p style={{ fontSize: "1rem", fontWeight: 600, marginTop: "1rem", marginBottom: "0.5rem" }}>New Models</p>
 
-- GLM 5.2 was added in `Rumoured` state with a notice that the entry is based on leaked private-testing references rather than a public Z.AI release.
+- GLM 5.2 was added in `Rumoured` state based on leaked private-testing references rather than a public Z.AI release.
 
 ***
 

--- a/supabase/migrations/20260617081000_remove_glm_52_page_notice.sql
+++ b/supabase/migrations/20260617081000_remove_glm_52_page_notice.sql
@@ -1,0 +1,2 @@
+delete from public.data_api_model_page_notices
+where api_model_id = 'z-ai/glm-5.2';


### PR DESCRIPTION
## Summary

- Delete any stale `z-ai/glm-5.2` row from `data_api_model_page_notices` via migration.
- Remove stale changelog wording that described the old GLM 5.2 notice.

## Validation

- `pnpm validate:data`
- `pnpm docs:build`

Created with Codex
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ai-stats/ai-stats/pull/776" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->