### PR TITLE
fix(data): disable Groq Qwen 3.6 gateway route

### DIFF
--- a/packages/data/catalog/src/data/api_providers/groq/models.json
+++ b/packages/data/catalog/src/data/api_providers/groq/models.json
@@ -214,7 +214,7 @@
     "provider_api_model_id": "groq:qwen/qwen3.6-27b",
     "provider_model_slug": "qwen/qwen3.6-27b",
     "internal_model_id": "qwen/qwen3.6-27b",
-    "is_active_gateway": true,
+    "is_active_gateway": false,
     "quantization_scheme": null,
     "input_modalities": "text",
     "output_modalities": "text",


### PR DESCRIPTION
## Summary

Disable Groq gateway routing for `qwen/qwen3.6-27b` while the provider route has no catalog pricing entry.

## Why

The model remains listed for Groq, but without pricing it should not be exposed as an active gateway route. Leaving it active risks routing traffic to a provider/model pair that cannot be priced correctly.

## Validation

- Confirmed the PR diff is limited to `packages/data/catalog/src/data/api_providers/groq/models.json`
- GitHub CI will run catalog validation and the normal build matrix

Created with Codex

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the Groq model catalog so `qwen/qwen3.6-27b` is no longer marked as an active gateway option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->