### PR TITLE
Add xAI video and W&B Kimi catalog updates

### DIFF
--- a/packages/data/catalog/src/data/api_providers/weights-and-biases/models.json
+++ b/packages/data/catalog/src/data/api_providers/weights-and-biases/models.json
@@ -315,6 +315,27 @@
     ]
   },
   {
+    "api_model_id": "moonshotai/kimi-k2.7-code",
+    "provider_api_model_id": "weights-and-biases:moonshotai/kimi-k2.7-code",
+    "provider_model_slug": "moonshotai/Kimi-K2.7-Code",
+    "internal_model_id": "moonshotai/kimi-k2.7-code",
+    "is_active_gateway": true,
+    "quantization_scheme": null,
+    "input_modalities": "text,image",
+    "output_modalities": "text",
+    "context_length": 262000,
+    "max_output_tokens": null,
+    "effective_from": "2026-06-17T00:00:00",
+    "effective_to": null,
+    "capabilities": [
+      {
+        "capability_id": "text.generate",
+        "status": "active",
+        "params": []
+      }
+    ]
+  },
+  {
     "api_model_id": "moonshotai/kimi-k2.5",
     "provider_api_model_id": "weights-and-biases:moonshotai/kimi-k2.5",
     "provider_model_slug": "moonshotai/Kimi-K2.5",

--- a/packages/data/catalog/src/data/api_providers/x-ai/models.json
+++ b/packages/data/catalog/src/data/api_providers/x-ai/models.json
@@ -1248,7 +1248,7 @@
     "context_length": null,
     "max_output_tokens": null,
     "effective_from": "2026-05-30T00:00:00",
-    "effective_to": null,
+    "effective_to": "2026-06-17T00:00:00",
     "capabilities": [
       {
         "capability_id": "video.generate",
@@ -1436,6 +1436,96 @@
             "notes": null
           }
         ]
+      }
+    ]
+  },
+  {
+    "api_model_id": "x-ai/grok-imagine-video-1.5",
+    "provider_api_model_id": "x-ai:x-ai/grok-imagine-video-1.5",
+    "provider_model_slug": "grok-imagine-video-1.5",
+    "internal_model_id": "x-ai/grok-imagine-video-1.5",
+    "is_active_gateway": false,
+    "quantization_scheme": null,
+    "input_modalities": "image,video",
+    "output_modalities": "video",
+    "context_length": null,
+    "max_output_tokens": null,
+    "effective_from": "2026-06-17T00:00:00",
+    "effective_to": null,
+    "capabilities": [
+      {
+        "capability_id": "video.generate",
+        "status": "active",
+        "params": {
+          "prompt": {
+            "type": "string"
+          },
+          "duration": {
+            "type": "number",
+            "min": 1,
+            "aliases": [
+              "seconds",
+              "duration_seconds"
+            ]
+          },
+          "size": {
+            "type": "string",
+            "aliases": [
+              "resolution"
+            ]
+          },
+          "quality": {
+            "type": "string"
+          },
+          "input_reference": {
+            "type": "string",
+            "aliases": [
+              "image_url"
+            ]
+          },
+          "seed": {
+            "type": "integer"
+          }
+        }
+      },
+      {
+        "capability_id": "video.edit",
+        "status": "active",
+        "params": {
+          "prompt": {
+            "type": "string"
+          },
+          "duration": {
+            "type": "number",
+            "min": 1,
+            "aliases": [
+              "seconds",
+              "duration_seconds"
+            ]
+          },
+          "size": {
+            "type": "enum",
+            "values": [
+              "480p",
+              "720p"
+            ],
+            "aliases": [
+              "resolution"
+            ]
+          },
+          "quality": {
+            "type": "string"
+          },
+          "input_reference": {
+            "type": "string",
+            "aliases": [
+              "image_url"
+            ]
+          },
+          "seed": {
+            "type": "integer"
+          }
+        }
       }
     ]
   }

--- a/packages/data/catalog/src/data/api_providers/x-ai/models.json
+++ b/packages/data/catalog/src/data/api_providers/x-ai/models.json
@@ -1446,7 +1446,7 @@
     "internal_model_id": "x-ai/grok-imagine-video-1.5",
     "is_active_gateway": false,
     "quantization_scheme": null,
