### PR TITLE
Only announce new public models

### DIFF
--- a/apps/web/src/lib/model-discovery/internalModelDiscordNotifier.test.ts
+++ b/apps/web/src/lib/model-discovery/internalModelDiscordNotifier.test.ts
@@ -14,7 +14,7 @@ describe("internal model discord notifier", () => {
 				{
 					modelId: "anthropic/claude-mythos-preview",
 					modelName: "Claude Mythos Preview",
-					modelUrl: "https://phaseo.ai/models/anthropic/claude-mythos-preview",
+					modelUrl: "https://phaseo.app/models/anthropic/claude-mythos-preview",
 					creatorName: "Anthropic",
 					creatorColor: "#cc785c",
 				},
@@ -32,20 +32,20 @@ describe("internal model discord notifier", () => {
 		expect(payload.embeds).toHaveLength(1);
 		expect(payload.embeds[0].title).toBe("Anthropic: Claude Mythos Preview");
 		expect(payload.embeds[0].url).toBe(
-			"https://phaseo.ai/models/anthropic/claude-mythos-preview"
+			"https://phaseo.app/models/anthropic/claude-mythos-preview"
 		);
 		expect(payload.embeds[0].description).toContain("Model ID: `anthropic/claude-mythos-preview`");
-		expect(payload.embeds[0].description).toContain("[View Model](https://phaseo.ai/models/anthropic/claude-mythos-preview)");
+		expect(payload.embeds[0].description).toContain("[View Model](https://phaseo.app/models/anthropic/claude-mythos-preview)");
 		expect(payload.embeds[0].footer.text).toBe("Phaseo | 10 Apr 2026");
 		expect(payload.embeds[0].color).toBe(0xcc785c);
-		expect(payload.avatar_url).toBe("https://phaseo.ai/png_logo_light.png");
+		expect(payload.avatar_url).toBe("https://phaseo.app/png_logo_light.png");
 	});
 
 	it("builds multi-model payload as model cards with one overflow card", () => {
 		const models = Array.from({ length: 15 }, (_, index) => ({
 			modelId: `openai/model-${index + 1}`,
 			modelName: `Model ${index + 1}`,
-			modelUrl: `https://phaseo.ai/models/openai/model-${index + 1}`,
+			modelUrl: `https://phaseo.app/models/openai/model-${index + 1}`,
 			creatorName: "OpenAI",
 		}));
 
@@ -58,7 +58,24 @@ describe("internal model discord notifier", () => {
 		expect(payload.embeds[0].title).toBe("OpenAI: Model 1");
 		expect(payload.embeds[1].title).toBe("OpenAI: Model 2");
 		expect(payload.embeds[2].title).toBe("+13 more models");
-		expect(payload.embeds[2].description).toContain("[View Models](https://phaseo.ai/models)");
+		expect(payload.embeds[2].description).toContain("[View Models](https://phaseo.app/models)");
+	});
+
+	it("does not include legacy event or status summary lines", () => {
+		const embed = formatSingleModelEmbed(
+			{
+				modelId: "openai/gpt-5.5",
+				modelName: "GPT 5.5",
+				modelUrl: "https://phaseo.app/models/openai/gpt-5-5",
+				changeSummaryLines: ["Event: Updated", "Status: active -> coming_soon"],
+			} as Parameters<typeof formatSingleModelEmbed>[0],
+			"2026-04-10T12:00:00.000Z"
+		);
+
+		expect(embed.description).toContain("Model ID: `openai/gpt-5.5`");
+		expect(embed.description).toContain("[View Model](https://phaseo.app/models/openai/gpt-5-5)");
+		expect(embed.description).not.toContain("Event:");
+		expect(embed.description).not.toContain("Status:");
 	});
 
 	it("filters duplicate and previously announced models", () => {
@@ -66,17 +83,17 @@ describe("internal model discord notifier", () => {
 			{
 				modelId: "voyage/voyage-3",
 				modelName: "Voyage 3",
-				modelUrl: "https://phaseo.ai/models/voyage/voyage-3",
+				modelUrl: "https://phaseo.app/models/voyage/voyage-3",
 			},
 			{
 				modelId: "voyage/voyage-3",
 				modelName: "Voyage 3 Duplicate",
-				modelUrl: "https://phaseo.ai/models/voyage/voyage-3",
+				modelUrl: "https://phaseo.app/models/voyage/voyage-3",
 			},
 			{
 				modelId: "voyage/voyage-4",
 				modelName: "Voyage 4",
-				modelUrl: "https://phaseo.ai/models/voyage/voyage-4",
+				modelUrl: "https://phaseo.app/models/voyage/voyage-4",
 			},
 		];
 		const announced = {
@@ -101,7 +118,7 @@ describe("internal model discord notifier", () => {
 				{
 					modelId: "voyage/voyage-4",
 					modelName: "Voyage 4",
-					modelUrl: "https://phaseo.ai/models/voyage/voyage-4",
+					modelUrl: "https://phaseo.app/models/voyage/voyage-4",
 				},
 			],
 			null
@@ -127,7 +144,7 @@ describe("internal model discord notifier", () => {
 			{
 				modelId: "voyage/voyage-3",
 				modelName: "Voyage 3",
-				modelUrl: "https://phaseo.ai/models/voyage/voyage-3",
+				modelUrl: "https://phaseo.app/models/voyage/voyage-3",
 				creatorName: "Voyage",
 				creatorColor: "#1A2B3C",
 			},
@@ -165,7 +182,7 @@ describe("internal model discord notifier", () => {
 				{
 					modelId: "voyage/voyage-4",
 					modelName: "Voyage 4",
-					modelUrl: "https://phaseo.ai/models/voyage/voyage-4",
+					modelUrl: "https://phaseo.app/models/voyage/voyage-4",
 				},
 			],
 			null

--- a/apps/web/src/lib/model-discovery/internalModelDiscordNotifier.ts
+++ b/apps/web/src/lib/model-discovery/internalModelDiscordNotifier.ts
@@ -5,7 +5,6 @@ export type InternalModelNotificationModel = {
 	creatorId?: string;
 	creatorName?: string;
 	creatorColor?: string;
-	changeSummaryLines?: string[];
 };
 
 export type DiscordEmbed = {
@@ -56,8 +55,8 @@ export type SendDiscordWebhookOptions = {
 const DEFAULT_EMBED_COLOR = 0x2563eb;
 const DEFAULT_USERNAME = "Phaseo Model Discovery";
 const DEFAULT_MAX_MODEL_EMBEDS = 10;
-const DEFAULT_LATEST_MODELS_URL = "https://phaseo.ai/models";
-const DEFAULT_ASSET_BASE_URL = "https://phaseo.ai";
+const DEFAULT_LATEST_MODELS_URL = "https://phaseo.app/models";
+const DEFAULT_ASSET_BASE_URL = "https://phaseo.app";
 const DEFAULT_AVATAR_PATH = "/png_logo_light.png";
 const ALLOWED_DISCORD_WEBHOOK_HOSTS = new Set([
 	"discord.com",
@@ -87,13 +86,6 @@ function sanitizeModel(input: InternalModelNotificationModel): InternalModelNoti
 	const creatorId = trimOrNull(input.creatorId) ?? modelId.split("/")[0] ?? null;
 	const creatorName = trimOrNull(input.creatorName);
 	const creatorColor = trimOrNull(input.creatorColor);
-	const changeSummaryLines = Array.isArray(input.changeSummaryLines)
-		? input.changeSummaryLines
-				.filter((line): line is string => typeof line === "string")
-				.map((line) => line.trim())
-				.filter(Boolean)
-				.slice(0, 8)
-		: [];
 	return {
 		modelId,
 		modelName,
@@ -101,7 +93,6 @@ function sanitizeModel(input: InternalModelNotificationModel): InternalModelNoti
 		creatorId: creatorId ?? undefined,
 		creatorName: creatorName ?? undefined,
 		creatorColor: creatorColor ?? undefined,
-		changeSummaryLines: changeSummaryLines.length > 0 ? changeSummaryLines : undefined,
 	};
 }
 
@@ -196,7 +187,6 @@ export function formatSingleModelEmbed(
 	const descriptionLines = [
 		`Model ID: \`${safeModel.modelId}\``,
 		`[View Model](${safeModel.modelUrl})`,
-		...(safeModel.changeSummaryLines ? ["", ...safeModel.changeSummaryLines] : []),
 	];
 
 	return {
@@ -220,7 +210,6 @@ function formatPerModelDetailEmbed(
 	const descriptionLines = [
 		`Model ID: \`${safeModel.modelId}\``,
 		`[View Model](${safeModel.modelUrl})`,
-		...(safeModel.changeSummaryLines ? ["", ...safeModel.changeSummaryLines] : []),
 	];
 
 	return {

--- a/scripts/model-discovery/README.md
+++ b/scripts/model-discovery/README.md
@@ -30,13 +30,7 @@ Issue state is stored in `scripts/model-discovery/state/provider-change-issues.j
 Public Phaseo catalog discovery checks Phaseo-owned state such as database records, public model/catalog files, provider mapping data, and generated SDK/OpenAPI model surfaces. These checks may send Discord notifications or write reports, but they do not create, update, comment on, close, label, or otherwise mutate GitHub issues.
 
 Internal model file checks read from `packages/data/catalog/src/data/models`.
-Internal Discord alerts are sent as embed payloads when internal models are added or when lifecycle fields change:
-
-- status
-- announced date
-- release date
-- deprecation date
-- retirement date
+Internal Discord alerts are sent as embed payloads only when internal models are added. Lifecycle/status edits are recorded in the discovery report but do not send Discord notifications.
 Already-announced model IDs are persisted to:
 
 - `scripts/model-discovery/state/internal-announced-models.json`
@@ -70,9 +64,9 @@ pnpm run data:check-new-models:test
 
 - `DISCORD_WEBHOOK_NEW_MODELS_PUBLIC` (public webhook URL for internal website model additions)
 - `DISCORD_WEBHOOK_URL` (private/default webhook URL for provider and Hugging Face tracking alerts)
-- `DISCORD_PUBLIC_MODEL_DISCOVERY_AVATAR_URL` (optional public bot avatar override; defaults to `https://phaseo.ai/png_logo_light.png`)
-- `DISCORD_PRIVATE_MODEL_DISCOVERY_AVATAR_URL` (optional private bot avatar override; defaults to `https://phaseo.ai/png_logo_dark.png`)
-- `DISCORD_MODEL_DISCOVERY_AVATAR_URL` (optional shared avatar override when calling internal runner scripts with `--discord-avatar-url` or `--hf-discord-avatar-url`)
+- `DISCORD_PUBLIC_MODEL_DISCOVERY_AVATAR_URL` (optional public bot avatar override; defaults to `https://phaseo.app/png_logo_light.png`)
+- `DISCORD_PRIVATE_MODEL_DISCOVERY_AVATAR_URL` (optional private bot avatar override; defaults to `https://phaseo.app/png_logo_dark.png`)
+- `DISCORD_MODEL_DISCOVERY_AVATAR_URL` (legacy fallback avatar override when calling internal runner scripts with `--discord-avatar-url`)
 - Watched Hugging Face orgs for the GitHub Actions scheduled runner are currently passed in `.github/workflows/huggingface-model-discovery.yml`
 - `HF_TOKEN` (optional Hugging Face token for orgs/models that require authenticated API access)
 - `GITHUB_TOKEN` or `GH_TOKEN` (optional, enables automatic GitHub issues for external provider and Hugging Face additions/changes/deletions)

--- a/scripts/model-discovery/run-internal.ts
+++ b/scripts/model-discovery/run-internal.ts
@@ -77,8 +77,8 @@ const HUGGING_FACE_API_ORIGIN = "https://huggingface.co";
 const HUGGING_FACE_MODELS_API_PATH = "/api/models";
 const PUBLIC_MODEL_DISCOVERY_USERNAME = "Phaseo Public Model Discovery";
 const PRIVATE_MODEL_DISCOVERY_USERNAME = "Phaseo Private Model Discovery";
-const PUBLIC_MODEL_DISCOVERY_AVATAR_URL = "https://phaseo.ai/png_logo_light.png";
-const PRIVATE_MODEL_DISCOVERY_AVATAR_URL = "https://phaseo.ai/png_logo_dark.png";
+const PUBLIC_MODEL_DISCOVERY_AVATAR_URL = "https://phaseo.app/png_logo_light.png";
+const PRIVATE_MODEL_DISCOVERY_AVATAR_URL = "https://phaseo.app/png_logo_dark.png";
 
 function nowIso(): string {
     return new Date().toISOString();
@@ -535,7 +535,7 @@ async function fetchHfOrgModelIds(org: string, hfToken: string | null): Promise<
     }
 
     const discovered = new Set<string>();
-    let nextUrl = `https://huggingface.co/api/models?author=${encodeURIComponent(org)}&limit=100&full=false&config=false&cardData=false`;
+    let nextUrl: string | null = `https://huggingface.co/api/models?author=${encodeURIComponent(org)}&limit=100&full=false&config=false&cardData=false`;
     let pageCount = 0;
     const maxPages = 50;
 
@@ -676,7 +676,7 @@ function displayModelName(snapshot: ModelFileSnapshot): string {
     return parts.length >= 2 ? parts[parts.length - 2] : snapshot.filePath;
 }
 
-const MODEL_DETAILS_BASE_URL = "https://phaseo.ai";
+const MODEL_DETAILS_BASE_URL = "https://phaseo.app";
 const HUGGING_FACE_BASE_URL = "https://huggingface.co";
 
 function appendBoundedLines(lines: string[], values: string[], maxItems = 40): void {
@@ -742,55 +742,6 @@ function toInternalNotificationModel(
         creatorName: creatorMeta?.name,
         creatorColor: creatorMeta?.colour,
     };
-}
-
-function formatStatusValue(status: string | null): string {
-    return status ?? "Not set";
-}
-
-function formatDateValue(value: string | null): string {
-    if (!value) return "Not set";
-    const parsed = new Date(value);
-    if (!Number.isFinite(parsed.getTime())) return value;
-    return parsed.toLocaleDateString("en-GB", {
-        year: "numeric",
-        month: "short",
-        day: "numeric",
-        timeZone: "UTC",
-    });
-}
-
-function buildAddedModelSummaryLines(snapshot: ModelFileSnapshot): string[] {
-    const lines = [`Event: Added`, `Status: ${formatStatusValue(snapshot.status)}`];
-    if (snapshot.announcedDate) lines.push(`Announced: ${formatDateValue(snapshot.announcedDate)}`);
-    if (snapshot.releaseDate) lines.push(`Release: ${formatDateValue(snapshot.releaseDate)}`);
-    if (snapshot.deprecationDate) lines.push(`Deprecation: ${formatDateValue(snapshot.deprecationDate)}`);
-    if (snapshot.retirementDate) lines.push(`Retirement: ${formatDateValue(snapshot.retirementDate)}`);
-    return lines;
-}
-
-function buildUpdatedModelSummaryLines(previous: ModelFileSnapshot, current: ModelFileSnapshot): string[] {
-    const lines: string[] = ["Event: Updated"];
-
-    if (previous.status !== current.status) {
-        lines.push(`Status: ${formatStatusValue(previous.status)} -> ${formatStatusValue(current.status)}`);
-    }
-    if (previous.announcedDate !== current.announcedDate) {
-        lines.push(`Announced: ${formatDateValue(previous.announcedDate)} -> ${formatDateValue(current.announcedDate)}`);
-    }
-    if (previous.releaseDate !== current.releaseDate) {
-        lines.push(`Release: ${formatDateValue(previous.releaseDate)} -> ${formatDateValue(current.releaseDate)}`);
-    }
-    if (previous.deprecationDate !== current.deprecationDate) {
-        lines.push(
-            `Deprecation: ${formatDateValue(previous.deprecationDate)} -> ${formatDateValue(current.deprecationDate)}`
-        );
-    }
-    if (previous.retirementDate !== current.retirementDate) {
-        lines.push(`Retirement: ${formatDateValue(previous.retirementDate)} -> ${formatDateValue(current.retirementDate)}`);
-    }
-
-    return lines.length > 1 ? lines : [];
 }
 
 function buildHfModelLine(modelId: string): string {
@@ -928,11 +879,7 @@ export async function runInternalModelDiscovery(argv: string[], hooks: InternalM
             .filter((snapshot): snapshot is ModelFileSnapshot => Boolean(snapshot))
             .map((snapshot) => {
                 const model = toInternalNotificationModel(snapshot, organisationMetaMap);
-                if (!model) return null;
-                return {
-                    ...model,
-                    changeSummaryLines: buildAddedModelSummaryLines(snapshot),
-                } satisfies InternalModelNotificationModel;
+                return model;
             })
             .filter((snapshot): snapshot is InternalModelNotificationModel => Boolean(snapshot))
         : [];
@@ -941,38 +888,10 @@ export async function runInternalModelDiscovery(argv: string[], hooks: InternalM
         0,
         detectedInternalAddedModels.length - newInternalModels.length
     );
-    const detectedInternalUpdatedModels = shouldCheckInternal
-        ? diff.changed
-            .map((filePath) => {
-                const previousSnapshot = previousState.files[filePath];
-                const currentSnapshot = currentFiles[filePath];
-                if (!previousSnapshot || !currentSnapshot) return null;
-                const changeSummaryLines = buildUpdatedModelSummaryLines(previousSnapshot, currentSnapshot);
-                if (changeSummaryLines.length === 0) return null;
-                const model = toInternalNotificationModel(currentSnapshot, organisationMetaMap);
-                if (!model) return null;
-                return {
-                    ...model,
-                    changeSummaryLines,
-                } satisfies InternalModelNotificationModel;
-            })
-            .filter((snapshot): snapshot is InternalModelNotificationModel => Boolean(snapshot))
-        : [];
-    const suppressLegacyLifecycleBackfillUpdates =
-        shouldCheckInternal &&
-        previous.sourceVersion !== null &&
-        previous.sourceVersion < 3 &&
-        detectedInternalUpdatedModels.length > 0;
-    const internalUpdatedModels = suppressLegacyLifecycleBackfillUpdates
-        ? []
-        : detectedInternalUpdatedModels;
-    const suppressedLegacyLifecycleUpdates = suppressLegacyLifecycleBackfillUpdates
-        ? detectedInternalUpdatedModels.length
-        : 0;
-    const internalNotificationModels = [...newInternalModels, ...internalUpdatedModels];
     const internalAdditionsCount = shouldCheckInternal ? newInternalModels.length : 0;
-    const internalUpdatesCount = shouldCheckInternal ? internalUpdatedModels.length : 0;
-    const internalNotificationCount = internalNotificationModels.length;
+    const internalUpdatesCount = shouldCheckInternal ? diff.changed.length : 0;
+    const internalNotificationModels = newInternalModels;
+    const internalNotificationCount = internalAdditionsCount;
 
     const hfFirstBaseline = shouldCheckHf && !previous.hasHfState;
     const hfAdditionsByOrg = !shouldCheckHf || hfFirstBaseline
@@ -995,9 +914,8 @@ export async function runInternalModelDiscovery(argv: string[], hooks: InternalM
             detectedAdded: detectedInternalAddedModels.length,
             detectedUpdated: internalUpdatesCount,
             newlyAnnouncedAdded: newInternalModels.length,
-            notifiedUpdates: internalUpdatesCount,
+            notifiedUpdates: 0,
             skippedAlreadyAnnounced: skippedAlreadyAnnouncedInternal,
-            suppressedLegacyLifecycleUpdates,
             announcedStatePath: path.relative(repoRoot, announcedStatePath),
         },
     });
@@ -1012,11 +930,8 @@ export async function runInternalModelDiscovery(argv: string[], hooks: InternalM
             );
         }
         if (internalUpdatesCount > 0) {
-            console.log(`[internal-model-check] Internal model updates detected: ${internalUpdatesCount}.`);
-        }
-        if (suppressedLegacyLifecycleUpdates > 0) {
             console.log(
-                `[internal-model-check] Suppressed ${suppressedLegacyLifecycleUpdates} lifecycle update notification(s) while upgrading legacy discovery state.`
+                `[internal-model-check] Internal model updates detected but not notified: ${internalUpdatesCount}.`
             );
         }
     } else {
@@ -1042,7 +957,7 @@ export async function runInternalModelDiscovery(argv: string[], hooks: InternalM
 
     if (internalNotificationCount === 0 && hfAdditionsTotal === 0) {
         writeDiscoveryState(statePath, currentFiles, currentHf.snapshots);
-        console.log("[internal-model-check] No internal model updates/additions or HF additions detected.");
+        console.log("[internal-model-check] No internal model additions or HF additions detected.");
         return;
     }
 


### PR DESCRIPTION
## Summary
- change internal public model Discord alerts to announce only newly added models
- remove event/status/lifecycle summary lines from model announcement embeds
- keep the Discord bot copy and avatar defaults aligned with the Phaseo rebrand, using the light PNG logo for public model announcements
- document the new new-model-only notification behavior and avatar env vars

## Validation
- `corepack pnpm test -- internalModelDiscordNotifier.test.ts` from `apps/web`
- `corepack pnpm exec tsc --ignoreConfig --noEmit --target ES2022 --module ES2022 --moduleResolution bundler --types node ../../scripts/model-discovery/run-internal.ts src/lib/model-discovery/internalModelDiscordNotifier.ts` from `apps/web`

Created with Codex