### PR TITLE
[codex] Show pricing for coming soon models

### DIFF
--- a/apps/web/src/app/(dashboard)/models/page.tsx
+++ b/apps/web/src/app/(dashboard)/models/page.tsx
@@ -8,6 +8,7 @@ import {
 } from "@/lib/fetchers/frontend/fetchPublicCatalog";
 import {
 	getCatalogPricingSummariesCached,
+	type CatalogPricingSummary,
 	type CatalogPricingSummaryByModelId,
 } from "@/lib/fetchers/models/getCatalogPricingSummaries";
 import type { Metadata } from "next";
@@ -877,6 +878,26 @@ function resolveModelWeeklyMetrics(
 	);
 }
 
+function resolveCatalogPricingSummary(
+	modelId: string,
+	signals: GatewaySignals | undefined,
+	catalogPricingSummaries: CatalogPricingSummaryByModelId,
+): CatalogPricingSummary | undefined {
+	const candidates = [
+		modelId,
+		...Array.from(signals?.apiModelIds ?? []),
+	]
+		.map((value) => String(value ?? "").trim())
+		.filter(Boolean);
+
+	for (const candidate of candidates) {
+		const summary = catalogPricingSummaries[candidate];
+		if (summary) return summary;
+	}
+
+	return undefined;
+}
+
 function withGatewayMetadata(
 	baseModels: ModelCard[],
 	monitorRows: NonNullable<ModelCard["gateway_monitor_rows"]>,
@@ -896,6 +917,11 @@ function withGatewayMetadata(
 			model ?? ({ model_id: modelId, name: modelId, organisation_id: "" } as ModelCard),
 			signals,
 			weeklyMetricsByKey,
+		);
+		const catalogPricing = resolveCatalogPricingSummary(
+			modelId,
+			signals,
+			catalogPricingSummaries,
 		);
 		const providerCount = signals?.providerIds.size ?? 0;
 		const activeProviderCount = signals?.activeProviderIds.size ?? 0;
@@ -1001,23 +1027,46 @@ function withGatewayMetadata(
 			supported_parameters: Array.from(
 				signals?.supportedParameters ?? [],
 			).sort(),
-			lowest_input_price: signals?.lowestInputPrice ?? null,
-			lowest_output_price: signals?.lowestOutputPrice ?? null,
-			lowest_standard_input_price: signals?.lowestStandardInputPrice ?? null,
-			lowest_standard_output_price: signals?.lowestStandardOutputPrice ?? null,
+			lowest_input_price:
+				signals?.lowestInputPrice ?? catalogPricing?.lowestInputPrice ?? null,
+			lowest_output_price:
+				signals?.lowestOutputPrice ?? catalogPricing?.lowestOutputPrice ?? null,
+			lowest_standard_input_price:
+				signals?.lowestStandardInputPrice ??
+				catalogPricing?.lowestStandardInputPrice ??
+				null,
+			lowest_standard_output_price:
+				signals?.lowestStandardOutputPrice ??
+				catalogPricing?.lowestStandardOutputPrice ??
+				null,
 			lowest_standard_input_price_label:
-				signals?.lowestStandardInputPriceLabel ?? null,
+				signals?.lowestStandardInputPriceLabel ??
+				catalogPricing?.lowestStandardInputPriceLabel ??
+				null,
 			lowest_standard_input_price_unit:
-				signals?.lowestStandardInputPriceUnit ?? null,
+				signals?.lowestStandardInputPriceUnit ??
+				catalogPricing?.lowestStandardInputPriceUnit ??
+				null,
 			lowest_standard_output_price_label:
-				signals?.lowestStandardOutputPriceLabel ?? null,
+				signals?.lowestStandardOutputPriceLabel ??
+				catalogPricing?.lowestStandardOutputPriceLabel ??
+				null,
 			lowest_standard_output_price_unit:
-				signals?.lowestStandardOutputPriceUnit ?? null,
-			lowest_from_price: signals?.lowestFromPrice ?? null,
-			lowest_from_price_unit: signals?.lowestFromPriceUnit ?? null,
-			pricing_detail_rows: mergePricingDetailRows(
-				(signals?.pricingDetailRows ?? []).slice(0, 12),
-			).slice(0, 6),
+				signals?.lowestStandardOutputPriceUnit ??
+				catalogPricing?.lowestStandardOutputPriceUnit ??
+				null,
+			lowest_from_price:
+				signals?.lowestFromPrice ?? catalogPricing?.lowestFromPrice ?? null,
+			lowest_from_price_unit:
+				signals?.lowestFromPriceUnit ?? catalogPricing?.lowestFromPriceUnit ?? null,
+			pricing_detail_rows: (() => {
+				const gatewayRows = mergePricingDetailRows(
+					(signals?.pricingDetailRows ?? []).slice(0, 12),
+				).slice(0, 6);
+				return gatewayRows.length > 0
+					? gatewayRows
+					: (catalogPricing?.pricingDetailRows ?? []);
+			})(),
 			popularity_tokens_week: weeklyMetrics.tokensWeek,
 			throughput_week: weeklyMetrics.throughputWeek,
 			latency_week: weeklyMetrics.latencyWeek,

--- a/apps/web/src/app/(dashboard)/models/page.tsx
+++ b/apps/web/src/app/(dashboard)/models/page.tsx
@@ -6,6 +6,10 @@ import {
 	fetchFrontendFreeRouterOverview,
 	fetchFrontendModels,
 } from "@/lib/fetchers/frontend/fetchPublicCatalog";
+import {
+	getCatalogPricingSummariesCached,
+	type CatalogPricingSummaryByModelId,
+} from "@/lib/fetchers/models/getCatalogPricingSummaries";
 import type { Metadata } from "next";
 import { buildMetadata } from "@/lib/seo";
 import { featureOrder } from "@/lib/config/featureLabels";
@@ -876,6 +880,7 @@ function resolveModelWeeklyMetrics(
 function withGatewayMetadata(
 	baseModels: ModelCard[],
 	monitorRows: NonNullable<ModelCard["gateway_monitor_rows"]>,
+	catalogPricingSummaries: CatalogPricingSummaryByModelId,
 ): ModelsPageModel[] {
 	const signalsByModelId = aggregateGatewaySignals(monitorRows);
 	const weeklyMetricsByKey = buildWeeklyMetricsByModel(monitorRows);
@@ -1064,6 +1069,7 @@ function withGatewayMetadata(
 				weeklyMetricsByKey,
 			);
 			const modelId = String(model.model_id ?? "").trim();
+			const catalogPricing = catalogPricingSummaries[modelId];
 
 			return {
 				model_id: modelId,
@@ -1093,19 +1099,28 @@ function withGatewayMetadata(
 				gateway_active_provider_names: [],
 				gateway_execution_regions: [],
 				gateway_provider_details: [],
-				gateway_api_model_ids: [],
+				gateway_api_model_ids: sortApiModelIdsForDisplay(
+					catalogPricing?.apiModelIds,
+				),
 				context_lengths: [],
 				supported_parameters: [],
-				lowest_input_price: null,
-				lowest_output_price: null,
-				lowest_standard_input_price: null,
-				lowest_standard_output_price: null,
-				lowest_standard_input_price_label: null,
-				lowest_standard_input_price_unit: null,
-				lowest_standard_output_price_label: null,
-				lowest_standard_output_price_unit: null,
-				lowest_from_price: null,
-				lowest_from_price_unit: null,
+				lowest_input_price: catalogPricing?.lowestInputPrice ?? null,
+				lowest_output_price: catalogPricing?.lowestOutputPrice ?? null,
+				lowest_standard_input_price:
+					catalogPricing?.lowestStandardInputPrice ?? null,
+				lowest_standard_output_price:
+					catalogPricing?.lowestStandardOutputPrice ?? null,
+				lowest_standard_input_price_label:
+					catalogPricing?.lowestStandardInputPriceLabel ?? null,
+				lowest_standard_input_price_unit:
+					catalogPricing?.lowestStandardInputPriceUnit ?? null,
+				lowest_standard_output_price_label:
+					catalogPricing?.lowestStandardOutputPriceLabel ?? null,
+				lowest_standard_output_price_unit:
+					catalogPricing?.lowestStandardOutputPriceUnit ?? null,
+				lowest_from_price: catalogPricing?.lowestFromPrice ?? null,
+				lowest_from_price_unit: catalogPricing?.lowestFromPriceUnit ?? null,
+				pricing_detail_rows: catalogPricing?.pricingDetailRows ?? [],
 				popularity_tokens_week: weeklyMetrics.tokensWeek,
 				throughput_week: weeklyMetrics.throughputWeek,
 				latency_week: weeklyMetrics.latencyWeek,
@@ -1186,14 +1201,19 @@ function buildFreeRouterModelsPageEntry(
 }
 
 async function ModelsPageDataSection() {
-	const [allModels, freeRouterOverview] = await Promise.all([
+	const [allModels, freeRouterOverview, catalogPricingSummaries] = await Promise.all([
 		fetchFrontendModels(),
 		fetchFrontendFreeRouterOverview(),
+		getCatalogPricingSummariesCached(),
 	]);
 	const monitorRows = allModels.flatMap(
 		(model) => model.gateway_monitor_rows ?? [],
 	);
-	const models = withGatewayMetadata(allModels, monitorRows);
+	const models = withGatewayMetadata(
+		allModels,
+		monitorRows,
+		catalogPricingSummaries,
+	);
 	const freeRouterModel = buildFreeRouterModelsPageEntry(freeRouterOverview);
 	const modelsWithFreeRouter = [
 		freeRouterModel,

--- a/apps/web/src/lib/fetchers/models/getCatalogPricingSummaries.ts
+++ b/apps/web/src/lib/fetchers/models/getCatalogPricingSummaries.ts
@@ -152,7 +152,7 @@ function formatPriceAmount(value: number): string {
 
 function formatDetailValue(price: number, unit: string): string {
     const amount = formatPriceAmount(price);
-    if (unit === "1M tokens") return `${amount} /M tokens`;
+    if (unit === "1M tokens") return `${amount} / 1M tokens`;
     return `${amount} / ${unit}`;
 }
 
@@ -247,6 +247,7 @@ async function fetchPricingRuleRows(): Promise<PricingRuleRow[]> {
             .select(
                 "model_key, pricing_plan, meter, note, unit, unit_size, price_per_unit, effective_from, effective_to",
             )
+            .order("rule_id", { ascending: true })
             .range(from, to);
         if (error) throw error;
 

--- a/apps/web/src/lib/fetchers/models/getCatalogPricingSummaries.ts
+++ b/apps/web/src/lib/fetchers/models/getCatalogPricingSummaries.ts
@@ -1,0 +1,310 @@
+import { cacheLife, cacheTag } from "next/cache";
+import { createAdminClient } from "@/utils/supabase/admin";
+
+type PricingRuleRow = {
+    model_key: string | null;
+    pricing_plan: string | null;
+    meter: string | null;
+    note: string | null;
+    unit: string | null;
+    unit_size: number | null;
+    price_per_unit: number | string | null;
+    effective_from: string | null;
+    effective_to: string | null;
+};
+
+export type CatalogPricingSummary = {
+    apiModelIds: string[];
+    lowestInputPrice: number | null;
+    lowestOutputPrice: number | null;
+    lowestStandardInputPrice: number | null;
+    lowestStandardOutputPrice: number | null;
+    lowestStandardInputPriceLabel: string | null;
+    lowestStandardInputPriceUnit: string | null;
+    lowestStandardOutputPriceLabel: string | null;
+    lowestStandardOutputPriceUnit: string | null;
+    lowestFromPrice: number | null;
+    lowestFromPriceUnit: string | null;
+    pricingDetailRows: Array<{
+        label: string;
+        value: string;
+    }>;
+};
+
+export type CatalogPricingSummaryByModelId = Record<string, CatalogPricingSummary>;
+
+const PRICING_RULE_PAGE_SIZE = 1000;
+
+function parseModelKey(modelKey: string): {
+    providerId: string;
+    apiModelId: string;
+    capabilityId: string;
+} | null {
+    const first = modelKey.indexOf(":");
+    const last = modelKey.lastIndexOf(":");
+    if (first <= 0 || last <= first) return null;
+    return {
+        providerId: modelKey.slice(0, first),
+        apiModelId: modelKey.slice(first + 1, last),
+        capabilityId: modelKey.slice(last + 1),
+    };
+}
+
+function isRuleExpired(rule: PricingRuleRow, nowMs: number): boolean {
+    const toMs = rule.effective_to ? new Date(rule.effective_to).getTime() : null;
+    return toMs !== null && Number.isFinite(toMs) && nowMs >= toMs;
+}
+
+function isRuleActive(rule: PricingRuleRow, nowMs: number): boolean {
+    if (isRuleExpired(rule, nowMs)) return false;
+    const fromMs = rule.effective_from ? new Date(rule.effective_from).getTime() : null;
+    return fromMs === null || !Number.isFinite(fromMs) || fromMs <= nowMs;
+}
+
+function normalizeDisplayUnit(unit: string | null | undefined): string | null {
+    const normalized = String(unit ?? "").trim().toLowerCase();
+    if (!normalized) return null;
+    if (["token", "tokens"].includes(normalized)) return "1M tokens";
+    if (["minute", "minutes", "min", "mins", "m"].includes(normalized)) return "second";
+    if (["hour", "hours", "hr", "hrs", "h"].includes(normalized)) return "second";
+    if (["second", "seconds", "sec", "secs", "s"].includes(normalized)) return "second";
+    if (["image", "images"].includes(normalized)) return "image";
+    if (["video", "videos"].includes(normalized)) return "video";
+    if (["character", "characters", "char", "chars"].includes(normalized)) {
+        return "character";
+    }
+    return normalized;
+}
+
+function parseMinutePricingNote(
+    note: string | null | undefined,
+): { price: number; unit: "minute" } | null {
+    const normalized = String(note ?? "").trim();
+    if (!normalized) return null;
+    const match = normalized.match(/\$([\d.]+)\s*\/\s*minute/i);
+    if (!match) return null;
+    const price = Number(match[1]);
+    if (!Number.isFinite(price) || price < 0) return null;
+    return { price, unit: "minute" };
+}
+
+function computeDisplayPrice(rule: PricingRuleRow): number | null {
+    const minutePricing = parseMinutePricingNote(rule.note);
+    if (minutePricing) return minutePricing.price;
+    const unitSize = Number(rule.unit_size ?? 0);
+    const pricePerUnit = Number(rule.price_per_unit ?? Number.NaN);
+    if (!Number.isFinite(pricePerUnit) || !Number.isFinite(unitSize) || unitSize <= 0) {
+        return null;
+    }
+    const meter = String(rule.meter ?? "").trim().toLowerCase();
+    const unit = String(rule.unit ?? "").trim().toLowerCase();
+    if (meter.includes("token") || ["token", "tokens"].includes(unit)) {
+        return pricePerUnit * (1_000_000 / unitSize);
+    }
+    if (["minute", "minutes", "min", "mins", "m"].includes(unit)) {
+        return pricePerUnit / unitSize / 60;
+    }
+    if (["hour", "hours", "hr", "hrs", "h"].includes(unit)) {
+        return pricePerUnit / unitSize / 3600;
+    }
+    return pricePerUnit / unitSize;
+}
+
+function getStandardSideAndLabel(
+    meter: string | null | undefined,
+): { side: "input" | "output" | null; label: string | null } {
+    const normalized = String(meter ?? "").trim().toLowerCase();
+    if (["input_text_tokens", "input_tokens"].includes(normalized)) {
+        return { side: "input", label: "Text Input" };
+    }
+    if (["output_text_tokens", "output_tokens"].includes(normalized)) {
+        return { side: "output", label: "Text Output" };
+    }
+    if (["input_audio_tokens", "input_audio"].includes(normalized)) {
+        return { side: "input", label: "Audio Input" };
+    }
+    if (["output_audio_tokens", "output_audio", "output_audio_seconds"].includes(normalized)) {
+        return { side: "output", label: "Audio Output" };
+    }
+    if (["input_image_tokens", "input_image"].includes(normalized)) {
+        return { side: "input", label: "Image Input" };
+    }
+    if (["output_image_tokens", "output_image"].includes(normalized)) {
+        return { side: "output", label: "Image Output" };
+    }
+    if (["input_video_tokens", "input_video"].includes(normalized)) {
+        return { side: "input", label: "Video Input" };
+    }
+    if (["output_video_tokens", "output_video", "output_video_seconds"].includes(normalized)) {
+        return { side: "output", label: "Video Output" };
+    }
+    return { side: null, label: null };
+}
+
+function formatPriceAmount(value: number): string {
+    if (!Number.isFinite(value) || value < 0) return "$0";
+    if (value === 0) return "$0";
+    if (value < 0.001) return `$${value.toFixed(4)}`;
+    if (value < 0.1) return `$${value.toFixed(3)}`;
+    if (value < 1) return `$${value.toFixed(2)}`;
+    return `$${value.toLocaleString(undefined, { maximumFractionDigits: 2 })}`;
+}
+
+function formatDetailValue(price: number, unit: string): string {
+    const amount = formatPriceAmount(price);
+    if (unit === "1M tokens") return `${amount} /M tokens`;
+    return `${amount} / ${unit}`;
+}
+
+function buildEmptySummary(): CatalogPricingSummary {
+    return {
+        apiModelIds: [],
+        lowestInputPrice: null,
+        lowestOutputPrice: null,
+        lowestStandardInputPrice: null,
+        lowestStandardOutputPrice: null,
+        lowestStandardInputPriceLabel: null,
+        lowestStandardInputPriceUnit: null,
+        lowestStandardOutputPriceLabel: null,
+        lowestStandardOutputPriceUnit: null,
+        lowestFromPrice: null,
+        lowestFromPriceUnit: null,
+        pricingDetailRows: [],
+    };
+}
+
+function buildSummary(apiModelId: string, rows: PricingRuleRow[]): CatalogPricingSummary {
+    const summary = buildEmptySummary();
+    summary.apiModelIds = [apiModelId];
+
+    const displayRows: Array<{ price: number; unit: string }> = [];
+    const displayUnits = new Set<string>();
+    const detailRows: Array<{ label: string; value: string }> = [];
+
+    for (const row of rows) {
+        const displayPrice = computeDisplayPrice(row);
+        const minutePricing = parseMinutePricingNote(row.note);
+        const displayUnit = minutePricing
+            ? minutePricing.unit
+            : normalizeDisplayUnit(row.unit);
+        if (displayPrice !== null && displayUnit) {
+            displayRows.push({ price: displayPrice, unit: displayUnit });
+            displayUnits.add(displayUnit);
+        }
+
+        const { side, label } = getStandardSideAndLabel(row.meter);
+        if (!side || !label || displayPrice === null || !displayUnit) continue;
+
+        detailRows.push({
+            label,
+            value: formatDetailValue(displayPrice, displayUnit),
+        });
+
+        if (side === "input") {
+            if (
+                summary.lowestStandardInputPrice === null ||
+                displayPrice < summary.lowestStandardInputPrice
+            ) {
+                summary.lowestInputPrice = displayPrice;
+                summary.lowestStandardInputPrice = displayPrice;
+                summary.lowestStandardInputPriceLabel = label;
+                summary.lowestStandardInputPriceUnit = displayUnit;
+            }
+        } else if (
+            summary.lowestStandardOutputPrice === null ||
+            displayPrice < summary.lowestStandardOutputPrice
+        ) {
+            summary.lowestOutputPrice = displayPrice;
+            summary.lowestStandardOutputPrice = displayPrice;
+            summary.lowestStandardOutputPriceLabel = label;
+            summary.lowestStandardOutputPriceUnit = displayUnit;
+        }
+    }
+
+    if (displayUnits.size === 1 && displayRows.length > 0) {
+        displayRows.sort((a, b) => a.price - b.price);
+        summary.lowestFromPrice = displayRows[0]?.price ?? null;
+        summary.lowestFromPriceUnit = displayRows[0]?.unit ?? null;
+    }
+
+    summary.pricingDetailRows = Array.from(
+        new Map(
+            detailRows.map((row) => [`${row.label}::${row.value}`, row] as const),
+        ).values(),
+    ).slice(0, 6);
+
+    return summary;
+}
+
+async function fetchPricingRuleRows(): Promise<PricingRuleRow[]> {
+    const supabase = createAdminClient();
+    const rows: PricingRuleRow[] = [];
+
+    for (let from = 0; ; from += PRICING_RULE_PAGE_SIZE) {
+        const to = from + PRICING_RULE_PAGE_SIZE - 1;
+        const { data, error } = await supabase
+            .from("data_api_pricing_rules")
+            .select(
+                "model_key, pricing_plan, meter, note, unit, unit_size, price_per_unit, effective_from, effective_to",
+            )
+            .range(from, to);
+        if (error) throw error;
+
+        const page = (data ?? []) as PricingRuleRow[];
+        rows.push(...page);
+        if (page.length < PRICING_RULE_PAGE_SIZE) break;
+    }
+
+    return rows;
+}
+
+export async function getCatalogPricingSummariesCached(): Promise<
+    CatalogPricingSummaryByModelId
+> {
+    "use cache";
+
+    cacheLife("hours");
+    cacheTag("public-model-catalogue");
+    cacheTag("data:data_api_pricing_rules");
+    cacheTag("frontend:catalog-pricing-summaries");
+
+    let rows: PricingRuleRow[];
+    try {
+        rows = await fetchPricingRuleRows();
+    } catch {
+        return {};
+    }
+
+    const nowMs = Date.now();
+    const rowsByApiModelId = new Map<string, PricingRuleRow[]>();
+    const activeRowsByApiModelId = new Map<string, PricingRuleRow[]>();
+
+    for (const row of rows) {
+        if (isRuleExpired(row, nowMs)) continue;
+        const plan = String(row.pricing_plan ?? "standard").trim().toLowerCase();
+        if (plan !== "standard") continue;
+        const parsed = parseModelKey(String(row.model_key ?? ""));
+        if (!parsed?.apiModelId) continue;
+
+        const allRows = rowsByApiModelId.get(parsed.apiModelId) ?? [];
+        allRows.push(row);
+        rowsByApiModelId.set(parsed.apiModelId, allRows);
+
+        if (isRuleActive(row, nowMs)) {
+            const activeRows = activeRowsByApiModelId.get(parsed.apiModelId) ?? [];
+            activeRows.push(row);
+            activeRowsByApiModelId.set(parsed.apiModelId, activeRows);
+        }
+    }
+
+    const result: CatalogPricingSummaryByModelId = {};
+    for (const [apiModelId, allRows] of rowsByApiModelId) {
+        const activeRows = activeRowsByApiModelId.get(apiModelId);
+        result[apiModelId] = buildSummary(
+            apiModelId,
+            activeRows?.length ? activeRows : allRows,
+        );
+    }
+
+    return result;
+}


### PR DESCRIPTION
## Summary
- Add a catalog pricing summary helper for models that have pricing rules but no active gateway monitor rows yet.
- Use those summaries on the main models page for catalog-only entries, so announced/Coming Soon models can show the same pricing pill and hover rows as released models.
- Keep provider counts and gateway availability unchanged; this only fills pricing display fields from known pricing rules.

## Root Cause
Coming Soon GPT-5.6 models are catalog-only today. The models page previously populated pricing fields only from gateway monitor rows, so catalog-only entries were explicitly sent to the card with `null` pricing despite having pricing rules in the catalog.

## Validation
- `pnpm --filter @ai-stats/web typecheck`
- `git diff --check`
- `pnpm --filter @ai-stats/web exec eslint 'src/app/(dashboard)/models/page.tsx' 'src/lib/fetchers/models/getCatalogPricingSummaries.ts'` passed with the existing `max-lines` warning on `models/page.tsx`
- Started `pnpm --filter @ai-stats/web dev`; local page rendering is limited in this workspace because Supabase env vars are missing

## Notes
Expected GPT-5.6 Coming Soon card pills from catalog pricing:
- GPT 5.6 Luna: `$1 / $6`
- GPT 5.6 Terra: `$2.5 / $15`
- GPT 5.6 Sol: `$5 / $30`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Model pages now show richer catalog pricing details for additional models, including clearer input/output pricing and “from” price labels.
  * Pricing information is now pulled in more broadly from the model catalog, improving coverage for internal-only models.

* **Bug Fixes**
  * Improved model pricing display consistency by using standardized pricing summaries and better handling of different usage units.
  * Enhanced model identifiers shown in the catalog to better match available pricing data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->