### PR TITLE
Add SiliconFlow Hy3 support

### DIFF
--- a/packages/data/catalog/src/data/api_providers/siliconflow/models.json
+++ b/packages/data/catalog/src/data/api_providers/siliconflow/models.json
@@ -1071,6 +1071,27 @@
     ]
   },
   {
+    "api_model_id": "tencent/hy3:free",
+    "provider_api_model_id": "siliconflow:tencent/hy3:free",
+    "provider_model_slug": "tencent/Hy3",
+    "internal_model_id": "tencent/hy3",
+    "is_active_gateway": true,
+    "quantization_scheme": "FP8",
+    "input_modalities": "text",
+    "output_modalities": "text",
+    "context_length": 262144,
+    "max_output_tokens": 262144,
+    "effective_from": "2026-07-06T00:00:00Z",
+    "effective_to": null,
+    "capabilities": [
+      {
+        "capability_id": "text.generate",
+        "status": "active",
+        "params": []
+      }
+    ]
+  },
+  {
     "api_model_id": "tencent/hy3-preview",
     "provider_api_model_id": "siliconflow:tencent/hy3-preview",
     "provider_model_slug": "tencent/Hy3-preview",

--- a/packages/data/catalog/src/data/pricing/siliconflow/tencent-hy3-free/text.generate/pricing.json
+++ b/packages/data/catalog/src/data/pricing/siliconflow/tencent-hy3-free/text.generate/pricing.json
@@ -1,0 +1,31 @@
+{
+  "key": "siliconflow:tencent/hy3:free:text.generate",
+  "api_provider_id": "siliconflow",
+  "provider_slug": "siliconflow",
+  "api_model_id": "tencent/hy3:free",
+  "capability_id": "text.generate",
+  "rules": [
+    {
+      "meter": "input_text_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 0,
+      "currency": "USD",
+      "pricing_plan": "free",
+      "note": "SiliconFlow dashboard lists final tencent/Hy3 input tokens at $0 per K tokens.",
+      "match": [],
+      "priority": 100
+    },
+    {
+      "meter": "output_text_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 0,
+      "currency": "USD",
+      "pricing_plan": "free",
+      "note": "SiliconFlow dashboard lists final tencent/Hy3 output tokens at $0 per K tokens.",
+      "match": [],
+      "priority": 100
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Adds SiliconFlow provider coverage for the final Tencent Hy3 model.

- Adds final `tencent/Hy3` to the SiliconFlow provider catalog.
- Maps it to the customer-facing free alias `tencent/hy3:free` while retaining `internal_model_id: tencent/hy3`.
- Enables the gateway entry now that SiliconFlow pricing has been verified.
- Adds SiliconFlow pricing rules for `tencent/hy3:free` with zero input and output token pricing.
- Leaves the existing `tencent/Hy3-preview` entry and its paid pricing untouched.

## SiliconFlow Verification

- Verified via SiliconFlow `/v1/models` that both `tencent/Hy3` and `tencent/Hy3-preview` are exposed by SiliconFlow.
- Verified in the signed-in SiliconFlow dashboard that final `tencent/Hy3` is present in the model list.
- Verified the dashboard business-pricing payload for the final Hy3 model shows:
  - input tokens: `0.000000000000 USD / K tokens`
  - output tokens: `0.000000000000 USD / K tokens`
- This PR therefore does not infer pricing from OpenRouter, Kilo, Novita, or any other provider.

## Validation

- `pnpm run validate:data`
- `pnpm run validate:pricing`
- `pnpm run validate:gateway`

Created with Codex