### PR TITLE
Sync OpenAPI GPT-5.6 model enums

### DIFF
--- a/apps/docs/openapi/v1/openapi.yaml
+++ b/apps/docs/openapi/v1/openapi.yaml
@@ -8374,6 +8374,9 @@ components:
         - openai/gpt-5.4-pro
         - openai/gpt-5.5
         - openai/gpt-5.5-pro
+        - openai/gpt-5.6-luna
+        - openai/gpt-5.6-sol
+        - openai/gpt-5.6-terra
         - openai/gpt-image-1
         - openai/gpt-image-1-mini
         - openai/gpt-image-1.5


### PR DESCRIPTION
## Summary
- add GPT-5.6 Sol, Terra, and Luna to the OpenAPI KnownModelId enum
- match the OpenAPI enum diff produced by CI after syncing catalog manifest data

## Validation
- Attempted `pnpm run openapi:sync-enums`; local clean worktree install stopped before script execution with `ERR_PNPM_IGNORED_BUILDS`.
- Applied the exact generated enum diff reported by CI for `apps/docs/openapi/v1/openapi.yaml`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for three additional model identifiers: `openai/gpt-5.6-luna`, `openai/gpt-5.6-sol`, and `openai/gpt-5.6-terra`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->