-    "input_modalities": "image,video",
+    "input_modalities": "text,image,video",
     "output_modalities": "video",
     "context_length": null,
     "max_output_tokens": null,

--- a/packages/data/catalog/src/data/models/x-ai/grok-imagine-video-1.5-preview/model.json
+++ b/packages/data/catalog/src/data/models/x-ai/grok-imagine-video-1.5-preview/model.json
@@ -2,13 +2,13 @@
   "model_id": "x-ai/grok-imagine-video-1.5-preview",
   "organisation_id": "x-ai",
   "name": "Grok Imagine Video 1.5 Preview",
-  "status": "Available",
+  "status": "Retired",
   "previous_model_id": "x-ai/grok-imagine-video",
   "description": "Grok Imagine Video 1.5 Preview is a preview video generation model from xAI's Grok Imagine family. It accepts text, image, and video inputs and generates video outputs through the Grok Imagine API.",
   "announced_date": "2026-05-30T00:00:00",
   "release_date": "2026-05-30T00:00:00",
-  "deprecation_date": null,
-  "retirement_date": null,
+  "deprecation_date": "2026-06-17T00:00:00",
+  "retirement_date": "2026-06-17T00:00:00",
   "license": "Proprietary",
   "input_types": "text,image,video",
   "output_types": "video",
@@ -27,6 +27,10 @@
     {
       "name": "regions",
       "value": "us-east-1,eu-west-1"
+    },
+    {
+      "name": "availability",
+      "value": "The upstream xAI model list now exposes the stable grok-imagine-video-1.5 ID; the preview alias was marked retired from the 2026-06-17 discovery signal."
     }
   ],
   "benchmarks": []

--- a/packages/data/catalog/src/data/models/x-ai/grok-imagine-video-1.5/model.json
+++ b/packages/data/catalog/src/data/models/x-ai/grok-imagine-video-1.5/model.json
@@ -4,19 +4,19 @@
   "name": "Grok Imagine Video 1.5",
   "status": "Available",
   "previous_model_id": "x-ai/grok-imagine-video-1.5-preview",
-  "description": "Grok Imagine Video 1.5 is a video generation and editing model from xAI's Grok Imagine family. It supports image and video inputs and generates short video outputs through the Grok Imagine API.",
+  "description": "Grok Imagine Video 1.5 is a video generation and editing model from xAI's Grok Imagine family. It supports text, image, and video inputs and generates short video outputs through the Grok Imagine API.",
   "announced_date": "2026-06-17T00:00:00",
   "release_date": "2026-06-17T00:00:00",
   "deprecation_date": null,
   "retirement_date": null,
   "license": "Proprietary",
