### PR TITLE
[codex] Add Gemini Omni Flash preview catalog entry

### DIFF
--- a/packages/data/catalog/src/data/api_providers/google-ai-studio/models.json
+++ b/packages/data/catalog/src/data/api_providers/google-ai-studio/models.json
@@ -1087,6 +1087,23 @@
                          ]
     },
     {
+        "api_model_id":  "google/gemini-omni-flash-preview",
+        "provider_api_model_id":  "google-ai-studio:google/gemini-omni-flash-preview",
+        "provider_model_slug":  "gemini-omni-flash-preview",
+        "internal_model_id":  "google/gemini-omni-flash-preview",
+        "is_active_gateway":  false,
+        "quantization_scheme":  null,
+        "input_modalities":  "text,image,audio,video",
+        "output_modalities":  null,
+        "context_length":  null,
+        "max_output_tokens":  null,
+        "effective_from":  null,
+        "effective_to":  null,
+        "capabilities":  [
+
+                           ]
+    },
+    {
         "api_model_id":  "google/gemini-3.1-flash-image-preview",
         "provider_api_model_id":  "google-ai-studio:google/gemini-3.1-flash-image-preview",
         "provider_model_slug":  "gemini-3.1-flash-image-preview",

--- a/packages/data/catalog/src/data/models/google/gemini-omni-flash-preview/model.json
+++ b/packages/data/catalog/src/data/models/google/gemini-omni-flash-preview/model.json
@@ -1,0 +1,28 @@
+{
+  "model_id": "google/gemini-omni-flash-preview",
+  "organisation_id": "google",
+  "name": "Gemini Omni Flash Preview",
+  "status": "Available",
+  "previous_model_id": null,
+  "description": "Gemini Omni Flash Preview is a provisional Google multimodal preview model. Pricing, release date, limits, output modalities, and the full API surface have not been officially published.",
+  "announced_date": null,
+  "release_date": null,
+  "deprecation_date": null,
+  "retirement_date": null,
+  "license": "Proprietary",
+  "input_types": "text,image,audio,video",
+  "output_types": null,
+  "api_model_id": "google/gemini-omni-flash-preview",
+  "page_notice": {
+    "tone": "warning",
+    "markdown": "This is a provisional preview entry. Google has not published confirmed pricing, release timing, output modalities, limits, or API capabilities for `gemini-omni-flash-preview`; do not use this entry for routing or billing estimates until those details are confirmed."
+  },
+  "links": [],
+  "details": [
+    {
+      "name": "catalog_note",
+      "value": "Provisional entry added ahead of official pricing and release documentation. The final modality and capability surface may include more than video generation."
+    }
+  ],
+  "benchmarks": []
+}


### PR DESCRIPTION
## Summary

- Adds a provisional `google/gemini-omni-flash-preview` model catalog entry.
- Adds a Google AI Studio provider mapping for `gemini-omni-flash-preview`.
- Keeps the provider row out of active gateway routing while pricing, release date, output modalities, limits, and API capabilities remain unconfirmed.

## Notes

- No pricing file is included because pricing is not confirmed.
- `announced_date`, `release_date`, context length, max output tokens, output modalities, and provider capabilities are intentionally unset.
- The capability list is intentionally empty rather than assuming `video.generate`, because the final Omni Flash API surface may include multiple output modalities or endpoint styles.
- The request mentioned `geminin-omni-flash-preview`; this PR uses `gemini-omni-flash-preview` to match Google Gemini naming conventions and the public preview-access wording I found. Please confirm the final provider slug before merging if the leaked ID really includes the extra `n`.

## Validation

- `node -e "JSON.parse(require('fs').readFileSync('packages/data/catalog/src/data/models/google/gemini-omni-flash-preview/model.json','utf8')); JSON.parse(require('fs').readFileSync('packages/data/catalog/src/data/api_providers/google-ai-studio/models.json','utf8')); console.log('json ok')"`
- `pnpm validate:data`
- `pnpm validate:pricing`
- `pnpm validate:gateway`
- `git diff --check`
