### PR TITLE
Correct Aion 3 release dates

### DIFF
--- a/packages/data/catalog/src/data/models/aion-labs/aion-3.0-mini/model.json
+++ b/packages/data/catalog/src/data/models/aion-labs/aion-3.0-mini/model.json
@@ -6,7 +6,7 @@
   "previous_model_id": "aion-labs/aion-1.0-mini",
   "description": "Aion 3.0 Mini is a multimodal system built on the DeepSeek family of models. It uses multiple specialized models during generation to improve narrative structure, tension, conflict, and mature-theme handling.",
   "announced_date": "2026-07-07T00:00:00",
-  "release_date": "2026-05-14T00:00:00",
+  "release_date": "2026-07-07T00:00:00",
   "deprecation_date": null,
   "retirement_date": null,
   "license": "Proprietary",

--- a/packages/data/catalog/src/data/models/aion-labs/aion-3.0/model.json
+++ b/packages/data/catalog/src/data/models/aion-labs/aion-3.0/model.json
@@ -6,7 +6,7 @@
   "previous_model_id": "aion-labs/aion-2.5",
   "description": "Aion 3.0 is a multimodal system built on the GLM family of models. It uses multiple specialized models during generation to improve narrative structure, tension, conflict, and mature-theme handling.",
   "announced_date": "2026-07-07T00:00:00",
-  "release_date": "2026-05-05T00:00:00",
+  "release_date": "2026-07-07T00:00:00",
   "deprecation_date": null,
   "retirement_date": null,
   "license": "Proprietary",


### PR DESCRIPTION
## Summary
- Set Aion 3.0 and Aion 3.0 Mini release dates to July 7, 2026.
- Kept the PR scoped to the two model JSON date fields only.

## Validation
- Passed: .\node_modules\.bin\tsx.cmd packages/data/catalog/src/data/validate.ts --preset structure
- Note: pnpm validate:data was attempted first, but pnpm stopped during install in the fresh worktree on ignored-build approvals before running the validator.

Created with Codex

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release dates for two model entries to reflect the latest availability.
  * No other model details or user-facing settings were changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->