### PR TITLE
Add ElevenLabs audio models

### DIFF
--- a/packages/data/catalog/src/data/api_providers/elevenlabs/models.json
+++ b/packages/data/catalog/src/data/api_providers/elevenlabs/models.json
@@ -1,5 +1,215 @@
 [
   {
+    "api_model_id": "elevenlabs/eleven_english_sts_v2",
+    "provider_api_model_id": "elevenlabs:elevenlabs/eleven_english_sts_v2",
+    "provider_model_slug": "eleven_english_sts_v2",
+    "internal_model_id": "",
+    "is_active_gateway": false,
+    "quantization_scheme": null,
+    "input_modalities": "audio",
+    "output_modalities": "audio",
+    "context_length": null,
+    "max_output_tokens": null,
+    "effective_from": null,
+    "effective_to": null,
+    "capabilities": [
+      {
+        "capability_id": "audio.speech",
+        "status": "active",
+        "params": []
+      }
+    ]
+  },
+  {
+    "api_model_id": "elevenlabs/eleven_flash_v2",
+    "provider_api_model_id": "elevenlabs:elevenlabs/eleven_flash_v2",
+    "provider_model_slug": "eleven_flash_v2",
+    "internal_model_id": "",
+    "is_active_gateway": false,
+    "quantization_scheme": null,
+    "input_modalities": "text",
+    "output_modalities": "audio_tts",
+    "context_length": null,
+    "max_output_tokens": null,
+    "effective_from": null,
+    "effective_to": null,
+    "capabilities": [
+      {
+        "capability_id": "audio.speech",
+        "status": "active",
+        "params": []
+      }
+    ]
+  },
+  {
+    "api_model_id": "elevenlabs/eleven_flash_v2_5",
+    "provider_api_model_id": "elevenlabs:elevenlabs/eleven_flash_v2_5",
+    "provider_model_slug": "eleven_flash_v2_5",
+    "internal_model_id": "",
+    "is_active_gateway": false,
+    "quantization_scheme": null,
+    "input_modalities": "text",
+    "output_modalities": "audio_tts",
+    "context_length": null,
+    "max_output_tokens": null,
+    "effective_from": null,
+    "effective_to": null,
+    "capabilities": [
+      {
+        "capability_id": "audio.speech",
+        "status": "active",
+        "params": []
+      }
+    ]
+  },
+  {
+    "api_model_id": "elevenlabs/eleven_monolingual_v1",
+    "provider_api_model_id": "elevenlabs:elevenlabs/eleven_monolingual_v1",
+    "provider_model_slug": "eleven_monolingual_v1",
+    "internal_model_id": "",
+    "is_active_gateway": false,
+    "quantization_scheme": null,
+    "input_modalities": "text",
+    "output_modalities": "audio_tts",
+    "context_length": null,
+    "max_output_tokens": null,
+    "effective_from": null,
+    "effective_to": "2026-07-09T00:00:00",
+    "capabilities": [
+      {
+        "capability_id": "audio.speech",
+        "status": "active",
+        "params": []
+      }
+    ]
+  },
+  {
+    "api_model_id": "elevenlabs/eleven_multilingual_sts_v2",
+    "provider_api_model_id": "elevenlabs:elevenlabs/eleven_multilingual_sts_v2",
+    "provider_model_slug": "eleven_multilingual_sts_v2",
+    "internal_model_id": "",
+    "is_active_gateway": false,
+    "quantization_scheme": null,
+    "input_modalities": "audio",
+    "output_modalities": "audio",
+    "context_length": null,
+    "max_output_tokens": null,
+    "effective_from": null,
+    "effective_to": null,
+    "capabilities": [
+      {
+        "capability_id": "audio.speech",
+        "status": "active",
+        "params": []
+      }
+    ]
+  },
+  {
+    "api_model_id": "elevenlabs/eleven_multilingual_v1",
+    "provider_api_model_id": "elevenlabs:elevenlabs/eleven_multilingual_v1",
+    "provider_model_slug": "eleven_multilingual_v1",
+    "internal_model_id": "",
+    "is_active_gateway": false,
+    "quantization_scheme": null,
+    "input_modalities": "text",
+    "output_modalities": "audio_tts",
+    "context_length": null,
+    "max_output_tokens": null,
+    "effective_from": null,
+    "effective_to": "2026-07-09T00:00:00",
+    "capabilities": [
+      {
+        "capability_id": "audio.speech",
+        "status": "active",
+        "params": []
+      }
+    ]
+  },
+  {
+    "api_model_id": "elevenlabs/eleven_multilingual_v2",
+    "provider_api_model_id": "elevenlabs:elevenlabs/eleven_multilingual_v2",
+    "provider_model_slug": "eleven_multilingual_v2",
+    "internal_model_id": "",
+    "is_active_gateway": false,
+    "quantization_scheme": null,
+    "input_modalities": "text",
+    "output_modalities": "audio_tts",
+    "context_length": null,
+    "max_output_tokens": null,
+    "effective_from": null,
+    "effective_to": null,
+    "capabilities": [
+      {
+        "capability_id": "audio.speech",
+        "status": "active",
+        "params": []
+      }
+    ]
+  },
+  {
+    "api_model_id": "elevenlabs/eleven_turbo_v2",
+    "provider_api_model_id": "elevenlabs:elevenlabs/eleven_turbo_v2",
+    "provider_model_slug": "eleven_turbo_v2",
+    "internal_model_id": "",
+    "is_active_gateway": false,
+    "quantization_scheme": null,
+    "input_modalities": "text",
+    "output_modalities": "audio_tts",
+    "context_length": null,
+    "max_output_tokens": null,
+    "effective_from": null,
+    "effective_to": null,
+    "capabilities": [
+      {
+        "capability_id": "audio.speech",
+        "status": "active",
+        "params": []
+      }
+    ]
+  },
+  {
+    "api_model_id": "elevenlabs/eleven_turbo_v2_5",
+    "provider_api_model_id": "elevenlabs:elevenlabs/eleven_turbo_v2_5",
+    "provider_model_slug": "eleven_turbo_v2_5",
+    "internal_model_id": "",
+    "is_active_gateway": false,
+    "quantization_scheme": null,
+    "input_modalities": "text",
+    "output_modalities": "audio_tts",
+    "context_length": null,
+    "max_output_tokens": null,
+    "effective_from": null,
+    "effective_to": null,
+    "capabilities": [
+      {
+        "capability_id": "audio.speech",
+        "status": "active",
+        "params": []
+      }
+    ]
+  },
+  {
+    "api_model_id": "elevenlabs/eleven_v3",
+    "provider_api_model_id": "elevenlabs:elevenlabs/eleven_v3",
+    "provider_model_slug": "eleven_v3",
+    "internal_model_id": "",
+    "is_active_gateway": false,
+    "quantization_scheme": null,
+    "input_modalities": "text",
+    "output_modalities": "audio_tts",
+    "context_length": null,
+    "max_output_tokens": null,
+    "effective_from": null,
+    "effective_to": null,
+    "capabilities": [
+      {
+        "capability_id": "audio.speech",
+        "status": "active",
+        "params": []
+      }
+    ]
+  },
+  {
     "api_model_id": "elevenlabs/music",
     "provider_api_model_id": "elevenlabs:elevenlabs/music",
     "provider_model_slug": "music",

--- a/packages/data/catalog/src/data/models/elevenlabs/eleven_english_sts_v2/model.json
+++ b/packages/data/catalog/src/data/models/elevenlabs/eleven_english_sts_v2/model.json
@@ -1,0 +1,25 @@
+{
+  "model_id": "elevenlabs/eleven_english_sts_v2",
+  "organisation_id": "eleven-labs",
+  "name": "English STS v2",
+  "status": "Available",
+  "previous_model_id": null,
+  "description": "English-only voice changer model for speech-to-speech conversion.",
+  "announced_date": null,
+  "release_date": null,
+  "deprecation_date": null,
+  "retirement_date": null,
+  "license": "Proprietary",
+  "input_types": "audio",
+  "output_types": "audio",
+  "api_model_id": "elevenlabs/eleven_english_sts_v2",
+  "links": [
+    {
+      "platform": "docs",
+      "label": "Models documentation",
+      "url": "https://elevenlabs.io/docs/overview/models"
+    }
+  ],
+  "details": [],
+  "benchmarks": []
+}

--- a/packages/data/catalog/src/data/models/elevenlabs/eleven_flash_v2/model.json
+++ b/packages/data/catalog/src/data/models/elevenlabs/eleven_flash_v2/model.json
@@ -1,0 +1,25 @@
+{
+  "model_id": "elevenlabs/eleven_flash_v2",
+  "organisation_id": "eleven-labs",
+  "name": "Eleven Flash v2",
+  "status": "Available",
+  "previous_model_id": null,
+  "description": "Ultra-fast English speech synthesis model optimized for real-time use.",
+  "announced_date": null,
+  "release_date": null,
+  "deprecation_date": null,
+  "retirement_date": null,
+  "license": "Proprietary",
+  "input_types": "text",
+  "output_types": "audio_tts",
+  "api_model_id": "elevenlabs/eleven_flash_v2",
+  "links": [
+    {
+      "platform": "docs",
+      "label": "Models documentation",
+      "url": "https://elevenlabs.io/docs/overview/models"
+    }
+  ],
+  "details": [],
+  "benchmarks": []
+}

--- a/packages/data/catalog/src/data/models/elevenlabs/eleven_flash_v2_5/model.json
+++ b/packages/data/catalog/src/data/models/elevenlabs/eleven_flash_v2_5/model.json
@@ -1,0 +1,25 @@
+{
+  "model_id": "elevenlabs/eleven_flash_v2_5",
+  "organisation_id": "eleven-labs",
+  "name": "Eleven Flash v2.5",
+  "status": "Available",
+  "previous_model_id": null,
+  "description": "Ultra-fast multilingual speech synthesis model optimized for real-time use.",
+  "announced_date": null,
+  "release_date": null,
+  "deprecation_date": null,
+  "retirement_date": null,
+  "license": "Proprietary",
+  "input_types": "text",
+  "output_types": "audio_tts",
+  "api_model_id": "elevenlabs/eleven_flash_v2_5",
+  "links": [
+    {
+      "platform": "docs",
+      "label": "Models documentation",
+      "url": "https://elevenlabs.io/docs/overview/models"
+    }
+  ],
+  "details": [],
+  "benchmarks": []
+}

--- a/packages/data/catalog/src/data/models/elevenlabs/eleven_monolingual_v1/model.json
+++ b/packages/data/catalog/src/data/models/elevenlabs/eleven_monolingual_v1/model.json
@@ -1,0 +1,25 @@
+{
+  "model_id": "elevenlabs/eleven_monolingual_v1",
+  "organisation_id": "eleven-labs",
+  "name": "Eleven Monolingual v1",
+  "status": "Available",
+  "previous_model_id": null,
+  "description": "First-generation English text-to-speech model.",
+  "announced_date": null,
+  "release_date": null,
+  "deprecation_date": "2026-06-23T00:00:00",
+  "retirement_date": "2026-07-09T00:00:00",
+  "license": "Proprietary",
+  "input_types": "text",
+  "output_types": "audio_tts",
+  "api_model_id": "elevenlabs/eleven_monolingual_v1",
+  "links": [
+    {
+      "platform": "docs",
+      "label": "Models documentation",
+      "url": "https://elevenlabs.io/docs/overview/models"
+    }
+  ],
+  "details": [],
+  "benchmarks": []
+}

--- a/packages/data/catalog/src/data/models/elevenlabs/eleven_multilingual_sts_v2/model.json
+++ b/packages/data/catalog/src/data/models/elevenlabs/eleven_multilingual_sts_v2/model.json
@@ -1,0 +1,25 @@
+{
+  "model_id": "elevenlabs/eleven_multilingual_sts_v2",
+  "organisation_id": "eleven-labs",
+  "name": "Eleven Multilingual STS v2",
+  "status": "Available",
+  "previous_model_id": null,
+  "description": "State-of-the-art multilingual voice changer model for speech-to-speech conversion.",
+  "announced_date": null,
+  "release_date": null,
+  "deprecation_date": null,
+  "retirement_date": null,
+  "license": "Proprietary",
+  "input_types": "audio",
+  "output_types": "audio",
+  "api_model_id": "elevenlabs/eleven_multilingual_sts_v2",
+  "links": [
+    {
+      "platform": "docs",
+      "label": "Models documentation",
+      "url": "https://elevenlabs.io/docs/overview/models"
+    }
+  ],
+  "details": [],
+  "benchmarks": []
+}

--- a/packages/data/catalog/src/data/models/elevenlabs/eleven_multilingual_v1/model.json
+++ b/packages/data/catalog/src/data/models/elevenlabs/eleven_multilingual_v1/model.json
@@ -1,0 +1,25 @@
+{
+  "model_id": "elevenlabs/eleven_multilingual_v1",
+  "organisation_id": "eleven-labs",
+  "name": "Eleven Multilingual v1",
+  "status": "Available",
+  "previous_model_id": null,
+  "description": "First-generation multilingual text-to-speech model.",
+  "announced_date": null,
+  "release_date": null,
+  "deprecation_date": "2026-06-23T00:00:00",
+  "retirement_date": "2026-07-09T00:00:00",
+  "license": "Proprietary",
+  "input_types": "text",
+  "output_types": "audio_tts",
+  "api_model_id": "elevenlabs/eleven_multilingual_v1",
+  "links": [
+    {
+      "platform": "docs",
+      "label": "Models documentation",
+      "url": "https://elevenlabs.io/docs/overview/models"
+    }
+  ],
+  "details": [],
+  "benchmarks": []
+}

--- a/packages/data/catalog/src/data/models/elevenlabs/eleven_multilingual_v2/model.json
+++ b/packages/data/catalog/src/data/models/elevenlabs/eleven_multilingual_v2/model.json
@@ -1,0 +1,25 @@
+{
+  "model_id": "elevenlabs/eleven_multilingual_v2",
+  "organisation_id": "eleven-labs",
+  "name": "Eleven Multilingual v2",
+  "status": "Available",
+  "previous_model_id": null,
+  "description": "Lifelike multilingual speech synthesis model with rich emotional expression.",
+  "announced_date": null,
+  "release_date": null,
+  "deprecation_date": null,
+  "retirement_date": null,
+  "license": "Proprietary",
+  "input_types": "text",
+  "output_types": "audio_tts",
+  "api_model_id": "elevenlabs/eleven_multilingual_v2",
+  "links": [
+    {
+      "platform": "docs",
+      "label": "Models documentation",
+      "url": "https://elevenlabs.io/docs/overview/models"
+    }
+  ],
+  "details": [],
+  "benchmarks": []
+}

--- a/packages/data/catalog/src/data/models/elevenlabs/eleven_turbo_v2/model.json
+++ b/packages/data/catalog/src/data/models/elevenlabs/eleven_turbo_v2/model.json
@@ -1,0 +1,25 @@
+{
+  "model_id": "elevenlabs/eleven_turbo_v2",
+  "organisation_id": "eleven-labs",
+  "name": "Eleven Turbo v2",
+  "status": "Available",
+  "previous_model_id": null,
+  "description": "First-generation low-latency English text-to-speech model.",
+  "announced_date": null,
+  "release_date": null,
+  "deprecation_date": null,
+  "retirement_date": null,
+  "license": "Proprietary",
+  "input_types": "text",
+  "output_types": "audio_tts",
+  "api_model_id": "elevenlabs/eleven_turbo_v2",
+  "links": [
+    {
+      "platform": "docs",
+      "label": "Models documentation",
+      "url": "https://elevenlabs.io/docs/overview/models"
+    }
+  ],
+  "details": [],
+  "benchmarks": []
+}

--- a/packages/data/catalog/src/data/models/elevenlabs/eleven_turbo_v2_5/model.json
+++ b/packages/data/catalog/src/data/models/elevenlabs/eleven_turbo_v2_5/model.json
@@ -1,0 +1,25 @@
+{
+  "model_id": "elevenlabs/eleven_turbo_v2_5",
+  "organisation_id": "eleven-labs",
+  "name": "Eleven Turbo v2.5",
+  "status": "Available",
+  "previous_model_id": null,
+  "description": "First-generation low-latency multilingual text-to-speech model.",
+  "announced_date": null,
+  "release_date": null,
+  "deprecation_date": null,
+  "retirement_date": null,
+  "license": "Proprietary",
+  "input_types": "text",
+  "output_types": "audio_tts",
+  "api_model_id": "elevenlabs/eleven_turbo_v2_5",
+  "links": [
+    {
+      "platform": "docs",
+      "label": "Models documentation",
+      "url": "https://elevenlabs.io/docs/overview/models"
+    }
+  ],
+  "details": [],
+  "benchmarks": []
+}

--- a/packages/data/catalog/src/data/models/elevenlabs/eleven_v3/model.json
+++ b/packages/data/catalog/src/data/models/elevenlabs/eleven_v3/model.json
@@ -1,0 +1,25 @@
+{
+  "model_id": "elevenlabs/eleven_v3",
+  "organisation_id": "eleven-labs",
+  "name": "Eleven v3",
+  "status": "Available",
+  "previous_model_id": null,
+  "description": "Expressive multilingual speech synthesis model for natural, lifelike speech.",
+  "announced_date": null,
+  "release_date": null,
+  "deprecation_date": null,
+  "retirement_date": null,
+  "license": "Proprietary",
+  "input_types": "text",
+  "output_types": "audio_tts",
+  "api_model_id": "elevenlabs/eleven_v3",
+  "links": [
+    {
+      "platform": "docs",
+      "label": "Models documentation",
+      "url": "https://elevenlabs.io/docs/overview/models"
+    }
+  ],
+  "details": [],
+  "benchmarks": []
+}


### PR DESCRIPTION
## Summary

- Adds the ElevenLabs model rows from the official model table.
- Adds lightweight base model records for the text-to-speech and speech-to-speech models so provider entries resolve cleanly.
- Marks the v1 text-to-speech models with the documented July 9, 2026 removal date.

## Official-source verification

- ElevenLabs models documentation: https://elevenlabs.io/docs/overview/models

## Linked issues

- AI-173

## Validation

- `pnpm validate:data`

Created with Codex