### PR TITLE
Add Laguna M.1 Hugging Face weights metadata

### DIFF
--- a/packages/data/catalog/src/data/models/poolside/laguna-m.1/model.json
+++ b/packages/data/catalog/src/data/models/poolside/laguna-m.1/model.json
@@ -4,12 +4,12 @@
   "name": "Laguna M.1",
   "status": "Available",
   "previous_model_id": null,
-  "description": "Laguna M.1 is a language model from Poolside for chat, writing, analysis, and general-purpose automation. It accepts text inputs and produces text outputs.",
+  "description": "Laguna M.1 is Poolside's flagship 225B total parameter agentic coding model for long-horizon work, now available as open weights on Hugging Face under Apache 2.0.",
   "announced_date": null,
   "release_date": null,
   "deprecation_date": null,
   "retirement_date": null,
-  "license": "Proprietary",
+  "license": "Apache 2.0",
   "input_types": "text",
   "output_types": "text",
   "api_model_id": "poolside/laguna-m.1",
@@ -21,6 +21,14 @@
     {
       "platform": "documentation",
       "url": "https://docs.poolside.ai/release-notes/laguna-m1"
+    },
+    {
+      "platform": "repository",
+      "url": "https://huggingface.co/poolside/Laguna-M.1"
+    },
+    {
+      "platform": "weights",
+      "url": "https://hf.co/collections/poolside/laguna-m1"
     }
   ],
   "details": [


### PR DESCRIPTION
## What changed
- updated the `poolside/laguna-m.1` catalog record to reflect the new open-weight release
- switched the model license from `Proprietary` to `Apache 2.0`
- added the Hugging Face repository link and the Poolside Laguna M.1 weights collection link
- refreshed the description so the model page reflects Poolside's current positioning

## Why
Poolside has now published Laguna M.1 weights on Hugging Face, including the base and post-trained checkpoints. The catalog entry still looked like an API-only proprietary model, so the model page was missing the weights surface entirely.

## Impact
Users browsing the model catalog can now reach the Laguna M.1 Hugging Face assets directly, and the displayed license matches the newly published open-weight release.

## Validation
- `pnpm tsx packages/data/catalog/src/data/validate.ts`

Created with Codex