### PR TITLE
Fix OpenAI GPT-5.6 catalog metadata

### DIFF
--- a/apps/docs/v1/model-migrations/index.mdx
+++ b/apps/docs/v1/model-migrations/index.mdx
@@ -35,7 +35,7 @@ These pages focus on the changes that usually break real integrations first:
 | [Anthropic: Claude Opus 4.6 to 4.7](./anthropic-claude-opus-4-6-to-4-7) | April 16, 2026 |
 | [Anthropic: Claude Opus 4.5 to 4.6](./anthropic-claude-opus-4-5-to-4-6) | February 5, 2026 |
 | [Anthropic: Claude Sonnet 4.5 to 4.6](./anthropic-claude-sonnet-4-5-to-4-6) | February 17, 2026 |
-| [OpenAI: Migrating to GPT-5.6](./openai-migrating-to-gpt-5-6) | Preview announced June 26, 2026 |
+| [OpenAI: Migrating to GPT-5.6](./openai-migrating-to-gpt-5-6) | Current OpenAI GPT family |
 | [OpenAI: Migrating to GPT-5.4](./openai-migrating-to-gpt-5-4) | March 5, 2026 |
 | [Google: Migrating to Gemini 3 and 3.1](./google-migrating-to-gemini-3-and-3-1) | Gemini 3: November 25, 2025; Gemini 3.1 Pro: February 19, 2026 |
 | [Google: Nano Banana 1 to Nano Banana 2](./google-nano-banana-1-to-nano-banana-2) | February 26, 2026 |

--- a/apps/docs/v1/model-migrations/openai-migrating-to-gpt-5-6.mdx
+++ b/apps/docs/v1/model-migrations/openai-migrating-to-gpt-5-6.mdx
@@ -7,27 +7,29 @@ description: "What to review before moving GPT-5.x traffic to GPT-5.6 Sol, Terra
 
 Use this guide when you are preparing existing OpenAI traffic for GPT-5.6.
 
-GPT-5.6 is currently tracked as a limited preview. In Phaseo, the models are listed as coming soon until public gateway routing is active, so treat this as a readiness checklist rather than a same-day production cutover.
+GPT-5.6 is the current OpenAI GPT family for complex production workflows. In AI Stats, the fixed tier IDs map to the OpenAI model IDs `gpt-5.6-sol`, `gpt-5.6-terra`, and `gpt-5.6-luna`.
 
 ## Choose the right GPT-5.6 model
 
 | Model | Use it for | Reasoning effort |
 | --- | --- | --- |
 | `openai/gpt-5.6-sol` | Highest-capability reasoning, agentic coding, scientific analysis, and complex professional work | `none`, `low`, `medium`, `high`, `xhigh`, `max` |
-| `openai/gpt-5.6-terra` | Balanced everyday work across reasoning, coding, and assistant workflows | `none`, `low`, `medium`, `high`, `xhigh` |
-| `openai/gpt-5.6-luna` | Lower-latency and cost-sensitive GPT-5.6 workloads | `none`, `low`, `medium`, `high`, `xhigh` |
+| `openai/gpt-5.6-terra` | Balanced everyday work across reasoning, coding, and assistant workflows | `none`, `low`, `medium`, `high`, `xhigh`, `max` |
+| `openai/gpt-5.6-luna` | Lower-latency and cost-sensitive GPT-5.6 workloads | `none`, `low`, `medium`, `high`, `xhigh`, `max` |
 
-Only Sol is currently marked for the new `max` reasoning effort. Do not send `max` to Terra or Luna unless their model metadata changes.
+OpenAI's `gpt-5.6` alias routes to `gpt-5.6-sol`. In AI Stats, use `openai/gpt-5.6` or `openai/gpt-sol-latest` when you want that Sol-tier default, and use the fixed tier IDs for controlled routing.
 
