### PR TITLE
Fix Poolside API base path

### DIFF
--- a/apps/api/src/providers/poolside/config.ts
+++ b/apps/api/src/providers/poolside/config.ts
@@ -4,7 +4,7 @@ export const POOLSIDE_OPENAI_COMPAT_CONFIGS = {
 	poolside: {
 		providerId: "poolside",
 		baseUrl: "https://inference.poolside.ai",
-		pathPrefix: "/openai/v1",
+		pathPrefix: "/v1",
 		apiKeyEnv: "POOLSIDE_API_KEY",
 		baseUrlEnv: "POOLSIDE_BASE_URL",
 		supportsResponses: false,


### PR DESCRIPTION
## Summary
- point the Poolside OpenAI-compatible adapter at Poolside's documented `/v1` API path
- keep Laguna XS 2.1 using the existing public AI Stats API id `poolside/laguna-xs-2.1:free`

## Validation
- local Workers API smoke against `/v1/responses` for `poolside/laguna-xs-2.1:free` with `provider.only = [poolside]`: returned 200
- `..\..\node_modules\.bin\tsx.cmd ..\..\packages\data\catalog\src\data\validate.ts --preset structure`
- `..\..\node_modules\.bin\tsx.cmd ..\..\packages\data\catalog\src\data\validate.ts --preset pricing`
- `..\..\node_modules\.bin\tsx.cmd ..\..\packages\data\catalog\src\data\validate-gateway.ts`
- `.\node_modules\.bin\tsc.cmd --noEmit` in `apps/api`

Created with Codex