### PR TITLE
Add AtlasCloud and Venice GLM 5.2

### DIFF
--- a/packages/data/catalog/src/data/api_providers/atlascloud/models.json
+++ b/packages/data/catalog/src/data/api_providers/atlascloud/models.json
@@ -1176,6 +1176,27 @@
     ]
   },
   {
+    "api_model_id": "z-ai/glm-5.2",
+    "provider_api_model_id": "atlascloud:z-ai/glm-5.2",
+    "provider_model_slug": "zai-org/glm-5.2",
+    "internal_model_id": "z-ai/glm-5.2",
+    "is_active_gateway": true,
+    "quantization_scheme": null,
+    "input_modalities": "text",
+    "output_modalities": "text",
+    "context_length": 202752,
+    "max_output_tokens": 202752,
+    "effective_from": "2026-06-16T00:00:00",
+    "effective_to": null,
+    "capabilities": [
+      {
+        "capability_id": "text.generate",
+        "status": "active",
+        "params": []
+      }
+    ]
+  },
+  {
     "api_model_id": "z-ai/glm-5-turbo",
     "provider_api_model_id": "atlascloud:z-ai/glm-5-turbo",
     "provider_model_slug": "zai-org/glm-5-turbo",

--- a/packages/data/catalog/src/data/api_providers/venice-e2ee/models.json
+++ b/packages/data/catalog/src/data/api_providers/venice-e2ee/models.json
@@ -250,5 +250,26 @@
         "params": []
       }
     ]
+  },
+  {
+    "api_model_id": "z-ai/glm-5.2",
+    "provider_api_model_id": "venice/e2ee:z-ai/glm-5.2",
+    "provider_model_slug": "e2ee-glm-5-2-p",
+    "internal_model_id": "z-ai/glm-5.2",
+    "is_active_gateway": true,
+    "quantization_scheme": null,
+    "input_modalities": "text",
+    "output_modalities": "text",
+    "context_length": 1000000,
+    "max_output_tokens": 32768,
+    "effective_from": "2026-06-16T00:00:00",
+    "effective_to": null,
+    "capabilities": [
+      {
+        "capability_id": "text.generate",
+        "status": "active",
+        "params": []
+      }
+    ]
   }
 ]

--- a/packages/data/catalog/src/data/api_providers/venice/models.json
+++ b/packages/data/catalog/src/data/api_providers/venice/models.json
@@ -1417,6 +1417,27 @@
     ]
   },
   {
+    "api_model_id": "z-ai/glm-5.2",
+    "provider_api_model_id": "venice:z-ai/glm-5.2",
+    "provider_model_slug": "zai-org-glm-5-2",
+    "internal_model_id": "z-ai/glm-5.2",
+    "is_active_gateway": true,
+    "quantization_scheme": "fp8",
+    "input_modalities": "text",
+    "output_modalities": "text",
+    "context_length": 1000000,
+    "max_output_tokens": 24000,
+    "effective_from": "2026-06-16T00:00:00",
+    "effective_to": null,
+    "capabilities": [
+      {
+        "capability_id": "text.generate",
+        "status": "active",
+        "params": []
+      }
+    ]
+  },
+  {
     "api_model_id": "arcee-ai/trinity-large-thinking",
     "provider_api_model_id": "venice:arcee-ai/trinity-large-thinking",
     "provider_model_slug": "arcee-trinity-large-thinking",

--- a/packages/data/catalog/src/data/pricing/atlascloud/z-ai-glm-5.2/text.generate/pricing.json
+++ b/packages/data/catalog/src/data/pricing/atlascloud/z-ai-glm-5.2/text.generate/pricing.json
@@ -1,0 +1,42 @@
+{
+  "key": "atlascloud:z-ai/glm-5.2:text.generate",
+  "api_provider_id": "atlascloud",
+  "provider_slug": "atlascloud",
+  "api_model_id": "z-ai/glm-5.2",
+  "capability_id": "text.generate",
+  "rules": [
+    {
+      "meter": "input_text_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 1.4,
+      "currency": "USD",
+      "pricing_plan": "standard",
+      "note": null,
+      "match": [],
+      "priority": 100
+    },
+    {
+      "meter": "cached_read_text_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 0.26,
+      "currency": "USD",
+      "pricing_plan": "standard",
+      "note": null,
+      "match": [],
+      "priority": 100
+    },
+    {
+      "meter": "output_text_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 4.4,
+      "currency": "USD",
+      "pricing_plan": "standard",
+      "note": null,
+      "match": [],
+      "priority": 100
+    }
+  ]
+}

--- a/packages/data/catalog/src/data/pricing/venice-e2ee/z-ai-glm-5.2/text.generate/pricing.json
+++ b/packages/data/catalog/src/data/pricing/venice-e2ee/z-ai-glm-5.2/text.generate/pricing.json
@@ -1,0 +1,31 @@
+{
+  "key": "venice-e2ee:z-ai/glm-5.2:text.generate",
+  "api_provider_id": "venice-e2ee",
+  "provider_slug": "venice-e2ee",
+  "api_model_id": "z-ai/glm-5.2",
+  "capability_id": "text.generate",
+  "rules": [
+    {
+      "meter": "input_text_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 1.75,
+      "currency": "USD",
+      "pricing_plan": "standard",
+      "note": null,
+      "match": [],
+      "priority": 100
+    },
+    {
+      "meter": "output_text_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 5.75,
+      "currency": "USD",
+      "pricing_plan": "standard",
+      "note": null,
+      "match": [],
+      "priority": 100
+    }
+  ]
+}

--- a/packages/data/catalog/src/data/pricing/venice/z-ai-glm-5.2/text.generate/pricing.json
+++ b/packages/data/catalog/src/data/pricing/venice/z-ai-glm-5.2/text.generate/pricing.json
@@ -1,0 +1,42 @@
+{
+  "key": "venice:z-ai/glm-5.2:text.generate",
+  "api_provider_id": "venice",
+  "provider_slug": "venice",
+  "api_model_id": "z-ai/glm-5.2",
+  "capability_id": "text.generate",
+  "rules": [
+    {
+      "meter": "input_text_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 1.75,
+      "currency": "USD",
+      "pricing_plan": "standard",
+      "note": null,
+      "match": [],
+      "priority": 100
+    },
+    {
+      "meter": "cached_read_text_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 0.325,
+      "currency": "USD",
+      "pricing_plan": "standard",
+      "note": null,
+      "match": [],
+      "priority": 100
+    },
+    {
+      "meter": "output_text_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 5.5,
+      "currency": "USD",
+      "pricing_plan": "standard",
+      "note": null,
+      "match": [],
+      "priority": 100
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Add AtlasCloud coverage for `z-ai/glm-5.2` via upstream slug `zai-org/glm-5.2`
- Add Venice E2EE coverage for `z-ai/glm-5.2` via upstream slug `e2ee-glm-5-2-p`
- Add provider pricing for both mappings using current provider-published rates

## Validation
- `pnpm run validate:data`
- `pnpm run validate:pricing`
- `pnpm run validate:gateway`

Closes #767
Closes #768

Chutes is intentionally deferred and not added in this PR.

Created with Codex

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ai-stats/ai-stats/pull/783" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->