### PR TITLE
Stage Bedrock Grok provider coverage

### DIFF
--- a/apps/api/src/executors/_shared/text-generate/openai-compat/reasoning.ts
+++ b/apps/api/src/executors/_shared/text-generate/openai-compat/reasoning.ts
@@ -37,6 +37,9 @@ function resolveReasoningConfig(providerId?: string): ReasoningConfig | null {
 	if (providerId === "openai") {
 		return { mode: "effort", field: "reasoning" };
 	}
+	if (providerId === "amazon-bedrock") {
+		return { mode: "effort", field: "reasoning" };
+	}
 	// Xiaomi uses a special format: chat_template_kwargs.enable_thinking
 	// This is handled entirely in the Xiaomi provider quirks (providers/xiaomi/quirks.ts)
 	// Do not add a config here - the quirk has full control

--- a/apps/api/src/executors/amazon-bedrock/text-generate/__tests__/index.test.ts
+++ b/apps/api/src/executors/amazon-bedrock/text-generate/__tests__/index.test.ts
@@ -195,6 +195,45 @@ describe("amazon-bedrock text executor", () => {
 		expect(result.ir?.choices?.[0]?.message?.content?.[0]?.type).toBe("text");
 	});
 
+	it("routes xAI Bedrock Mantle models to the OpenAI-compatible endpoint", async () => {
+		const mock = installFetchMock([{
+			match: (url) => url === "https://api.bedrock.example/openai/v1/chat/completions",
+			onRequest: (call) => {
+				expect(call.bodyJson?.model).toBe("xai.grok-4.3");
+				expect(call.bodyJson?.messages?.[0]?.role).toBe("user");
+			},
+			response: jsonResponse({
+				id: "chatcmpl_bedrock_xai",
+				object: "chat.completion",
+				created: 1710000002,
+				model: "xai.grok-4.3",
+				choices: [{
+					index: 0,
+					message: { role: "assistant", content: "grok ok" },
+					finish_reason: "stop",
+				}],
+				usage: {
+					prompt_tokens: 4,
+					completion_tokens: 2,
+					total_tokens: 6,
+				},
+			}),
+		}]);
+
+		const result = await execute(buildArgs({
+			model: "xai.grok-4.3",
+			stream: false,
+			messages: [{ role: "user", content: [{ type: "text", text: "hello" }] }],
+		}, {
+			providerModelSlug: "xai.grok-4.3",
+		}));
+
+		mock.restore();
+
+		expect(result.kind).toBe("completed");
+		expect(result.ir?.choices?.[0]?.message?.content?.[0]?.type).toBe("text");
+	});
+
 	it("falls back from /responses to /chat/completions when responses is unavailable", async () => {
 		const mock = installFetchMock([
 			{

--- a/apps/api/src/executors/amazon-bedrock/text-generate/__tests__/index.test.ts
+++ b/apps/api/src/executors/amazon-bedrock/text-generate/__tests__/index.test.ts
@@ -201,6 +201,7 @@ describe("amazon-bedrock text executor", () => {
 			onRequest: (call) => {
 				expect(call.bodyJson?.model).toBe("xai.grok-4.3");
 				expect(call.bodyJson?.messages?.[0]?.role).toBe("user");
+				expect(call.bodyJson?.reasoning).toEqual({ effort: "high" });
 			},
 			response: jsonResponse({
 				id: "chatcmpl_bedrock_xai",
@@ -223,6 +224,7 @@ describe("amazon-bedrock text executor", () => {
 		const result = await execute(buildArgs({
 			model: "xai.grok-4.3",
 			stream: false,
+			reasoning: { effort: "high" },
 			messages: [{ role: "user", content: [{ type: "text", text: "hello" }] }],
 		}, {
 			providerModelSlug: "xai.grok-4.3",

--- a/apps/api/src/executors/amazon-bedrock/text-generate/index.ts
+++ b/apps/api/src/executors/amazon-bedrock/text-generate/index.ts
@@ -862,7 +862,8 @@ function isBedrockOpenAIModel(model: string): boolean {
 		normalizedModel.startsWith("openai.") ||
 		normalizedModel.startsWith("us.openai.") ||
 		normalizedModel.startsWith("eu.openai.") ||
-		normalizedModel.startsWith("apac.openai.")
+		normalizedModel.startsWith("apac.openai.") ||
+		normalizedModel.startsWith("xai.")
 	);
 }
 

--- a/apps/docs/v1/changelog.mdx
+++ b/apps/docs/v1/changelog.mdx
@@ -4,6 +4,15 @@ description: "Recent product updates, SDK changes, and model releases across AI 
 rss: true
 ---
 
+## June 15, 2026
+
+<p style={{ fontSize: "1rem", fontWeight: 600, marginTop: "1rem", marginBottom: "0.5rem" }}>Provider Coverage</p>
+
+- Amazon Bedrock provider coverage was staged for xAI Grok 4.3 with Bedrock Mantle model id `xai.grok-4.3`, standard pricing, and current `us-west-2` in-region availability. The provider-model capability is currently disabled pending setup. AWS currently lists Grok 4.3 as the only xAI model on Bedrock, and does not list Geo or Global inference for it.
+- Amazon Bedrock OpenAI frontier model coverage was checked; AWS still documents GPT-5.5 and GPT-5.4 as regional/Geo in-region offerings, with Global cross-region pricing marked as coming soon.
+
+***
+
 ## June 11, 2026
 
 <p style={{ fontSize: "1rem", fontWeight: 600, marginTop: "1rem", marginBottom: "0.5rem" }}>New Models</p>

--- a/packages/data/catalog/src/data/api_providers/amazon-bedrock/models.json
+++ b/packages/data/catalog/src/data/api_providers/amazon-bedrock/models.json
@@ -924,6 +924,91 @@
     ]
   },
   {
+    "api_model_id": "x-ai/grok-4.3",
+    "provider_api_model_id": "amazon-bedrock:x-ai/grok-4.3",
+    "provider_model_slug": "xai.grok-4.3",
+    "internal_model_id": "x-ai/grok-4.3",
+    "is_active_gateway": false,
+    "quantization_scheme": null,
+    "input_modalities": "text,image",
+    "output_modalities": "text",
+    "context_length": 1000000,
+    "max_output_tokens": 131072,
+    "effective_from": "2026-06-15T00:00:00",
+    "effective_to": null,
+    "capabilities": [
+      {
+        "capability_id": "text.generate",
+        "status": "disabled",
+        "params": [
+          {
+            "param_id": "reasoning",
+            "provider_min": null,
+            "provider_max": null,
+            "provider_default": "low",
+            "notes": "Amazon Bedrock supports reasoning effort values none, low, medium, and high for Grok 4.3.",
+            "type": "enum",
+            "values": [
+              "none",
+              "low",
+              "medium",
+              "high"
+            ]
+          },
+          {
+            "param_id": "max_completion_tokens",
+            "provider_min": null,
+            "provider_max": 131072,
+            "provider_default": 131072,
+            "notes": null
+          },
+          {
+            "param_id": "response_format",
+            "provider_min": null,
+            "provider_max": null,
+            "provider_default": null,
+            "notes": null
+          },
+          {
+            "param_id": "structured_outputs",
+            "provider_min": null,
+            "provider_max": null,
+            "provider_default": null,
+            "notes": null
+          },
+          {
+            "param_id": "temperature",
+            "provider_min": null,
+            "provider_max": null,
+            "provider_default": 0.7,
+            "notes": null
+          },
+          {
+            "param_id": "tool_choice",
+            "provider_min": null,
+            "provider_max": null,
+            "provider_default": null,
+            "notes": null
+          },
+          {
+            "param_id": "tools",
+            "provider_min": null,
+            "provider_max": null,
+            "provider_default": null,
+            "notes": null
+          },
+          {
+            "param_id": "top_p",
+            "provider_min": null,
+            "provider_max": null,
+            "provider_default": 0.95,
+            "notes": null
+          }
+        ]
+      }
+    ]
+  },
+  {
     "api_model_id": "anthropic/claude-fable-5",
     "provider_api_model_id": "amazon-bedrock:anthropic/claude-fable-5",
     "provider_model_slug": "anthropic.claude-fable-5-v1",

--- a/packages/data/catalog/src/data/manifest.json
+++ b/packages/data/catalog/src/data/manifest.json
@@ -1995,6 +1995,7 @@
     "amazon-bedrock:text.generate:openai-gpt-oss-20b",
     "amazon-bedrock:text.generate:openai-gpt-oss-safeguard-120b",
     "amazon-bedrock:text.generate:openai-gpt-oss-safeguard-20b",
+    "amazon-bedrock:text.generate:x-ai-grok-4.3",
     "amazon-bedrock:text.generate:z-ai-glm-4.7",
     "amazon-bedrock:text.generate:z-ai-glm-4.7-flash",
     "amazon-bedrock:text.generate:z-ai-glm-5",

--- a/packages/data/catalog/src/data/pricing/amazon-bedrock/x-ai-grok-4.3/text.generate/pricing.json
+++ b/packages/data/catalog/src/data/pricing/amazon-bedrock/x-ai-grok-4.3/text.generate/pricing.json
@@ -1,0 +1,45 @@
+{
+  "key": "amazon-bedrock:x-ai/grok-4.3:text.generate",
+  "api_provider_id": "amazon-bedrock",
+  "provider_slug": "amazon-bedrock",
+  "api_model_id": "x-ai/grok-4.3",
+  "capability_id": "text.generate",
+  "rules": [
+    {
+      "meter": "input_text_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 1.25,
+      "currency": "USD",
+      "pricing_plan": "standard",
+      "note": null,
+      "match": [],
+      "priority": 100,
+      "effective_from": "2026-06-15T00:00:00Z"
+    },
+    {
+      "meter": "cached_read_text_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 0.2,
+      "currency": "USD",
+      "pricing_plan": "standard",
+      "note": null,
+      "match": [],
+      "priority": 100,
+      "effective_from": "2026-06-15T00:00:00Z"
+    },
+    {
+      "meter": "output_text_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 2.5,
+      "currency": "USD",
+      "pricing_plan": "standard",
+      "note": null,
+      "match": [],
+      "priority": 100,
+      "effective_from": "2026-06-15T00:00:00Z"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Stage disabled Amazon Bedrock provider coverage for xAI Grok 4.3 with the Bedrock Mantle slug and pricing.
- Route Bedrock `xai.*` Mantle model IDs through the OpenAI-compatible endpoint.
- Document the Bedrock xAI/OpenAI global support check in the changelog.

## Validation
- `pnpm validate:data`
- `pnpm --filter @ai-stats/gateway-api test -- amazon-bedrock/text-generate`

Created with Codex
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ai-stats/ai-stats/pull/784" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->