-Phaseo also tracks preview aliases for the latest model in each tier: `openai/gpt-sol-latest`, `openai/gpt-terra-latest`, and `openai/gpt-luna-latest`. Use the fixed GPT-5.6 IDs for controlled migrations, and use the tier aliases only when you deliberately want future Sol, Terra, or Luna releases to roll forward through the same route.
+AI Stats also tracks tier aliases for the latest model in each tier: `openai/gpt-sol-latest`, `openai/gpt-terra-latest`, and `openai/gpt-luna-latest`. Use the fixed GPT-5.6 IDs for controlled migrations, and use the tier aliases only when you deliberately want future Sol, Terra, or Luna releases to roll forward through the same route.
 
 ## What changed
 
 - GPT-5.6 adds the new Sol/Terra/Luna split instead of one default GPT route.
-- Sol adds `reasoning.effort: "max"` for the highest reasoning budget.
-- Terra and Luna keep the standard non-`max` GPT-5.6 reasoning effort set.
+- All three GPT-5.6 tiers support `reasoning.effort: "max"` for the highest reasoning budget.
+- GPT-5.6 supports `reasoning.mode: "pro"` without switching to a separate Pro model slug.
+- GPT-5.6 adds persisted reasoning controls through `reasoning.context`.
+- GPT-5.6 adds beta multi-agent support and Programmatic Tool Calling for eligible tool-heavy workflows.
 - Prompt caching is priced with separate uncached input, cache read, cache write, and output meters.
-- Explicit cache breakpoints are supported during preview, with a 30-minute minimum cache life noted in the model metadata.
+- Explicit prompt caching is supported through `prompt_cache_options`; OpenAI currently recommends `prompt_cache_options.ttl` instead of `prompt_cache_retention`.
 
 ## Update your request
 
@@ -45,7 +47,7 @@ The first examples use the Responses API-style `input` shape. If you are migrati
 }
 ```
 
-Use Sol's `max` effort only for routes where the extra reasoning budget is worth the latency and cost.
+Use `max` effort only for routes where the extra reasoning budget is worth the latency and cost.
 
 ```json
 {
@@ -57,7 +59,7 @@ Use Sol's `max` effort only for routes where the extra reasoning budget is worth
 }
 ```
 
-If your integration still sends the flat OpenAI-compatible field, Phaseo also accepts `reasoning_effort` where the route supports it:
+If your integration still sends the flat OpenAI-compatible field, AI Stats also accepts `reasoning_effort` where the route supports it:
 
 ```json
 {
@@ -110,18 +112,21 @@ For repeated context, keep the stable part of the prompt in cacheable blocks and
       ]
     }
   ],
