### PR TITLE
Add Claude Sonnet 5 benchmark results

### DIFF
--- a/packages/data/catalog/src/data/models/anthropic/claude-sonnet-5/model.json
+++ b/packages/data/catalog/src/data/models/anthropic/claude-sonnet-5/model.json
@@ -108,7 +108,7 @@
     {
       "benchmark_id": "cursorbench-3.1",
       "score": 61.2,
-      "is_self_reported": true,
+      "is_self_reported": false,
       "other_info": "Cursor production agent harness; measured and reported independently by Cursor",
       "source_link": "https://www.anthropic.com/claude-sonnet-5-system-card"
     },
@@ -199,7 +199,7 @@
     {
       "benchmark_id": "gdpval-aa",
       "score": 1609,
-      "is_self_reported": true,
+      "is_self_reported": false,
       "other_info": "GDPval-AA v2; Elo; independent Artificial Analysis evaluation, score as of 2026-06-06",
       "source_link": "https://www.anthropic.com/claude-sonnet-5-system-card"
     },

--- a/packages/data/catalog/src/data/models/anthropic/claude-sonnet-5/model.json
+++ b/packages/data/catalog/src/data/models/anthropic/claude-sonnet-5/model.json
@@ -21,11 +21,11 @@
     },
     {
       "platform": "api_reference",
-      "url": "https://docs.anthropic.com/en/docs/about-claude/models/overview"
+      "url": "https://platform.claude.com/docs/en/about-claude/models/overview"
     },
     {
-      "platform": "paper",
-      "url": "https://assets.anthropic.com/m/6f133da8a5e09cf6/original/claude-sonnet-5-system-card.pdf"
+      "platform": "model_card",
+      "url": "https://www.anthropic.com/claude-sonnet-5-system-card"
     }
   ],
   "details": [
@@ -62,5 +62,160 @@
       "value": "Claude Sonnet 5 uses a new tokenizer; Anthropic reports text-heavy workloads may see approximately 1.0x to 1.35x token-count changes compared with prior Claude models."
     }
   ],
