### PR TITLE
Harden server tools and pricing edges

### DIFF
--- a/apps/api/src/core/schemas.ts
+++ b/apps/api/src/core/schemas.ts
@@ -479,7 +479,7 @@ const GatewayDatetimeToolSchema = z.object({
 	type: z.literal("gateway:datetime"),
 	parameters: z.object({
 		timezone: z.string().min(1).optional(),
-		timezones: z.array(z.string().min(1)).optional(),
+		timezones: z.array(z.string().min(1)).max(5).optional(),
 	}).optional(),
 });
 

--- a/apps/api/src/pipeline/pricing/persist.test.ts
+++ b/apps/api/src/pipeline/pricing/persist.test.ts
@@ -1,0 +1,72 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const rpcMock = vi.fn();
+const invalidateGatewayCreditCacheMock = vi.fn();
+const releaseRuntimeMock = vi.fn();
+
+function makeTableQuery() {
+	return {
+		select: vi.fn().mockReturnThis(),
+		eq: vi.fn().mockReturnThis(),
+		maybeSingle: vi.fn().mockResolvedValue({ data: null, error: null }),
+	};
+}
+
+vi.mock("../../runtime/env", () => ({
+	ensureRuntimeForBackground: vi.fn(() => releaseRuntimeMock),
+	getSupabaseAdmin: vi.fn(() => ({
+		rpc: rpcMock,
+		from: vi.fn(() => makeTableQuery()),
+	})),
+}));
+
+vi.mock("../../core/gateway-credit-cache", () => ({
+	invalidateGatewayCreditCache: (...args: unknown[]) =>
+		invalidateGatewayCreditCacheMock(...args),
+}));
+
+vi.mock("../notifications/low-balance", () => ({
+	enqueueLowBalanceEmail: vi.fn(),
+}));
+
+describe("recordUsageAndCharge", () => {
+	beforeEach(() => {
+		rpcMock.mockReset();
+		invalidateGatewayCreditCacheMock.mockReset();
+		releaseRuntimeMock.mockReset();
+	});
+
+	it("invalidates the workspace credit cache after a successful new charge", async () => {
+		rpcMock.mockResolvedValue({
+			data: { status: "charged", already_applied: false },
+			error: null,
+		});
+		const { recordUsageAndCharge } = await import("./persist");
+
+		await recordUsageAndCharge({
+			requestId: "req_123",
+			workspaceId: "workspace_123",
+			cost_nanos: 123,
+		});
+
+		expect(invalidateGatewayCreditCacheMock).toHaveBeenCalledWith("workspace_123");
+		expect(releaseRuntimeMock).toHaveBeenCalledTimes(1);
+	});
+
+	it("does not invalidate the workspace credit cache for idempotent replays", async () => {
+		rpcMock.mockResolvedValue({
+			data: { status: "charged", already_applied: true },
+			error: null,
+		});
+		const { recordUsageAndCharge } = await import("./persist");
+
+		await recordUsageAndCharge({
+			requestId: "req_123",
+			workspaceId: "workspace_123",
+			cost_nanos: 123,
+		});
+
+		expect(invalidateGatewayCreditCacheMock).not.toHaveBeenCalled();
+		expect(releaseRuntimeMock).toHaveBeenCalledTimes(1);
+	});
+});

--- a/apps/api/src/pipeline/pricing/persist.ts
+++ b/apps/api/src/pipeline/pricing/persist.ts
@@ -3,6 +3,7 @@ import Stripe from "stripe";
 // Why: Centralizes all cost calculations.
 // How: Persists pricing/usage data into storage.
 
+import { invalidateGatewayCreditCache } from "../../core/gateway-credit-cache";
 import { getSupabaseAdmin, ensureRuntimeForBackground } from "../../runtime/env";
 import { enqueueLowBalanceEmail } from "../notifications/low-balance";
 
