### PR TITLE
Fix Sonnet 5 adaptive thinking

### DIFF
--- a/apps/api/src/core/claudeModelCapabilities.ts
+++ b/apps/api/src/core/claudeModelCapabilities.ts
@@ -1,0 +1,23 @@
+export function normalizeClaudeModelId(model: string | null | undefined): string {
+	return typeof model === "string" ? model.trim().toLowerCase() : "";
+}
+
+export function usesClaudeAdaptiveThinkingControls(model: string | null | undefined): boolean {
+	const normalized = normalizeClaudeModelId(model);
+	if (!normalized) return false;
+	return (
+		normalized.includes("claude-sonnet-5") ||
+		normalized.includes("claude-fable-5") ||
+		normalized.includes("claude-mythos-5") ||
+		normalized.includes("claude-opus-4-7") ||
+		normalized.includes("claude-opus-4.7") ||
+		normalized.includes("claude-opus-4-8") ||
+		normalized.includes("claude-opus-4.8")
+	);
+}
+
+export function supportsAnthropicThinkingDisabled(model: string | null | undefined): boolean {
+	const normalized = normalizeClaudeModelId(model);
+	if (!normalized) return false;
+	return normalized.includes("claude-sonnet-5");
+}

--- a/apps/api/src/executors/amazon-bedrock/text-generate/__tests__/index.test.ts
+++ b/apps/api/src/executors/amazon-bedrock/text-generate/__tests__/index.test.ts
@@ -359,6 +359,65 @@ describe("amazon-bedrock text executor", () => {
 		expect(result.ir?.choices?.[0]?.message?.content?.[0]?.type).toBe("text");
 	});
 