-  "benchmarks": []
+  "benchmarks": [
+    {
+      "benchmark_id": "swe-bench",
+      "score": 85.2,
+      "is_self_reported": true,
+      "other_info": "SWE-bench Verified; standard configuration; average over five trials",
+      "source_link": "https://www.anthropic.com/claude-sonnet-5-system-card"
+    },
+    {
+      "benchmark_id": "swe-bench-pro",
+      "score": 63.2,
+      "is_self_reported": true,
+      "other_info": "SWE-bench Pro; standard configuration; average over five trials",
+      "source_link": "https://www.anthropic.com/claude-sonnet-5-system-card"
+    },
+    {
+      "benchmark_id": "swe-bench-multilingual",
+      "score": 78.3,
+      "is_self_reported": true,
+      "other_info": "SWE-bench Multilingual; standard configuration; average over five trials",
+      "source_link": "https://www.anthropic.com/claude-sonnet-5-system-card"
+    },
+    {
+      "benchmark_id": "swe-bench-multimodal",
+      "score": 28.1,
+      "is_self_reported": true,
+      "other_info": "SWE-bench Multimodal; internal harness; average over five trials",
+      "source_link": "https://www.anthropic.com/claude-sonnet-5-system-card"
+    },
+    {
+      "benchmark_id": "terminal-bench-2.1",
+      "score": 80.4,
+      "is_self_reported": true,
+      "other_info": "mini-SWE-agent harness; xhigh effort; mean reward across 445 trials",
+      "source_link": "https://www.anthropic.com/claude-sonnet-5-system-card"
+    },
+    {
+      "benchmark_id": "frontiercode-diamond",
+      "score": 38.8,
+      "is_self_reported": true,
+      "other_info": "FrontierCode v1; adaptive thinking at max effort; summary-table score",
+      "source_link": "https://www.anthropic.com/claude-sonnet-5-system-card"
+    },
+    {
+      "benchmark_id": "cursorbench-3.1",
+      "score": 61.2,
+      "is_self_reported": true,
+      "other_info": "Cursor production agent harness; measured and reported independently by Cursor",
+      "source_link": "https://www.anthropic.com/claude-sonnet-5-system-card"
+    },
+    {
+      "benchmark_id": "usamo-2026",
+      "score": 79.5,
+      "is_self_reported": true,
+      "other_info": "High effort; 300k token limit; average over ten attempts per problem",
+      "source_link": "https://www.anthropic.com/claude-sonnet-5-system-card"
+    },
+    {
+      "benchmark_id": "humanitys-last-exam",
+      "score": 43.2,
+      "is_self_reported": true,
+      "other_info": "No tools; auto thinking; 1M total-token cap",
+      "source_link": "https://www.anthropic.com/claude-sonnet-5-system-card"
+    },
+    {
+      "benchmark_id": "humanitys-last-exam",
+      "score": 57.4,
+      "is_self_reported": true,
+      "other_info": "With web search, web fetch, programmatic tool calling, and code execution; auto thinking; 1M total-token cap",
+      "source_link": "https://www.anthropic.com/claude-sonnet-5-system-card"
+    },
+    {
+      "benchmark_id": "browsecomp",
+      "score": 84.7,
+      "is_self_reported": true,
+      "other_info": "Single-agent run; adaptive thinking at maximum effort; 10M-token limit with context compaction triggered at 200k",
+      "source_link": "https://www.anthropic.com/claude-sonnet-5-system-card"
+    },
+    {
+      "benchmark_id": "browsecomp",
+      "score": 86.6,
+      "is_self_reported": true,
+      "other_info": "Multi-agent run from Anthropic capability summary table",
+      "source_link": "https://www.anthropic.com/claude-sonnet-5-system-card"
+    },
+    {
+      "benchmark_id": "gdp-pdf",
+      "score": 67.5,
+      "is_self_reported": true,
+      "other_info": "No tools; mean criteria pass rate; full 100 prompts; average over five runs",
+      "source_link": "https://www.anthropic.com/claude-sonnet-5-system-card"
+    },
+    {
+      "benchmark_id": "gdp-pdf",
+      "score": 81.6,
+      "is_self_reported": true,
+      "other_info": "With Python and image-cropping tools; mean criteria pass rate; full 100 prompts; average over five runs",
+      "source_link": "https://www.anthropic.com/claude-sonnet-5-system-card"
+    },
+    {
+      "benchmark_id": "os-world",
+      "score": 81.2,
+      "is_self_reported": true,
+      "other_info": "OSWorld-Verified; pass@1 averaged over five runs; 361 tasks, 100 steps; adaptive thinking at max effort",
+      "source_link": "https://www.anthropic.com/claude-sonnet-5-system-card"
+    },
+    {
+      "benchmark_id": "officeqa",
+      "score": 73.3,
+      "is_self_reported": true,
+      "other_info": "Exact-match accuracy on Anthropic internal agentic harness; mean of five trials",
+      "source_link": "https://www.anthropic.com/claude-sonnet-5-system-card"
+    },
+    {
+      "benchmark_id": "officeqa-pro",
+      "score": 59.4,
+      "is_self_reported": true,
+      "other_info": "Exact-match accuracy on Anthropic internal agentic harness; mean of five trials",
+      "source_link": "https://www.anthropic.com/claude-sonnet-5-system-card"
+    },
+    {
+      "benchmark_id": "legal-agent-benchmark",
+      "score": 8.92,
+      "is_self_reported": true,
+      "other_info": "Full public set; all-pass rate; adaptive thinking at max effort; n=5",
+      "source_link": "https://www.anthropic.com/claude-sonnet-5-system-card"
+    },
+    {
+      "benchmark_id": "legal-agent-benchmark",
+      "score": 5.8,
+      "is_self_reported": true,
+      "other_info": "Harvey held-out set; all-pass rate; reported in Anthropic's system card",
+      "source_link": "https://www.anthropic.com/claude-sonnet-5-system-card"
+    },
+    {
+      "benchmark_id": "gdpval-aa",
+      "score": 1609,
+      "is_self_reported": true,
+      "other_info": "GDPval-AA v2; Elo; independent Artificial Analysis evaluation, score as of 2026-06-06",
+      "source_link": "https://www.anthropic.com/claude-sonnet-5-system-card"
+    },
+    {
+      "benchmark_id": "toolathlon",
+      "score": 54.3,
+      "is_self_reported": true,
+      "other_info": "Pass@1; internal harness; adaptive thinking at max effort; averaged over three trials across 108 tasks",
+      "source_link": "https://www.anthropic.com/claude-sonnet-5-system-card"
+    },
+    {
+      "benchmark_id": "automationbench",
+      "score": 13.5,
+      "is_self_reported": true,
+      "other_info": "Zapier leaderboard private held-out tasks; max effort",
+      "source_link": "https://www.anthropic.com/claude-sonnet-5-system-card"
+    }
+  ]
 }


### PR DESCRIPTION
## Summary
- Add Anthropic-reported Claude Sonnet 5 benchmark results from the official system card.
- Replace the stale system-card asset URL with Anthropic's stable system-card URL.
- Normalize the Anthropic docs link to the resolved platform.claude.com URL.

## Benchmarks added
- SWE-bench Verified, SWE-bench Pro, SWE-bench Multilingual, SWE-bench Multimodal
- Terminal-Bench 2.1, FrontierCode v1, CursorBench 3.1, USAMO 2026
- Humanity's Last Exam, BrowseComp, GDP.pdf, OSWorld-Verified
- OfficeQA, OfficeQA Pro, Legal Agent Benchmark, GDPval-AA v2, Toolathlon, AutomationBench

## Link check
- https://www.anthropic.com/news/claude-sonnet-5 -> 200
- https://platform.claude.com/docs/en/about-claude/models/overview -> 200
- https://www.anthropic.com/claude-sonnet-5-system-card -> 200 application/pdf

## Validation
- `pnpm --config.verify-deps-before-run=false validate:data` passed with existing non-blocking warnings
- `git diff --check` passed with Git line-ending warning only

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a comprehensive set of benchmark results for the model, including code, agent, multilingual, and multimodal evaluations.
  * Updated the model’s reference links to point to the latest documentation and system card pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->