### PR TITLE
[codex] Shorten CI dependency graph

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -150,17 +150,25 @@ jobs:
               continue-on-error: true
               run: pnpm run docs:links
 
-            - if: matrix.app == 'web'
-              parallel:
-                  - name: Web lint
-                    continue-on-error: true
-                    working-directory: apps/web
-                    run: pnpm run lint
+            - name: Web lint
+              if: matrix.app == 'web'
+              id: web-lint
+              continue-on-error: true
+              working-directory: apps/web
+              run: pnpm run lint
+              background: true
 
-                  - name: Web typecheck
-                    continue-on-error: true
-                    working-directory: apps/web
-                    run: pnpm run typecheck
+            - name: Web typecheck
+              if: matrix.app == 'web'
+              id: web-typecheck
+              continue-on-error: true
+              working-directory: apps/web
+              run: pnpm run typecheck
+              background: true
+
+            - name: Wait for web checks
+              if: matrix.app == 'web'
+              wait: [web-lint, web-typecheck]
 
     api-aimock:
         name: API AIMock matrix

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,18 +38,29 @@ jobs:
             - name: Install dependencies
               run: corepack pnpm install --frozen-lockfile
 
-            - parallel:
-                  - name: Test model-discovery GitHub issue sync helpers
-                    run: pnpm exec tsx scripts/model-discovery/github-issues.test.ts
+            - name: Run data checks in parallel
+              shell: bash
+              run: |
+                  set -euo pipefail
 
-                  - name: Validate data files
-                    run: pnpm run validate:data
+                  pnpm exec tsx scripts/model-discovery/github-issues.test.ts &
+                  issues_pid=$!
 
-                  - name: Validate pricing data
-                    run: pnpm run validate:pricing
+                  pnpm run validate:data &
+                  data_pid=$!
 
-                  - name: Validate gateway data
-                    run: pnpm run validate:gateway
+                  pnpm run validate:pricing &
+                  pricing_pid=$!
+
+                  pnpm run validate:gateway &
+                  gateway_pid=$!
+
+                  status=0
+                  wait "$issues_pid" || status=1
+                  wait "$data_pid" || status=1
+                  wait "$pricing_pid" || status=1
+                  wait "$gateway_pid" || status=1
+                  exit "$status"
 
     check-paths:
         name: Check for data changes
@@ -150,25 +161,24 @@ jobs:
               continue-on-error: true
               run: pnpm run docs:links
 
-            - name: Web lint
+            - name: Web lint & typecheck
               if: matrix.app == 'web'
-              id: web-lint
               continue-on-error: true
               working-directory: apps/web
-              run: pnpm run lint
-              background: true
+              shell: bash
+              run: |
+                  set -euo pipefail
 
-            - name: Web typecheck
-              if: matrix.app == 'web'
-              id: web-typecheck
-              continue-on-error: true
-              working-directory: apps/web
-              run: pnpm run typecheck
-              background: true
+                  pnpm run lint &
+                  lint_pid=$!
 
-            - name: Wait for web checks
-              if: matrix.app == 'web'
-              wait: [web-lint, web-typecheck]
+                  pnpm run typecheck &
+                  typecheck_pid=$!
+
+                  status=0
+                  wait "$lint_pid" || status=1
+                  wait "$typecheck_pid" || status=1
+                  exit "$status"
 
     api-aimock:
         name: API AIMock matrix

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,11 +38,18 @@ jobs:
             - name: Install dependencies
               run: corepack pnpm install --frozen-lockfile
 
-            - name: Test model-discovery GitHub issue sync helpers
-              run: pnpm exec tsx scripts/model-discovery/github-issues.test.ts
+            - parallel:
+                  - name: Test model-discovery GitHub issue sync helpers
+                    run: pnpm exec tsx scripts/model-discovery/github-issues.test.ts
 
-            - name: Validate data files
-              run: pnpm run validate:data && pnpm run validate:pricing && pnpm run validate:gateway
+                  - name: Validate data files
+                    run: pnpm run validate:data
+
+                  - name: Validate pricing data
+                    run: pnpm run validate:pricing
+
+                  - name: Validate gateway data
+                    run: pnpm run validate:gateway
 
     check-paths:
         name: Check for data changes
@@ -62,7 +69,6 @@ jobs:
     openapi-lint:
         name: OpenAPI lint
         runs-on: ubuntu-latest
-        needs: data
         if: github.event_name == 'push' || !startsWith(github.head_ref, 'chore/auto-model-statuses')
         steps:
             - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
@@ -106,7 +112,9 @@ jobs:
     apps:
         name: Apps ${{ matrix.app }}
         runs-on: ubuntu-latest
