### PR TITLE
Fix model catalogue cache refresh

### DIFF
--- a/apps/web/scripts/importer/loaders/pricing.ts
+++ b/apps/web/scripts/importer/loaders/pricing.ts
@@ -168,6 +168,23 @@ function resolveTouchedModelId(
     );
 }
 
+function matchesModelFilter(
+    rawModelId: string,
+    modelFilter: string | null,
+    lookups: {
+        modelIds: Set<string>;
+        apiToModelId: Map<string, string>;
+        normalizedModelIdToModelId: Map<string, string>;
+    }
+): boolean {
+    if (!modelFilter) return true;
+    const filter = modelFilter.trim();
+    if (!filter) return true;
+    const normalizedRawModelId = rawModelId.trim();
+    if (normalizedRawModelId === filter) return true;
+    return resolveTouchedModelId(normalizedRawModelId, lookups) === filter;
+}
+
 function deepSortObjectKeys(x: any): any {
     if (Array.isArray(x)) {
         // preserve array order (priority often matters)
@@ -316,7 +333,9 @@ export async function loadPricing(
                 if (!modelIdFromFile) {
                     throw new Error(`pricing.json missing model_id/api_model_id: ${fp}`);
                 }
-                if (modelId && modelIdFromFile !== modelId) continue;
+                if (!matchesModelFilter(modelIdFromFile, modelId, knownModelIds)) {
+                    continue;
+                }
                 scannedFiles += 1;
                 const capability_id = j.capability_id ?? j.endpoint ?? capabilityFallback;
                 const computedKey =

--- a/apps/web/scripts/importer/loaders/providers.ts
+++ b/apps/web/scripts/importer/loaders/providers.ts
@@ -591,6 +591,44 @@ function resolveTouchedModelIds(
     return Array.from(resolved);
 }
 
+function resolveProviderSourceModelId(
+    apiModelId: string,
+    internalModelId: string,
+    lookups: {
+        knownModelIds: Set<string>;
+        apiToModelId: Map<string, string>;
+        normalizedModelIdToModelId: Map<string, string>;
+    }
+): string | null {
+    return (
+        (internalModelId && lookups.knownModelIds.has(internalModelId)
+            ? internalModelId
+            : "") ||
+        lookups.apiToModelId.get(apiModelId) ||
+        lookups.normalizedModelIdToModelId.get(
+            normalizeModelIdForMatch(apiModelId)
+        ) ||
+        (lookups.knownModelIds.has(apiModelId) ? apiModelId : "") ||
+        null
+    );
+}
+
+function matchesModelFilter(
+    modelFilter: string | null,
+    apiModelId: string,
+    internalModelId: string,
+    resolvedModelId: string | null,
+): boolean {
+    if (!modelFilter) return true;
+    const filter = modelFilter.trim();
+    if (!filter) return true;
+    return (
+        apiModelId === filter ||
+        internalModelId === filter ||
+        resolvedModelId === filter
+    );
+}
+
 export async function loadProviders(
     tracker: ChangeTracker,
     opts?: { modelId?: string | null }
@@ -798,17 +836,26 @@ export async function loadProviders(
                         ? model.internal_model_id.trim()
                         : "";
                 if (!model?.provider_api_model_id || !apiModelId) continue;
-                if (modelFilter && apiModelId !== modelFilter) continue;
 
-                const resolvedModelId =
-                    (internalModelId && knownModelIds.has(internalModelId)
-                        ? internalModelId
-                        : "") ||
-                    apiToModelId.get(apiModelId) ||
-                    normalizedModelIdToModelId.get(
-                        normalizeModelIdForMatch(apiModelId)
-                    ) ||
-                    (knownModelIds.has(apiModelId) ? apiModelId : "");
+                const resolvedModelId = resolveProviderSourceModelId(
+                    apiModelId,
+                    internalModelId,
+                    {
+                        knownModelIds,
+                        apiToModelId,
+                        normalizedModelIdToModelId,
+                    }
+                );
+                if (
+                    !matchesModelFilter(
+                        modelFilter,
+                        apiModelId,
+                        internalModelId,
+                        resolvedModelId,
+                    )
+                ) {
+                    continue;
+                }
 
                 const hasResolvedModelId = Boolean(resolvedModelId);
                 if (!hasResolvedModelId) {
@@ -833,7 +880,7 @@ export async function loadProviders(
                 const effectiveInternalModelId =
                     (hasValidInternalModelId ? internalModelId : "") ||
                     (hasResolvedModelId ? resolvedModelId : null);
-                if (shouldTouchProviderModels && hasResolvedModelId) {
+                if (shouldTouchProviderModels && resolvedModelId) {
                     touchedModelIds.add(resolvedModelId);
                 }
                 const provider_api_model_id = model.provider_api_model_id;

--- a/apps/web/src/app/(dashboard)/internal/cache/actions.ts
+++ b/apps/web/src/app/(dashboard)/internal/cache/actions.ts
@@ -2,6 +2,7 @@
 
 import { revalidatePath, revalidateTag } from "next/cache";
 import {
+	expirePublicModelCatalogueCache,
 	revalidateAppDataTags,
 	revalidateBenchmarkDataTags,
 	revalidateModelDataOnlyTags,
@@ -166,18 +167,12 @@ export async function revalidateModelsGlobalDataAction(): Promise<CacheOpResult>
 }
 
 export async function revalidatePublicModelCatalogueAction(): Promise<CacheOpResult> {
-	return runAdminAction("Public catalogue", async () => {
-		revalidateModelDataTags();
+	return runAdminAction("Public catalogue", () => {
+		expirePublicModelCatalogueCache();
 		for (const tag of APP_FRONTEND_TAGS) {
 			revalidateTag(tag, EXPIRE_NOW);
 		}
 		revalidateTag("collections", EXPIRE_NOW);
-		revalidatePath("/models");
-		revalidatePath("/models/collections");
-		revalidatePath("/monitor");
-		revalidatePath("/compare");
-		revalidatePath("/api-providers");
-		revalidatePath("/apps");
 	});
 }
 

--- a/apps/web/src/app/(dashboard)/models/page.tsx
+++ b/apps/web/src/app/(dashboard)/models/page.tsx
@@ -307,6 +307,23 @@ function firstNonEmptyString(
 	return null;
 }
 
+function applyApiVariantModelName(baseName: string, modelId: string): string {
+	const normalizedModelId = String(modelId ?? "").trim().toLowerCase();
+	if (normalizedModelId.endsWith(":free")) {
+		const trimmedName = baseName.trim();
+		if (/\(\s*free\s*\)$/i.test(trimmedName)) {
+			return trimmedName.replace(/\(\s*free\s*\)$/i, "(Free)");
+		}
+		if (/\s+free$/i.test(trimmedName)) {
+			return trimmedName.replace(/\s+free$/i, " (Free)");
+		}
+		if (!/\bfree\b/i.test(trimmedName)) {
+			return `${trimmedName} (Free)`;
+		}
+	}
+	return baseName;
+}
+
 function buildCanonicalModelLookupCandidates(value: string): string[] {
 	const normalized = String(value ?? "").trim();
 	if (!normalized) return [];
@@ -776,7 +793,6 @@ function normalizeModelTailForDedup(modelId: string): string {
 		.replace(/-\d{4}-\d{2}$/g, "")
 		.replace(/-\d{4}$/g, "")
 		.replace(/-latest$/g, "")
-		.replace(/-preview$/g, "")
 		.replace(/-stable$/g, "")
 		.replace(/-+/g, "-")
 		.replace(/^-|-$/g, "");
@@ -960,6 +976,7 @@ function withGatewayMetadata(
 				modelId.split("/").slice(-1)[0],
 				modelId,
 			) ?? modelId;
+		const displayName = applyApiVariantModelName(fallbackName, modelId);
 		const fallbackOrganisationId =
 			firstNonEmptyString(
 				model?.organisation_id,
@@ -969,7 +986,7 @@ function withGatewayMetadata(
 
 		const compactModel: ModelsPageModel = {
 			model_id: modelId,
-			name: fallbackName,
+			name: displayName,
 			organisation_id: fallbackOrganisationId,
 			organisation_name:
 				normalizeOrganisationDisplayName(

--- a/apps/web/src/components/(data)/models/Models/ModelCard.tsx
+++ b/apps/web/src/components/(data)/models/Models/ModelCard.tsx
@@ -23,6 +23,7 @@ import {
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 import type { ModelCard as ModelCardType } from "@/lib/fetchers/models/getAllModels";
+import { getModelDetailsHref } from "@/lib/models/modelHref";
 import { normalizeOrganisationDisplayName } from "@/lib/models/organisationDisplay";
 
 type ModelCardLike = Omit<ModelCardType, "gateway_status"> & {
@@ -433,7 +434,9 @@ function ModelCardImpl({
 	contentPaddingClassName?: string;
 }) {
 	const modelSlug = model.model_id;
-	const modelHref = `/models/${modelSlug}`;
+	const modelHref =
+		getModelDetailsHref(model.organisation_id, model.model_id) ??
+		`/models/${modelSlug}`;
 	const router = useRouter();
 	const apiModelId =
 		model.gateway_api_model_ids

--- a/apps/web/src/lib/cache/revalidateDataTags.ts
+++ b/apps/web/src/lib/cache/revalidateDataTags.ts
@@ -1,4 +1,4 @@
-import { revalidatePath, revalidateTag } from "next/cache";
+import { revalidatePath, revalidateTag, updateTag } from "next/cache";
 
 const STALE_WHILE_REVALIDATE = "max" as const;
 const EXPIRE_IMMEDIATELY = { expire: 0 } as const;
@@ -169,7 +169,7 @@ function revalidateTagList(tags: readonly string[]) {
 
 function expireTagList(tags: readonly string[]) {
 	for (const tag of new Set(tags)) {
-		revalidateTag(tag, EXPIRE_IMMEDIATELY);
+		updateTag(tag);
 	}
 }
 
@@ -181,6 +181,7 @@ function revalidatePublicCataloguePaths(options: RevalidateModelDataTagOptions) 
 	revalidatePath("/chat/audio");
 	revalidatePath("/chat/moderation");
 	revalidatePath("/chat/embeddings");
+	revalidatePath("/models");
 	revalidatePath("/models", "layout");
 	revalidatePath("/models/table");
 	revalidatePath("/models/collections");

--- a/apps/web/src/lib/fetchers/models/resolveCanonicalModelId.ts
+++ b/apps/web/src/lib/fetchers/models/resolveCanonicalModelId.ts
@@ -24,6 +24,7 @@ function isMissingRelationError(error: unknown): boolean {
 		text.includes("does not exist") ||
 		text.includes("could not find table") ||
 		text.includes("could not find the table") ||
+		text.includes("schema cache") ||
 		text.includes("relation")
 	);
 }
@@ -237,6 +238,10 @@ async function resolveCanonicalModelIdUncached(
 	}
 
 	const providerMappingCandidate = normalizeId(providerByApiRes.data?.[0]?.model_id);
+	const providerApiModelCandidate = normalizeId(providerByApiRes.data?.[0]?.api_model_id);
+	if (providerApiModelCandidate === modelId && providerMappingCandidate) {
+		return buildResult(modelId, "api_model", providerMappingCandidate);
+	}
 	if (providerMappingCandidate) {
 		return buildResult(providerMappingCandidate, "provider_mapping");
 	}

--- a/apps/web/src/lib/models/modelHref.test.ts
+++ b/apps/web/src/lib/models/modelHref.test.ts
@@ -1,0 +1,25 @@
+import { getModelDetailsHref, getModelRouteSlug } from "./modelHref";
+
+describe("model href helpers", () => {
+	it("uses the model id namespace for catalog routes", () => {
+		expect(getModelDetailsHref("mistral", "mistralai/mistral-nemo")).toBe(
+			"/models/mistralai/mistral-nemo",
+		);
+		expect(getModelRouteSlug("mistralai/mistral-nemo", "mistral")).toBe(
+			"mistral-nemo",
+		);
+	});
+
+	it("falls back to the organisation id for un-namespaced model ids", () => {
+		expect(getModelDetailsHref("openai", "gpt-5.4")).toBe(
+			"/models/openai/gpt-5.4",
+		);
+		expect(getModelRouteSlug("gpt-5.4", "openai")).toBe("gpt-5.4");
+	});
+
+	it("returns null when a route cannot be built", () => {
+		expect(getModelDetailsHref(null, "gpt-5.4")).toBeNull();
+		expect(getModelDetailsHref("openai", null)).toBeNull();
+		expect(getModelRouteSlug("", "openai")).toBe("");
+	});
+});

--- a/apps/web/src/lib/models/modelHref.ts
+++ b/apps/web/src/lib/models/modelHref.ts
@@ -1,28 +1,51 @@
-export function getModelRouteSlug(modelId: string, organisationId: string) {
-	const normalizedModelId = modelId.trim();
-	const normalizedOrganisationId = organisationId.trim();
+type ModelRouteParts = {
+	organisationId: string;
+	routeSlug: string;
+};
 
-	if (!normalizedModelId || !normalizedOrganisationId) return "";
+function getModelRouteParts(
+	modelId?: string | null,
+	organisationId?: string | null,
+): ModelRouteParts | null {
+	const normalizedModelId = String(modelId ?? "").trim();
+	const normalizedOrganisationId = String(organisationId ?? "").trim();
+
+	if (!normalizedModelId) return null;
 
 	const [firstSegment, ...restSegments] = normalizedModelId.split("/");
-	if (
-		restSegments.length > 0 &&
-		firstSegment.toLowerCase() === normalizedOrganisationId.toLowerCase()
-	) {
-		return restSegments.join("/");
+	if (firstSegment && restSegments.length > 0) {
+		const routeSlug = restSegments.join("/").trim();
+		if (!routeSlug) return null;
+		return {
+			organisationId: firstSegment,
+			routeSlug,
+		};
 	}
 
-	return normalizedModelId;
+	if (!normalizedOrganisationId) return null;
+
+	return {
+		organisationId: normalizedOrganisationId,
+		routeSlug: normalizedModelId,
+	};
+}
+
+export function getModelRouteSlug(
+	modelId: string,
+	organisationId?: string | null,
+) {
+	const routeParts = getModelRouteParts(modelId, organisationId);
+	if (!routeParts) return "";
+
+	return routeParts.routeSlug;
 }
 
 export function getModelDetailsHref(
 	organisationId?: string | null,
-	modelId?: string | null
+	modelId?: string | null,
 ) {
-	if (!organisationId || !modelId) return null;
+	const routeParts = getModelRouteParts(modelId, organisationId);
+	if (!routeParts) return null;
 
-	const routeSlug = getModelRouteSlug(modelId, organisationId);
-	if (!routeSlug) return null;
-
-	return `/models/${encodeURIComponent(organisationId)}/${encodeURIComponent(routeSlug)}`;
+	return `/models/${encodeURIComponent(routeParts.organisationId)}/${encodeURIComponent(routeParts.routeSlug)}`;
 }


### PR DESCRIPTION
﻿## Summary
- Make public model catalogue invalidation use immediate tag updates and refresh the `/models` route directly.
- Add an authenticated internal Gateway cache purge route and call it from the web cache admin action.
- Preserve distinct stable and preview model IDs in the models grid, fix model card detail links, and make canonical model resolution handle API-model mappings more reliably.
- Update scoped importer matching so model-scoped provider/pricing imports include API variants such as `tencent/hy3:free`.

## Root Cause
Hy3 stable and Hy3 Preview were being collapsed by frontend dedupe because `-preview` was stripped from model IDs. Separately, the public catalogue revalidate action used stale-while-revalidate semantics, so manual cache invalidation could leave `/models` stale long enough to make newly merged models look missing.

## Validation
- `cmd /c apps\\web\\node_modules\\.bin\\tsc.cmd --noEmit --pretty false --project apps\\web\\tsconfig.json`
- `cmd /c apps\\api\\node_modules\\.bin\\tsc.cmd --noEmit --pretty false --project apps\\api\\tsconfig.json`
- `cmd /c node_modules\\.bin\\tsx.cmd packages\\data\\catalog\\src\\data\\validate.ts --preset structure`

Note: `pnpm install --frozen-lockfile` is currently blocked on `main` by an existing pnpm overrides/lockfile mismatch, so validation ran in an isolated worktree after a non-frozen install. The branch itself does not include dependency or lockfile changes.

Created with Codex
