### PR TITLE
Update Claude Fable 5 return notice

### DIFF
--- a/packages/data/catalog/src/data/models/anthropic/claude-fable-5/model.json
+++ b/packages/data/catalog/src/data/models/anthropic/claude-fable-5/model.json
@@ -15,8 +15,8 @@
   "api_model_id": "anthropic/claude-fable-5",
   "family_id": "anthropic/claude-fable",
   "page_notice": {
-    "tone": "critical",
-    "markdown": "Anthropic said on June 12, 2026 that it had to disable Fable 5 and Mythos 5 for all customers to comply with a U.S. export control directive. Requests to this model are currently expected to fail. [Read Anthropic's statement](https://www.anthropic.com/news/fable-mythos-access)."
+    "tone": "info",
+    "markdown": "Claude Fable 5 has returned. Anthropic says Fable 5 access was restored globally from July 1, 2026 after the related export controls were lifted, with updated safeguards and fallback routing for flagged requests. [Read Anthropic's redeployment note](https://www.anthropic.com/news/redeploying-fable-5) or [see Claude's update on X](https://x.com/claudeai/status/2072402636813607381?s=20)."
   },
   "links": [
     {


### PR DESCRIPTION
﻿## Summary
- Update Claude Fable 5's model page notice from a suspension warning to an availability notice.
- Link Anthropic's redeployment note and Claude's X update for the returned-model source trail.

## Validation
- `tsx ../../packages/data/catalog/src/data/validate.ts --preset structure`

Created with Codex
