### PR TITLE
Restrict chat gateway target overrides

### DIFF
--- a/apps/web/src/app/api/chat/_shared/gatewayProxy.test.ts
+++ b/apps/web/src/app/api/chat/_shared/gatewayProxy.test.ts
@@ -1,4 +1,4 @@
-import { resolveGatewayBaseUrlForEnvironment } from "./gatewayProxy";
+import { resolveGatewayBaseUrlForEnvironment } from "@/app/api/chat/_shared/gatewayProxy";
 
 describe("resolveGatewayBaseUrlForEnvironment", () => {
 	it("uses only the configured gateway in production", () => {
@@ -14,6 +14,14 @@ describe("resolveGatewayBaseUrlForEnvironment", () => {
 			resolveGatewayBaseUrlForEnvironment({
 				configuredBaseUrl: "https://private-gateway.example.com",
 				requestedBaseUrl: "http://127.0.0.1:8787/v1",
+				nodeEnv: "production",
+			}),
+		).toBe("https://private-gateway.example.com/v1");
+
+		expect(
+			resolveGatewayBaseUrlForEnvironment({
+				configuredBaseUrl: "https://private-gateway.example.com",
+				requestedBaseUrl: "https://attacker.example.com/v1",
 				nodeEnv: "production",
 			}),
 		).toBe("https://private-gateway.example.com/v1");

--- a/apps/web/src/app/api/chat/_shared/gatewayProxy.test.ts
+++ b/apps/web/src/app/api/chat/_shared/gatewayProxy.test.ts
@@ -1,0 +1,58 @@
+import { resolveGatewayBaseUrlForEnvironment } from "./gatewayProxy";
+
+describe("resolveGatewayBaseUrlForEnvironment", () => {
+	it("uses only the configured gateway in production", () => {
+		expect(
+			resolveGatewayBaseUrlForEnvironment({
+				configuredBaseUrl: "https://private-gateway.example.com",
+				requestedBaseUrl: "https://api.phaseo.app/v1",
+				nodeEnv: "production",
+			}),
+		).toBe("https://private-gateway.example.com/v1");
+
+		expect(
+			resolveGatewayBaseUrlForEnvironment({
+				configuredBaseUrl: "https://private-gateway.example.com",
+				requestedBaseUrl: "http://127.0.0.1:8787/v1",
+				nodeEnv: "production",
+			}),
+		).toBe("https://private-gateway.example.com/v1");
+	});
+
+	it("fails closed in production when the gateway is not configured", () => {
+		expect(
+			resolveGatewayBaseUrlForEnvironment({
+				requestedBaseUrl: "https://api.phaseo.app/v1",
+				nodeEnv: "production",
+			}),
+		).toBeNull();
+	});
+
+	it("allows explicit public and localhost gateway targets in development", () => {
+		expect(
+			resolveGatewayBaseUrlForEnvironment({
+				configuredBaseUrl: "https://private-gateway.example.com",
+				requestedBaseUrl: "https://api.phaseo.app/v1",
+				nodeEnv: "development",
+			}),
+		).toBe("https://api.phaseo.app/v1");
+
+		expect(
+			resolveGatewayBaseUrlForEnvironment({
+				configuredBaseUrl: "https://private-gateway.example.com",
+				requestedBaseUrl: "http://localhost:8787",
+				nodeEnv: "development",
+			}),
+		).toBe("http://localhost:8787/v1");
+	});
+
+	it("does not allow arbitrary gateway targets in development", () => {
+		expect(
+			resolveGatewayBaseUrlForEnvironment({
+				configuredBaseUrl: "https://private-gateway.example.com",
+				requestedBaseUrl: "https://attacker.example.com/v1",
+				nodeEnv: "development",
+			}),
+		).toBe("https://private-gateway.example.com/v1");
+	});
+});

--- a/apps/web/src/app/api/chat/_shared/gatewayProxy.ts
+++ b/apps/web/src/app/api/chat/_shared/gatewayProxy.ts
@@ -220,8 +220,11 @@ function buildGatewayMissingConfigResponse(): Response {
 	);
 }
 
-function isDevelopmentLocalGatewayBaseUrl(baseUrl: string): boolean {
-	if (process.env.NODE_ENV === "production") return false;
+function isDevelopmentLocalGatewayBaseUrl(
+	baseUrl: string,
+	nodeEnv: string | undefined = process.env.NODE_ENV,
+): boolean {
+	if (nodeEnv === "production") return false;
 	try {
 		const url = new URL(baseUrl);
 		return (
@@ -235,17 +238,39 @@ function isDevelopmentLocalGatewayBaseUrl(baseUrl: string): boolean {
 	}
 }
 
-function resolveGatewayBaseUrl(requestedBaseUrl?: string): string | null {
-	const normalizedRequestedBaseUrl = normalizeGatewayBaseUrl(requestedBaseUrl);
+export function resolveGatewayBaseUrlForEnvironment(args: {
+	configuredBaseUrl?: string;
+	requestedBaseUrl?: string;
+	nodeEnv?: string;
+}): string | null {
+	const nodeEnv = args.nodeEnv ?? process.env.NODE_ENV;
+	const normalizedConfiguredBaseUrl = normalizeGatewayBaseUrl(
+		args.configuredBaseUrl,
+	);
+	if (nodeEnv === "production") {
+		return normalizedConfiguredBaseUrl ?? null;
+	}
+
+	const normalizedRequestedBaseUrl = normalizeGatewayBaseUrl(
+		args.requestedBaseUrl,
+	);
 	if (
 		normalizedRequestedBaseUrl &&
 		(normalizedRequestedBaseUrl === PUBLIC_GATEWAY_BASE_URL ||
-			normalizedRequestedBaseUrl === configuredGatewayBaseUrl ||
-			isDevelopmentLocalGatewayBaseUrl(normalizedRequestedBaseUrl))
+			normalizedRequestedBaseUrl === normalizedConfiguredBaseUrl ||
+			isDevelopmentLocalGatewayBaseUrl(normalizedRequestedBaseUrl, nodeEnv))
 	) {
 		return normalizedRequestedBaseUrl;
 	}
-	return configuredGatewayBaseUrl ?? PUBLIC_GATEWAY_BASE_URL;
+	return normalizedConfiguredBaseUrl ?? PUBLIC_GATEWAY_BASE_URL;
+}
+
+function resolveGatewayBaseUrl(requestedBaseUrl?: string): string | null {
+	return resolveGatewayBaseUrlForEnvironment({
+		configuredBaseUrl: process.env.AI_STATS_GATEWAY_URL,
+		requestedBaseUrl,
+		nodeEnv: process.env.NODE_ENV,
+	});
 }
 
 export async function forwardUpstreamResponse(args: {


### PR DESCRIPTION
## Summary

- Restrict chat gateway target resolution so production uses only the configured `AI_STATS_GATEWAY_URL`.
- Fail closed in production when the gateway URL is missing instead of falling back to the public API.
- Preserve local development testing by allowing the public gateway and localhost gateway targets outside production.
- Add regression coverage for production fail-closed behavior and development-only overrides.

## Validation

- `pnpm --filter @ai-stats/web test -- gatewayProxy.test.ts`
- `pnpm --filter @ai-stats/web typecheck`
- `pnpm --filter @ai-stats/web exec eslint "src/app/api/chat/_shared/gatewayProxy.ts" "src/app/api/chat/_shared/gatewayProxy.test.ts"`

Note: full `pnpm --filter @ai-stats/web lint` still fails on existing repo-wide lint issues unrelated to this change.

Created with Codex

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved gateway URL handling across environments.
  * In production, the app now uses only the configured gateway URL and no longer falls back to a public default when it isn’t set.
  * In development, local and approved public gateway targets continue to work, while unsupported external targets are ignored in favor of a safe fallback.

* **Tests**
  * Added coverage for production and development gateway URL resolution behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->