### PR TITLE
fix(catalog): remove Claude Fable 5 notice

### DIFF
--- a/packages/data/catalog/src/data/models/anthropic/claude-fable-5/model.json
+++ b/packages/data/catalog/src/data/models/anthropic/claude-fable-5/model.json
@@ -14,10 +14,6 @@
   "output_types": "text",
   "api_model_id": "anthropic/claude-fable-5",
   "family_id": "anthropic/claude-fable",
-  "page_notice": {
-    "tone": "info",
-    "markdown": "Claude Fable 5 has returned. Anthropic says Fable 5 access was restored globally from July 1, 2026 after the related export controls were lifted, with updated safeguards and fallback routing for flagged requests. [Read Anthropic's redeployment note](https://www.anthropic.com/news/redeploying-fable-5) or [see Claude's update on X](https://x.com/claudeai/status/2072402636813607381?s=20)."
-  },
   "links": [
     {
       "platform": "announcement",


### PR DESCRIPTION
## Summary
- Remove the temporary `page_notice` from Claude Fable 5 now that the returned-model notice is no longer needed.
- Follows up the temporary notice added in PR #885.

## Validation
- `./node_modules/.bin/tsx.cmd packages/data/catalog/src/data/validate.ts --preset structure`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed an outdated notice from the model page, so the page now shows the remaining details without the extra message.
  * No other visible information on the page was changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->