### PR TITLE
Delete stale model notices during import

### DIFF
--- a/apps/web/scripts/importer/loaders/models.ts
+++ b/apps/web/scripts/importer/loaders/models.ts
@@ -322,7 +322,7 @@ export async function loadModels(
             }
             if (hasPageNotice) {
                 await syncModelPageNotice(apiModelId, m.page_notice ?? null);
-            } else if (previousHadPageNotice) {
+            } else {
                 await syncModelPageNotice(apiModelId, null);
             }
 


### PR DESCRIPTION
## Summary

- Make model notice deletion idempotent during model imports.
- If a model JSON no longer has `page_notice`, delete any existing `data_api_model_page_notices` row even when import-state does not record a previous notice.
- This should clear stale public notices such as the old Claude Sonnet 5 release notice on the next targeted or full model import.

## Verification

- `pnpm --config.verify-deps-before-run=false validate:data`
- `git diff --check`

## Notes

- Targeted importer dry-run could not be executed in this worktree because `dotenv` is not installed/resolved here.
- `pnpm --config.verify-deps-before-run=false --filter @ai-stats/web typecheck` could not run because this worktree has no `node_modules` / local `tsc`.