### PR TITLE
Restore chat tags

### DIFF
--- a/apps/web/src/components/(chat)/ChatPlayground.tsx
+++ b/apps/web/src/components/(chat)/ChatPlayground.tsx
@@ -15,10 +15,17 @@ import type {
 	ChatServerToolConfigs,
 	ChatServerToolType,
 	ChatSettings,
+	ChatTag,
 	ChatThread,
 	UnifiedChatEndpoint,
 } from "@/lib/indexeddb/chats";
-import { deleteChat, getAllChats, upsertChat } from "@/lib/indexeddb/chats";
+import {
+	deleteChat,
+	getAllChatTags,
+	getAllChats,
+	upsertChat,
+	upsertChatTags,
+} from "@/lib/indexeddb/chats";
 import {
 	ChatConversation,
 	type ChatSendPayload,
@@ -32,6 +39,7 @@ import { ChatSearchDialog } from "@/components/(chat)/ChatSearchDialog";
 import { ChatRenameDialog } from "@/components/(chat)/ChatRenameDialog";
 import { ChatDeleteDialog } from "@/components/(chat)/ChatDeleteDialog";
 import { ChatNewChatDialog } from "@/components/(chat)/ChatNewChatDialog";
+import { ChatTagsDialog } from "@/components/(chat)/ChatTagsDialog";
 import {
 	coerceResponseText,
 	appendImagesToText,
@@ -94,6 +102,10 @@ type ChatPlaygroundProps = {
 	promptParam?: string | null;
 };
 
+function compareChatTags(a: ChatTag, b: ChatTag) {
+	return a.name.localeCompare(b.name, undefined, { sensitivity: "base" });
+}
+
 function ChatPlaygroundContent({
 	models,
 	modelParam,
@@ -129,6 +141,10 @@ function ChatPlaygroundContent({
 	const [renameTargetId, setRenameTargetId] = useState<string | null>(null);
 	const [deleteOpen, setDeleteOpen] = useState(false);
 	const [deleteTarget, setDeleteTarget] = useState<ChatThread | null>(null);
+	const [tagsOpen, setTagsOpen] = useState(false);
+	const [tagsTarget, setTagsTarget] = useState<ChatThread | null>(null);
+	const [chatTags, setChatTags] = useState<ChatTag[]>([]);
+	const [activeTagId, setActiveTagId] = useState<string | null>(null);
 	const [newChatDialogOpen, setNewChatDialogOpen] = useState(false);
 	const [pendingNewChat, setPendingNewChat] = useState<{
 		modelId: string;
@@ -236,8 +252,35 @@ function ChatPlaygroundContent({
 		if (!activeThread?.modelId) return null;
 		return "responses" as UnifiedChatEndpoint;
 	}, [activeThread?.modelId]);
+	const allTags = useMemo(() => {
+		const byId = new Map<string, ChatTag>();
+		for (const tag of chatTags) {
+			byId.set(tag.id, tag);
+		}
+		for (const thread of threads) {
+			for (const tag of thread.tags ?? []) {
+				if (!byId.has(tag.id)) {
+					byId.set(tag.id, tag);
+				}
+			}
+		}
+		return Array.from(byId.values()).sort(compareChatTags);
+	}, [chatTags, threads]);
+	const activeVisibleTagId = useMemo(
+		() =>
+			activeTagId && allTags.some((tag) => tag.id === activeTagId)
+				? activeTagId
+				: null,
+		[activeTagId, allTags],
+	);
+	const visibleThreads = useMemo(() => {
+		if (!activeVisibleTagId) return threads;
+		return threads.filter((thread) =>
+			thread.tags?.some((tag) => tag.id === activeVisibleTagId),
+		);
+	}, [activeVisibleTagId, threads]);
 	const { sortedThreads, groupedThreads } = useGroupedChatThreads(
-		threads,
+		visibleThreads,
 		groupingNowMs,
 	);
 
@@ -317,10 +360,14 @@ function ChatPlaygroundContent({
 				accentColor: storedAccent,
 			});
 
-			const chats = await getAllChats("text");
+			const [chats, storedTags] = await Promise.all([
+				getAllChats("text"),
+				getAllChatTags(),
+			]);
 			const normalized = await ensureInitialThread(chats);
 			if (!mounted) return;
 			setThreads(normalized);
+			setChatTags(storedTags.sort(compareChatTags));
 
 			const initialId =
 				storedActive && normalized.some((t) => t.id === storedActive)
@@ -2796,6 +2843,41 @@ function ChatPlaygroundContent({
 		});
 	};
 
+	const handleEditTags = (thread: ChatThread) => {
+		setTagsTarget(thread);
+		setTagsOpen(true);
+	};
+
+	const handleTagsOpenChange = (open: boolean) => {
+		setTagsOpen(open);
+		if (!open) {
+			setTagsTarget(null);
+		}
+	};
+
+	const handleTagsSave = async (tags: ChatTag[]) => {
+		if (!tagsTarget) return;
+		const thread = threads.find((candidate) => candidate.id === tagsTarget.id);
+		if (!thread) return;
+		const sortedTags = [...tags].sort(compareChatTags);
+		if (sortedTags.length > 0) {
+			await upsertChatTags(sortedTags);
+			setChatTags((prev) => {
+				const byId = new Map(prev.map((tag) => [tag.id, tag]));
+				for (const tag of sortedTags) {
+					byId.set(tag.id, tag);
+				}
+				return Array.from(byId.values()).sort(compareChatTags);
+			});
+		}
+		await updateStoredThread({
+			...thread,
+			tags: sortedTags,
+			updatedAt: nowIso(),
+		});
+		handleTagsOpenChange(false);
+	};
+
 	const toggleTemporaryMode = () => {
 		if (!temporaryMode) {
 			setPreviousStoredId(activeId);
@@ -3148,7 +3230,11 @@ function ChatPlaygroundContent({
 					onSelectThread={setActiveThread}
 					onRenameThread={handleRename}
 					onPinToggle={handlePinToggle}
+					onEditTags={handleEditTags}
 					onRequestDelete={requestDeleteThread}
+					tags={allTags}
+					activeTagId={activeVisibleTagId}
+					onTagFilterChange={setActiveTagId}
 					authUser={authUser}
 					authLoading={authLoading}
 					onSignOut={handleSignOut}
@@ -3327,6 +3413,14 @@ function ChatPlaygroundContent({
 				open={deleteOpen}
 				onOpenChange={handleDeleteOpenChange}
 				onConfirm={handleDeleteThread}
+			/>
+			<ChatTagsDialog
+				key={tagsTarget?.id ?? "chat-tags"}
+				open={tagsOpen}
+				thread={tagsTarget}
+				availableTags={allTags}
+				onOpenChange={handleTagsOpenChange}
+				onSave={handleTagsSave}
 			/>
 			<ChatNewChatDialog
 				open={newChatDialogOpen}

--- a/apps/web/src/components/(chat)/ChatSidebar.tsx
+++ b/apps/web/src/components/(chat)/ChatSidebar.tsx
@@ -1,8 +1,13 @@
 "use client";
 
 import Link from "next/link";
-import type { ReactElement } from "react";
+import { useState, type ReactElement } from "react";
 import { Button } from "@/components/ui/button";
+import {
+	Collapsible,
+	CollapsibleContent,
+	CollapsibleTrigger,
+} from "@/components/ui/collapsible";
 import {
 	DropdownMenu,
 	DropdownMenuContent,
@@ -27,12 +32,13 @@ import {
 	useSidebar,
 } from "@/components/ui/sidebar";
 import { ScrollArea } from "@/components/ui/scroll-area";
-import type { ChatThread } from "@/lib/indexeddb/chats";
+import type { ChatTag, ChatThread } from "@/lib/indexeddb/chats";
 import { ChatRoomSwitcher } from "@/components/(chat)/ChatRoomSwitcher";
 import { ThemeSelector } from "@/components/theme-toggle";
 import { cn } from "@/lib/utils";
 import {
 	ArrowUpRight,
+	ChevronRight,
 	Database,
 	Gauge,
 	LogOut,
@@ -43,6 +49,7 @@ import {
 	PinOff,
 	Search,
 	SquarePen,
+	Tag,
 	Trash2,
 	UserRound,
 } from "lucide-react";
@@ -66,7 +73,11 @@ type ChatSidebarProps = {
 	onSelectThread: (thread: ChatThread) => void;
 	onRenameThread: (thread: ChatThread) => void;
 	onPinToggle: (thread: ChatThread) => void;
+	onEditTags: (thread: ChatThread) => void;
 	onRequestDelete: (thread: ChatThread) => void;
+	tags: ChatTag[];
+	activeTagId: string | null;
+	onTagFilterChange: (tagId: string | null) => void;
 	authUser: {
 		id: string;
 		email: string | null;
@@ -167,12 +178,17 @@ export function ChatSidebar({
 	onSelectThread,
 	onRenameThread,
 	onPinToggle,
+	onEditTags,
 	onRequestDelete,
+	tags,
+	activeTagId,
+	onTagFilterChange,
 	authUser,
 	authLoading,
 	onSignOut,
 }: ChatSidebarProps) {
 	const { toggleSidebar, state: sidebarState, isMobile } = useSidebar();
+	const [tagsOpen, setTagsOpen] = useState(true);
 	const collapsed = sidebarState === "collapsed" && !isMobile;
 	const brandLightSrc = collapsed ? "/logo_light.svg" : "/wordmark_light.svg";
 	const brandDarkSrc = collapsed ? "/logo_dark.svg" : "/wordmark_dark.svg";
@@ -194,6 +210,7 @@ export function ChatSidebar({
 		.join("")
 		.slice(0, 2)
 		.toUpperCase();
+	const activeTag = tags.find((tag) => tag.id === activeTagId) ?? null;
 	const dateThreadGroups = buildThreadDateGroups(groupedThreads);
 	const renderThreadItem = (thread: ChatThread, pinned = false) => (
 		<SidebarMenuItem key={thread.id} className="w-full overflow-hidden">
@@ -226,6 +243,10 @@ export function ChatSidebar({
 							<Pin className="mr-2 h-4 w-4" />
 						)}
 						{pinned ? "Unpin" : "Pin"}
+					</DropdownMenuItem>
+					<DropdownMenuItem onClick={() => onEditTags(thread)}>
+						<Tag className="mr-2 h-4 w-4" />
+						Tags
 					</DropdownMenuItem>
 					<DropdownMenuSeparator />
 					<DropdownMenuItem
@@ -360,8 +381,79 @@ export function ChatSidebar({
 				<SidebarSeparator className="my-0" />
 				<ScrollArea className="h-full group-data-[collapsible=icon]:hidden">
 					<SidebarGroup className="px-2 pb-2 pt-1.5">
+						{tags.length > 0 ? (
+							<Collapsible
+								open={tagsOpen}
+								onOpenChange={setTagsOpen}
+								className="border-b border-border/70 pb-2"
+							>
+								<div className="flex h-8 items-center gap-2 px-2">
+									<CollapsibleTrigger asChild>
+										<button
+											type="button"
+											className="flex h-8 min-w-0 flex-1 items-center justify-between rounded-md text-xs font-semibold text-muted-foreground outline-none transition-colors hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring"
+										>
+											<span className="truncate">Tags</span>
+											<ChevronRight
+												className={cn(
+													"h-3.5 w-3.5 shrink-0 transition-transform",
+													tagsOpen && "rotate-90",
+												)}
+											/>
+										</button>
+									</CollapsibleTrigger>
+									{activeTag ? (
+										<Button
+											type="button"
+											variant="ghost"
+											size="sm"
+											className="h-6 px-1.5 text-xs text-muted-foreground"
+											onClick={() => onTagFilterChange(null)}
+										>
+											All
+										</Button>
+									) : null}
+								</div>
+								<CollapsibleContent>
+									<SidebarMenu className="gap-0.5">
+										{tags.map((tag) => {
+											const selected = activeTagId === tag.id;
+											return (
+												<SidebarMenuItem key={tag.id}>
+													<SidebarMenuButton
+														isActive={selected}
+														onClick={() =>
+															onTagFilterChange(selected ? null : tag.id)
+														}
+														className="h-8 px-2"
+													>
+														<span
+															className="h-2.5 w-2.5 shrink-0 rounded-full"
+															style={{ backgroundColor: tag.color }}
+														/>
+														<span className="w-0 grow overflow-hidden text-ellipsis whitespace-nowrap">
+															{tag.name}
+														</span>
+													</SidebarMenuButton>
+												</SidebarMenuItem>
+											);
+										})}
+									</SidebarMenu>
+								</CollapsibleContent>
+							</Collapsible>
+						) : null}
 						<SidebarGroupLabel className="h-6 px-3 text-[13px] font-semibold text-foreground/80">
-							Chats
+							{activeTag ? (
+								<span className="flex min-w-0 items-center gap-1.5">
+									<span
+										className="h-2 w-2 shrink-0 rounded-full"
+										style={{ backgroundColor: activeTag.color }}
+									/>
+									<span className="truncate">{activeTag.name}</span>
+								</span>
+							) : (
+								"Chats"
+							)}
 						</SidebarGroupLabel>
 						<SidebarGroupContent className="overflow-hidden">
 							<SidebarMenu>
@@ -387,7 +479,7 @@ export function ChatSidebar({
 								))}
 								{threads.length === 0 && (
 									<p className="px-2 py-4 text-xs text-muted-foreground">
-										No chats yet.
+										{activeTagId ? "No chats with this tag." : "No chats yet."}
 									</p>
 								)}
 							</SidebarMenu>

--- a/apps/web/src/components/(chat)/ChatTagsDialog.tsx
+++ b/apps/web/src/components/(chat)/ChatTagsDialog.tsx
@@ -1,0 +1,223 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { Check, Plus, TagIcon, X } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import {
+	Dialog,
+	DialogContent,
+	DialogDescription,
+	DialogFooter,
+	DialogHeader,
+	DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import type { ChatTag, ChatThread } from "@/lib/indexeddb/chats";
+import { cn } from "@/lib/utils";
+
+const TAG_COLORS = [
+	"#52525b",
+	"#2563eb",
+	"#059669",
+	"#d97706",
+	"#dc2626",
+	"#7c3aed",
+	"#0891b2",
+	"#be123c",
+];
+
+function makeTagId(name: string) {
+	const slug = name
+		.trim()
+		.toLowerCase()
+		.replace(/[^a-z0-9]+/g, "-")
+		.replace(/^-+|-+$/g, "");
+	return slug || `tag-${Date.now()}`;
+}
+
+type ChatTagsDialogProps = {
+	open: boolean;
+	thread: ChatThread | null;
+	availableTags: ChatTag[];
+	onOpenChange: (open: boolean) => void;
+	onSave: (tags: ChatTag[]) => void;
+};
+
+export function ChatTagsDialog({
+	open,
+	thread,
+	availableTags,
+	onOpenChange,
+	onSave,
+}: ChatTagsDialogProps) {
+	const [selectedTags, setSelectedTags] = useState<ChatTag[]>(
+		() => thread?.tags ?? [],
+	);
+	const [name, setName] = useState("");
+	const [color, setColor] = useState(TAG_COLORS[0]);
+
+	const selectedTagIds = useMemo(
+		() => new Set(selectedTags.map((tag) => tag.id)),
+		[selectedTags],
+	);
+
+	const addTag = () => {
+		const normalizedName = name.trim().replace(/\s+/g, " ");
+		if (!normalizedName) return;
+		const existing = availableTags.find(
+			(tag) => tag.name.toLowerCase() === normalizedName.toLowerCase(),
+		);
+		const nextTag =
+			existing ?? { id: makeTagId(normalizedName), name: normalizedName, color };
+		setSelectedTags((prev) => {
+			if (prev.some((tag) => tag.id === nextTag.id)) return prev;
+			return [...prev, nextTag];
+		});
+		setName("");
+	};
+
+	const toggleTag = (tag: ChatTag) => {
+		setSelectedTags((prev) => {
+			if (prev.some((entry) => entry.id === tag.id)) {
+				return prev.filter((entry) => entry.id !== tag.id);
+			}
+			return [...prev, tag];
+		});
+	};
+
+	return (
+		<Dialog open={open} onOpenChange={onOpenChange}>
+			<DialogContent className="max-w-lg gap-5 p-5">
+				<DialogHeader>
+					<DialogTitle>Chat Tags</DialogTitle>
+					<DialogDescription>
+						Organise this chat with tags that can be filtered from the sidebar.
+					</DialogDescription>
+				</DialogHeader>
+				<div className="grid gap-4">
+					{availableTags.length > 0 ? (
+						<div className="grid gap-2">
+							<Label>Existing Tags</Label>
+							<div className="flex max-h-32 flex-wrap gap-2 overflow-y-auto rounded-xl border border-border bg-muted/20 p-2">
+								{availableTags.map((tag) => {
+									const selected = selectedTagIds.has(tag.id);
+									return (
+										<button
+											key={tag.id}
+											type="button"
+											className={cn(
+												"inline-flex h-8 items-center gap-1.5 rounded-full border px-2.5 text-xs transition-colors",
+												selected
+													? "border-foreground bg-foreground text-background"
+													: "border-border bg-background hover:bg-muted",
+											)}
+											onClick={() => toggleTag(tag)}
+										>
+											<span
+												className="h-2.5 w-2.5 rounded-full"
+												style={{ backgroundColor: tag.color }}
+											/>
+											{tag.name}
+											{selected ? <Check className="h-3 w-3" /> : null}
+										</button>
+									);
+								})}
+							</div>
+						</div>
+					) : null}
+					<div className="grid gap-2">
+						<Label htmlFor="chat-tag-name">New Tag</Label>
+						<div className="flex gap-2">
+							<div className="relative min-w-0 flex-1">
+								<TagIcon className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+								<Input
+									id="chat-tag-name"
+									value={name}
+									onChange={(event) => setName(event.target.value)}
+									onKeyDown={(event) => {
+										if (event.key === "Enter") {
+											event.preventDefault();
+											addTag();
+										}
+									}}
+									placeholder="Research, billing, ideas..."
+									className="pl-9"
+								/>
+							</div>
+							<div className="flex items-center gap-1 rounded-xl border border-border px-1.5">
+								{TAG_COLORS.slice(0, 5).map((option) => (
+									<button
+										key={option}
+										type="button"
+										className="h-5 w-5 rounded-full border border-border ring-offset-background transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+										style={{
+											backgroundColor: option,
+											boxShadow:
+												option === color
+													? "0 0 0 2px hsl(var(--background)), 0 0 0 4px hsl(var(--foreground))"
+													: undefined,
+										}}
+										onClick={() => setColor(option)}
+										aria-label={`Use tag color ${option}`}
+									/>
+								))}
+							</div>
+							<Button type="button" size="icon" onClick={addTag}>
+								<Plus className="h-4 w-4" />
+								<span className="sr-only">Add tag</span>
+							</Button>
+						</div>
+					</div>
+					<div className="grid gap-2">
+						<Label>Assigned Tags</Label>
+						{selectedTags.length > 0 ? (
+							<div className="flex flex-wrap gap-2">
+								{selectedTags.map((tag) => (
+									<span
+										key={tag.id}
+										className="inline-flex items-center gap-1.5 rounded-full border border-border bg-muted/40 px-2 py-1 text-xs"
+									>
+										<span
+											className="h-2.5 w-2.5 rounded-full"
+											style={{ backgroundColor: tag.color }}
+										/>
+										{tag.name}
+										<button
+											type="button"
+											className="text-muted-foreground hover:text-foreground"
+											onClick={() =>
+												setSelectedTags((prev) =>
+													prev.filter((entry) => entry.id !== tag.id),
+												)
+											}
+											aria-label={`Remove ${tag.name}`}
+										>
+											<X className="h-3 w-3" />
+										</button>
+									</span>
+								))}
+							</div>
+						) : (
+							<p className="rounded-xl border border-dashed border-border px-3 py-4 text-sm text-muted-foreground">
+								No tags assigned.
+							</p>
+						)}
+					</div>
+				</div>
+				<DialogFooter>
+					<Button
+						type="button"
+						variant="outline"
+						onClick={() => onOpenChange(false)}
+					>
+						Cancel
+					</Button>
+					<Button type="button" onClick={() => onSave(selectedTags)}>
+						Save Tags
+					</Button>
+				</DialogFooter>
+			</DialogContent>
+		</Dialog>
+	);
+}

--- a/apps/web/src/lib/indexeddb/chats.ts
+++ b/apps/web/src/lib/indexeddb/chats.ts
@@ -22,6 +22,12 @@ export type ChatMessage = {
     meta?: Record<string, unknown> | null;
 };
 
+export type ChatTag = {
+    id: string;
+    name: string;
+    color: string;
+};
+
 export type UnifiedChatEndpoint =
     | "responses"
     | "images.generations"
@@ -97,11 +103,13 @@ export type ChatThread = {
     updatedAt: string;
     messages: ChatMessage[];
     settings: ChatSettings;
+    tags?: ChatTag[];
 };
 
 const DB_NAME = "ai-stats-chat";
-const DB_VERSION = 6;
+const DB_VERSION = 7;
 const LEGACY_TEXT_STORE_NAME = "chats";
+const TAG_STORE_NAME = "chat-tags";
 const ROOM_STORE_NAMES: Record<ChatRoomId, string> = {
     text: LEGACY_TEXT_STORE_NAME,
     image: "chats-image",
@@ -134,6 +142,9 @@ function openDb(): Promise<IDBDatabase> {
                 if (!db.objectStoreNames.contains(storeName)) {
                     db.createObjectStore(storeName, { keyPath: "id" });
                 }
+            }
+            if (!db.objectStoreNames.contains(TAG_STORE_NAME)) {
+                db.createObjectStore(TAG_STORE_NAME, { keyPath: "id" });
             }
         };
         request.onsuccess = () => resolve(request.result);
@@ -189,4 +200,43 @@ export async function deleteChat(
     roomId: ChatRoomId = "text",
 ): Promise<void> {
     await withStore("readwrite", (store) => store.delete(id), roomId);
+}
+
+export async function getAllChatTags(): Promise<ChatTag[]> {
+    const db = await openDb();
+    return new Promise((resolve, reject) => {
+        const tx = db.transaction(TAG_STORE_NAME, "readonly");
+        const store = tx.objectStore(TAG_STORE_NAME);
+        const request = store.getAll();
+        request.onerror = () => reject(request.error ?? new Error("IndexedDB error"));
+        request.onsuccess = () => {
+            const result = request.result;
+            resolve(Array.isArray(result) ? (result as ChatTag[]) : []);
+        };
+    });
+}
+
+export async function upsertChatTags(tags: ChatTag[]): Promise<void> {
+    if (tags.length === 0) return;
+    const db = await openDb();
+    await new Promise<void>((resolve, reject) => {
+        const tx = db.transaction(TAG_STORE_NAME, "readwrite");
+        const store = tx.objectStore(TAG_STORE_NAME);
+        tx.onerror = () => reject(tx.error ?? new Error("IndexedDB error"));
+        tx.oncomplete = () => resolve();
+        for (const tag of tags) {
+            store.put(tag);
+        }
+    });
+}
+
+export async function clearChatTags(): Promise<void> {
+    const db = await openDb();
+    await new Promise<void>((resolve, reject) => {
+        const tx = db.transaction(TAG_STORE_NAME, "readwrite");
+        const store = tx.objectStore(TAG_STORE_NAME);
+        const request = store.clear();
+        request.onerror = () => reject(request.error ?? new Error("IndexedDB error"));
+        request.onsuccess = () => resolve();
+    });
 }


### PR DESCRIPTION
﻿## Summary
- restore local chat tags with IndexedDB persistence
- add a Base UI-compatible dialog for assigning and creating tags on chats
- add sidebar tag filtering and per-chat tag actions

## Validation
- `pnpm --filter @ai-stats/web exec tsc --noEmit`
- `pnpm --filter @ai-stats/web exec eslint 'src/lib/indexeddb/chats.ts' 'src/components/(chat)/ChatTagsDialog.tsx' 'src/components/(chat)/ChatSidebar.tsx' 'src/components/(chat)/ChatPlayground.tsx'` (existing max-lines and no-img warnings only)
- `$env:NODE_OPTIONS='--max_old_space_size=8192'; pnpm --filter @ai-stats/web build`

Created with Codex
