### PR TITLE
Fix internal menu navigation

### DIFF
--- a/apps/web/src/components/header/TeamSwitcher.tsx
+++ b/apps/web/src/components/header/TeamSwitcher.tsx
@@ -273,14 +273,20 @@ export default function TeamSwitcher({
 					{(userRole === "editor" || userRole === "admin") && (
 						<>
 							<DropdownMenuItem
+								asChild
 								className="cursor-pointer"
-								onSelect={(e) => {
-									e.preventDefault();
-									router.push("/internal");
-								}}
 							>
-								<Lock className="h-4 w-4" />
-								<span>Internal</span>
+								<Link
+									href="/internal"
+									onClick={(e) => {
+										e.preventDefault();
+										setIsProfileMenuOpen(false);
+										navigateWithViewTransition("/internal");
+									}}
+								>
+									<Lock className="h-4 w-4" />
+									<span>Internal</span>
+								</Link>
 							</DropdownMenuItem>
 							<DropdownMenuSeparator />
 						</>


### PR DESCRIPTION
## Summary
- Render the profile dropdown Internal action as a real link-backed dropdown item.
- Close the profile dropdown and use the existing view-transition navigation path when opening `/internal`.

## Notes
- The internal cache ops fix (`fix: refresh model catalogue cache handling`) is already present on current `main`, so this PR only carries the missing dropdown navigation fix.

## Validation
- `pnpm --filter @ai-stats/web typecheck`

Created with Codex