+	it("strips removed Claude Sonnet 5 sampling and budget params in Converse payload", async () => {
+		const mock = installFetchMock([{
+			match: (url) => url.includes("/model/anthropic.claude-sonnet-5-v1%3A0/converse-stream"),
+			onRequest: (call) => {
+				const payload = call.bodyJson ?? {};
+				expect(payload.inferenceConfig?.temperature).toBeUndefined();
+				expect(payload.inferenceConfig?.topP).toBeUndefined();
+				expect(payload.additionalModelRequestFields?.top_k).toBeUndefined();
+				expect(payload.additionalModelRequestFields?.thinking?.type).toBe("adaptive");
+				expect(payload.additionalModelRequestFields?.thinking?.display).toBe("summarized");
+				expect(payload.additionalModelRequestFields?.thinking?.budget_tokens).toBeUndefined();
+				expect(payload.additionalModelRequestFields?.output_config?.effort).toBe("xhigh");
+			},
+			response: bedrockStreamResponse(basicBedrockTextEvents("sonnet5 ok")),
+		}]);
+
+		const result = await execute(buildArgs({
+			model: "anthropic.claude-sonnet-5-v1:0",
+			stream: false,
+			temperature: 0.2,
+			topP: 0.9,
+			topK: 40,
+			reasoning: { enabled: true, effort: "xhigh", maxTokens: 32000 },
+			messages: [{ role: "user", content: [{ type: "text", text: "hello sonnet" }] }],
+		}));
+
+		mock.restore();
+
+		expect(result.kind).toBe("completed");
+		expect(result.ir?.choices?.[0]?.message?.content?.[0]?.type).toBe("text");
+	});
+
+	it("uses adaptive thinking for Claude Fable 5 and ignores disabled thinking in Converse payload", async () => {
+		const mock = installFetchMock([{
+			match: (url) => url.includes("/model/anthropic.claude-fable-5-v1%3A0/converse-stream"),
+			onRequest: (call) => {
+				const payload = call.bodyJson ?? {};
+				expect(payload.additionalModelRequestFields?.thinking).toEqual({
+					type: "adaptive",
+					display: "summarized",
+				});
+				expect(payload.additionalModelRequestFields?.thinking?.budget_tokens).toBeUndefined();
+			},
+			response: bedrockStreamResponse(basicBedrockTextEvents("fable5 ok")),
+		}]);
+
+		const result = await execute(buildArgs({
+			model: "anthropic.claude-fable-5-v1:0",
+			stream: false,
+			reasoning: { enabled: false },
+			messages: [{ role: "user", content: [{ type: "text", text: "hello fable" }] }],
+		}));
+
+		mock.restore();
+
+		expect(result.kind).toBe("completed");
+		expect(result.ir?.choices?.[0]?.message?.content?.[0]?.type).toBe("text");
+	});
+
 	it("normalizes /openai/v1 base URL for Converse Anthropic models", async () => {
 		const mock = installFetchMock([{
 			match: (url) => url === "https://bedrock-runtime.us-east-1.amazonaws.com/model/anthropic.claude-3-5-sonnet-v1%3A0/converse-stream",

--- a/apps/api/src/executors/amazon-bedrock/text-generate/index.ts
+++ b/apps/api/src/executors/amazon-bedrock/text-generate/index.ts
@@ -514,14 +514,26 @@ function normalizeModelId(model: string | null | undefined): string {
 	return typeof model === "string" ? model.trim().toLowerCase() : "";
 }
 
-function isClaudeOpus47Model(model: string | null | undefined): boolean {
+function usesClaudeAdaptiveThinkingControls(model: string | null | undefined): boolean {
 	const normalized = normalizeModelId(model);
 	if (!normalized) return false;
 	return (
+		normalized.includes("claude-sonnet-5") ||
+		normalized.includes("claude-fable-5") ||
+		normalized.includes("claude-mythos-5") ||
 		normalized.includes("claude-opus-4-7") ||
 		normalized.includes("claude-opus-4.7") ||
-		normalized.includes("claude-opus-4-7-v1")
+		normalized.includes("claude-opus-4-7-v1") ||
+		normalized.includes("claude-opus-4-8") ||
+		normalized.includes("claude-opus-4.8") ||
+		normalized.includes("claude-opus-4-8-v1")
 	);
+}
+
+function supportsAnthropicThinkingDisabled(model: string | null | undefined): boolean {
+	const normalized = normalizeModelId(model);
+	if (!normalized) return false;
+	return normalized.includes("claude-sonnet-5");
 }
 
 async function irToBedrockConverse(
@@ -532,7 +544,7 @@ async function irToBedrockConverse(
 	const messages: any[] = [];
 	const system: any[] = [];
 	const resolvedModel = modelHint || ir.model;
-	const isOpus47 = isClaudeOpus47Model(resolvedModel);
+	const usesAdaptiveThinkingControls = usesClaudeAdaptiveThinkingControls(resolvedModel);
 
 	for (const msg of ir.messages) {
 		if (msg.role === "system" || msg.role === "developer") {
@@ -602,33 +614,41 @@ async function irToBedrockConverse(
 	const maxTokens = ir.maxTokens ?? providerMaxOutputTokens ?? 4096;
 	const inferenceConfig: Record<string, any> = {};
 	if (typeof maxTokens === "number") inferenceConfig.maxTokens = maxTokens;
-	if (!isOpus47 && typeof ir.temperature === "number") inferenceConfig.temperature = ir.temperature;
-	if (!isOpus47 && typeof ir.topP === "number") inferenceConfig.topP = ir.topP;
+	if (!usesAdaptiveThinkingControls && typeof ir.temperature === "number") inferenceConfig.temperature = ir.temperature;
+	if (!usesAdaptiveThinkingControls && typeof ir.topP === "number") inferenceConfig.topP = ir.topP;
 	if (ir.stop) inferenceConfig.stopSequences = Array.isArray(ir.stop) ? ir.stop : [ir.stop];
 	if (Object.keys(inferenceConfig).length > 0) {
 		request.inferenceConfig = inferenceConfig;
 	}
 
-	if (!isOpus47 && typeof ir.topK === "number") {
+	if (!usesAdaptiveThinkingControls && typeof ir.topK === "number") {
 		request.additionalModelRequestFields = {
 			...(request.additionalModelRequestFields ?? {}),
 			top_k: ir.topK,
 		};
 	}
 
-	if (isOpus47) {
-		request.additionalModelRequestFields = {
-			...(request.additionalModelRequestFields ?? {}),
-			thinking: { type: "adaptive", display: "summarized" },
-		};
-		const anthropicEffort = mapIrEffortToAnthropic(ir.reasoning?.effort, { preferXHigh: true });
-		if (anthropicEffort) {
+	const reasoningDisabled = ir.reasoning?.enabled === false || ir.reasoning?.effort === "none";
+	if (usesAdaptiveThinkingControls) {
+		if (reasoningDisabled && supportsAnthropicThinkingDisabled(resolvedModel)) {
 			request.additionalModelRequestFields = {
 				...(request.additionalModelRequestFields ?? {}),
-				output_config: {
-					effort: anthropicEffort,
-				},
+				thinking: { type: "disabled" },
 			};
+		} else {
+			request.additionalModelRequestFields = {
+				...(request.additionalModelRequestFields ?? {}),
+				thinking: { type: "adaptive", display: "summarized" },
+			};
+			const anthropicEffort = mapIrEffortToAnthropic(ir.reasoning?.effort, { preferXHigh: true });
+			if (anthropicEffort) {
+				request.additionalModelRequestFields = {
+					...(request.additionalModelRequestFields ?? {}),
+					output_config: {
+						effort: anthropicEffort,
+					},
+				};
+			}
 		}
 	} else if (ir.reasoning) {
 		const reasoningMaxTokens = typeof ir.reasoning.maxTokens === "number" ? ir.reasoning.maxTokens : maxTokens;

--- a/apps/api/src/executors/amazon-bedrock/text-generate/index.ts
+++ b/apps/api/src/executors/amazon-bedrock/text-generate/index.ts
@@ -13,6 +13,10 @@ import { shouldFallbackToChatFromError, readErrorPayload } from "@executors/_sha
 import { normalizeTextUsageForPricing } from "@executors/_shared/usage/text";
 import { upstreamTestHeaders } from "@providers/shared/testing";
 import { mapIrEffortToAnthropic } from "@core/reasoningEffort";
+import {
+	supportsAnthropicThinkingDisabled,
+	usesClaudeAdaptiveThinkingControls,
+} from "@core/claudeModelCapabilities";
 import type { ProviderExecutor } from "../../types";
 import {
 	bedrockConverseToIR,
@@ -510,32 +514,6 @@ export function transformStream(stream: ReadableStream<Uint8Array>): ReadableStr
 	return stream;
 }
 
-function normalizeModelId(model: string | null | undefined): string {
-	return typeof model === "string" ? model.trim().toLowerCase() : "";
-}
-
-function usesClaudeAdaptiveThinkingControls(model: string | null | undefined): boolean {
-	const normalized = normalizeModelId(model);
-	if (!normalized) return false;
-	return (
-		normalized.includes("claude-sonnet-5") ||
-		normalized.includes("claude-fable-5") ||
-		normalized.includes("claude-mythos-5") ||
-		normalized.includes("claude-opus-4-7") ||
-		normalized.includes("claude-opus-4.7") ||
-		normalized.includes("claude-opus-4-7-v1") ||
-		normalized.includes("claude-opus-4-8") ||
-		normalized.includes("claude-opus-4.8") ||
-		normalized.includes("claude-opus-4-8-v1")
-	);
-}
-
-function supportsAnthropicThinkingDisabled(model: string | null | undefined): boolean {
-	const normalized = normalizeModelId(model);
-	if (!normalized) return false;
-	return normalized.includes("claude-sonnet-5");
-}
-
 async function irToBedrockConverse(
 	ir: IRChatRequest,
 	providerMaxOutputTokens?: number | null,
@@ -640,14 +618,16 @@ async function irToBedrockConverse(
 				...(request.additionalModelRequestFields ?? {}),
 				thinking: { type: "adaptive", display: "summarized" },
 			};
-			const anthropicEffort = mapIrEffortToAnthropic(ir.reasoning?.effort, { preferXHigh: true });
-			if (anthropicEffort) {
-				request.additionalModelRequestFields = {
-					...(request.additionalModelRequestFields ?? {}),
-					output_config: {
-						effort: anthropicEffort,
-					},
-				};
+			if (!reasoningDisabled) {
+				const anthropicEffort = mapIrEffortToAnthropic(ir.reasoning?.effort, { preferXHigh: true });
+				if (anthropicEffort) {
+					request.additionalModelRequestFields = {
+						...(request.additionalModelRequestFields ?? {}),
+						output_config: {
+							effort: anthropicEffort,
+						},
+					};
+				}
 			}
 		}
 	} else if (ir.reasoning) {

--- a/apps/api/src/executors/anthropic/text-generate/__tests__/request-transform.test.ts
+++ b/apps/api/src/executors/anthropic/text-generate/__tests__/request-transform.test.ts
@@ -362,6 +362,18 @@ describe("irToAnthropicMessages service controls", () => {
 		expect(payload.thinking?.budget_tokens).toBeUndefined();
 	});
 
+	it("omits stale Fable 5 effort when reasoning is disabled", () => {
+		const request = decodeOpenAIChatRequest({
+			model: "anthropic/claude-fable-5",
+			messages: [{ role: "user", content: "Hello" }],
+			reasoning: { enabled: false, effort: "high" },
+		} as any);
+
+		const payload = irToAnthropicMessages(request);
+		expect(payload.thinking).toEqual({ type: "adaptive", display: "summarized" });
+		expect(payload.output_config).toBeUndefined();
+	});
+
 	it("uses adaptive summarized thinking for Mythos 5 and omits legacy thinking budgets", () => {
 		const request = decodeOpenAIChatRequest({
 			model: "anthropic/claude-mythos-5",

--- a/apps/api/src/executors/anthropic/text-generate/__tests__/request-transform.test.ts
+++ b/apps/api/src/executors/anthropic/text-generate/__tests__/request-transform.test.ts
@@ -319,6 +319,62 @@ describe("irToAnthropicMessages service controls", () => {
 		expect(payload.output_config?.effort).toBe("high");
 	});
 
+	it("uses adaptive summarized thinking for Sonnet 5 and omits legacy thinking budgets", () => {
+		const request = decodeOpenAIChatRequest({
+			model: "anthropic/claude-sonnet-5",
+			messages: [{ role: "user", content: "Hello" }],
+			reasoning: { effort: "xhigh", max_tokens: 32000, enabled: true },
+			temperature: 0.2,
+			top_p: 0.8,
+		} as any);
+		(request as any).topK = 20;
+
+		const payload = irToAnthropicMessages(request);
+		expect(payload.thinking).toEqual({ type: "adaptive", display: "summarized" });
+		expect(payload.thinking?.budget_tokens).toBeUndefined();
+		expect(payload.output_config?.effort).toBe("xhigh");
+		expect(payload.temperature).toBeUndefined();
+		expect(payload.top_p).toBeUndefined();
+		expect(payload.top_k).toBeUndefined();
+	});
+
+	it("uses the Sonnet 5 disabled thinking control when reasoning is disabled", () => {
+		const request = decodeOpenAIChatRequest({
+			model: "anthropic/claude-sonnet-5",
+			messages: [{ role: "user", content: "Hello" }],
+			reasoning: { enabled: false },
+		} as any);
+
+		const payload = irToAnthropicMessages(request);
+		expect(payload.thinking).toEqual({ type: "disabled" });
+		expect(payload.output_config).toBeUndefined();
+	});
+
+	it("keeps adaptive summarized thinking for Fable 5 when reasoning is explicitly disabled", () => {
+		const request = decodeOpenAIChatRequest({
+			model: "anthropic/claude-fable-5",
+			messages: [{ role: "user", content: "Hello" }],
+			reasoning: { enabled: false },
+		} as any);
+
+		const payload = irToAnthropicMessages(request);
+		expect(payload.thinking).toEqual({ type: "adaptive", display: "summarized" });
+		expect(payload.thinking?.budget_tokens).toBeUndefined();
+	});
+
+	it("uses adaptive summarized thinking for Mythos 5 and omits legacy thinking budgets", () => {
+		const request = decodeOpenAIChatRequest({
+			model: "anthropic/claude-mythos-5",
+			messages: [{ role: "user", content: "Hello" }],
+			reasoning: { effort: "high", max_tokens: 32000, enabled: true },
+		} as any);
+
+		const payload = irToAnthropicMessages(request);
+		expect(payload.thinking).toEqual({ type: "adaptive", display: "summarized" });
+		expect(payload.thinking?.budget_tokens).toBeUndefined();
+		expect(payload.output_config?.effort).toBe("high");
+	});
+
 	it("keeps adaptive summarized thinking for Opus 4.7 even when reasoning is explicitly disabled", () => {
 		const request = decodeOpenAIChatRequest({
 			model: "anthropic/claude-opus-4.7",

--- a/apps/api/src/executors/anthropic/text-generate/index.ts
+++ b/apps/api/src/executors/anthropic/text-generate/index.ts
@@ -364,10 +364,24 @@ function normalizeModelId(model: string | null | undefined): string {
 	return typeof model === "string" ? model.trim().toLowerCase() : "";
 }
 
-function isClaudeOpus47Model(model: string | null | undefined): boolean {
+function usesClaudeAdaptiveThinkingControls(model: string | null | undefined): boolean {
 	const normalized = normalizeModelId(model);
 	if (!normalized) return false;
-	return normalized.includes("claude-opus-4-7") || normalized.includes("claude-opus-4.7");
+	return (
+		normalized.includes("claude-sonnet-5") ||
+		normalized.includes("claude-fable-5") ||
+		normalized.includes("claude-mythos-5") ||
+		normalized.includes("claude-opus-4-7") ||
+		normalized.includes("claude-opus-4.7") ||
+		normalized.includes("claude-opus-4-8") ||
+		normalized.includes("claude-opus-4.8")
+	);
+}
+
+function supportsAnthropicThinkingDisabled(model: string | null | undefined): boolean {
+	const normalized = normalizeModelId(model);
+	if (!normalized) return false;
+	return normalized.includes("claude-sonnet-5");
 }
 
 function supportsAnthropicFastMode(model: string | null | undefined): boolean {
@@ -392,7 +406,7 @@ export function irToAnthropicMessages(
 	const messages: any[] = [];
 	let system: string | any[] | undefined;
 	const resolvedModel = modelHint || ir.model;
-	const isOpus47 = isClaudeOpus47Model(resolvedModel);
+	const usesAdaptiveThinkingControls = usesClaudeAdaptiveThinkingControls(resolvedModel);
 
 	for (const msg of ir.messages) {
 		if (msg.role === "system") {
@@ -458,8 +472,8 @@ export function irToAnthropicMessages(
 		request.inference_geo = options.inferenceGeo;
 	}
 
-	// Sampling params are rejected by Claude Opus 4.7, so omit them on that model.
-	if (!isOpus47) {
+	// Adaptive-thinking Claude models reject non-default sampling params, so omit them.
+	if (!usesAdaptiveThinkingControls) {
 		if (ir.temperature !== undefined) request.temperature = ir.temperature;
 		if (ir.topP !== undefined) request.top_p = ir.topP;
 		if (ir.topK !== undefined) request.top_k = ir.topK;
@@ -500,19 +514,21 @@ export function irToAnthropicMessages(
 	if (ir.metadata) request.metadata = ir.metadata;
 	const reasoningDisabled = ir.reasoning?.enabled === false || ir.reasoning?.effort === "none";
 
-	if (isOpus47) {
-		// Opus 4.7 uses adaptive thinking and rejects legacy thinking budgets.
-		// Always request summarized traces to avoid empty-thinking regressions.
-		request.thinking = {
-			type: "adaptive",
-			display: "summarized",
-		};
-		const anthropicEffort = mapIrEffortToAnthropic(ir.reasoning?.effort, { preferXHigh: true });
-		if (anthropicEffort) {
-			request.output_config = {
-				...(request.output_config ?? {}),
-				effort: anthropicEffort,
+	if (usesAdaptiveThinkingControls) {
+		if (reasoningDisabled && supportsAnthropicThinkingDisabled(resolvedModel)) {
+			request.thinking = { type: "disabled" };
+		} else {
+			request.thinking = {
+				type: "adaptive",
+				display: "summarized",
 			};
+			const anthropicEffort = mapIrEffortToAnthropic(ir.reasoning?.effort, { preferXHigh: true });
+			if (anthropicEffort) {
+				request.output_config = {
+					...(request.output_config ?? {}),
+					effort: anthropicEffort,
+				};
+			}
 		}
 	} else if (ir.reasoning) {
 		const hasThinkingControl =

--- a/apps/api/src/executors/anthropic/text-generate/index.ts
+++ b/apps/api/src/executors/anthropic/text-generate/index.ts
@@ -16,6 +16,11 @@ import { createAnthropicToResponsesStreamTransformer } from "./stream-transforme
 import { resolveStreamForProtocol } from "@executors/_shared/text-generate/openai-compat";
 import { mapIrEffortToAnthropic } from "@core/reasoningEffort";
 import { isIRNativeToolDefinition } from "@core/nativeTools";
+import {
+	normalizeClaudeModelId,
+	supportsAnthropicThinkingDisabled,
+	usesClaudeAdaptiveThinkingControls,
+} from "@core/claudeModelCapabilities";
 
 const ANTHROPIC_FAST_MODE_BETA = "fast-mode-2026-02-01";
 const ANTHROPIC_ADVISOR_BETA = "advisor-tool-2026-03-01";
@@ -360,32 +365,8 @@ async function bufferAnthropicStreamToMessage(res: Response, upstreamStartMs: nu
 /**
  * Transform IR request to Anthropic Messages format
  */
-function normalizeModelId(model: string | null | undefined): string {
-	return typeof model === "string" ? model.trim().toLowerCase() : "";
-}
-
-function usesClaudeAdaptiveThinkingControls(model: string | null | undefined): boolean {
-	const normalized = normalizeModelId(model);
-	if (!normalized) return false;
-	return (
-		normalized.includes("claude-sonnet-5") ||
-		normalized.includes("claude-fable-5") ||
-		normalized.includes("claude-mythos-5") ||
-		normalized.includes("claude-opus-4-7") ||
-		normalized.includes("claude-opus-4.7") ||
-		normalized.includes("claude-opus-4-8") ||
-		normalized.includes("claude-opus-4.8")
-	);
-}
-
-function supportsAnthropicThinkingDisabled(model: string | null | undefined): boolean {
-	const normalized = normalizeModelId(model);
-	if (!normalized) return false;
-	return normalized.includes("claude-sonnet-5");
-}
-
 function supportsAnthropicFastMode(model: string | null | undefined): boolean {
-	const normalized = normalizeModelId(model);
+	const normalized = normalizeClaudeModelId(model);
 	if (!normalized) return false;
 	return (
 		normalized.includes("claude-opus-4-6") ||
@@ -522,12 +503,14 @@ export function irToAnthropicMessages(
 				type: "adaptive",
 				display: "summarized",
 			};
-			const anthropicEffort = mapIrEffortToAnthropic(ir.reasoning?.effort, { preferXHigh: true });
-			if (anthropicEffort) {
-				request.output_config = {
-					...(request.output_config ?? {}),
-					effort: anthropicEffort,
-				};
+			if (!reasoningDisabled) {
+				const anthropicEffort = mapIrEffortToAnthropic(ir.reasoning?.effort, { preferXHigh: true });
+				if (anthropicEffort) {
+					request.output_config = {
+						...(request.output_config ?? {}),
+						effort: anthropicEffort,
+					};
+				}
 			}
 		}
 	} else if (ir.reasoning) {


### PR DESCRIPTION
## Summary
- use adaptive Anthropic thinking controls for Claude Sonnet 5 and newer Opus 4.x models
- omit legacy thinking budgets and rejected sampling params for those adaptive-thinking models
- mirror the request shaping in both direct Anthropic and Amazon Bedrock Converse executors
- add regression coverage for Sonnet 5 request payloads

## Validation
- `apps/api/node_modules/.bin/vitest run src/executors/anthropic/text-generate/__tests__/request-transform.test.ts src/executors/amazon-bedrock/text-generate/__tests__/index.test.ts` - passed, 40 tests
- `apps/api/node_modules/.bin/tsc --noEmit` - passed

Created with Codex


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded support for Anthropic “adaptive thinking” across more Claude model variants.
  * Added handling for disabling thinking on supported models while keeping the request format consistent.

* **Bug Fixes**
  * Sampling settings are now excluded from requests when adaptive thinking is used.
  * Preserved effort settings where supported, while removing legacy budget-token fields from generated payloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->