### PR TITLE
Improve API key reveal flows

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -30,6 +30,7 @@
 		"test": "jest --runInBand"
 	},
 	"dependencies": {
+		"@1password/save-button": "^1.3.0",
 		"@base-ui/react": "^1.3.0",
 		"@dqbd/tiktoken": "^1.0.22",
 		"@flags-sdk/statsig": "^0.2.5",

--- a/apps/web/src/app/(dashboard)/settings/keys/actions.ts
+++ b/apps/web/src/app/(dashboard)/settings/keys/actions.ts
@@ -1,6 +1,5 @@
 "use server"
 
-import { createClient } from '@/utils/supabase/server'
 import { revalidatePath } from 'next/cache'
 import { makeKeyV2, hmacSecret } from '@/lib/keygen';
 import { invalidateGatewayKeyCache } from '@/lib/gateway/invalidateKeyCache';
@@ -28,6 +27,12 @@ export type RotateApiKeyInput = {
     previousKeyExpiresAt?: string | null;
 };
 
+function nonNegativeInteger(value: unknown): number {
+    const parsed = Number(value);
+    if (!Number.isFinite(parsed) || parsed <= 0) return 0;
+    return Math.floor(parsed);
+}
+
 function isMissingExpiresAtColumnError(error: unknown): boolean {
     const message = String((error as { message?: unknown } | null)?.message ?? "").toLowerCase();
     return message.includes("expires_at") && message.includes("schema cache");
@@ -37,7 +42,8 @@ export async function createApiKeyAction(
     name: string,
     creatorUserId: string,
     workspaceId: string,
-    scopes: string = '[]' // store JSON string if that's your current pattern
+    scopes: string = '[]', // store JSON string if that's your current pattern
+    limits?: KeyLimitPayload
 ) {
     if (!name) throw new Error('Missing name');
     if (!creatorUserId) throw new Error('Missing creatorUserId');
@@ -64,14 +70,14 @@ export async function createApiKeyAction(
         created_by: creatorUserId,
         // DB constraints: request limit columns are NOT NULL.
         // Use 0 to represent "no request limit".
-        daily_limit_requests: 0,
-        weekly_limit_requests: 0,
-        monthly_limit_requests: 0,
+        daily_limit_requests: nonNegativeInteger(limits?.dailyRequests),
+        weekly_limit_requests: nonNegativeInteger(limits?.weeklyRequests),
+        monthly_limit_requests: nonNegativeInteger(limits?.monthlyRequests),
         // DB constraints: cost limit nanos columns are NOT NULL.
         // Use 0 to represent "no cost limit" (UI can still treat 0 as unlimited).
-        daily_limit_cost_nanos: 0,
-        weekly_limit_cost_nanos: 0,
-        monthly_limit_cost_nanos: 0,
+        daily_limit_cost_nanos: nonNegativeInteger(limits?.dailyCostNanos),
+        weekly_limit_cost_nanos: nonNegativeInteger(limits?.weeklyCostNanos),
+        monthly_limit_cost_nanos: nonNegativeInteger(limits?.monthlyCostNanos),
     };
 
     const { data, error } = await supabase

--- a/apps/web/src/app/api/internal/secret-ux/test-key/route.ts
+++ b/apps/web/src/app/api/internal/secret-ux/test-key/route.ts
@@ -1,0 +1,85 @@
+import { NextResponse } from "next/server";
+
+import { AI_STATS_GATEWAY_BASE_URL } from "@/lib/gateway/secretReveal";
+import { createClient } from "@/utils/supabase/server";
+
+function gatewayBaseUrl() {
+	const raw = (
+		process.env.NEXT_PUBLIC_GATEWAY_API_URL ??
+		process.env.NEXT_PUBLIC_API_URL ??
+		AI_STATS_GATEWAY_BASE_URL
+	).replace(/\/+$/, "");
+	return raw.endsWith("/v1") ? raw : `${raw}/v1`;
+}
+
+function looksLikeAiStatsKey(value: string) {
+	return /^aistats(_v\d+)?_sk_[A-Za-z0-9_-]{16,}$/.test(value);
+}
+
+export async function POST(request: Request) {
+	const supabase = await createClient();
+	const {
+		data: { user },
+	} = await supabase.auth.getUser();
+
+	if (!user) {
+		return NextResponse.json(
+			{ ok: false, message: "Sign in to test API keys." },
+			{ status: 401 },
+		);
+	}
+
+	const body = await request.json().catch(() => ({}));
+	const apiKey = typeof body?.apiKey === "string" ? body.apiKey.trim() : "";
+	if (!apiKey || !looksLikeAiStatsKey(apiKey)) {
+		return NextResponse.json(
+			{ ok: false, message: "This does not look like an AI Stats API key." },
+			{ status: 400 },
+		);
+	}
+
+	try {
+		const response = await fetch(
+			`${gatewayBaseUrl()}/models?endpoints=chat/completions`,
+			{
+				headers: {
+					Authorization: `Bearer ${apiKey}`,
+				},
+				cache: "no-store",
+			},
+		);
+		const payload = await response.json().catch(() => null);
+		if (!response.ok) {
+			const message =
+				typeof payload?.error?.message === "string"
+					? payload.error.message
+					: typeof payload?.message === "string"
+						? payload.message
+						: response.status === 401
+							? "The gateway rejected this key."
+							: "The gateway could not verify this key.";
+			return NextResponse.json(
+				{ ok: false, status: response.status, message },
+				{ status: 400 },
+			);
+		}
+
+		const modelCount = Array.isArray(payload?.data)
+			? payload.data.length
+			: Array.isArray(payload)
+				? payload.length
+				: null;
+		return NextResponse.json(
+			{ ok: true, status: response.status, modelCount },
+			{ headers: { "Cache-Control": "no-store" } },
+		);
+	} catch {
+		return NextResponse.json(
+			{
+				ok: false,
+				message: "Could not reach the gateway to test this key.",
+			},
+			{ status: 502 },
+		);
+	}
+}

--- a/apps/web/src/components/(gateway)/onboarding/InteractiveOnboarding.tsx
+++ b/apps/web/src/components/(gateway)/onboarding/InteractiveOnboarding.tsx
@@ -20,6 +20,7 @@ import { CodeBlock as HighlightedCodeBlock } from "@/components/ai-elements/code
 import { Logo } from "@/components/Logo";
 import { Button } from "@/components/ui/button";
 import { CopyButton } from "@/components/ui/copy-button";
+import { SecretRevealActions } from "@/components/(gateway)/settings/keys/SecretRevealActions";
 import {
 	Drawer,
 	DrawerContent,
@@ -782,10 +783,12 @@ export default function InteractiveOnboarding({
 													<code className="min-w-0 flex-1 overflow-auto whitespace-nowrap text-sm">
 														{createdPlaintextKey}
 													</code>
-													<CopyButton
-														content={createdPlaintextKey}
-														variant="outline"
-														onCopy={() => toast.success("Copied API key")}
+												</div>
+												<div className="mt-3">
+													<SecretRevealActions
+														secret={createdPlaintextKey}
+														name={keyName || "AI Stats onboarding key"}
+														kind="api-key"
 													/>
 												</div>
 											</div>

--- a/apps/web/src/components/(gateway)/settings/keys/CreateKeyDialog.tsx
+++ b/apps/web/src/components/(gateway)/settings/keys/CreateKeyDialog.tsx
@@ -13,7 +13,6 @@ import {
 import { Button } from "@/components/ui/button";
 import { Plus } from "lucide-react";
 import { Input } from "@/components/ui/input";
-import { CopyButton } from "@/components/ui/copy-button";
 import { createApiKeyAction } from "@/app/(dashboard)/settings/keys/actions";
 import {
 	DropdownMenu,
@@ -23,6 +22,12 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { ChevronDown } from "lucide-react";
 import { toast } from "sonner";
+import {
+	API_KEY_LIMIT_PRESETS,
+	getApiKeyPreset,
+	type ApiKeyPresetId,
+} from "@/lib/gateway/secretReveal";
+import { SecretRevealActions } from "./SecretRevealActions";
 
 export default function CreateKeyDialog({
 	currentUserId,
@@ -43,6 +48,8 @@ export default function CreateKeyDialog({
 	const [name, setName] = useState("");
 	const [loading, setLoading] = useState(false);
 	const [plainKey, setPlainKey] = useState<string | null>(null);
+	const [selectedPresetId, setSelectedPresetId] =
+		useState<ApiKeyPresetId>("production");
 	const [selectedTeamId, setSelectedTeamId] = useState<string | null>(
 		resolvedCurrentTeamId
 	);
@@ -70,7 +77,8 @@ export default function CreateKeyDialog({
 				name,
 				currentUserId as string,
 				teamArg,
-				JSON.stringify([]) // default empty scopes
+				JSON.stringify([]), // default empty scopes
+				getApiKeyPreset(selectedPresetId).limits
 			);
 			setPlainKey(res?.plaintext ?? null);
 		} catch (err: any) {
@@ -82,16 +90,11 @@ export default function CreateKeyDialog({
 		}
 	}
 
-	function onCopy() {
-		if (!plainKey) return;
-		// CopyButton already writes to clipboard; just show a toast
-		toast.success("Copied to clipboard", { duration: 2000 });
-	}
-
 	function onClose() {
 		setOpen(false);
 		setName("");
 		setPlainKey(null);
+		setSelectedPresetId("production");
 	}
 
 	return (
@@ -171,6 +174,34 @@ export default function CreateKeyDialog({
 							onChange={(e) => setName(e.target.value)}
 							placeholder="Key name (e.g. my app)"
 						/>
+						<div className="space-y-2">
+							<div className="text-sm font-medium">Preset</div>
+							<div className="grid gap-2 sm:grid-cols-2">
+								{API_KEY_LIMIT_PRESETS.map((preset) => {
+									const selected = selectedPresetId === preset.id;
+									return (
+										<button
+											key={preset.id}
+											type="button"
+											onClick={() => setSelectedPresetId(preset.id)}
+											className={[
+												"rounded-md border p-3 text-left transition",
+												selected
+													? "border-foreground bg-muted/60"
+													: "border-border hover:border-foreground/40",
+											].join(" ")}
+										>
+											<div className="text-sm font-medium">
+												{preset.label}
+											</div>
+											<div className="mt-1 text-xs leading-5 text-muted-foreground">
+												{preset.description}
+											</div>
+										</button>
+									);
+								})}
+							</div>
+						</div>
 						<DialogFooter>
 							<DialogClose asChild>
 								<Button
@@ -198,15 +229,12 @@ export default function CreateKeyDialog({
 								Keep this code secret at all times.
 							</div>
 						</div>
+						<SecretRevealActions
+							secret={plainKey}
+							name={name || "AI Stats API key"}
+							kind="api-key"
+						/>
 						<DialogFooter>
-							<CopyButton
-								content={plainKey ?? ""}
-								size="default"
-								variant="outline"
-								onCopy={() => onCopy()}
-								className="mr-2"
-								aria-label="Copy API key"
-							/>
 							<DialogClose asChild>
 								<Button onClick={onClose}>Done</Button>
 							</DialogClose>

--- a/apps/web/src/components/(gateway)/settings/keys/OnePasswordSaveButton.tsx
+++ b/apps/web/src/components/(gateway)/settings/keys/OnePasswordSaveButton.tsx
@@ -1,0 +1,73 @@
+"use client";
+
+import * as React from "react";
+
+type OnePasswordSaveButtonProps = {
+	title: string;
+	secret: string;
+	notes?: string;
+	urls?: string[];
+};
+
+type SaveButtonModule = {
+	activateOPButton?: () => void;
+	encodeOPSaveRequest?: (request: {
+		title: string;
+		fields: Array<{ autocomplete: string; value: string }>;
+		notes?: string;
+		urls?: string[];
+	}) => string | undefined;
+};
+
+export function OnePasswordSaveButton({
+	title,
+	secret,
+	notes,
+	urls,
+}: OnePasswordSaveButtonProps) {
+	const [encodedValue, setEncodedValue] = React.useState<string | null>(null);
+
+	React.useEffect(() => {
+		let cancelled = false;
+
+		async function loadButton() {
+			try {
+				const saveButton = (await import(
+					"@1password/save-button"
+				)) as SaveButtonModule;
+				const encoded = saveButton.encodeOPSaveRequest?.({
+					title,
+					fields: [
+						{
+							autocomplete: "current-password",
+							value: secret,
+						},
+					],
+					notes,
+					urls,
+				});
+				if (!cancelled && encoded) {
+					setEncodedValue(encoded);
+					window.setTimeout(() => saveButton.activateOPButton?.(), 0);
+				}
+			} catch {
+				// The browser extension is optional; other reveal actions still work.
+			}
+		}
+
+		void loadButton();
+		return () => {
+			cancelled = true;
+		};
+	}, [title, secret, notes, urls]);
+
+	if (!encodedValue) return null;
+
+	return React.createElement("onepassword-save-button", {
+		"data-onepassword-type": "api-key",
+		value: encodedValue,
+		lang: "en",
+		"data-theme": "light",
+		padding: "compact",
+	});
+}

--- a/apps/web/src/components/(gateway)/settings/keys/RotateKeyItem.tsx
+++ b/apps/web/src/components/(gateway)/settings/keys/RotateKeyItem.tsx
@@ -14,7 +14,6 @@ import {
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import { CopyButton } from "@/components/ui/copy-button";
 import {
 	Select,
 	SelectContent,
@@ -25,6 +24,7 @@ import {
 import { RefreshCw } from "lucide-react";
 import { toast } from "sonner";
 import { rotateApiKeyAction } from "@/app/(dashboard)/settings/keys/actions";
+import { SecretRevealActions } from "./SecretRevealActions";
 
 type ExpiryMode = "immediate" | "1h" | "24h" | "7d" | "custom" | "never";
 
@@ -205,13 +205,12 @@ export default function RotateKeyItem({ k }: { k: any }) {
 						<div className="text-sm text-muted-foreground font-semibold">
 							Store this key now. It will not be shown again.
 						</div>
+						<SecretRevealActions
+							secret={newPlaintext}
+							name={newName || "AI Stats rotated API key"}
+							kind="api-key"
+						/>
 						<DialogFooter>
-							<CopyButton
-								content={newPlaintext}
-								size="default"
-								variant="outline"
-								aria-label="Copy rotated API key"
-							/>
 							<DialogClose asChild>
 								<Button>Done</Button>
 							</DialogClose>

--- a/apps/web/src/components/(gateway)/settings/keys/SecretRevealActions.tsx
+++ b/apps/web/src/components/(gateway)/settings/keys/SecretRevealActions.tsx
@@ -1,0 +1,250 @@
+"use client";
+
+import * as React from "react";
+import {
+	Check,
+	ChevronDown,
+	Copy,
+	Download,
+	ShieldCheck,
+	TestTube2,
+} from "lucide-react";
+import { toast } from "sonner";
+
+import { Button } from "@/components/ui/button";
+import {
+	DropdownMenu,
+	DropdownMenuContent,
+	DropdownMenuItem,
+	DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import {
+	AI_STATS_GATEWAY_BASE_URL,
+	buildAppConfigSnippets,
+	buildCollectionExports,
+	buildEnvFile,
+} from "@/lib/gateway/secretReveal";
+import { OnePasswordSaveButton } from "./OnePasswordSaveButton";
+
+type SecretKind = "api-key" | "management-key";
+
+type SecretRevealActionsProps = {
+	secret: string;
+	name: string;
+	kind?: SecretKind;
+	envVarName?: string;
+	baseUrl?: string;
+	enableTest?: boolean;
+};
+
+type CopyTextButtonProps = {
+	value: string;
+	children: React.ReactNode;
+	onCopied?: () => void;
+	variant?: React.ComponentProps<typeof Button>["variant"];
+};
+
+function downloadTextFile(filename: string, content: string, mimeType: string) {
+	const blob = new Blob([content], { type: mimeType });
+	const url = URL.createObjectURL(blob);
+	const anchor = document.createElement("a");
+	anchor.href = url;
+	anchor.download = filename;
+	document.body.appendChild(anchor);
+	anchor.click();
+	anchor.remove();
+	window.setTimeout(() => URL.revokeObjectURL(url), 0);
+}
+
+function CopyTextButton({
+	value,
+	children,
+	onCopied,
+	variant = "outline",
+}: CopyTextButtonProps) {
+	const [copied, setCopied] = React.useState(false);
+
+	async function copy() {
+		try {
+			await navigator.clipboard.writeText(value);
+			setCopied(true);
+			window.setTimeout(() => setCopied(false), 2000);
+			onCopied?.();
+		} catch {
+			toast.error("Could not copy to clipboard");
+		}
+	}
+
+	return (
+		<Button type="button" variant={variant} size="sm" onClick={copy}>
+			{copied ? <Check className="h-4 w-4" /> : <Copy className="h-4 w-4" />}
+			{copied ? "Copied" : children}
+		</Button>
+	);
+}
+
+export function SecretRevealActions({
+	secret,
+	name,
+	kind = "api-key",
+	envVarName = kind === "management-key"
+		? "AI_STATS_MANAGEMENT_KEY"
+		: "AI_STATS_API_KEY",
+	baseUrl = AI_STATS_GATEWAY_BASE_URL,
+	enableTest = kind === "api-key",
+}: SecretRevealActionsProps) {
+	const [testState, setTestState] = React.useState<
+		"idle" | "testing" | "success" | "error"
+	>("idle");
+	const appConfigSnippets = React.useMemo(
+		() => buildAppConfigSnippets({ apiKey: secret, baseUrl }),
+		[secret, baseUrl],
+	);
+	const collectionExports = React.useMemo(
+		() => buildCollectionExports(baseUrl),
+		[baseUrl],
+	);
+	const envFile = React.useMemo(
+		() => buildEnvFile({ apiKey: secret, baseUrl, envVarName }),
+		[secret, baseUrl, envVarName],
+	);
+	const onePasswordUrls = React.useMemo(
+		() => ["https://ai-stats.phaseo.app", "https://api.phaseo.app"],
+		[],
+	);
+
+	async function testKey() {
+		setTestState("testing");
+		try {
+			const response = await fetch("/api/internal/secret-ux/test-key", {
+				method: "POST",
+				headers: { "Content-Type": "application/json" },
+				body: JSON.stringify({ apiKey: secret }),
+			});
+			const body = await response.json().catch(() => ({}));
+			if (!response.ok || body?.ok === false) {
+				throw new Error(
+					body?.message || "The key could not be verified right now.",
+				);
+			}
+			setTestState("success");
+			toast.success("Key works");
+		} catch (error) {
+			setTestState("error");
+			toast.error(
+				error instanceof Error ? error.message : "Could not test API key",
+			);
+		}
+	}
+
+	return (
+		<div className="space-y-3">
+			<div className="flex flex-wrap items-center gap-2">
+				<CopyTextButton
+					value={secret}
+					variant="default"
+					onCopied={() => toast.success("Copied key")}
+				>
+					Copy key
+				</CopyTextButton>
+				<CopyTextButton
+					value={envFile}
+					onCopied={() => toast.success("Copied .env")}
+				>
+					Copy .env
+				</CopyTextButton>
+
+				{kind === "api-key" ? (
+					<DropdownMenu>
+						<DropdownMenuTrigger asChild>
+							<Button type="button" variant="outline" size="sm">
+								Copy config
+								<ChevronDown className="h-4 w-4" />
+							</Button>
+						</DropdownMenuTrigger>
+						<DropdownMenuContent align="start">
+							{appConfigSnippets.map((snippet) => (
+								<DropdownMenuItem
+									key={snippet.id}
+									onSelect={() => {
+										void navigator.clipboard
+											.writeText(snippet.value)
+											.then(() => toast.success(`Copied ${snippet.label}`))
+											.catch(() => toast.error("Could not copy config"));
+									}}
+								>
+									{snippet.label}
+								</DropdownMenuItem>
+							))}
+						</DropdownMenuContent>
+					</DropdownMenu>
+				) : null}
+
+				{kind === "api-key" ? (
+					<DropdownMenu>
+						<DropdownMenuTrigger asChild>
+							<Button type="button" variant="outline" size="sm">
+								<Download className="h-4 w-4" />
+								Export
+								<ChevronDown className="h-4 w-4" />
+							</Button>
+						</DropdownMenuTrigger>
+						<DropdownMenuContent align="start">
+							{collectionExports.map((item) => (
+								<DropdownMenuItem
+									key={item.id}
+									onSelect={() => {
+										downloadTextFile(
+											item.filename,
+											item.content,
+											item.mimeType,
+										);
+										toast.success(`Downloaded ${item.label} collection`);
+									}}
+								>
+									{item.label}
+								</DropdownMenuItem>
+							))}
+						</DropdownMenuContent>
+					</DropdownMenu>
+				) : null}
+
+				{enableTest ? (
+					<Button
+						type="button"
+						variant="outline"
+						size="sm"
+						onClick={testKey}
+						disabled={testState === "testing"}
+					>
+						{testState === "success" ? (
+							<ShieldCheck className="h-4 w-4 text-emerald-600" />
+						) : (
+							<TestTube2 className="h-4 w-4" />
+						)}
+						{testState === "testing" ? "Testing..." : "Test key"}
+					</Button>
+				) : null}
+			</div>
+
+			<div className="flex flex-wrap items-center gap-2">
+				<OnePasswordSaveButton
+					title={name || "AI Stats API key"}
+					secret={secret}
+					notes={
+						kind === "management-key"
+							? "AI Stats management API key. Store securely and use only for management API calls."
+							: "AI Stats Gateway API key. Keep server-side and rotate if exposed."
+					}
+					urls={onePasswordUrls}
+				/>
+				{kind === "api-key" ? (
+					<p className="text-xs text-muted-foreground">
+						Exports use placeholders so downloaded collections do not contain the
+						secret.
+					</p>
+				) : null}
+			</div>
+		</div>
+	);
+}

--- a/apps/web/src/components/(gateway)/settings/management-api-keys/CreateManagementKeyDialog.tsx
+++ b/apps/web/src/components/(gateway)/settings/management-api-keys/CreateManagementKeyDialog.tsx
@@ -13,7 +13,6 @@ import {
 import { Button } from "@/components/ui/button";
 import { Plus, ShieldAlert } from "lucide-react";
 import { Input } from "@/components/ui/input";
-import { CopyButton } from "@/components/ui/copy-button";
 import { createManagementKeyAction } from "@/app/(dashboard)/settings/management-api-keys/actions";
 import {
 	DropdownMenu,
@@ -23,6 +22,7 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { ChevronDown } from "lucide-react";
 import { toast } from "sonner";
+import { SecretRevealActions } from "../keys/SecretRevealActions";
 
 function toIsoFromDateTimeLocalInput(value: string): string | null {
 	if (!value) return null;
@@ -71,7 +71,10 @@ export default function CreateManagementKeyDialog({
 	React.useEffect(() => {
 		const nextWorkspaceId = resolveInitialWorkspaceId();
 		if (nextWorkspaceId !== selectedWorkspaceId) {
-			setSelectedWorkspaceId(nextWorkspaceId);
+			const timeoutId = window.setTimeout(() => {
+				setSelectedWorkspaceId(nextWorkspaceId);
+			}, 0);
+			return () => window.clearTimeout(timeoutId);
 		}
 	}, [resolveInitialWorkspaceId, selectedWorkspaceId]);
 
@@ -108,11 +111,6 @@ export default function CreateManagementKeyDialog({
 		} finally {
 			setLoading(false);
 		}
-	}
-
-	function onCopy() {
-		if (!plainKey) return;
-		toast.success("Copied to clipboard", { duration: 2000 });
 	}
 
 	function onClose() {
@@ -237,15 +235,13 @@ export default function CreateManagementKeyDialog({
 								privileges. Keep this code secret at all times.
 							</div>
 						</div>
+						<SecretRevealActions
+							secret={plainKey}
+							name={name || "AI Stats management API key"}
+							kind="management-key"
+							enableTest={false}
+						/>
 						<DialogFooter>
-							<CopyButton
-								content={plainKey ?? ""}
-								size="default"
-								variant="outline"
-								onCopy={() => onCopy()}
-								className="mr-2"
-								aria-label="Copy management API key"
-							/>
 							<DialogClose asChild>
 								<Button onClick={onClose}>Done</Button>
 							</DialogClose>

--- a/apps/web/src/lib/gateway/secretReveal.test.ts
+++ b/apps/web/src/lib/gateway/secretReveal.test.ts
@@ -1,0 +1,55 @@
+import {
+	API_KEY_LIMIT_PRESETS,
+	buildAppConfigSnippets,
+	buildCollectionExports,
+	buildEnvFile,
+	getApiKeyPreset,
+} from "./secretReveal";
+
+describe("secret reveal helpers", () => {
+	it("builds .env content with the selected env var and base URL", () => {
+		expect(
+			buildEnvFile({
+				apiKey: "aistats_v1_sk_kid_secret",
+				envVarName: "AI_STATS_MANAGEMENT_KEY",
+				baseUrl: "https://api.phaseo.app/v1/",
+			}),
+		).toBe(
+			'AI_STATS_MANAGEMENT_KEY="aistats_v1_sk_kid_secret"\nAI_STATS_BASE_URL="https://api.phaseo.app/v1"\n',
+		);
+	});
+
+	it("keeps downloaded collection exports free of the real secret", () => {
+		const exports = buildCollectionExports();
+		expect(exports.length).toBeGreaterThanOrEqual(3);
+		for (const item of exports) {
+			expect(item.content).toContain("paste-your-ai-stats-key");
+			expect(item.content).not.toContain("aistats_v1_sk_real");
+		}
+	});
+
+	it("includes ready app config snippets for common clients", () => {
+		const snippets = buildAppConfigSnippets({
+			apiKey: "aistats_v1_sk_real",
+		});
+		expect(snippets.map((snippet) => snippet.id)).toEqual(
+			expect.arrayContaining([
+				"openai-node",
+				"openai-python",
+				"vercel-ai-sdk",
+				"codex",
+				"claude-code",
+				"opencode",
+			]),
+		);
+	});
+
+	it("defines selectable API key presets with non-negative limits", () => {
+		expect(getApiKeyPreset("production").limits.dailyRequests).toBe(0);
+		for (const preset of API_KEY_LIMIT_PRESETS) {
+			for (const value of Object.values(preset.limits)) {
+				expect(value).toBeGreaterThanOrEqual(0);
+			}
+		}
+	});
+});

--- a/apps/web/src/lib/gateway/secretReveal.ts
+++ b/apps/web/src/lib/gateway/secretReveal.ts
@@ -1,0 +1,305 @@
+export const AI_STATS_GATEWAY_BASE_URL = "https://api.phaseo.app/v1";
+
+export type ApiKeyPresetId = "development" | "production" | "ci" | "sandbox";
+
+export type ApiKeyLimitPreset = {
+	id: ApiKeyPresetId;
+	label: string;
+	description: string;
+	limits: {
+		dailyRequests: number;
+		weeklyRequests: number;
+		monthlyRequests: number;
+		dailyCostNanos: number;
+		weeklyCostNanos: number;
+		monthlyCostNanos: number;
+	};
+};
+
+export const API_KEY_LIMIT_PRESETS: ApiKeyLimitPreset[] = [
+	{
+		id: "development",
+		label: "Development",
+		description: "Low daily spend cap for local apps and prototypes.",
+		limits: {
+			dailyRequests: 1_000,
+			weeklyRequests: 0,
+			monthlyRequests: 0,
+			dailyCostNanos: 1_000_000_000,
+			weeklyCostNanos: 0,
+			monthlyCostNanos: 0,
+		},
+	},
+	{
+		id: "production",
+		label: "Production",
+		description: "No preset caps. Add limits later if you need them.",
+		limits: {
+			dailyRequests: 0,
+			weeklyRequests: 0,
+			monthlyRequests: 0,
+			dailyCostNanos: 0,
+			weeklyCostNanos: 0,
+			monthlyCostNanos: 0,
+		},
+	},
+	{
+		id: "ci",
+		label: "CI",
+		description: "Request cap for tests, evals, and release jobs.",
+		limits: {
+			dailyRequests: 5_000,
+			weeklyRequests: 25_000,
+			monthlyRequests: 0,
+			dailyCostNanos: 2_000_000_000,
+			weeklyCostNanos: 10_000_000_000,
+			monthlyCostNanos: 0,
+		},
+	},
+	{
+		id: "sandbox",
+		label: "Sandbox",
+		description: "Tight cap for demos, trials, and shared experiments.",
+		limits: {
+			dailyRequests: 100,
+			weeklyRequests: 1_000,
+			monthlyRequests: 0,
+			dailyCostNanos: 250_000_000,
+			weeklyCostNanos: 1_000_000_000,
+			monthlyCostNanos: 0,
+		},
+	},
+];
+
+export function getApiKeyPreset(id: ApiKeyPresetId): ApiKeyLimitPreset {
+	return (
+		API_KEY_LIMIT_PRESETS.find((preset) => preset.id === id) ??
+		API_KEY_LIMIT_PRESETS[0]
+	);
+}
+
+type SecretConfigArgs = {
+	apiKey: string;
+	baseUrl?: string;
+	envVarName?: string;
+};
+
+function normalizeBaseUrl(baseUrl?: string): string {
+	return (baseUrl || AI_STATS_GATEWAY_BASE_URL).replace(/\/+$/, "");
+}
+
+export function buildEnvFile(args: SecretConfigArgs): string {
+	const envVarName = args.envVarName || "AI_STATS_API_KEY";
+	return `${envVarName}="${args.apiKey}"\nAI_STATS_BASE_URL="${normalizeBaseUrl(args.baseUrl)}"\n`;
+}
+
+export type AppConfigSnippet = {
+	id: string;
+	label: string;
+	value: string;
+};
+
+export function buildAppConfigSnippets(args: SecretConfigArgs): AppConfigSnippet[] {
+	const baseUrl = normalizeBaseUrl(args.baseUrl);
+	const apiKey = args.apiKey;
+
+	return [
+		{
+			id: "shell",
+			label: "Shell exports",
+			value: `export AI_STATS_API_KEY="${apiKey}"\nexport AI_STATS_BASE_URL="${baseUrl}"`,
+		},
+		{
+			id: "openai-node",
+			label: "OpenAI SDK (Node)",
+			value: `import OpenAI from "openai";\n\nconst client = new OpenAI({\n  apiKey: process.env.AI_STATS_API_KEY,\n  baseURL: "${baseUrl}",\n});`,
+		},
+		{
+			id: "openai-python",
+			label: "OpenAI SDK (Python)",
+			value: `import os\nfrom openai import OpenAI\n\nclient = OpenAI(\n    api_key=os.environ["AI_STATS_API_KEY"],\n    base_url="${baseUrl}",\n)`,
+		},
+		{
+			id: "vercel-ai-sdk",
+			label: "Vercel AI SDK",
+			value: `import { createOpenAI } from "@ai-sdk/openai";\n\nexport const aiStats = createOpenAI({\n  apiKey: process.env.AI_STATS_API_KEY,\n  baseURL: "${baseUrl}",\n});`,
+		},
+		{
+			id: "codex",
+			label: "Codex",
+			value: `[model_providers.ai-stats]\nname = "AI Stats"\nbase_url = "${baseUrl}"\nenv_key = "AI_STATS_API_KEY"`,
+		},
+		{
+			id: "claude-code",
+			label: "Claude Code",
+			value: `export ANTHROPIC_BASE_URL="${baseUrl.replace(/\/v1$/, "")}"\nexport ANTHROPIC_AUTH_TOKEN="${apiKey}"\nexport ANTHROPIC_API_KEY=""`,
+		},
+		{
+			id: "opencode",
+			label: "OpenCode",
+			value: `{\n  "provider": {\n    "ai-stats": {\n      "npm": "@ai-sdk/openai-compatible",\n      "options": {\n        "baseURL": "${baseUrl}",\n        "apiKey": "{env:AI_STATS_API_KEY}"\n      }\n    }\n  }\n}`,
+		},
+	];
+}
+
+export type CollectionExport = {
+	id: string;
+	label: string;
+	filename: string;
+	mimeType: string;
+	content: string;
+};
+
+export function buildCollectionExports(baseUrl = AI_STATS_GATEWAY_BASE_URL): CollectionExport[] {
+	const normalizedBaseUrl = normalizeBaseUrl(baseUrl);
+	const origin = normalizedBaseUrl.replace(/\/v1$/, "");
+
+	return [
+		{
+			id: "postman",
+			label: "Postman",
+			filename: "ai-stats-gateway.postman_collection.json",
+			mimeType: "application/json",
+			content: JSON.stringify(
+				{
+					info: {
+						name: "AI Stats Gateway",
+						schema:
+							"https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
+					},
+					variable: [
+						{ key: "base_url", value: normalizedBaseUrl },
+						{ key: "api_key", value: "paste-your-ai-stats-key" },
+						{ key: "model", value: "openai/gpt-4.1-mini" },
+					],
+					item: [
+						{
+							name: "List models",
+							request: {
+								method: "GET",
+								header: [
+									{ key: "Authorization", value: "Bearer {{api_key}}" },
+								],
+								url: "{{base_url}}/models?endpoints=chat/completions",
+							},
+						},
+						{
+							name: "Chat completion",
+							request: {
+								method: "POST",
+								header: [
+									{ key: "Authorization", value: "Bearer {{api_key}}" },
+									{ key: "Content-Type", value: "application/json" },
+								],
+								url: "{{base_url}}/chat/completions",
+								body: {
+									mode: "raw",
+									raw: JSON.stringify(
+										{
+											model: "{{model}}",
+											messages: [
+												{
+													role: "user",
+													content: "Say hello from AI Stats.",
+												},
+											],
+										},
+										null,
+										2,
+									),
+								},
+							},
+						},
+					],
+				},
+				null,
+				2,
+			),
+		},
+		{
+			id: "insomnia",
+			label: "Insomnia",
+			filename: "ai-stats-gateway.insomnia.json",
+			mimeType: "application/json",
+			content: JSON.stringify(
+				{
+					_type: "export",
+					__export_format: 4,
+					__export_source: "ai-stats",
+					resources: [
+						{
+							_id: "wrk_ai_stats_gateway",
+							_type: "workspace",
+							name: "AI Stats Gateway",
+						},
+						{
+							_id: "env_ai_stats_gateway",
+							_type: "environment",
+							parentId: "wrk_ai_stats_gateway",
+							name: "Base Environment",
+							data: {
+								base_url: normalizedBaseUrl,
+								api_key: "paste-your-ai-stats-key",
+								model: "openai/gpt-4.1-mini",
+							},
+						},
+						{
+							_id: "req_ai_stats_models",
+							_type: "request",
+							parentId: "wrk_ai_stats_gateway",
+							name: "List models",
+							method: "GET",
+							url: "{{ _.base_url }}/models?endpoints=chat/completions",
+							headers: [
+								{
+									name: "Authorization",
+									value: "Bearer {{ _.api_key }}",
+								},
+							],
+						},
+						{
+							_id: "req_ai_stats_chat",
+							_type: "request",
+							parentId: "wrk_ai_stats_gateway",
+							name: "Chat completion",
+							method: "POST",
+							url: "{{ _.base_url }}/chat/completions",
+							headers: [
+								{
+									name: "Authorization",
+									value: "Bearer {{ _.api_key }}",
+								},
+								{ name: "Content-Type", value: "application/json" },
+							],
+							body: {
+								mimeType: "application/json",
+								text: JSON.stringify(
+									{
+										model: "{{ _.model }}",
+										messages: [
+											{
+												role: "user",
+												content: "Say hello from AI Stats.",
+											},
+										],
+									},
+									null,
+									2,
+								),
+							},
+						},
+					],
+				},
+				null,
+				2,
+			),
+		},
+		{
+			id: "http",
+			label: ".http file",
+			filename: "ai-stats-gateway.http",
+			mimeType: "text/plain",
+			content: `@baseUrl = ${normalizedBaseUrl}\n@apiKey = paste-your-ai-stats-key\n@model = openai/gpt-4.1-mini\n\n### List models\nGET {{baseUrl}}/models?endpoints=chat/completions\nAuthorization: Bearer {{apiKey}}\n\n### Chat completion\nPOST {{baseUrl}}/chat/completions\nAuthorization: Bearer {{apiKey}}\nContent-Type: application/json\nOrigin: ${origin}\n\n{\n  "model": "{{model}}",\n  "messages": [\n    {\n      "role": "user",\n      "content": "Say hello from AI Stats."\n    }\n  ]\n}\n`,
+		},
+	];
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -146,6 +146,9 @@ importers:
 
   apps/web:
     dependencies:
+      '@1password/save-button':
+        specifier: ^1.3.0
+        version: 1.3.0
       '@base-ui/react':
         specifier: ^1.3.0
         version: 1.3.0(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
@@ -521,7 +524,7 @@ importers:
         version: 10.4.0(jiti@2.7.0)
       eslint-config-next:
         specifier: 16.2.6
-        version: 16.2.6(eslint@10.4.0(jiti@2.7.0))(typescript@6.0.3)
+        version: 16.2.6(@typescript-eslint/parser@8.58.1(eslint@10.4.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.4.0(jiti@2.7.0))(typescript@6.0.3)
       jest:
         specifier: ^30.4.2
         version: 30.4.2(@types/node@25.6.0)(ts-node@10.9.2(@types/node@25.6.0)(typescript@6.0.3))
@@ -976,6 +979,9 @@ importers:
         version: 6.0.3
 
 packages:
+
+  '@1password/save-button@1.3.0':
+    resolution: {integrity: sha512-jyVhFEwZEigiWimyjnPlOdEepiIZbPuCc4YpkWrghi5nwl5IYT3dk1yxL2drz/JrleUpBoaYDJUAZw0CX9ZU7Q==}
 
   '@ai-sdk/gateway@3.0.104':
     resolution: {integrity: sha512-ZKX5n74io8VIRlhIMSLWVlvT3sXC8Z7cZ9GHuWBWZDVi96+62AIsWuLGvMfcBA1STYuSoDrp6rIziZmvrTq0TA==}
@@ -11533,6 +11539,8 @@ packages:
 
 snapshots:
 
+  '@1password/save-button@1.3.0': {}
+
   '@ai-sdk/gateway@3.0.104(zod@4.4.3)':
     dependencies:
       '@ai-sdk/provider': 3.0.8
@@ -18377,13 +18385,13 @@ snapshots:
     optionalDependencies:
       source-map: 0.6.1
 
-  eslint-config-next@16.2.6(eslint@10.4.0(jiti@2.7.0))(typescript@6.0.3):
+  eslint-config-next@16.2.6(@typescript-eslint/parser@8.58.1(eslint@10.4.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.4.0(jiti@2.7.0))(typescript@6.0.3):
     dependencies:
       '@next/eslint-plugin-next': 16.2.6
       eslint: 10.4.0(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.10
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(eslint@10.4.0(jiti@2.7.0)))(eslint@10.4.0(jiti@2.7.0))
-      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@10.4.0(jiti@2.7.0)))(eslint@10.4.0(jiti@2.7.0)))(eslint@10.4.0(jiti@2.7.0))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@10.4.0(jiti@2.7.0))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.58.1(eslint@10.4.0(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-typescript@3.10.1)(eslint@10.4.0(jiti@2.7.0))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@10.4.0(jiti@2.7.0))
       eslint-plugin-react: 7.37.5(eslint@10.4.0(jiti@2.7.0))
       eslint-plugin-react-hooks: 7.1.1(eslint@10.4.0(jiti@2.7.0))
@@ -18409,7 +18417,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@10.4.0(jiti@2.7.0)))(eslint@10.4.0(jiti@2.7.0)):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@10.4.0(jiti@2.7.0)):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3(supports-color@8.1.1)
@@ -18420,21 +18428,22 @@ snapshots:
       tinyglobby: 0.2.16
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@10.4.0(jiti@2.7.0)))(eslint@10.4.0(jiti@2.7.0)))(eslint@10.4.0(jiti@2.7.0))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.58.1(eslint@10.4.0(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-typescript@3.10.1)(eslint@10.4.0(jiti@2.7.0))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@10.4.0(jiti@2.7.0)))(eslint@10.4.0(jiti@2.7.0)))(eslint@10.4.0(jiti@2.7.0)):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.58.1(eslint@10.4.0(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@10.4.0(jiti@2.7.0)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
+      '@typescript-eslint/parser': 8.58.1(eslint@10.4.0(jiti@2.7.0))(typescript@6.0.3)
       eslint: 10.4.0(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.10
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(eslint@10.4.0(jiti@2.7.0)))(eslint@10.4.0(jiti@2.7.0))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@10.4.0(jiti@2.7.0))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@10.4.0(jiti@2.7.0)))(eslint@10.4.0(jiti@2.7.0)))(eslint@10.4.0(jiti@2.7.0)):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.1(eslint@10.4.0(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-typescript@3.10.1)(eslint@10.4.0(jiti@2.7.0)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -18445,7 +18454,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 10.4.0(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.10
-      eslint-module-utils: 2.12.1(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@10.4.0(jiti@2.7.0)))(eslint@10.4.0(jiti@2.7.0)))(eslint@10.4.0(jiti@2.7.0))
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.58.1(eslint@10.4.0(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@10.4.0(jiti@2.7.0))
       hasown: 2.0.3
       is-core-module: 2.16.2
       is-glob: 4.0.3
@@ -18456,6 +18465,8 @@ snapshots:
       semver: 6.3.1
       string.prototype.trimend: 1.0.9
       tsconfig-paths: 3.15.0
+    optionalDependencies:
+      '@typescript-eslint/parser': 8.58.1(eslint@10.4.0(jiti@2.7.0))(typescript@6.0.3)
     transitivePeerDependencies:
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack


### PR DESCRIPTION
﻿## Summary

This PR improves the one-time API key reveal experience across the gateway settings and onboarding flows.

It adds a shared secret reveal action surface that supports copying the raw key, copying a ready `.env` file, copying app-specific configuration snippets, exporting starter API client collections, saving secrets to 1Password, and testing newly revealed gateway API keys against the models endpoint.

## What changed

- Adds `@1password/save-button` and a small `OnePasswordSaveButton` wrapper for one-time secret reveal states.
- Adds reusable secret reveal helpers for `.env` output, app config snippets, and collection exports.
- Adds API key creation presets for development, production, CI, and sandbox keys.
- Wires the shared reveal actions into API key creation, API key rotation, onboarding-created keys, and management key creation.
- Adds an authenticated internal test-key route that verifies newly revealed gateway API keys with a cheap `/models` request.
- Adds focused tests for the secret reveal helper output and collection export safety.

## User impact

Users can store and use newly created keys without manually building config from docs. The downloaded collections intentionally use placeholders, so exported files do not contain live secrets. Management keys get the safer subset of actions without inference-client snippets or test requests.

## Validation

- `pnpm --filter @ai-stats/web test -- secretReveal.test.ts`
- `pnpm --filter @ai-stats/web exec eslint "src/lib/gateway/secretReveal.ts" "src/lib/gateway/secretReveal.test.ts" "src/components/(gateway)/settings/keys/OnePasswordSaveButton.tsx" "src/components/(gateway)/settings/keys/SecretRevealActions.tsx" "src/components/(gateway)/settings/keys/CreateKeyDialog.tsx" "src/components/(gateway)/settings/keys/RotateKeyItem.tsx" "src/components/(gateway)/settings/management-api-keys/CreateManagementKeyDialog.tsx" "src/components/(gateway)/onboarding/InteractiveOnboarding.tsx" "src/app/(dashboard)/settings/keys/actions.ts" "src/app/api/internal/secret-ux/test-key/route.ts"`
- `pnpm --filter @ai-stats/web typecheck`
- `git diff --check`

Created with Codex
