### PR TITLE
Restore lazy header search loading

### DIFF
--- a/apps/web/src/app/api/frontend/search/route.ts
+++ b/apps/web/src/app/api/frontend/search/route.ts
@@ -1,0 +1,21 @@
+import { NextResponse } from "next/server";
+import {
+	compactSearchData,
+	getSearchDataCached,
+} from "@/lib/fetchers/search/getSearchData";
+import { PUBLIC_CDN_CACHE_HEADERS } from "@/lib/cache/publicCacheHeaders";
+
+export async function GET() {
+	try {
+		const data = await getSearchDataCached(false);
+		return NextResponse.json(compactSearchData(data), {
+			headers: PUBLIC_CDN_CACHE_HEADERS,
+		});
+	} catch (error) {
+		console.error("[api/frontend/search] failed to fetch search data", error);
+		return NextResponse.json(
+			{ error: "Failed to load search data" },
+			{ status: 500 }
+		);
+	}
+}

--- a/apps/web/src/components/header/Search/Search.tsx
+++ b/apps/web/src/components/header/Search/Search.tsx
@@ -13,11 +13,13 @@ import { ScrollArea } from "@/components/ui/scroll-area";
 import { Logo } from "@/components/Logo";
 import { cn } from "@/lib/utils";
 import { ArrowUpRight, Search as SearchIcon, Trophy } from "lucide-react";
