### PR TITLE
Fix Together model discovery

### DIFF
--- a/apps/api/src/pipeline/model-discovery/helpers.test.ts
+++ b/apps/api/src/pipeline/model-discovery/helpers.test.ts
@@ -12,6 +12,13 @@ const POOLSIDE_DISCOVERY_PROVIDER = {
 	apiKeyEnv: ["POOLSIDE_API_KEY"],
 } as const;
 
+const TOGETHER_DISCOVERY_PROVIDER = {
+	providerId: "together",
+	providerName: "Together",
+	modelsEndpoint: "https://api.together.ai/v1/models",
+	apiKeyEnv: ["TOGETHER_API_KEY"],
+} as const;
+
 afterEach(() => {
 	teardownTestRuntime();
 });
@@ -70,6 +77,60 @@ describe("fetchProviderModels", () => {
 			]);
 			expect(fetchMock.calls).toHaveLength(1);
 			expect(fetchMock.calls[0]?.headers.Authorization).toBe("Bearer test-poolside-key");
+		} finally {
+			fetchMock.restore();
+		}
+	});
+
+	it("extracts Together models from the documented top-level array response", async () => {
+		setupRuntimeFromEnv({
+			TOGETHER_API_KEY: "test-together-key",
+		} as any);
+
+		const fetchMock = installFetchMock([
+			{
+				match: (url) => url === "https://api.together.ai/v1/models",
+				response: jsonResponse([
+					{
+						id: "zai-org/GLM-5.2",
+						object: "model",
+						created: 1718582400,
+						type: "chat",
+						context_length: 262144,
+						pricing: {
+							input: 1.4,
+							output: 4.4,
+							cached_input: 0.26,
+						},
+					},
+					{
+						id: "moonshotai/Kimi-K2.7-Code",
+						object: "model",
+						created: 1718236800,
+						type: "code",
+						context_length: 262144,
+					},
+				]),
+			},
+		]);
+
+		try {
+			const models = await fetchProviderModels(TOGETHER_DISCOVERY_PROVIDER, "test-together-key");
+
+			expect(models.map((model) => model.id)).toEqual([
+				"moonshotai/Kimi-K2.7-Code",
+				"zai-org/GLM-5.2",
+			]);
+			expect(models[1]?.modelDetails.context_length).toBe(262144);
+			expect(models[1]?.pricingDetails).toEqual({
+				pricing: {
+					cached_input: 0.26,
+					input: 1.4,
+					output: 4.4,
+				},
+			});
+			expect(fetchMock.calls).toHaveLength(1);
+			expect(fetchMock.calls[0]?.headers.Authorization).toBe("Bearer test-together-key");
 		} finally {
 			fetchMock.restore();
 		}

--- a/apps/api/src/pipeline/model-discovery/helpers.ts
+++ b/apps/api/src/pipeline/model-discovery/helpers.ts
@@ -508,13 +508,11 @@ export function shouldIncludeDiscoveredModel(providerId: string, row: Record<str
 
 export function extractDiscoveredModels(providerId: string, payload: unknown): DiscoveredModel[] {
 	const root = asRecord(payload);
-	if (!root) return [];
-
-	const candidateCollections: unknown[] = [
-		root.data,
-		root.models,
-		asRecord(root.result)?.models,
-	];
+	const candidateCollections: unknown[] = Array.isArray(payload)
+		? [payload]
+		: root
+			? [root.data, root.models, asRecord(root.result)?.models]
+			: [];
 
 	const output = new Map<string, DiscoveredModel>();
 

--- a/apps/api/src/pipeline/model-discovery/index.ts
+++ b/apps/api/src/pipeline/model-discovery/index.ts
@@ -318,7 +318,7 @@ const PROVIDERS: ProviderConfig[] = [
 	},
 	{ providerId: "voyage", providerName: "Voyage", modelsEndpoint: "https://api.voyageai.com/v1/models", apiKeyEnv: ["VOYAGE_API_KEY"] },
 	{ providerId: "stepfun", providerName: "StepFun", modelsEndpoint: "https://api.stepfun.ai/v1/models", apiKeyEnv: ["STEPFUN_API_KEY"] },
-	{ providerId: "together", providerName: "Together", modelsEndpoint: "https://api.together.xyz/v1/models", apiKeyEnv: ["TOGETHER_API_KEY"] },
+	{ providerId: "together", providerName: "Together", modelsEndpoint: "https://api.together.ai/v1/models", apiKeyEnv: ["TOGETHER_API_KEY"] },
 	{ providerId: "venice", providerName: "Venice", modelsEndpoint: "https://api.venice.ai/api/v1/models", apiKeyEnv: ["VENICE_API_KEY"] },
 		{
 			providerId: "weights-and-biases",

--- a/apps/api/src/providers/openai-compatible/__tests__/config.test.ts
+++ b/apps/api/src/providers/openai-compatible/__tests__/config.test.ts
@@ -455,7 +455,7 @@ describe("openAICompatUrl", () => {
 		} as any);
 
 		expect(openAICompatUrl("together", "/chat/completions")).toBe(
-			"https://api.together.xyz/v1/chat/completions",
+			"https://api.together.ai/v1/chat/completions",
 		);
 	});
 

--- a/apps/api/src/providers/together/config.ts
+++ b/apps/api/src/providers/together/config.ts
@@ -3,7 +3,7 @@ import type { OpenAICompatConfig } from "../openai-compatible/types";
 export const TOGETHER_OPENAI_COMPAT_CONFIGS = {
 	together: {
 		providerId: "together",
-		baseUrl: "https://api.together.xyz",
+		baseUrl: "https://api.together.ai",
 		pathPrefix: "/v1",
 		apiKeyEnv: "TOGETHER_API_KEY",
 		baseUrlEnv: "TOGETHER_BASE_URL",

--- a/scripts/model-discovery/check-new-models.py
+++ b/scripts/model-discovery/check-new-models.py
@@ -266,11 +266,17 @@ def fetch_together_models() -> list[str]:
     if not api_key:
         return []
     try:
-        response = requests.get('https://api.together.ai/models', headers={'Authorization': f'Bearer {api_key}'})
+        response = requests.get('https://api.together.ai/v1/models', headers={'Authorization': f'Bearer {api_key}'})
         if response.status_code != 200:
             return []
         data = response.json()
-        return [f"together/{m['id']}" for m in data.get('data', [])]
+        if isinstance(data, list):
+            rows = data
+        elif isinstance(data, dict):
+            rows = data.get('data', [])
+        else:
+            rows = []
+        return [f"together/{m['id']}" for m in rows if isinstance(m, dict) and 'id' in m]
     except requests.RequestException:
         return []
 

--- a/scripts/model-discovery/check-new-models.py
+++ b/scripts/model-discovery/check-new-models.py
@@ -266,7 +266,7 @@ def fetch_together_models() -> list[str]:
     if not api_key:
         return []
     try:
-        response = requests.get('https://api.together.ai/v1/models', headers={'Authorization': f'Bearer {api_key}'})
+        response = requests.get('https://api.together.ai/v1/models', headers={'Authorization': f'Bearer {api_key}'}, timeout=30)
         if response.status_code != 200:
             return []
         data = response.json()

--- a/scripts/model-discovery/providers/discovery-policy.ts
+++ b/scripts/model-discovery/providers/discovery-policy.ts
@@ -411,7 +411,7 @@ export const PLATFORM_DISCOVERY_RULES: PlatformDiscoveryRule[] = [
         platformId: "together",
         platformName: "Together",
         providerIds: ["together"],
-        modelsEndpoint: "https://api.together.xyz/v1/models",
+        modelsEndpoint: "https://api.together.ai/v1/models",
         active: true,
     },
     {

--- a/scripts/model-discovery/providers/together.ts
+++ b/scripts/model-discovery/providers/together.ts
@@ -4,7 +4,7 @@ export default defineOpenAICompatibleProvider({
     providerId: "together",
     name: "Together",
     apiKeyEnv: "TOGETHER_API_KEY",
-    baseUrl: "https://api.together.xyz",
+    baseUrl: "https://api.together.ai",
     baseUrlEnv: "TOGETHER_BASE_URL",
     pathPrefix: "/v1",
 });


### PR DESCRIPTION
## Summary

This PR scopes only the Together API fixes:

- switch the API-layer Together base URL from `api.together.xyz` to `api.together.ai`
- update the API model-discovery watcher to accept Together's top-level array `/v1/models` response
- update the legacy Together discovery checker to call `/v1/models` and handle both array and wrapped responses

## Validation

- `pnpm --filter @ai-stats/gateway-api exec vitest run src/providers/openai-compatible/__tests__/config.test.ts src/pipeline/model-discovery/helpers.test.ts`
- Live Together discovery probe via `fetchProviderModels(...)` against `https://api.together.ai/v1/models`
  - returned `265` models
  - confirmed presence of `zai-org/GLM-5.2`
  - confirmed presence of `moonshotai/Kimi-K2.7-Code`
  - confirmed presence of `MiniMaxAI/MiniMax-M3`

Created with Codex

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ai-stats/ai-stats/pull/789" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated Together AI provider configuration to use the correct production API endpoint, improving reliability and connectivity.
  * Enhanced the model discovery pipeline to properly handle both array-based and object-based model responses from providers.
  * Improved extraction and parsing of model metadata including context length and pricing details from provider APIs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->