### PR TITLE
Fix devtools viewer changeset package name

### DIFF
--- a/.changeset/bright-react-devtools-alignment.md
+++ b/.changeset/bright-react-devtools-alignment.md
@@ -1,5 +1,5 @@
 ---
-"@ai-stats/devtools-viewer": patch
+"@phaseo/devtools-viewer": patch
 ---
 
 Align React and React DOM package versions in the devtools viewer dependency set.


### PR DESCRIPTION
## Summary
- Update the stale devtools viewer changeset package name from `@ai-stats/devtools-viewer` to `@phaseo/devtools-viewer`.
- Unblocks the `Handle Versions` job after the Phaseo GitHub App secrets were added.

## Validation
- `pnpm exec changeset status --verbose`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release metadata to correctly specify a patch version bump for the DevTools viewer package.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->