-  "input_types": "image,video",
+  "input_types": "text,image,video",
   "output_types": "video",
   "api_model_id": "x-ai/grok-imagine-video-1.5",
   "links": [
     {
       "platform": "api_reference",
-      "url": "https://docs.x.ai/developers/models/grok-imagine-video-1.5-preview"
+      "url": "https://docs.x.ai/developers/models/grok-imagine-video-1.5"
     }
   ],
   "details": [

--- a/packages/data/catalog/src/data/models/x-ai/grok-imagine-video-1.5/model.json
+++ b/packages/data/catalog/src/data/models/x-ai/grok-imagine-video-1.5/model.json
@@ -1,0 +1,41 @@
+{
+  "model_id": "x-ai/grok-imagine-video-1.5",
+  "organisation_id": "x-ai",
+  "name": "Grok Imagine Video 1.5",
+  "status": "Available",
+  "previous_model_id": "x-ai/grok-imagine-video-1.5-preview",
+  "description": "Grok Imagine Video 1.5 is a video generation and editing model from xAI's Grok Imagine family. It supports image and video inputs and generates short video outputs through the Grok Imagine API.",
+  "announced_date": "2026-06-17T00:00:00",
+  "release_date": "2026-06-17T00:00:00",
+  "deprecation_date": null,
+  "retirement_date": null,
+  "license": "Proprietary",
+  "input_types": "image,video",
+  "output_types": "video",
+  "api_model_id": "x-ai/grok-imagine-video-1.5",
+  "links": [
+    {
+      "platform": "api_reference",
+      "url": "https://docs.x.ai/developers/models/grok-imagine-video-1.5-preview"
+    }
+  ],
+  "details": [
+    {
+      "name": "api_alias",
+      "value": "grok-imagine-video-1.5-preview"
+    },
+    {
+      "name": "api_alias",
+      "value": "grok-imagine-video-1.5-2026-05-30"
+    },
+    {
+      "name": "regions",
+      "value": "us-east-1"
+    },
+    {
+      "name": "availability",
+      "value": "xAI documentation lists grok-imagine-video-1.5 as the model name and grok-imagine-video-1.5-preview as an alias."
+    }
+  ],
+  "benchmarks": []
+}

--- a/packages/data/catalog/src/data/pricing/weights-and-biases/moonshotai-kimi-k2.7-code/text.generate/pricing.json
+++ b/packages/data/catalog/src/data/pricing/weights-and-biases/moonshotai-kimi-k2.7-code/text.generate/pricing.json
@@ -1,0 +1,45 @@
+{
+  "key": "weights-and-biases:moonshotai/kimi-k2.7-code:text.generate",
+  "api_provider_id": "weights-and-biases",
+  "provider_slug": "weights-and-biases",
+  "api_model_id": "moonshotai/kimi-k2.7-code",
+  "capability_id": "text.generate",
+  "rules": [
+    {
+      "meter": "input_text_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 0.95,
+      "currency": "USD",
+      "pricing_plan": "standard",
+      "note": "Provider follows Moonshot Kimi K2.7 Code public API pricing.",
+      "match": [],
+      "priority": 100,
+      "effective_from": "2026-06-17T00:00:00Z"
+    },
+    {
+      "meter": "cached_read_text_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 0.19,
+      "currency": "USD",
+      "pricing_plan": "standard",
+      "note": "Provider follows Moonshot Kimi K2.7 Code public API pricing.",
+      "match": [],
+      "priority": 100,
+      "effective_from": "2026-06-17T00:00:00Z"
+    },
+    {
+      "meter": "output_text_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 4,
+      "currency": "USD",
+      "pricing_plan": "standard",
+      "note": "Provider follows Moonshot Kimi K2.7 Code public API pricing.",
+      "match": [],
+      "priority": 100,
+      "effective_from": "2026-06-17T00:00:00Z"
+    }
+  ]
+}

--- a/packages/data/catalog/src/data/pricing/x-ai/x-ai-grok-imagine-video-1.5-preview/video.generate/pricing.json
+++ b/packages/data/catalog/src/data/pricing/x-ai/x-ai-grok-imagine-video-1.5-preview/video.generate/pricing.json
@@ -15,7 +15,8 @@
       "note": null,
       "match": [],
       "priority": 100,
-      "effective_from": "2026-05-30T00:00:00Z"
+      "effective_from": "2026-05-30T00:00:00Z",
+      "effective_to": "2026-06-17T00:00:00Z"
     },
     {
       "meter": "input_video_seconds",
@@ -27,7 +28,8 @@
       "note": null,
       "match": [],
       "priority": 100,
-      "effective_from": "2026-05-30T00:00:00Z"
+      "effective_from": "2026-05-30T00:00:00Z",
+      "effective_to": "2026-06-17T00:00:00Z"
     },
     {
       "meter": "output_video_seconds",
@@ -47,7 +49,8 @@
         }
       ],
       "priority": 100,
-      "effective_from": "2026-05-30T00:00:00Z"
+      "effective_from": "2026-05-30T00:00:00Z",
+      "effective_to": "2026-06-17T00:00:00Z"
     },
     {
       "meter": "output_video_seconds",
@@ -67,7 +70,8 @@
         }
       ],
       "priority": 100,
-      "effective_from": "2026-05-30T00:00:00Z"
+      "effective_from": "2026-05-30T00:00:00Z",
+      "effective_to": "2026-06-17T00:00:00Z"
     }
   ]
 }