-        needs: openapi-lint
+        needs:
+            - data
+            - openapi-lint
         if: github.event_name == 'push' || !startsWith(github.head_ref, 'chore/auto-model-statuses')
         strategy:
             matrix:
@@ -142,18 +150,24 @@ jobs:
               continue-on-error: true
               run: pnpm run docs:links
 
-            - name: Web lint & typecheck
-              if: matrix.app == 'web'
-              continue-on-error: true
-              run: |
-                  cd apps/web
-                  pnpm run lint
-                  pnpm run typecheck
+            - if: matrix.app == 'web'
+              parallel:
+                  - name: Web lint
+                    continue-on-error: true
+                    working-directory: apps/web
+                    run: pnpm run lint
+
+                  - name: Web typecheck
+                    continue-on-error: true
+                    working-directory: apps/web
+                    run: pnpm run typecheck
 
     api-aimock:
         name: API AIMock matrix
         runs-on: ubuntu-latest
-        needs: openapi-lint
+        needs:
+            - data
+            - openapi-lint
         if: github.event_name == 'push' || !startsWith(github.head_ref, 'chore/auto-model-statuses')
         steps:
             - uses: actions/checkout@v6
@@ -182,7 +196,9 @@ jobs:
     devtools:
         name: Devtools build
         runs-on: ubuntu-latest
-        needs: openapi-lint
+        needs:
+            - data
+            - openapi-lint
         if: github.event_name == 'push' || !startsWith(github.head_ref, 'chore/auto-model-statuses')
         steps:
             - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
@@ -265,7 +281,9 @@ jobs:
     sdk-gen:
         name: Generate SDKs
         runs-on: ubuntu-latest
-        needs: openapi-lint
+        needs:
+            - data
+            - openapi-lint
         if: github.event_name == 'push' || !startsWith(github.head_ref, 'chore/auto-model-statuses')
         strategy:
             fail-fast: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,29 +38,11 @@ jobs:
             - name: Install dependencies
               run: corepack pnpm install --frozen-lockfile
 
-            - name: Run data checks in parallel
-              shell: bash
-              run: |
-                  set -euo pipefail
+            - name: Test model-discovery GitHub issue sync helpers
+              run: pnpm exec tsx scripts/model-discovery/github-issues.test.ts
 
-                  pnpm exec tsx scripts/model-discovery/github-issues.test.ts &
-                  issues_pid=$!
-
-                  pnpm run validate:data &
-                  data_pid=$!
-
-                  pnpm run validate:pricing &
-                  pricing_pid=$!
-
-                  pnpm run validate:gateway &
-                  gateway_pid=$!
-
-                  status=0
-                  wait "$issues_pid" || status=1
-                  wait "$data_pid" || status=1
-                  wait "$pricing_pid" || status=1
-                  wait "$gateway_pid" || status=1
-                  exit "$status"
+            - name: Validate data files
+              run: pnpm run validate:data && pnpm run validate:pricing && pnpm run validate:gateway
 
     check-paths:
         name: Check for data changes
@@ -164,21 +146,10 @@ jobs:
             - name: Web lint & typecheck
               if: matrix.app == 'web'
               continue-on-error: true
-              working-directory: apps/web
-              shell: bash
               run: |
-                  set -euo pipefail
-
-                  pnpm run lint &
-                  lint_pid=$!
-
-                  pnpm run typecheck &
-                  typecheck_pid=$!
-
-                  status=0
-                  wait "$lint_pid" || status=1
-                  wait "$typecheck_pid" || status=1
-                  exit "$status"
+                  cd apps/web
+                  pnpm run lint
+                  pnpm run typecheck
 
     api-aimock:
         name: API AIMock matrix


### PR DESCRIPTION
## Summary

- Let OpenAPI lint run alongside data validation instead of waiting for it.
- Keep downstream app, AIMock, devtools, and SDK generation jobs gated on both data validation and OpenAPI lint.
- Hold off on GitHub Actions native step-level parallelism until the newly announced syntax behaves consistently in this repo.

## Why

GitHub announced native background/parallel step support, but the CI workflow parser rejected the new workflow keywords on this branch before jobs were created. This PR keeps the safe dependency-graph improvement and avoids relying on the new step syntax for now.

## Expected impact

Based on recent CI runs, this should save roughly 40-45 seconds on typical PR CI by removing the unnecessary serial `data -> openapi-lint` dependency. Preview deploy remains the largest variable and is not changed here.

## Validation

- `node -e "const fs=require('fs'); const yaml=require('js-yaml'); yaml.load(fs.readFileSync('.github/workflows/ci.yml','utf8')); console.log('YAML OK')"`
- `git diff --check`
- Confirmed no `parallel`, `background`, `wait`, `wait-all`, or `cancel` workflow keywords remain
