### PR TITLE
Add Meta Muse media models

### DIFF
--- a/packages/data/catalog/src/data/models/meta/muse-image/model.json
+++ b/packages/data/catalog/src/data/models/meta/muse-image/model.json
@@ -25,6 +25,10 @@
       "value": "Available in Meta AI; powers creative experiences on Instagram and WhatsApp, with Facebook, Messenger, and Meta Advantage+ creative support planned."
     },
     {
+      "name": "api_availability",
+      "value": "No public Meta API or AI Stats Gateway route has been announced or configured for Muse Image."
+    },
+    {
       "name": "reasoning_workflow",
       "value": "Pairs with Muse Spark to plan layouts, use real-time web context, and blend multiple visual references."
     },

--- a/packages/data/catalog/src/data/models/meta/muse-image/model.json
+++ b/packages/data/catalog/src/data/models/meta/muse-image/model.json
@@ -1,0 +1,41 @@
+{
+  "model_id": "meta/muse-image",
+  "organisation_id": "meta",
+  "name": "Muse Image",
+  "status": "Available",
+  "previous_model_id": null,
+  "description": "Muse Image is Meta Superintelligence Labs' first image generation model, built for Meta AI and creative workflows across Meta apps. It supports text and photo-based image generation, editing, and restyling workflows.",
+  "announced_date": "2026-07-07T00:00:00",
+  "release_date": "2026-07-07T00:00:00",
+  "deprecation_date": null,
+  "retirement_date": null,
+  "license": "Proprietary",
+  "input_types": "text,image",
+  "output_types": "image",
+  "api_model_id": "meta/muse-image",
+  "links": [
+    {
+      "platform": "announcement",
+      "url": "https://about.fb.com/news/2026/07/introducing-muse-image-meta-ai/"
+    }
+  ],
+  "details": [
+    {
+      "name": "availability",
+      "value": "Available in Meta AI; powers creative experiences on Instagram and WhatsApp, with Facebook, Messenger, and Meta Advantage+ creative support planned."
+    },
+    {
+      "name": "reasoning_workflow",
+      "value": "Pairs with Muse Spark to plan layouts, use real-time web context, and blend multiple visual references."
+    },
+    {
+      "name": "editing",
+      "value": "Supports direct image edits through markup, sketches, annotations, and conversational refinements."
+    },
+    {
+      "name": "social_context",
+      "value": "Can use @-mentioned Instagram accounts in Meta AI to bring public profile photos into generated images, subject to user controls."
+    }
+  ],
+  "benchmarks": []
+}

--- a/packages/data/catalog/src/data/models/meta/muse-video/model.json
+++ b/packages/data/catalog/src/data/models/meta/muse-video/model.json
@@ -1,0 +1,29 @@
+{
+  "model_id": "meta/muse-video",
+  "organisation_id": "meta",
+  "name": "Muse Video",
+  "status": "Coming Soon",
+  "previous_model_id": null,
+  "description": "Muse Video is Meta's in-development video generation model in the Muse family, intended to bring prompt-driven creative video workflows into Meta's AI products.",
+  "announced_date": "2026-07-07T00:00:00",
+  "release_date": null,
+  "deprecation_date": null,
+  "retirement_date": null,
+  "license": "Proprietary",
+  "input_types": null,
+  "output_types": "video",
+  "api_model_id": "meta/muse-video",
+  "links": [
+    {
+      "platform": "announcement",
+      "url": "https://about.fb.com/news/2026/07/introducing-muse-image-meta-ai/"
+    }
+  ],
+  "details": [
+    {
+      "name": "availability",
+      "value": "Meta says Muse Video is already in development; no public release surface or external API availability has been announced."
+    }
+  ],
+  "benchmarks": []
+}

--- a/packages/data/catalog/src/data/models/meta/muse-video/model.json
+++ b/packages/data/catalog/src/data/models/meta/muse-video/model.json
@@ -23,6 +23,10 @@
     {
       "name": "availability",
       "value": "Meta says Muse Video is already in development; no public release surface or external API availability has been announced."
+    },
+    {
+      "name": "api_availability",
+      "value": "No public Meta API or AI Stats Gateway route has been announced or configured for Muse Video."
     }
   ],
   "benchmarks": []

--- a/packages/data/catalog/src/data/models/meta/muse-video/model.json
+++ b/packages/data/catalog/src/data/models/meta/muse-video/model.json
@@ -2,7 +2,7 @@
   "model_id": "meta/muse-video",
   "organisation_id": "meta",
   "name": "Muse Video",
-  "status": "Coming Soon",
+  "status": "Announced",
   "previous_model_id": null,
   "description": "Muse Video is Meta's in-development video generation model in the Muse family, intended to bring prompt-driven creative video workflows into Meta's AI products.",
   "announced_date": "2026-07-07T00:00:00",


### PR DESCRIPTION
## Summary
- Add Meta Muse Image as an available image generation model announced on July 7, 2026.
- Add Meta Muse Video as a coming-soon video model because Meta says it is in development but has not announced a public release surface.
- Source both records to Meta's official Muse Image announcement.
- Do not add provider, pricing, or gateway routing records; both model records explicitly note that no public Meta API or AI Stats Gateway route has been announced or configured.

## Validation
- Passed: `E:\ai-stats-public-aion-dates-20260707\node_modules\.bin\tsx.cmd packages/data/catalog/src/data/validate.ts --preset structure`
- Passed: `E:\ai-stats-public-aion-dates-20260707\node_modules\.bin\tsx.cmd packages/data/catalog/src/data/validate.ts --preset pricing`
- Passed: `E:\ai-stats-public-aion-dates-20260707\node_modules\.bin\tsx.cmd packages/data/catalog/src/data/validate-gateway.ts`

Created with Codex

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added catalog entries for new Meta media models, including image and video offerings.
  * Expanded model details with availability, API support, licensing, supported input/output types, and announcement links.
  * Included status and lifecycle information for each model, with benchmark sections prepared for future updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->