### PR TITLE
Refresh Together provider models

### DIFF
--- a/packages/data/catalog/src/data/api_providers/together/models.json
+++ b/packages/data/catalog/src/data/api_providers/together/models.json
@@ -25,7 +25,7 @@
     "provider_api_model_id": "together:deepseek/deepseek-r1-0528",
     "provider_model_slug": "deepseek-ai/DeepSeek-R1",
     "internal_model_id": "deepseek/deepseek-r1-2025-05-28",
-    "is_active_gateway": true,
+    "is_active_gateway": false,
     "quantization_scheme": "FP4",
     "input_modalities": "text",
     "output_modalities": "text",
@@ -53,7 +53,7 @@
     "context_length": 128000,
     "max_output_tokens": 128000,
     "effective_from": null,
-    "effective_to": "2026-05-21T00:00:00",
+    "effective_to": "2026-05-14T00:00:00",
     "capabilities": [
       {
         "capability_id": "text.generate",
@@ -252,6 +252,27 @@
     ]
   },
   {
+    "api_model_id": "minimax/minimax-m3",
+    "provider_api_model_id": "together:minimax/minimax-m3",
+    "provider_model_slug": "MiniMaxAI/MiniMax-M3",
+    "internal_model_id": "minimax/minimax-m3",
+    "is_active_gateway": true,
+    "quantization_scheme": "FP4",
+    "input_modalities": "text",
+    "output_modalities": "text",
+    "context_length": 524288,
+    "max_output_tokens": 524288,
+    "effective_from": "2026-06-12T00:00:00",
+    "effective_to": null,
+    "capabilities": [
+      {
+        "capability_id": "text.generate",
+        "status": "active",
+        "params": []
+      }
+    ]
+  },
+  {
     "api_model_id": "moonshotai/kimi-k2.5",
     "provider_api_model_id": "together:moonshotai/kimi-k2.5",
     "provider_model_slug": "moonshotai/Kimi-K2.5",
@@ -263,7 +284,7 @@
     "context_length": 262144,
     "max_output_tokens": 262144,
     "effective_from": null,
-    "effective_to": null,
+    "effective_to": "2026-05-21T00:00:00",
     "capabilities": [
       {
         "capability_id": "text.generate",
@@ -284,6 +305,27 @@
     "context_length": 262144,
     "max_output_tokens": 262144,
     "effective_from": null,
+    "effective_to": null,
+    "capabilities": [
+      {
+        "capability_id": "text.generate",
+        "status": "active",
+        "params": []
+      }
+    ]
+  },
+  {
+    "api_model_id": "moonshotai/kimi-k2.7-code",
+    "provider_api_model_id": "together:moonshotai/kimi-k2.7-code",
+    "provider_model_slug": "moonshotai/Kimi-K2.7-Code",
+    "internal_model_id": "moonshotai/kimi-k2.7-code",
+    "is_active_gateway": true,
+    "quantization_scheme": "FP4",
+    "input_modalities": "text",
+    "output_modalities": "text",
+    "context_length": 262144,
+    "max_output_tokens": 262144,
+    "effective_from": "2026-06-13T00:00:00",
     "effective_to": null,
     "capabilities": [
       {
@@ -403,14 +445,14 @@
     "provider_api_model_id": "together:qwen/qwen3-coder-next",
     "provider_model_slug": "Qwen/Qwen3-Coder-Next-FP8",
     "internal_model_id": "qwen/qwen3-coder-next",
-    "is_active_gateway": true,
+    "is_active_gateway": false,
     "quantization_scheme": "FP8",
     "input_modalities": "text",
     "output_modalities": "text",
     "context_length": 262144,
     "max_output_tokens": 262144,
     "effective_from": null,
-    "effective_to": null,
+    "effective_to": "2026-05-14T00:00:00",
     "capabilities": [
       {
         "capability_id": "text.generate",
@@ -515,6 +557,27 @@
     "context_length": 202752,
     "max_output_tokens": 202752,
     "effective_from": null,
+    "effective_to": null,
+    "capabilities": [
+      {
+        "capability_id": "text.generate",
+        "status": "active",
+        "params": []
+      }
+    ]
+  },
+  {
+    "api_model_id": "z-ai/glm-5.2",
+    "provider_api_model_id": "together:z-ai/glm-5.2",
+    "provider_model_slug": "zai-org/GLM-5.2",
+    "internal_model_id": "z-ai/glm-5.2",
+    "is_active_gateway": true,
+    "quantization_scheme": "FP4",
+    "input_modalities": "text",
+    "output_modalities": "text",
+    "context_length": 262144,
+    "max_output_tokens": 262144,
+    "effective_from": "2026-06-17T00:00:00",
     "effective_to": null,
     "capabilities": [
       {

--- a/packages/data/catalog/src/data/pricing/together/minimax-minimax-m3/text.generate/pricing.json
+++ b/packages/data/catalog/src/data/pricing/together/minimax-minimax-m3/text.generate/pricing.json
@@ -1,0 +1,42 @@
+{
+  "key": "together:minimax/minimax-m3:text.generate",
+  "api_provider_id": "together",
+  "provider_slug": "together",
+  "api_model_id": "minimax/minimax-m3",
+  "capability_id": "text.generate",
+  "rules": [
+    {
+      "meter": "input_text_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 0.3,
+      "currency": "USD",
+      "pricing_plan": "standard",
+      "note": null,
+      "match": [],
+      "priority": 100
+    },
+    {
+      "meter": "cached_read_text_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 0.06,
+      "currency": "USD",
+      "pricing_plan": "standard",
+      "note": null,
+      "match": [],
+      "priority": 100
+    },
+    {
+      "meter": "output_text_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 1.2,
+      "currency": "USD",
+      "pricing_plan": "standard",
+      "note": null,
+      "match": [],
+      "priority": 100
+    }
+  ]
+}

--- a/packages/data/catalog/src/data/pricing/together/minimax-minimax-m3/text.generate/pricing.json
+++ b/packages/data/catalog/src/data/pricing/together/minimax-minimax-m3/text.generate/pricing.json
@@ -14,7 +14,8 @@
       "pricing_plan": "standard",
       "note": null,
       "match": [],
-      "priority": 100
+      "priority": 100,
+      "effective_from": "2026-06-12T00:00:00Z"
     },
     {
       "meter": "cached_read_text_tokens",
@@ -25,7 +26,8 @@
       "pricing_plan": "standard",
       "note": null,
       "match": [],
-      "priority": 100
+      "priority": 100,
+      "effective_from": "2026-06-12T00:00:00Z"
     },
     {
       "meter": "output_text_tokens",
@@ -36,7 +38,8 @@
       "pricing_plan": "standard",
       "note": null,
       "match": [],
-      "priority": 100
+      "priority": 100,
+      "effective_from": "2026-06-12T00:00:00Z"
     }
   ]
 }

--- a/packages/data/catalog/src/data/pricing/together/moonshotai-kimi-k2.7-code/text.generate/pricing.json
+++ b/packages/data/catalog/src/data/pricing/together/moonshotai-kimi-k2.7-code/text.generate/pricing.json
@@ -1,0 +1,42 @@
+{
+  "key": "together:moonshotai/kimi-k2.7-code:text.generate",
+  "api_provider_id": "together",
+  "provider_slug": "together",
+  "api_model_id": "moonshotai/kimi-k2.7-code",
+  "capability_id": "text.generate",
+  "rules": [
+    {
+      "meter": "input_text_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 0.95,
+      "currency": "USD",
+      "pricing_plan": "standard",
+      "note": null,
+      "match": [],
+      "priority": 100
+    },
+    {
+      "meter": "cached_read_text_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 0.19,
+      "currency": "USD",
+      "pricing_plan": "standard",
+      "note": null,
+      "match": [],
+      "priority": 100
+    },
+    {
+      "meter": "output_text_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 4,
+      "currency": "USD",
+      "pricing_plan": "standard",
+      "note": null,
+      "match": [],
+      "priority": 100
+    }
+  ]
+}

--- a/packages/data/catalog/src/data/pricing/together/moonshotai-kimi-k2.7-code/text.generate/pricing.json
+++ b/packages/data/catalog/src/data/pricing/together/moonshotai-kimi-k2.7-code/text.generate/pricing.json
@@ -14,7 +14,8 @@
       "pricing_plan": "standard",
       "note": null,
       "match": [],
-      "priority": 100
+      "priority": 100,
+      "effective_from": "2026-06-13T00:00:00Z"
     },
     {
       "meter": "cached_read_text_tokens",
@@ -25,7 +26,8 @@
       "pricing_plan": "standard",
       "note": null,
       "match": [],
-      "priority": 100
+      "priority": 100,
+      "effective_from": "2026-06-13T00:00:00Z"
     },
     {
       "meter": "output_text_tokens",
@@ -36,7 +38,8 @@
       "pricing_plan": "standard",
       "note": null,
       "match": [],
-      "priority": 100
+      "priority": 100,
+      "effective_from": "2026-06-13T00:00:00Z"
     }
   ]
 }

--- a/packages/data/catalog/src/data/pricing/together/z-ai-glm-5.2/text.generate/pricing.json
+++ b/packages/data/catalog/src/data/pricing/together/z-ai-glm-5.2/text.generate/pricing.json
@@ -1,0 +1,42 @@
+{
+  "key": "together:z-ai/glm-5.2:text.generate",
+  "api_provider_id": "together",
+  "provider_slug": "together",
+  "api_model_id": "z-ai/glm-5.2",
+  "capability_id": "text.generate",
+  "rules": [
+    {
+      "meter": "input_text_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 1.4,
+      "currency": "USD",
+      "pricing_plan": "standard",
+      "note": null,
+      "match": [],
+      "priority": 100
+    },
+    {
+      "meter": "cached_read_text_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 0.26,
+      "currency": "USD",
+      "pricing_plan": "standard",
+      "note": null,
+      "match": [],
+      "priority": 100
+    },
+    {
+      "meter": "output_text_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 4.4,
+      "currency": "USD",
+      "pricing_plan": "standard",
+      "note": null,
+      "match": [],
+      "priority": 100
+    }
+  ]
+}

--- a/packages/data/catalog/src/data/pricing/together/z-ai-glm-5.2/text.generate/pricing.json
+++ b/packages/data/catalog/src/data/pricing/together/z-ai-glm-5.2/text.generate/pricing.json
@@ -14,7 +14,8 @@
       "pricing_plan": "standard",
       "note": null,
       "match": [],
-      "priority": 100
+      "priority": 100,
+      "effective_from": "2026-06-17T00:00:00Z"
     },
     {
       "meter": "cached_read_text_tokens",
@@ -25,7 +26,8 @@
       "pricing_plan": "standard",
       "note": null,
       "match": [],
-      "priority": 100
+      "priority": 100,
+      "effective_from": "2026-06-17T00:00:00Z"
     },
     {
       "meter": "output_text_tokens",
@@ -36,7 +38,8 @@
       "pricing_plan": "standard",
       "note": null,
       "match": [],
-      "priority": 100
+      "priority": 100,
+      "effective_from": "2026-06-17T00:00:00Z"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- add MiniMaxAI/MiniMax-M3, moonshotai/Kimi-K2.7-Code, and zai-org/GLM-5.2 to Together's provider catalog
- keep Together support for MiniMaxAI/MiniMax-M2.7, moonshotai/Kimi-K2.6, and zai-org/GLM-5.1
- retire Together rows for deepseek-ai/DeepSeek-R1, deepseek-ai/DeepSeek-V3.1, moonshotai/Kimi-K2.5, and Qwen/Qwen3-Coder-Next-FP8 based on Together's current changelog state

## Why
Together's provider catalog on main was out of date relative to the current serverless lineup. This updates the provider rows to match the approved shortlist without mirroring the full upstream models feed.

## Validation
- pnpm validate:data
- pnpm validate:gateway

Created with Codex
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ai-stats/ai-stats/pull/793" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Updates**
  * Refreshed availability windows and gateway routing flags for select Together models
  * Added three new Together models to the catalog: minimax/minimax-m3, moonshotai/kimi-k2.7-code, and z-ai/glm-5.2
  * Introduced new text generation pricing for minimax/minimax-m3, moonshotai/kimi-k2.7-code, and z-ai/glm-5.2
<!-- end of auto-generated comment: release notes by coderabbit.ai -->