-import type { SearchData } from "@/lib/fetchers/search/getSearchData";
+import type {
+	CompactSearchData,
+	SearchData,
+} from "@/lib/fetchers/search/getSearchData";
 
 interface Props {
 	className?: string;
-	initialData?: SearchData | null;
 }
 
 type SearchableItem = {
@@ -134,6 +136,97 @@ function createSearchIndex<T extends SearchableItem>(
 }
 
 let cachedSearchData: SearchData | null = null;
+let searchDataRequest: Promise<SearchData> | null = null;
+
+function isCompactSearchData(value: unknown): value is CompactSearchData {
+	return Boolean(
+		value &&
+			typeof value === "object" &&
+			Array.isArray((value as CompactSearchData).m) &&
+			Array.isArray((value as CompactSearchData).o) &&
+			Array.isArray((value as CompactSearchData).b) &&
+			Array.isArray((value as CompactSearchData).p) &&
+			Array.isArray((value as CompactSearchData).s) &&
+			Array.isArray((value as CompactSearchData).c),
+	);
+}
+
+function expandSearchData(value: SearchData | CompactSearchData): SearchData {
+	if (!isCompactSearchData(value)) return value;
+
+	return {
+		models: value.m.map(([id, title, subtitle, href, logoId, releaseGroupLabel]) => ({
+			id,
+			title,
+			subtitle,
+			href,
+			logoId,
+			releaseGroupLabel,
+		})),
+		organisations: value.o.map(([id, title, subtitle, href, logoId]) => ({
+			id,
+			title,
+			subtitle,
+			href,
+			logoId,
+		})),
+		benchmarks: value.b.map(([id, title, subtitle, href]) => ({
+			id,
+			title,
+			subtitle,
+			href,
+		})),
+		apiProviders: value.p.map(([id, title, subtitle, href, logoId]) => ({
+			id,
+			title,
+			subtitle,
+			href,
+			logoId,
+		})),
+		subscriptionPlans: value.s.map(([id, title, subtitle, href, logoId]) => ({
+			id,
+			title,
+			subtitle,
+			href,
+			logoId,
+		})),
+		countries: value.c.map(([id, title, subtitle, href, flagIso]) => ({
+			id,
+			title,
+			subtitle,
+			href,
+			flagIso,
+		})),
+	};
+}
+
+async function fetchSearchData(): Promise<SearchData> {
+	if (cachedSearchData) return cachedSearchData;
+	if (searchDataRequest) return searchDataRequest;
+
+	searchDataRequest = fetch("/api/frontend/search", {
+		method: "GET",
+		cache: "no-store",
+		credentials: "same-origin",
+	})
+		.then(async (response) => {
+			if (!response.ok) {
+				throw new Error("Failed to load search data");
+			}
+			return expandSearchData(
+				(await response.json()) as SearchData | CompactSearchData,
+			);
+		})
+		.then((data) => {
+			cachedSearchData = data;
+			return data;
+		})
+		.finally(() => {
+			searchDataRequest = null;
+		});
+
+	return searchDataRequest;
+}
 
 function getIndexedMatchScore<T extends SearchableItem>(
 	indexedItem: IndexedSearchItem<T>,
@@ -344,24 +437,18 @@ function SearchEmptyState({
 	);
 }
 
-export default function Search({ className, initialData = null }: Props) {
+export default function Search({ className }: Props) {
 	const router = useRouter();
 	const listRef = useRef<HTMLDivElement>(null);
 	const queryUpdateTimeoutRef = useRef<number | null>(null);
 	const [open, setOpen] = useState(false);
 	const [query, setQuery] = useState("");
 	const [searchData, setSearchData] = useState<SearchData | null>(
-		initialData ?? cachedSearchData
+		cachedSearchData
 	);
 	const [isLoadingSearchData, setIsLoadingSearchData] = useState(false);
 	const [searchDataError, setSearchDataError] = useState<string | null>(null);
 	const [scrollViewport, setScrollViewport] = useState<HTMLDivElement | null>(null);
-
-	useEffect(() => {
-		if (!initialData) return;
-		cachedSearchData = initialData;
-		setSearchData(initialData);
-	}, [initialData]);
 
 	useEffect(() => {
 		function onKeyDown(event: KeyboardEvent) {
@@ -401,7 +488,27 @@ export default function Search({ className, initialData = null }: Props) {
 
 	useEffect(() => {
 		if (!open || searchData || searchDataError) return;
-		setSearchDataError("Unable to load search data.");
+
+		let cancelled = false;
+		setIsLoadingSearchData(true);
+
+		void fetchSearchData()
+			.then((data) => {
+				if (cancelled) return;
+				setSearchData(data);
+			})
+			.catch(() => {
+				if (cancelled) return;
+				setSearchDataError("Unable to load search data.");
+			})
+			.finally(() => {
+				if (cancelled) return;
+				setIsLoadingSearchData(false);
+			});
+
+		return () => {
+			cancelled = true;
+		};
 	}, [open, searchData, searchDataError]);
 
 	useEffect(() => {

--- a/apps/web/src/components/header/Search/SearchWrapper.tsx
+++ b/apps/web/src/components/header/Search/SearchWrapper.tsx
@@ -1,11 +1,9 @@
 import Search from "./Search";
-import { getSearchDataCached } from "@/lib/fetchers/search/getSearchData";
 
 interface SearchWrapperProps {
 	className?: string;
 }
 
-export async function SearchWrapper({ className }: SearchWrapperProps) {
-	const initialData = await getSearchDataCached(false).catch(() => null);
-	return <Search className={className} initialData={initialData} />;
+export function SearchWrapper({ className }: SearchWrapperProps) {
+	return <Search className={className} />;
 }


### PR DESCRIPTION
## Summary
- restore the compact `/api/frontend/search` endpoint with public CDN cache headers
- make the header search wrapper synchronous again so it no longer fetches search data during every dashboard render
- lazy-load and expand the compact search payload only when the search dialog opens, with the existing in-session request/data cache

## Root cause
PR #888 moved header search data into a server component prop. Because `Search` is a client component in the global dashboard header, that serialized the full search index through normal page/RSC responses even when users never opened search, increasing Vercel Fast Origin Transfer usage.

## Validation
- `E:\ai-stats-public\apps\web\node_modules\.bin\tsc.CMD --noEmit -p apps/web/tsconfig.json --pretty false`
- `E:\ai-stats-public\apps\web\node_modules\.bin\eslint.CMD apps/web/src/components/header/Search/Search.tsx apps/web/src/components/header/Search/SearchWrapper.tsx apps/web/src/app/api/frontend/search/route.ts` passed with existing warnings only: `no-console` on API route logging, existing mixed whitespace/no-img/react-compiler warnings in `Search.tsx`, and the existing Next pages-directory warning

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new search data endpoint that returns cached, compact search results in JSON.
  * Updated the search experience to load data on demand and handle faster, deduplicated requests.

* **Bug Fixes**
  * Improved search loading reliability by handling failures gracefully and showing an error response when data cannot be loaded.
  * Better manages late responses so the search UI stays in sync when opened and closed quickly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->