-  "prompt_cache_retention": "24h"
+  "prompt_cache_options": {
+    "mode": "explicit",
+    "ttl": "24h"
+  }
 }
 ```
 
-Use `cache_control` when you want provider-neutral cache hints or explicit cache breakpoints. Use `prompt_cache_retention` when you want to pass OpenAI cache-retention options directly.
+Use `cache_control` when you want provider-neutral cache hints or explicit cache breakpoints. Use `prompt_cache_options` when you want to pass OpenAI cache mode and TTL options directly.
 
 ## What to test
 
 ### Reasoning and output quality
 
-- Sol at `high`, `xhigh`, and `max` on your hardest tasks
-- Terra and Luna at the effort levels you expect to expose to users
+- Sol, Terra, and Luna at the effort levels you expect to expose to users, including `max` where quality-first workflows justify it
+- standard mode versus `reasoning.mode: "pro"` on difficult tasks where quality matters more than latency
 - structured outputs and schema pass rate at each effort level
 - tool-call selection and argument quality
 
@@ -137,10 +142,12 @@ Use `cache_control` when you want provider-neutral cache hints or explicit cache
 - keep your previous GPT-5.x route available as a fallback
 - keep `max` behind a config flag or preset until it is proven on production-like prompts
 - monitor cache write volume separately from cache read volume
-- do not make GPT-5.6 your default route until the model page shows active gateway providers
+- move GPT-5.6 into default routing only after your own evals confirm task success, cost, and latency
 
 ## Sources
 
 - [OpenAI GPT-5.6 preview announcement](https://openai.com/index/previewing-gpt-5-6-sol/)
+- [OpenAI GPT-5.6 model guidance](https://developers.openai.com/api/docs/guides/latest-model)
+- [OpenAI model catalog](https://developers.openai.com/api/docs/models)
 - [GPT-5.6 preview system card](https://deploymentsafety.openai.com/gpt-5-6-preview)
-- [Phaseo prompt caching guide](../guides/prompt-caching)
+- [AI Stats prompt caching guide](../guides/prompt-caching)

--- a/packages/data/catalog/src/data/aliases/openai-gpt-latest/alias.json
+++ b/packages/data/catalog/src/data/aliases/openai-gpt-latest/alias.json
@@ -1,7 +1,8 @@
 {
   "alias_slug": "openai/gpt-latest",
-  "resolved_api_model_id": "openai/gpt-5.5",
+  "resolved_api_model_id": "openai/gpt-5.6-sol",
+  "resolved_model_id": "openai/gpt-5.6-sol",
   "channel": "stable",
   "is_enabled": true,
-  "notes": null
+  "notes": "Latest stable OpenAI GPT alias; GPT-5.6 routes to the Sol tier."
 }

--- a/packages/data/catalog/src/data/aliases/openai-gpt-luna-latest/alias.json
+++ b/packages/data/catalog/src/data/aliases/openai-gpt-luna-latest/alias.json
@@ -2,7 +2,7 @@
   "alias_slug": "openai/gpt-luna-latest",
   "resolved_api_model_id": "openai/gpt-5.6-luna",
   "resolved_model_id": "openai/gpt-5.6-luna",
-  "channel": "preview",
+  "channel": "stable",
   "is_enabled": true,
-  "notes": "Preview alias for the latest OpenAI Luna-tier GPT model."
+  "notes": "Alias for the latest OpenAI Luna-tier GPT model."
 }

--- a/packages/data/catalog/src/data/aliases/openai-gpt-sol-latest/alias.json
+++ b/packages/data/catalog/src/data/aliases/openai-gpt-sol-latest/alias.json
@@ -2,7 +2,7 @@
   "alias_slug": "openai/gpt-sol-latest",
   "resolved_api_model_id": "openai/gpt-5.6-sol",
   "resolved_model_id": "openai/gpt-5.6-sol",
-  "channel": "preview",
+  "channel": "stable",
   "is_enabled": true,
-  "notes": "Preview alias for the latest OpenAI Sol-tier GPT model."
+  "notes": "Alias for the latest OpenAI Sol-tier GPT model."
 }

--- a/packages/data/catalog/src/data/aliases/openai-gpt-terra-latest/alias.json
+++ b/packages/data/catalog/src/data/aliases/openai-gpt-terra-latest/alias.json
@@ -2,7 +2,7 @@
   "alias_slug": "openai/gpt-terra-latest",
   "resolved_api_model_id": "openai/gpt-5.6-terra",
   "resolved_model_id": "openai/gpt-5.6-terra",
-  "channel": "preview",
+  "channel": "stable",
   "is_enabled": true,
-  "notes": "Preview alias for the latest OpenAI Terra-tier GPT model."
+  "notes": "Alias for the latest OpenAI Terra-tier GPT model."
 }

--- a/packages/data/catalog/src/data/api_providers/openai/models.json
+++ b/packages/data/catalog/src/data/api_providers/openai/models.json
@@ -4354,18 +4354,18 @@
     "provider_api_model_id": "openai:openai/gpt-5.6-luna",
     "provider_model_slug": "gpt-5.6-luna",
     "internal_model_id": "openai/gpt-5.6-luna",
-    "is_active_gateway": false,
+    "is_active_gateway": true,
     "quantization_scheme": null,
     "input_modalities": "text,image",
     "output_modalities": "text",
-    "context_length": null,
-    "max_output_tokens": null,
-    "effective_from": "2026-06-26T00:00:00",
+    "context_length": 1050000,
+    "max_output_tokens": 128000,
+    "effective_from": "2026-07-09T00:00:00",
     "effective_to": null,
     "capabilities": [
       {
         "capability_id": "text.generate",
-        "status": "coming_soon",
+        "status": "active",
         "params": [
           {
             "param_id": "seed",
@@ -4386,7 +4386,15 @@
             "provider_min": null,
             "provider_max": null,
             "provider_default": null,
-            "notes": "Supports the confirmed non-max reasoning effort set."
+            "values": [
+              "none",
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ],
+            "notes": null
           },
           {
             "param_id": "response_format",
@@ -4422,8 +4430,43 @@
             "provider_max": null,
             "provider_default": null,
             "notes": null
+          },
+          {
+            "param_id": "temperature",
+            "provider_min": null,
+            "provider_max": null,
+            "provider_default": null,
+            "notes": null
+          },
+          {
+            "param_id": "top_p",
+            "provider_min": null,
+            "provider_max": null,
+            "provider_default": null,
+            "notes": null
           }
         ]
+      },
+      {
+        "capability_id": "batch",
+        "status": "active",
+        "params": {
+          "endpoint": {
+            "type": "enum",
+            "values": [
+              "/v1/responses",
+              "/v1/chat/completions"
+            ],
+            "default": "/v1/responses"
+          },
+          "completion_window": {
+            "type": "enum",
+            "values": [
+              "24h"
+            ],
+            "default": "24h"
+          }
+        }
       }
     ]
   },
@@ -4432,18 +4475,18 @@
     "provider_api_model_id": "openai:openai/gpt-5.6-sol",
     "provider_model_slug": "gpt-5.6-sol",
     "internal_model_id": "openai/gpt-5.6-sol",
-    "is_active_gateway": false,
+    "is_active_gateway": true,
     "quantization_scheme": null,
     "input_modalities": "text,image",
     "output_modalities": "text",
-    "context_length": null,
-    "max_output_tokens": null,
-    "effective_from": "2026-06-26T00:00:00",
+    "context_length": 1050000,
+    "max_output_tokens": 128000,
+    "effective_from": "2026-07-09T00:00:00",
     "effective_to": null,
     "capabilities": [
       {
         "capability_id": "text.generate",
-        "status": "coming_soon",
+        "status": "active",
         "params": [
           {
             "param_id": "seed",
@@ -4464,7 +4507,15 @@
             "provider_min": null,
             "provider_max": null,
             "provider_default": null,
-            "notes": "Preview post confirms a new max reasoning effort for Sol."
+            "values": [
+              "none",
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ],
+            "notes": null
           },
           {
             "param_id": "response_format",
@@ -4500,8 +4551,43 @@
             "provider_max": null,
             "provider_default": null,
             "notes": null
+          },
+          {
+            "param_id": "temperature",
+            "provider_min": null,
+            "provider_max": null,
+            "provider_default": null,
+            "notes": null
+          },
+          {
+            "param_id": "top_p",
+            "provider_min": null,
+            "provider_max": null,
+            "provider_default": null,
+            "notes": null
           }
         ]
+      },
+      {
+        "capability_id": "batch",
+        "status": "active",
+        "params": {
+          "endpoint": {
+            "type": "enum",
+            "values": [
+              "/v1/responses",
+              "/v1/chat/completions"
+            ],
+            "default": "/v1/responses"
+          },
+          "completion_window": {
+            "type": "enum",
+            "values": [
+              "24h"
+            ],
+            "default": "24h"
+          }
+        }
       }
     ]
   },
@@ -4510,18 +4596,18 @@
     "provider_api_model_id": "openai:openai/gpt-5.6-terra",
     "provider_model_slug": "gpt-5.6-terra",
     "internal_model_id": "openai/gpt-5.6-terra",
-    "is_active_gateway": false,
+    "is_active_gateway": true,
     "quantization_scheme": null,
     "input_modalities": "text,image",
     "output_modalities": "text",
-    "context_length": null,
-    "max_output_tokens": null,
-    "effective_from": "2026-06-26T00:00:00",
+    "context_length": 1050000,
+    "max_output_tokens": 128000,
+    "effective_from": "2026-07-09T00:00:00",
     "effective_to": null,
     "capabilities": [
       {
         "capability_id": "text.generate",
-        "status": "coming_soon",
+        "status": "active",
         "params": [
           {
             "param_id": "seed",
@@ -4542,7 +4628,15 @@
             "provider_min": null,
             "provider_max": null,
             "provider_default": null,
-            "notes": "Supports the confirmed non-max reasoning effort set."
+            "values": [
+              "none",
+              "low",
+              "medium",
+              "high",
+              "xhigh",
+              "max"
+            ],
+            "notes": null
           },
           {
             "param_id": "response_format",
@@ -4578,8 +4672,43 @@
             "provider_max": null,
             "provider_default": null,
             "notes": null
+          },
+          {
+            "param_id": "temperature",
+            "provider_min": null,
+            "provider_max": null,
+            "provider_default": null,
+            "notes": null
+          },
+          {
+            "param_id": "top_p",
+            "provider_min": null,
+            "provider_max": null,
+            "provider_default": null,
+            "notes": null
           }
         ]
+      },
+      {
+        "capability_id": "batch",
+        "status": "active",
+        "params": {
+          "endpoint": {
+            "type": "enum",
+            "values": [
+              "/v1/responses",
+              "/v1/chat/completions"
+            ],
+            "default": "/v1/responses"
+          },
+          "completion_window": {
+            "type": "enum",
+            "values": [
+              "24h"
+            ],
+            "default": "24h"
+          }
+        }
       }
     ]
   },
@@ -4869,48 +4998,6 @@
     "context_length": 128000,
     "max_output_tokens": 32000,
     "effective_from": "2026-05-07T00:00:00",
-    "effective_to": null,
-    "capabilities": [
-      {
-        "capability_id": "audio.realtime",
-        "status": "active",
-        "params": []
-      }
-    ]
-  },
-  {
-    "api_model_id": "openai/gpt-realtime-2.1",
-    "provider_api_model_id": "openai:openai/gpt-realtime-2.1",
-    "provider_model_slug": "gpt-realtime-2.1",
-    "internal_model_id": "openai/gpt-realtime-2.1",
-    "is_active_gateway": false,
-    "quantization_scheme": null,
-    "input_modalities": "text,image,audio",
-    "output_modalities": "text,audio",
-    "context_length": 128000,
-    "max_output_tokens": 32000,
-    "effective_from": "2026-07-06T00:00:00",
-    "effective_to": null,
-    "capabilities": [
-      {
-        "capability_id": "audio.realtime",
-        "status": "active",
-        "params": []
-      }
-    ]
-  },
-  {
-    "api_model_id": "openai/gpt-realtime-2.1-mini",
-    "provider_api_model_id": "openai:openai/gpt-realtime-2.1-mini",
-    "provider_model_slug": "gpt-realtime-2.1-mini",
-    "internal_model_id": "openai/gpt-realtime-2.1-mini",
-    "is_active_gateway": false,
-    "quantization_scheme": null,
-    "input_modalities": "text,image,audio",
-    "output_modalities": "text,audio",
-    "context_length": 128000,
-    "max_output_tokens": 32000,
-    "effective_from": "2026-07-06T00:00:00",
     "effective_to": null,
     "capabilities": [
       {

--- a/packages/data/catalog/src/data/models/openai/gpt-5.6-luna/model.json
+++ b/packages/data/catalog/src/data/models/openai/gpt-5.6-luna/model.json
@@ -2,11 +2,11 @@
   "model_id": "openai/gpt-5.6-luna",
   "organisation_id": "openai",
   "name": "GPT 5.6 Luna",
-  "status": "Announced",
+  "status": "Available",
   "previous_model_id": "openai/gpt-5.5",
-  "description": "GPT 5.6 Luna is OpenAI's preview fast and affordable GPT-5.6 model for lower-latency and cost-sensitive workloads.",
+  "description": "GPT 5.6 Luna is OpenAI's fast and affordable GPT-5.6 model for lower-latency and cost-sensitive workloads.",
   "announced_date": "2026-06-26T00:00:00",
-  "release_date": null,
+  "release_date": "2026-07-09T00:00:00",
   "deprecation_date": null,
   "retirement_date": null,
   "license": "Proprietary",
@@ -20,18 +20,46 @@
       "url": "https://openai.com/index/previewing-gpt-5-6-sol/"
     },
     {
+      "platform": "api_reference",
+      "url": "https://developers.openai.com/api/docs/models"
+    },
+    {
       "platform": "paper",
       "url": "https://deploymentsafety.openai.com/gpt-5-6-preview"
     }
   ],
   "details": [
     {
+      "name": "input_context_length",
+      "value": 1050000
+    },
+    {
+      "name": "output_context_length",
+      "value": 128000
+    },
+    {
+      "name": "knowledge_cutoff",
+      "value": "2026-02-16T00:00:00"
+    },
+    {
       "name": "availability",
-      "value": "Limited preview in the API and Codex for select trusted partners; broader availability planned in the coming weeks."
+      "value": "Available via the OpenAI Responses API and client SDKs."
     },
     {
       "name": "prompt_caching",
-      "value": "Supports explicit cache breakpoints and a 30-minute minimum cache life during preview."
+      "value": "Supports automatic and explicit prompt caching; cache writes are billed at 1.25x uncached input and cache reads remain discounted."
+    },
+    {
+      "name": "reasoning_effort",
+      "value": "Supports none, low, medium, high, xhigh, and max reasoning effort."
+    },
+    {
+      "name": "pro_mode",
+      "value": "Supports pro mode with reasoning.mode set to pro in the Responses API."
+    },
+    {
+      "name": "multi_agent",
+      "value": "Supports the beta multi-agent feature in the Responses API."
     }
   ],
   "benchmarks": []

--- a/packages/data/catalog/src/data/models/openai/gpt-5.6-sol/model.json
+++ b/packages/data/catalog/src/data/models/openai/gpt-5.6-sol/model.json
@@ -2,11 +2,11 @@
   "model_id": "openai/gpt-5.6-sol",
   "organisation_id": "openai",
   "name": "GPT 5.6 Sol",
-  "status": "Announced",
+  "status": "Available",
   "previous_model_id": "openai/gpt-5.5",
-  "description": "GPT 5.6 Sol is OpenAI's preview flagship GPT-5.6 model for advanced reasoning, agentic coding, scientific analysis, and complex professional work.",
+  "description": "GPT 5.6 Sol is OpenAI's flagship GPT-5.6 model for advanced reasoning, agentic coding, scientific analysis, and complex professional work.",
   "announced_date": "2026-06-26T00:00:00",
-  "release_date": null,
+  "release_date": "2026-07-09T00:00:00",
   "deprecation_date": null,
   "retirement_date": null,
   "license": "Proprietary",
@@ -20,30 +20,50 @@
       "url": "https://openai.com/index/previewing-gpt-5-6-sol/"
     },
     {
+      "platform": "api_reference",
+      "url": "https://developers.openai.com/api/docs/models"
+    },
+    {
       "platform": "paper",
       "url": "https://deploymentsafety.openai.com/gpt-5-6-preview"
     }
   ],
   "details": [
     {
+      "name": "input_context_length",
+      "value": 1050000
+    },
+    {
+      "name": "output_context_length",
+      "value": 128000
+    },
+    {
+      "name": "knowledge_cutoff",
+      "value": "2026-02-16T00:00:00"
+    },
+    {
       "name": "availability",
-      "value": "Limited preview in the API and Codex for select trusted partners; broader availability planned in the coming weeks."
+      "value": "Available via the OpenAI Responses API and client SDKs."
     },
     {
       "name": "prompt_caching",
-      "value": "Supports explicit cache breakpoints and a 30-minute minimum cache life during preview."
+      "value": "Supports automatic and explicit prompt caching; cache writes are billed at 1.25x uncached input and cache reads remain discounted."
     },
     {
       "name": "reasoning_effort",
-      "value": "Supports the new max reasoning effort during preview."
+      "value": "Supports none, low, medium, high, xhigh, and max reasoning effort."
     },
     {
-      "name": "ultra_mode",
-      "value": "Supports ultra mode for complex work using subagents."
+      "name": "alias",
+      "value": "gpt-5.6 routes to gpt-5.6-sol."
     },
     {
-      "name": "cerebras_preview",
-      "value": "Cerebras support is planned for July 2026 for select customers, with OpenAI reporting up to 750 tokens per second."
+      "name": "pro_mode",
+      "value": "Supports pro mode with reasoning.mode set to pro in the Responses API."
+    },
+    {
+      "name": "multi_agent",
+      "value": "Supports the beta multi-agent feature in the Responses API."
     }
   ],
   "benchmarks": []

--- a/packages/data/catalog/src/data/models/openai/gpt-5.6-terra/model.json
+++ b/packages/data/catalog/src/data/models/openai/gpt-5.6-terra/model.json
@@ -2,11 +2,11 @@
   "model_id": "openai/gpt-5.6-terra",
   "organisation_id": "openai",
   "name": "GPT 5.6 Terra",
-  "status": "Announced",
+  "status": "Available",
   "previous_model_id": "openai/gpt-5.5",
-  "description": "GPT 5.6 Terra is OpenAI's preview balanced GPT-5.6 model for everyday work across reasoning, coding, and assistant workflows.",
+  "description": "GPT 5.6 Terra is OpenAI's balanced GPT-5.6 model for everyday work across reasoning, coding, and assistant workflows.",
   "announced_date": "2026-06-26T00:00:00",
-  "release_date": null,
+  "release_date": "2026-07-09T00:00:00",
   "deprecation_date": null,
   "retirement_date": null,
   "license": "Proprietary",
@@ -20,18 +20,46 @@
       "url": "https://openai.com/index/previewing-gpt-5-6-sol/"
     },
     {
+      "platform": "api_reference",
+      "url": "https://developers.openai.com/api/docs/models"
+    },
+    {
       "platform": "paper",
       "url": "https://deploymentsafety.openai.com/gpt-5-6-preview"
     }
   ],
   "details": [
     {
+      "name": "input_context_length",
+      "value": 1050000
+    },
+    {
+      "name": "output_context_length",
+      "value": 128000
+    },
+    {
+      "name": "knowledge_cutoff",
+      "value": "2026-02-16T00:00:00"
+    },
+    {
       "name": "availability",
-      "value": "Limited preview in the API and Codex for select trusted partners; broader availability planned in the coming weeks."
+      "value": "Available via the OpenAI Responses API and client SDKs."
     },
     {
       "name": "prompt_caching",
-      "value": "Supports explicit cache breakpoints and a 30-minute minimum cache life during preview."
+      "value": "Supports automatic and explicit prompt caching; cache writes are billed at 1.25x uncached input and cache reads remain discounted."
+    },
+    {
+      "name": "reasoning_effort",
+      "value": "Supports none, low, medium, high, xhigh, and max reasoning effort."
+    },
+    {
+      "name": "pro_mode",
+      "value": "Supports pro mode with reasoning.mode set to pro in the Responses API."
+    },
+    {
+      "name": "multi_agent",
+      "value": "Supports the beta multi-agent feature in the Responses API."
     }
   ],
   "benchmarks": []


### PR DESCRIPTION
## Summary
- update OpenAI GPT-5.6 Sol, Terra, and Luna catalog metadata to match the current OpenAI model docs
- mark OpenAI provider rows active with current context/output limits and reasoning effort values
- update latest tier aliases and migration docs while leaving the direct `openai/gpt-5.6` alias out

## Validation
- Not run per request.
