### PR TITLE
data: add Kwaipilot API model ID details

### DIFF
--- a/packages/data/catalog/src/data/models/kwaipilot/kat-coder-air-v2.5/model.json
+++ b/packages/data/catalog/src/data/models/kwaipilot/kat-coder-air-v2.5/model.json
@@ -20,6 +20,10 @@
   "links": [],
   "details": [
     {
+      "name": "api_model_id",
+      "value": "kwaipilot/kat-coder-air-v2.5"
+    },
+    {
       "name": "upstream_discovery",
       "value": "AI Stats provider discovery detected AtlasCloud adding kwaipilot/kat-coder-air-v2.5 on 2026-07-08."
     }

--- a/packages/data/catalog/src/data/models/kwaipilot/kat-coder-pro-v2.5/model.json
+++ b/packages/data/catalog/src/data/models/kwaipilot/kat-coder-pro-v2.5/model.json
@@ -20,6 +20,10 @@
   "links": [],
   "details": [
     {
+      "name": "api_model_id",
+      "value": "kwaipilot/kat-coder-pro-v2.5"
+    },
+    {
       "name": "upstream_discovery",
       "value": "AI Stats provider discovery detected AtlasCloud adding kwaipilot/kat-coder-pro-v2.5 on 2026-07-08."
     }


### PR DESCRIPTION
﻿## Summary

- Adds explicit `api_model_id` detail rows for the two AtlasCloud Kwaipilot V2.5 model records.
- Keeps the change scoped to the newly added model catalog data.

## Validation

- `.\node_modules\.bin\tsx.cmd packages/data/catalog/src/data/validate.ts --preset structure`
- `.\node_modules\.bin\tsx.cmd packages/data/catalog/src/data/validate.ts --preset pricing`
- `.\node_modules\.bin\tsx.cmd packages/data/catalog/src/data/validate-gateway.ts`

Structure validation passed with the repo's existing non-blocking warnings.