--- a/packages/data/catalog/src/data/pricing/x-ai/x-ai-grok-imagine-video-1.5/video.edit/pricing.json
+++ b/packages/data/catalog/src/data/pricing/x-ai/x-ai-grok-imagine-video-1.5/video.edit/pricing.json
@@ -1,8 +1,8 @@
 {
-  "key": "x-ai:x-ai/grok-imagine-video-1.5-preview:video.edit",
+  "key": "x-ai:x-ai/grok-imagine-video-1.5:video.edit",
   "api_provider_id": "x-ai",
   "provider_slug": "x-ai",
-  "api_model_id": "x-ai/grok-imagine-video-1.5-preview",
+  "api_model_id": "x-ai/grok-imagine-video-1.5",
   "capability_id": "video.edit",
   "rules": [
     {
@@ -15,8 +15,7 @@
       "note": null,
       "match": [],
       "priority": 100,
-      "effective_from": "2026-05-30T00:00:00Z",
-      "effective_to": "2026-06-17T00:00:00Z"
+      "effective_from": "2026-06-17T00:00:00Z"
     },
     {
       "meter": "input_video_seconds",
@@ -28,8 +27,7 @@
       "note": null,
       "match": [],
       "priority": 100,
-      "effective_from": "2026-05-30T00:00:00Z",
-      "effective_to": "2026-06-17T00:00:00Z"
+      "effective_from": "2026-06-17T00:00:00Z"
     },
     {
       "meter": "output_video_seconds",
@@ -49,8 +47,7 @@
         }
       ],
       "priority": 100,
-      "effective_from": "2026-05-30T00:00:00Z",
-      "effective_to": "2026-06-17T00:00:00Z"
+      "effective_from": "2026-06-17T00:00:00Z"
     },
     {
       "meter": "output_video_seconds",
@@ -70,8 +67,7 @@
         }
       ],
       "priority": 100,
-      "effective_from": "2026-05-30T00:00:00Z",
-      "effective_to": "2026-06-17T00:00:00Z"
+      "effective_from": "2026-06-17T00:00:00Z"
     }
   ]
 }

--- a/packages/data/catalog/src/data/pricing/x-ai/x-ai-grok-imagine-video-1.5/video.generate/pricing.json
+++ b/packages/data/catalog/src/data/pricing/x-ai/x-ai-grok-imagine-video-1.5/video.generate/pricing.json
@@ -1,9 +1,9 @@
 {
-  "key": "x-ai:x-ai/grok-imagine-video-1.5-preview:video.edit",
+  "key": "x-ai:x-ai/grok-imagine-video-1.5:video.generate",
   "api_provider_id": "x-ai",
   "provider_slug": "x-ai",
-  "api_model_id": "x-ai/grok-imagine-video-1.5-preview",
-  "capability_id": "video.edit",
+  "api_model_id": "x-ai/grok-imagine-video-1.5",
+  "capability_id": "video.generate",
   "rules": [
     {
       "meter": "input_image",
@@ -15,8 +15,7 @@
       "note": null,
       "match": [],
       "priority": 100,
-      "effective_from": "2026-05-30T00:00:00Z",
-      "effective_to": "2026-06-17T00:00:00Z"
+      "effective_from": "2026-06-17T00:00:00Z"
     },
     {
       "meter": "input_video_seconds",
@@ -28,8 +27,7 @@
       "note": null,
       "match": [],
       "priority": 100,
-      "effective_from": "2026-05-30T00:00:00Z",
-      "effective_to": "2026-06-17T00:00:00Z"
+      "effective_from": "2026-06-17T00:00:00Z"
     },
     {
       "meter": "output_video_seconds",
@@ -49,8 +47,7 @@
         }
       ],
       "priority": 100,
-      "effective_from": "2026-05-30T00:00:00Z",
-      "effective_to": "2026-06-17T00:00:00Z"
+      "effective_from": "2026-06-17T00:00:00Z"
     },
     {
       "meter": "output_video_seconds",
@@ -70,8 +67,7 @@
         }
       ],
       "priority": 100,
-      "effective_from": "2026-05-30T00:00:00Z",
-      "effective_to": "2026-06-17T00:00:00Z"
+      "effective_from": "2026-06-17T00:00:00Z"
     }
   ]
 }


### PR DESCRIPTION
## Summary

- add xAI `grok-imagine-video-1.5` model, provider mapping, and video pricing
- retire xAI `grok-imagine-video-1.5-preview` with `effective_to` on provider and pricing rows
- add Weights & Biases `moonshotai/Kimi-K2.7-Code` provider mapping and text pricing

## Why

The upstream discovery cron detected xAI replacing the 1.5 preview video model with the stable `grok-imagine-video-1.5` model, and W&B adding Moonshot's Kimi K2.7 Code model. This keeps provider model availability and pricing windows aligned with the discovery signal.

## Validation

- `pnpm validate:data`

Closes #773
Closes #774
Closes #781

Created with Codex