@@ -184,6 +185,7 @@ export async function recordUsageAndCharge(args: {
 
         if (!chargeResult) return;
         if (chargeResult.already_applied) return;
+        await invalidateGatewayCreditCache(args.workspaceId);
 
         try {
             await maybeEnqueueLowBalanceAlert(args.workspaceId);

--- a/apps/api/src/pipeline/surfaces/server-tools.test.ts
+++ b/apps/api/src/pipeline/surfaces/server-tools.test.ts
@@ -111,6 +111,33 @@ describe("prepareServerToolsForTextRequest", () => {
 		expect(result.config.datetimeDefaultTimezones).toEqual(["Europe/London"]);
 	});
 
+	it("rejects gateway datetime defaults with too many timezones", () => {
+		const result = prepareServerToolsForTextRequest(
+			{
+				model: "openai/gpt-5-nano",
+				tools: [{
+					type: "gateway:datetime",
+					parameters: {
+						timezones: [
+							"UTC",
+							"Europe/London",
+							"America/New_York",
+							"Asia/Tokyo",
+							"Australia/Sydney",
+							"Pacific/Auckland",
+						],
+					},
+				}],
+			},
+			"openai.responses",
+		);
+		expect(result.ok).toBe(false);
+		if (result.ok) {
+			throw new Error("Expected prepareServerToolsForTextRequest to reject oversized timezone defaults");
+		}
+		expect(result.message).toContain("at most 5 timezones");
+	});
+
 	it("rewrites AI Stats web search into a callable function tool", () => {
 		const result = prepareServerToolsForTextRequest(
 			{
@@ -641,6 +668,54 @@ describe("buildServerToolContinuation", () => {
 		} finally {
 			vi.useRealTimers();
 		}
+	});
+
+	it("rejects oversized datetime tool-call timezone lists without echoing them", async () => {
+		const continuation = await buildServerToolContinuation(
+			{
+				choices: [{
+					message: {
+						role: "assistant",
+						content: [],
+						toolCalls: [{
+							id: "call_datetime",
+							name: "gateway_datetime",
+							arguments: JSON.stringify({
+								timezones: [
+									"UTC",
+									"Europe/London",
+									"America/New_York",
+									"Asia/Tokyo",
+									"Australia/Sydney",
+									"Pacific/Auckland",
+								],
+							}),
+						}],
+					},
+					finishReason: "tool_calls",
+				}],
+			} as any,
+			{
+				enabled: true,
+				datetimeDefaultTimezones: ["UTC"],
+				webSearchEnabled: false,
+				webSearchMaxResults: 5,
+				webSearchIncludeText: false,
+				webSearchIncludeHighlights: true,
+				webFetchEnabled: false,
+				webFetchMaxChars: 12000,
+			},
+		);
+
+		const toolResult = continuation?.toolResults[0];
+		expect(toolResult?.isError).toBe(true);
+		const parsed = JSON.parse(String(toolResult?.content));
+		expect(parsed).toEqual({
+			error: "too_many_timezones",
+			max_timezones: 5,
+			message: "timezones must contain at most 5 entries",
+		});
+		expect(parsed).not.toHaveProperty("timezones");
 	});
 
 	it("executes AI Stats web search calls and records search usage", async () => {

--- a/apps/api/src/pipeline/surfaces/server-tools.ts
+++ b/apps/api/src/pipeline/surfaces/server-tools.ts
@@ -1386,12 +1386,13 @@ function readDatetimeTimezones(
 ): { timezones: string[]; tooMany: boolean } {
 	const timezones: string[] = [];
 	const ok = appendTimezoneList(timezones, args.timezones);
+	if (!ok) return { timezones: [], tooMany: true };
 	const resolved = timezones.length > 0
 		? timezones
 		: fallback.length > 0
 			? fallback
 			: [DEFAULT_TIMEZONE];
-	return { timezones: resolved.slice(0, MAX_DATETIME_TIMEZONES), tooMany: !ok };
+	return { timezones: resolved.slice(0, MAX_DATETIME_TIMEZONES), tooMany: false };
 }
 
 function extractOffsetString(date: Date, timezone: string): string {

--- a/apps/api/src/pipeline/surfaces/server-tools.ts
+++ b/apps/api/src/pipeline/surfaces/server-tools.ts
@@ -23,6 +23,7 @@ export const IMAGE_GENERATION_SERVER_TOOL_FUNCTION_NAME = "ai_stats_image_genera
 export const APPLY_PATCH_SERVER_TOOL_TYPE = "ai-stats:apply_patch";
 export const APPLY_PATCH_SERVER_TOOL_FUNCTION_NAME = "ai_stats_apply_patch";
 const DEFAULT_TIMEZONE = "UTC";
+const MAX_DATETIME_TIMEZONES = 5;
 const DEFAULT_WEB_SEARCH_MAX_RESULTS = 5;
 const MAX_WEB_SEARCH_RESULTS = 25;
 const DEFAULT_WEB_SEARCH_MAX_TOTAL_RESULTS = 25;
@@ -49,8 +50,9 @@ const DATETIME_TOOL_PARAMETERS = {
 		timezones: {
 			type: "array",
 			items: { type: "string" },
+			maxItems: MAX_DATETIME_TIMEZONES,
 			description:
-				"IANA timezone names to return in one call. Use this when comparing local time with UTC or another timezone.",
+				"IANA timezone names to return in one call. Use this when comparing local time with UTC or another timezone. Maximum 5.",
 		},
 	},
 	additionalProperties: false,
@@ -423,25 +425,27 @@ function toNonEmptyString(value: unknown): string | null {
 	return trimmed.length > 0 ? trimmed : null;
 }
 
-function appendTimezone(timezones: string[], value: unknown): void {
+function appendTimezone(timezones: string[], value: unknown): boolean {
 	const timezone = toNonEmptyString(value);
-	if (timezone && !timezones.includes(timezone)) {
-		timezones.push(timezone);
-	}
+	if (!timezone || timezones.includes(timezone)) return true;
+	if (timezones.length >= MAX_DATETIME_TIMEZONES) return false;
+	timezones.push(timezone);
+	return true;
 }
 
-function appendTimezoneList(timezones: string[], value: unknown): void {
-	if (!Array.isArray(value)) return;
+function appendTimezoneList(timezones: string[], value: unknown): boolean {
+	if (!Array.isArray(value)) return true;
 	for (const item of value) {
-		appendTimezone(timezones, item);
+		if (!appendTimezone(timezones, item)) return false;
 	}
+	return true;
 }
 
-function parseDatetimeToolTimezones(tool: any): string[] {
+function parseDatetimeToolTimezones(tool: any): { timezones: string[]; tooMany: boolean } {
 	const timezones: string[] = [];
-	appendTimezone(timezones, tool?.parameters?.timezone);
-	appendTimezoneList(timezones, tool?.parameters?.timezones);
-	return timezones;
+	const singularOk = appendTimezone(timezones, tool?.parameters?.timezone);
+	const listOk = appendTimezoneList(timezones, tool?.parameters?.timezones);
+	return { timezones, tooMany: !singularOk || !listOk };
 }
 
 function readBooleanWithFallback(value: unknown, fallback: boolean): boolean {
@@ -1051,7 +1055,14 @@ export function prepareServerToolsForTextRequest(
 
 		if (tool.type === DATETIME_SERVER_TOOL_TYPE) {
 			datetimeEnabled = true;
-			const requestedTimezones = parseDatetimeToolTimezones(tool);
+			const requested = parseDatetimeToolTimezones(tool);
+			if (requested.tooMany) {
+				return {
+					ok: false,
+					message: `Datetime tool supports at most ${MAX_DATETIME_TIMEZONES} timezones per request.`,
+				};
+			}
+			const requestedTimezones = requested.timezones;
 			if (requestedTimezones.length > 0) {
 				const invalidTimezone = requestedTimezones.find(
 					(timezone) => !isValidTimezone(timezone),
@@ -1372,14 +1383,15 @@ function parseJsonObject(value: string | undefined): Record<string, unknown> {
 function readDatetimeTimezones(
 	args: Record<string, unknown>,
 	fallback: string[],
-): string[] {
+): { timezones: string[]; tooMany: boolean } {
 	const timezones: string[] = [];
-	appendTimezoneList(timezones, args.timezones);
-	return timezones.length > 0
+	const ok = appendTimezoneList(timezones, args.timezones);
+	const resolved = timezones.length > 0
 		? timezones
 		: fallback.length > 0
 			? fallback
 			: [DEFAULT_TIMEZONE];
+	return { timezones: resolved.slice(0, MAX_DATETIME_TIMEZONES), tooMany: !ok };
 }
 
 function extractOffsetString(date: Date, timezone: string): string {
@@ -1431,7 +1443,19 @@ function executeDatetimeToolCall(
 	defaultTimezones: string[],
 ): IRToolResult {
 	const args = parseJsonObject(call.arguments);
-	const timezones = readDatetimeTimezones(args, defaultTimezones);
+	const requested = readDatetimeTimezones(args, defaultTimezones);
+	const timezones = requested.timezones;
+	if (requested.tooMany) {
+		return {
+			toolCallId: call.id,
+			isError: true,
+			content: JSON.stringify({
+				error: "too_many_timezones",
+				max_timezones: MAX_DATETIME_TIMEZONES,
+				message: `timezones must contain at most ${MAX_DATETIME_TIMEZONES} entries`,
+			}),
+		};
+	}
 	const invalidTimezone = timezones.find((timezone) => !isValidTimezone(timezone));
 	if (invalidTimezone) {
 		return {
@@ -1440,7 +1464,6 @@ function executeDatetimeToolCall(
 			content: JSON.stringify({
 				error: "invalid_timezone",
 				timezone: invalidTimezone,
-				timezones,
 				message: "timezones must contain valid IANA timezone names",
 			}),
 		};

--- a/apps/docs/v1/guides/server-tools/datetime.mdx
+++ b/apps/docs/v1/guides/server-tools/datetime.mdx
@@ -42,7 +42,7 @@ curl https://api.phaseo.app/v1/chat/completions \
 
 | Parameter | Type | Default | Description |
 | --- | --- | --- | --- |
-| `timezones` | string[] | `["UTC"]` | IANA timezone names to return in one tool call, such as `["Europe/London", "UTC"]`. |
+| `timezones` | string[] | `["UTC"]` | Up to 5 IANA timezone names to return in one tool call, such as `["Europe/London", "UTC"]`. |
 
 ## Tool result
 

--- a/apps/docs/v1/guides/server-tools/index.mdx
+++ b/apps/docs/v1/guides/server-tools/index.mdx
@@ -15,7 +15,7 @@ Server tools are in beta. Request shapes and result payloads may evolve as provi
 
 | Tool | Type | Use it for |
 | --- | --- | --- |
-| Datetime | `gateway:datetime` | Current date and time in one or more timezones |
+| Datetime | `gateway:datetime` | Current date and time in up to 5 timezones |
 | Web Search | `ai-stats:web_search` | Model-directed web searches during a request |
 | Web Fetch | `ai-stats:web_fetch` | Fetching and extracting text from specific URLs |
 | Advisor | `ai-stats:advisor` | Consulting another model mid-generation |

--- a/apps/docs/v1/guides/tool-calling.mdx
+++ b/apps/docs/v1/guides/tool-calling.mdx
@@ -109,7 +109,7 @@ Supported request shape:
 
 Notes:
 
-- `parameters.timezones` is optional and can request multiple valid IANA timezones in one call.
+- `parameters.timezones` is optional and can request up to 5 valid IANA timezones in one call.
 - The result contains a `timezones` array with ISO datetime plus the resolved timezone for each requested zone.
 - Usage includes `usage.server_tool_use.datetime_requests`.
 - Prefer `tool_choice: "auto"` so the model can decide when to call it.

--- a/apps/web/src/components/monitor/MonitorHistoryClient.tsx
+++ b/apps/web/src/components/monitor/MonitorHistoryClient.tsx
@@ -21,6 +21,7 @@ import {
 	type LucideIcon,
 } from "lucide-react";
 import { Logo } from "@/components/Logo";
+import { normalizeMonitorHistoryLinkHref } from "@/lib/monitor/urlSafety";
 import {
 	Command,
 	CommandEmpty,
@@ -396,8 +397,7 @@ function renderMonitorLinkValue(
 	value: unknown,
 	variant: "current" | "previous" = "current",
 ) {
-	if (value == null) return null;
-	const href = String(value).trim();
+	const href = normalizeMonitorHistoryLinkHref(value);
 	if (!href) return null;
 	return (
 		<a

--- a/apps/web/src/lib/monitor/urlSafety.test.ts
+++ b/apps/web/src/lib/monitor/urlSafety.test.ts
@@ -1,0 +1,18 @@
+import { normalizeMonitorHistoryLinkHref } from "./urlSafety";
+
+describe("normalizeMonitorHistoryLinkHref", () => {
+	it("allows HTTP and HTTPS monitor history links", () => {
+		expect(normalizeMonitorHistoryLinkHref("https://example.com/path")).toBe(
+			"https://example.com/path",
+		);
+		expect(normalizeMonitorHistoryLinkHref(" http://example.com/path ")).toBe(
+			"http://example.com/path",
+		);
+	});
+
+	it("rejects scriptable or non-web URL schemes", () => {
+		expect(normalizeMonitorHistoryLinkHref("javascript:alert(1)")).toBeNull();
+		expect(normalizeMonitorHistoryLinkHref("data:text/html,<script>alert(1)</script>")).toBeNull();
+		expect(normalizeMonitorHistoryLinkHref("/relative/path")).toBeNull();
+	});
+});

--- a/apps/web/src/lib/monitor/urlSafety.ts
+++ b/apps/web/src/lib/monitor/urlSafety.ts
@@ -1,0 +1,5 @@
+import { normalizeHttpUrl } from "@/lib/utils/urlSafety";
+
+export function normalizeMonitorHistoryLinkHref(value: unknown): string | null {
+	return normalizeHttpUrl(value);
+}

--- a/packages/data/catalog/src/data/__tests__/validate.test.ts
+++ b/packages/data/catalog/src/data/__tests__/validate.test.ts
@@ -1,4 +1,13 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { checkApiProviderModelEntrySafety, checkPricingEntrySafety, isMajorError } from '@/data/validate';
+
+const DATA_ROOT = path.resolve(fileURLToPath(new URL('..', import.meta.url)));
+
+function readPricingJson(relativePath: string) {
+    return JSON.parse(fs.readFileSync(path.join(DATA_ROOT, relativePath), 'utf8'));
+}
 
 describe('pricing safety checks', () => {
     test('active on gateway with no rules -> error flagged', () => {
@@ -144,6 +153,34 @@ describe('pricing safety checks', () => {
         };
         const errs = checkPricingEntrySafety(bad);
         expect(errs.some((e) => /cached_read_text_tokens price > input_text_tokens/.test(e))).toBe(true);
+    });
+
+    test('GMICloud MiniMax M3 includes cached-read pricing for high-context requests', () => {
+        const pricing = readPricingJson(
+            'pricing/gmicloud/minimax-minimax-m3/text.generate/pricing.json'
+        );
+        expect(pricing.rules).toEqual(
+            expect.arrayContaining([
+                expect.objectContaining({
+                    meter: 'cached_read_text_tokens',
+                    price_per_unit: 0.24,
+                    match: expect.arrayContaining([
+                        expect.objectContaining({
+                            path: 'input_tokens',
+                            op: 'gt',
+                            value: 512000,
+                        }),
+                    ]),
+                }),
+            ])
+        );
+    });
+
+    test('Google Vertex image model does not advertise flex pricing without executor support', () => {
+        const pricing = readPricingJson(
+            'pricing/google-vertex/google-gemini-3.1-flash-lite-image/text.generate/pricing.json'
+        );
+        expect(pricing.rules.some((rule: any) => rule?.pricing_plan === 'flex')).toBe(false);
     });
 });
 

--- a/packages/data/catalog/src/data/pricing/gmicloud/minimax-minimax-m3/text.generate/pricing.json
+++ b/packages/data/catalog/src/data/pricing/gmicloud/minimax-minimax-m3/text.generate/pricing.json
@@ -86,6 +86,26 @@
       "effective_from": "2026-06-13T00:00:00Z"
     },
     {
+      "meter": "cached_read_text_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 0.24,
+      "currency": "USD",
+      "pricing_plan": "standard",
+      "note": "From authenticated GMICloud console model page on 2026-06-13.",
+      "match": [
+        {
+          "path": "input_tokens",
+          "op": "gt",
+          "or_group": 1,
+          "and_index": 1,
+          "value": 512000
+        }
+      ],
+      "priority": 100,
+      "effective_from": "2026-06-13T00:00:00Z"
+    },
+    {
       "meter": "output_text_tokens",
       "unit": "token",
       "unit_size": 1000000,

--- a/packages/data/catalog/src/data/pricing/google-vertex/google-gemini-3.1-flash-lite-image/text.generate/pricing.json
+++ b/packages/data/catalog/src/data/pricing/google-vertex/google-gemini-3.1-flash-lite-image/text.generate/pricing.json
@@ -124,66 +124,6 @@
       "match": [],
       "priority": 100,
       "effective_from": "2026-06-30T00:00:00Z"
-    },
-    {
-      "meter": "input_text_tokens",
-      "unit": "token",
-      "unit_size": 1000000,
-      "price_per_unit": 0.125,
-      "currency": "USD",
-      "pricing_plan": "flex",
-      "note": null,
-      "match": [],
-      "priority": 100,
-      "effective_from": "2026-06-30T00:00:00Z"
-    },
-    {
-      "meter": "input_image_tokens",
-      "unit": "token",
-      "unit_size": 1000000,
-      "price_per_unit": 0.125,
-      "currency": "USD",
-      "pricing_plan": "flex",
-      "note": null,
-      "match": [],
-      "priority": 100,
-      "effective_from": "2026-06-30T00:00:00Z"
-    },
-    {
-      "meter": "input_video_tokens",
-      "unit": "token",
-      "unit_size": 1000000,
-      "price_per_unit": 0.125,
-      "currency": "USD",
-      "pricing_plan": "flex",
-      "note": "Videos are sampled at 1 frame per second, and each video frame accounts for 70 tokens.",
-      "match": [],
-      "priority": 100,
-      "effective_from": "2026-06-30T00:00:00Z"
-    },
-    {
-      "meter": "output_text_tokens",
-      "unit": "token",
-      "unit_size": 1000000,
-      "price_per_unit": 0.75,
-      "currency": "USD",
-      "pricing_plan": "flex",
-      "note": "Includes response and reasoning tokens.",
-      "match": [],
-      "priority": 100,
-      "effective_from": "2026-06-30T00:00:00Z"
-    },
-    {
-      "meter": "output_image_tokens",
-      "unit": "token",
-      "unit_size": 1000000,
-      "price_per_unit": 15,
-      "currency": "USD",
-      "pricing_plan": "flex",
-      "note": "Equivalent to $0.0168 per 1K output image using 1120 output image tokens with Flex processing.",
-      "match": [],
-      "priority": 100,
-      "effective_from": "2026-06-30T00:00:00Z"
     }
   ]
 }


### PR DESCRIPTION
﻿## Summary
- Limit `gateway:datetime` timezone lists to 5 entries and avoid echoing oversized attacker-controlled timezone arrays in tool errors.
- Invalidate workspace credit cache after successful new gateway charge persistence.
- Sanitize monitor history links before rendering them.
- Correct MiniMax M3 GMICloud high-context cached-read pricing and remove unsupported Google Vertex flex pricing for the image model.
- Document the datetime server tool timezone limit.

## Validation
- `pnpm --filter @ai-stats/gateway-api exec vitest run src/pipeline/surfaces/server-tools.test.ts src/pipeline/pricing/persist.test.ts`
- `pnpm --filter @ai-stats/web test -- src/lib/monitor/urlSafety.test.ts`
- `pnpm --filter @ai-stats/gateway-api run typecheck`
- `pnpm --filter @ai-stats/web run typecheck`
- `pnpm validate:pricing`
- `pnpm docs:links`
- `pnpm docs:build`

Created with Codex


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Datetime tools now support up to 5 timezones per request, with clearer error handling when the limit is exceeded.
  * Monitor history links are now normalized for safer opening in the web app.

* **Bug Fixes**
  * Improved handling of invalid or oversized datetime tool inputs.
  * Updated pricing data for select models to reflect current billing rules.

* **Documentation**
  * Clarified datetime tool usage and the 5-timezone limit.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->