### PR TITLE
Fix chat mobile viewport locking

### DIFF
--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -9,9 +9,16 @@ const monorepoRoot = path.join(__dirname, "..", "..");
 // Skip remote font downloads in offline or locked-down environments so builds don't fail.
 process.env.NEXT_FONT_IGNORE_FAILED_DOWNLOADS ||= "true";
 
+const configuredAllowedDevOrigins =
+  process.env.NEXT_ALLOWED_DEV_ORIGINS?.split(",")
+    .map((origin) => origin.trim())
+    .filter(Boolean) ?? [];
+
 /** @type {import("next").NextConfig} */
 const nextConfig = {
-  allowedDevOrigins: ["127.0.0.1"],
+  ...(configuredAllowedDevOrigins.length > 0
+    ? { allowedDevOrigins: configuredAllowedDevOrigins }
+    : {}),
   cacheComponents: true,
   env: {
     NEXT_PUBLIC_DEPLOY_TIME:

--- a/apps/web/src/app/chat/ChatViewportLock.tsx
+++ b/apps/web/src/app/chat/ChatViewportLock.tsx
@@ -1,0 +1,179 @@
+"use client";
+
+import { useLayoutEffect } from "react";
+
+const CHAT_VIEWPORT_HEIGHT = "--chat-viewport-height";
+const CHAT_VIEWPORT_TOP = "--chat-viewport-top";
+const CHAT_KEYBOARD_INSET = "--chat-keyboard-inset";
+
+type VirtualKeyboardLike = EventTarget & {
+	boundingRect?: DOMRectReadOnly;
+	overlaysContent: boolean;
+};
+
+type NavigatorWithVirtualKeyboard = Navigator & {
+	virtualKeyboard?: VirtualKeyboardLike;
+};
+
+function getVirtualKeyboard() {
+	return (navigator as NavigatorWithVirtualKeyboard).virtualKeyboard ?? null;
+}
+
+export function ChatViewportLock() {
+	useLayoutEffect(() => {
+		const html = document.documentElement;
+		const body = document.body;
+		const visualViewport = window.visualViewport;
+		const virtualKeyboard = getVirtualKeyboard();
+		let animationFrame: number | null = null;
+		let focusUpdateTimer: number | null = null;
+		let usesVirtualKeyboardOverlay = false;
+		const previous = {
+			bodyHeight: body.style.height,
+			bodyInset: body.style.inset,
+			bodyOverflow: body.style.overflow,
+			bodyPosition: body.style.position,
+			bodyWidth: body.style.width,
+			htmlOverflow: html.style.overflow,
+			keyboardInset: html.style.getPropertyValue(CHAT_KEYBOARD_INSET),
+			virtualKeyboardOverlaysContent: virtualKeyboard?.overlaysContent,
+			viewportHeight: html.style.getPropertyValue(CHAT_VIEWPORT_HEIGHT),
+			viewportTop: html.style.getPropertyValue(CHAT_VIEWPORT_TOP),
+		};
+		const scrollX = window.scrollX;
+		const scrollY = window.scrollY;
+
+		if (virtualKeyboard) {
+			try {
+				virtualKeyboard.overlaysContent = true;
+				usesVirtualKeyboardOverlay = virtualKeyboard.overlaysContent;
+			} catch {
+				usesVirtualKeyboardOverlay = false;
+			}
+		}
+
+		const getKeyboardHeight = () => {
+			if (!usesVirtualKeyboardOverlay) return 0;
+			return Math.max(0, virtualKeyboard?.boundingRect?.height ?? 0);
+		};
+
+		const resetDocumentScroll = () => {
+			const chatRoot = document.querySelector<HTMLElement>(
+				"[data-chat-viewport-root='true']"
+			);
+			if (chatRoot && chatRoot.scrollTop !== 0) {
+				chatRoot.scrollTop = 0;
+			}
+			if (window.scrollX === 0 && window.scrollY === 0) return;
+			window.scrollTo(0, 0);
+		};
+
+		const updateViewport = () => {
+			const visualHeight = visualViewport?.height ?? window.innerHeight;
+			const keyboardHeight = getKeyboardHeight();
+			const keyboardAdjustedHeight =
+				keyboardHeight > 0
+					? Math.max(0, window.innerHeight - keyboardHeight)
+					: Number.POSITIVE_INFINITY;
+			const height = Math.min(visualHeight, keyboardAdjustedHeight);
+			const top =
+				keyboardAdjustedHeight < visualHeight
+					? 0
+					: (visualViewport?.offsetTop ?? 0);
+			html.style.setProperty(CHAT_VIEWPORT_HEIGHT, `${height}px`);
+			html.style.setProperty(CHAT_VIEWPORT_TOP, `${top}px`);
+			html.style.setProperty(CHAT_KEYBOARD_INSET, `${keyboardHeight}px`);
+			resetDocumentScroll();
+		};
+
+		const scheduleViewportUpdate = () => {
+			if (animationFrame !== null) return;
+			animationFrame = window.requestAnimationFrame(() => {
+				animationFrame = null;
+				updateViewport();
+			});
+		};
+
+		const scheduleFocusViewportUpdate = () => {
+			scheduleViewportUpdate();
+			if (focusUpdateTimer !== null) {
+				window.clearTimeout(focusUpdateTimer);
+			}
+			focusUpdateTimer = window.setTimeout(() => {
+				focusUpdateTimer = null;
+				scheduleViewportUpdate();
+			}, 120);
+		};
+
+		// Mobile keyboards can resize or offset only the visual viewport, so the
+		// chat route follows that visible area while its internal pane gives up space.
+		html.style.overflow = "hidden";
+		body.style.position = "fixed";
+		body.style.inset = "0";
+		body.style.width = "100%";
+		body.style.height = "100%";
+		body.style.overflow = "hidden";
+		updateViewport();
+		resetDocumentScroll();
+
+		visualViewport?.addEventListener("resize", scheduleViewportUpdate);
+		visualViewport?.addEventListener("scroll", scheduleViewportUpdate);
+		virtualKeyboard?.addEventListener("geometrychange", scheduleViewportUpdate);
+		window.addEventListener("focusin", scheduleFocusViewportUpdate);
+		window.addEventListener("focusout", scheduleFocusViewportUpdate);
+		window.addEventListener("resize", scheduleViewportUpdate);
+		window.addEventListener("scroll", resetDocumentScroll, { passive: true });
+
+		return () => {
+			if (animationFrame !== null) {
+				window.cancelAnimationFrame(animationFrame);
+			}
+			if (focusUpdateTimer !== null) {
+				window.clearTimeout(focusUpdateTimer);
+			}
+			visualViewport?.removeEventListener("resize", scheduleViewportUpdate);
+			visualViewport?.removeEventListener("scroll", scheduleViewportUpdate);
+			virtualKeyboard?.removeEventListener(
+				"geometrychange",
+				scheduleViewportUpdate
+			);
+			window.removeEventListener("focusin", scheduleFocusViewportUpdate);
+			window.removeEventListener("focusout", scheduleFocusViewportUpdate);
+			window.removeEventListener("resize", scheduleViewportUpdate);
+			window.removeEventListener("scroll", resetDocumentScroll);
+			html.style.overflow = previous.htmlOverflow;
+			body.style.position = previous.bodyPosition;
+			body.style.inset = previous.bodyInset;
+			body.style.width = previous.bodyWidth;
+			body.style.height = previous.bodyHeight;
+			body.style.overflow = previous.bodyOverflow;
+			if (
+				virtualKeyboard &&
+				typeof previous.virtualKeyboardOverlaysContent === "boolean"
+			) {
+				try {
+					virtualKeyboard.overlaysContent =
+						previous.virtualKeyboardOverlaysContent;
+				} catch {}
+			}
+			if (previous.keyboardInset) {
+				html.style.setProperty(CHAT_KEYBOARD_INSET, previous.keyboardInset);
+			} else {
+				html.style.removeProperty(CHAT_KEYBOARD_INSET);
+			}
+			if (previous.viewportHeight) {
+				html.style.setProperty(CHAT_VIEWPORT_HEIGHT, previous.viewportHeight);
+			} else {
+				html.style.removeProperty(CHAT_VIEWPORT_HEIGHT);
+			}
+			if (previous.viewportTop) {
+				html.style.setProperty(CHAT_VIEWPORT_TOP, previous.viewportTop);
+			} else {
+				html.style.removeProperty(CHAT_VIEWPORT_TOP);
+			}
+			window.scrollTo(scrollX, scrollY);
+		};
+	}, []);
+
+	return null;
+}

--- a/apps/web/src/app/chat/layout.tsx
+++ b/apps/web/src/app/chat/layout.tsx
@@ -1,4 +1,5 @@
-import type { Metadata } from "next";
+import type { Metadata, Viewport } from "next";
+import { ChatViewportLock } from "@/app/chat/ChatViewportLock";
 import { buildMetadata } from "@/lib/seo";
 
 export const metadata: Metadata = buildMetadata({
@@ -9,14 +10,22 @@ export const metadata: Metadata = buildMetadata({
 	keywords: ["AI chat", "chat playground", "model comparison", "gateway chat"],
 });
 
+export const viewport: Viewport = {
+	interactiveWidget: "resizes-content",
+};
+
 export default function ChatLayout({
-    children,
+	children,
 }: {
-    children: React.ReactNode;
+	children: React.ReactNode;
 }) {
-    return (
-        <main className="box-border flex h-[100svh] min-h-0 flex-col overflow-hidden overscroll-none bg-background pt-[env(safe-area-inset-top)] pb-[env(safe-area-inset-bottom)] md:h-dvh">
-            {children}
-        </main>
-    );
+	return (
+		<main
+			data-chat-viewport-root="true"
+			className="fixed inset-x-0 top-[var(--chat-viewport-top,0px)] box-border flex h-[var(--chat-viewport-height,100dvh)] min-h-0 flex-col overflow-hidden overscroll-none bg-background pt-[env(safe-area-inset-top)] pb-[env(safe-area-inset-bottom)]"
+		>
+			<ChatViewportLock />
+			{children}
+		</main>
+	);
 }

--- a/apps/web/src/components/(chat)/ChatConversation.tsx
+++ b/apps/web/src/components/(chat)/ChatConversation.tsx
@@ -80,6 +80,12 @@ type ChatConversationProps = {
 
 type SendGateType = "auth";
 
+function shouldFocusComposerAfterThreadChange() {
+	if (typeof window === "undefined") return false;
+	if (typeof window.matchMedia !== "function") return true;
+	return window.matchMedia("(hover: hover) and (pointer: fine)").matches;
+}
+
 export function ChatConversation({
 	activeThread,
 	isSending,
@@ -173,7 +179,9 @@ export function ChatConversation({
 		const raf = requestAnimationFrame(() => {
 			setComposer("");
 			setAttachments([]);
-			textareaRef.current?.focus();
+			if (shouldFocusComposerAfterThreadChange()) {
+				textareaRef.current?.focus();
+			}
 		});
 		return () => cancelAnimationFrame(raf);
 	}, [activeThread?.id]);

--- a/apps/web/src/components/ui/sidebar.tsx
+++ b/apps/web/src/components/ui/sidebar.tsx
@@ -144,7 +144,8 @@ function SidebarProvider({
           } as React.CSSProperties
         }
         className={cn(
-          "group/sidebar-wrapper flex min-h-svh w-full has-data-[variant=inset]:bg-sidebar",
+          "group/sidebar-wrapper flex w-full has-data-[variant=inset]:bg-sidebar",
+          contained ? "min-h-0" : "min-h-svh",
           desktopClassName,
           className
         )}


### PR DESCRIPTION
## Summary
- add `interactive-widget=resizes-content` on the chat route so Android Chrome can resize chat content for the keyboard instead of panning the page
- keep the `/chat/*` shell locked to the visible viewport with rAF-batched updates and root-scroll reset
- use Chromium VirtualKeyboard geometry when available so overlay keyboards/toolbars reduce the chat shell height instead of covering the composer
- make contained sidebar layouts respect parent height so the chat shell can shrink cleanly
- avoid auto-focusing the composer after thread changes on touch/coarse-pointer devices
- allow local dev origins to be configured through `NEXT_ALLOWED_DEV_ORIGINS` without hardcoding any IP addresses
- remove the temporary viewport debug query parameter now that the fix is validated
- address review nitpicks by using the app import alias and Tailwind arbitrary classes for chat layout sizing

## Validation
- `cd apps/web; .\node_modules\.bin\tsc.cmd --noEmit`
- `node -e "import('./apps/web/next.config.mjs').then((m)=>{ if (!m.default || typeof m.default !== 'object') process.exit(1); console.log('next config ok'); })"`
- `git diff --check`
- `pnpm --filter @ai-stats/web exec eslint src/app/chat/ChatViewportLock.tsx src/app/chat/layout.tsx src/components/ui/sidebar.tsx "src/components/(chat)/ChatConversation.tsx"`
- added-line PR diff scan for private/LAN IP address literals
- Playwright touch-tablet geometry check with mocked 180px VirtualKeyboard overlay: header remains visible, root scroll stays 0, composer remains inside the reduced 440px chat viewport, and no debug overlay is rendered
- Playwright mobile fallback check without a visible VirtualKeyboard overlay: document/root scroll stay pinned and composer remains inside the chat viewport, with no debug overlay rendered
- LAN tablet smoke test over local dev server after local dev-origin allowance confirmed client JS hydrates; note VirtualKeyboard is secure-context-only on HTTP
- verified `/chat` emits `width=device-width, initial-scale=1, interactive-widget=resizes-content`

Created with Codex