### PR TITLE
Fix OpenAI pro reasoning requests

### DIFF
--- a/.changeset/openai-gpt56-pro-safety-reasoning.md
+++ b/.changeset/openai-gpt56-pro-safety-reasoning.md
@@ -1,0 +1,14 @@
+---
+"@phaseo/gateway-api": patch
+"@phaseo/sdk": patch
+"@phaseo/go-sdk": patch
+"@phaseo/py-sdk": patch
+"@phaseo/csharp-sdk": patch
+"@phaseo/java-sdk": patch
+"@phaseo/php-sdk": patch
+"@phaseo/ruby-sdk": patch
+"@phaseo/rust-sdk": patch
+"@phaseo/cpp-sdk": patch
+---
+
+Preserve GPT-5.6 Pro `max` reasoning effort, expose `reasoning.mode` in SDK request types, and send stable OpenAI safety identifiers.

--- a/apps/api/src/executors/openai/text-generate/index.test.ts
+++ b/apps/api/src/executors/openai/text-generate/index.test.ts
@@ -89,7 +89,7 @@ describe("openai text executor HTTP mode", () => {
 		expect(mapped.type).toBeUndefined();
 		expect(mapped.model).toBe("openai/gpt-5-nano-2025-08-07");
 		expect(mapped.metadata?.phaseo_request_id).toBe("req_openai_http_test");
-		expect(mapped.safety_identifier).toBe("req_openai_http_test");
+		expect(mapped.safety_identifier).toBe("team_test");
 		expect(mock.calls[0]?.bodyJson?.store).toBe(false);
 	});
 
@@ -139,6 +139,7 @@ describe("openai text executor HTTP mode", () => {
 		expect(mock.calls[0]?.bodyJson?.max_completion_tokens).toBe(128);
 		expect(mock.calls[0]?.bodyJson?.max_tokens).toBeUndefined();
 		expect(mock.calls[0]?.bodyJson?.metadata).toBeUndefined();
+		expect(mock.calls[0]?.bodyJson?.safety_identifier).toBe("team_test");
 		expect(mock.calls[0]?.bodyJson?.stream).toBe(true);
 	});
 
@@ -334,6 +335,39 @@ describe("openai text executor HTTP mode", () => {
 		expect(mock.calls[0]?.bodyJson?.safety_identifier).toBe("safe_user_123");
 	});
 
+	it("truncates OpenAI safety identifiers to the upstream limit", async () => {
+		const mock = installFetchMock([{
+			match: (url) => url === "https://api.openai.com/v1/responses",
+			response: jsonResponse({
+				id: "resp_http_3b",
+				object: "response",
+				created_at: Math.floor(Date.now() / 1000),
+				model: "gpt-5-nano",
+				status: "completed",
+				output: [{
+					type: "message",
+					role: "assistant",
+					content: [{ type: "output_text", text: "ok" }],
+				}],
+				usage: {
+					input_tokens: 2,
+					output_tokens: 1,
+					total_tokens: 3,
+				},
+			}, { status: 200 }),
+		}]);
+
+		const longSafetyIdentifier = `user_${"x".repeat(100)}`;
+		const result = await executor(buildArgs({
+			safetyIdentifier: longSafetyIdentifier,
+		}));
+		mock.restore();
+
+		expect(result.kind).toBe("completed");
+		expect(mock.calls).toHaveLength(1);
+		expect(mock.calls[0]?.bodyJson?.safety_identifier).toBe(longSafetyIdentifier.slice(0, 64));
+	});
+
 	it("passes provider_options.openai.context_management to OpenAI responses requests", async () => {
 		const mock = installFetchMock([{
 			match: (url) => url === "https://api.openai.com/v1/responses",
@@ -408,6 +442,51 @@ describe("openai text executor HTTP mode", () => {
 		expect(mock.calls).toHaveLength(1);
 		expect(mock.calls[0]?.bodyJson?.stream).toBe(true);
 		expect(mock.calls[0]?.bodyJson?.reasoning).toMatchObject({ effort: "medium" });
+	});
+
+	it("preserves max effort and pro mode for GPT-5.6 pro slugs", async () => {
+		const mock = installFetchMock([{
+			match: (url) => url === "https://api.openai.com/v1/responses",
+			response: jsonResponse({
+				id: "resp_http_6",
+				object: "response",
+				created_at: Math.floor(Date.now() / 1000),
+				model: "gpt-5.6-sol",
+				status: "completed",
+				output: [{
+					type: "message",
+					role: "assistant",
+					content: [{ type: "output_text", text: "ok" }],
+				}],
+				usage: {
+					input_tokens: 2,
+					output_tokens: 1,
+					total_tokens: 3,
+				},
+			}, { status: 200 }),
+		}]);
+
+		const result = await executor({
+			...buildArgs({
+				model: "openai/gpt-5.6-sol-pro",
+				reasoning: { effort: "max" },
+			}),
+			providerModelSlug: "gpt-5.6-sol-pro",
+			capabilityParams: {
+				request: {
+					allowlist: ["reasoning.effort", "reasoning.mode", "max_tokens"],
+				},
+			},
+		});
+		mock.restore();
+
+		expect(result.kind).toBe("completed");
+		expect(mock.calls).toHaveLength(1);
+		expect(mock.calls[0]?.bodyJson?.model).toBe("gpt-5.6-sol");
+		expect(mock.calls[0]?.bodyJson?.reasoning).toMatchObject({
+			effort: "max",
+			mode: "pro",
+		});
 	});
 
 	it("prices cached input as subset (no double count)", async () => {

--- a/apps/api/src/executors/openai/text-generate/index.test.ts
+++ b/apps/api/src/executors/openai/text-generate/index.test.ts
@@ -303,7 +303,7 @@ describe("openai text executor HTTP mode", () => {
 		expect(mock.calls[0]?.headers["Idempotency-Key"] ?? mock.calls[0]?.headers["idempotency-key"]).toBe("req_openai_http_test");
 	});
 
-	it("does not overwrite caller-provided safety identifier", async () => {
+	it("ignores caller-provided safety identifier and uses workspace id", async () => {
 		const mock = installFetchMock([{
 			match: (url) => url === "https://api.openai.com/v1/responses",
 			response: jsonResponse({
@@ -332,7 +332,7 @@ describe("openai text executor HTTP mode", () => {
 
 		expect(result.kind).toBe("completed");
 		expect(mock.calls).toHaveLength(1);
-		expect(mock.calls[0]?.bodyJson?.safety_identifier).toBe("safe_user_123");
+		expect(mock.calls[0]?.bodyJson?.safety_identifier).toBe("team_test");
 	});
 
 	it("uses workspace id for OpenAI safety identifier even when the request has a user id", async () => {
@@ -392,15 +392,16 @@ describe("openai text executor HTTP mode", () => {
 			}, { status: 200 }),
 		}]);
 
-		const longSafetyIdentifier = `user_${"x".repeat(100)}`;
-		const result = await executor(buildArgs({
-			safetyIdentifier: longSafetyIdentifier,
-		}));
+		const longWorkspaceId = `workspace_${"x".repeat(100)}`;
+		const result = await executor({
+			...buildArgs(),
+			workspaceId: longWorkspaceId,
+		});
 		mock.restore();
 
 		expect(result.kind).toBe("completed");
 		expect(mock.calls).toHaveLength(1);
-		expect(mock.calls[0]?.bodyJson?.safety_identifier).toBe(longSafetyIdentifier.slice(0, 64));
+		expect(mock.calls[0]?.bodyJson?.safety_identifier).toBe(longWorkspaceId.slice(0, 64));
 	});
 
 	it("passes provider_options.openai.context_management to OpenAI responses requests", async () => {

--- a/apps/api/src/executors/openai/text-generate/index.test.ts
+++ b/apps/api/src/executors/openai/text-generate/index.test.ts
@@ -335,6 +335,41 @@ describe("openai text executor HTTP mode", () => {
 		expect(mock.calls[0]?.bodyJson?.safety_identifier).toBe("safe_user_123");
 	});
 
+	it("uses workspace id for OpenAI safety identifier even when the request has a user id", async () => {
+		const mock = installFetchMock([{
+			match: (url) => url === "https://api.openai.com/v1/responses",
+			response: jsonResponse({
+				id: "resp_http_3a",
+				object: "response",
+				created_at: Math.floor(Date.now() / 1000),
+				model: "gpt-5-nano",
+				status: "completed",
+				output: [{
+					type: "message",
+					role: "assistant",
+					content: [{ type: "output_text", text: "ok" }],
+				}],
+				usage: {
+					input_tokens: 2,
+					output_tokens: 1,
+					total_tokens: 3,
+				},
+			}, { status: 200 }),
+		}]);
+
+		const result = await executor({
+			...buildArgs({
+				userId: "user_123",
+			}),
+			workspaceId: "workspace_safety_scope",
+		});
+		mock.restore();
+
+		expect(result.kind).toBe("completed");
+		expect(mock.calls).toHaveLength(1);
+		expect(mock.calls[0]?.bodyJson?.safety_identifier).toBe("workspace_safety_scope");
+	});
+
 	it("truncates OpenAI safety identifiers to the upstream limit", async () => {
 		const mock = installFetchMock([{
 			match: (url) => url === "https://api.openai.com/v1/responses",

--- a/apps/api/src/executors/openai/text-generate/index.ts
+++ b/apps/api/src/executors/openai/text-generate/index.ts
@@ -53,6 +53,12 @@ const OPENAI_REASONING_EFFORT_SUPPORT: Record<string, Set<ReasoningEffort>> = {
 	"gpt-5.4-mini": new Set(["none", "low", "medium", "high", "xhigh"]),
 	"gpt-5.4-nano": new Set(["none", "low", "medium", "high", "xhigh"]),
 	"gpt-5.4-pro": new Set(["medium", "high", "xhigh"]),
+	"gpt-5.6-luna": new Set(["none", "low", "medium", "high", "xhigh", "max"]),
+	"gpt-5.6-luna-pro": new Set(["none", "low", "medium", "high", "xhigh", "max"]),
+	"gpt-5.6-sol": new Set(["none", "low", "medium", "high", "xhigh", "max"]),
+	"gpt-5.6-sol-pro": new Set(["none", "low", "medium", "high", "xhigh", "max"]),
+	"gpt-5.6-terra": new Set(["none", "low", "medium", "high", "xhigh", "max"]),
+	"gpt-5.6-terra-pro": new Set(["none", "low", "medium", "high", "xhigh", "max"]),
 	"o1": new Set(["low", "medium", "high"]),
 	"o1-preview": new Set(["low", "medium", "high"]),
 	"o1-mini": new Set(["low", "medium", "high"]),
@@ -537,6 +543,7 @@ function withOpenAIRequestMetadata(
 	ir: IRChatRequest,
 	providerId: string,
 	requestId: string,
+	workspaceId: string,
 	options?: {
 		includeMetadata?: boolean;
 	},
@@ -550,10 +557,19 @@ function withOpenAIRequestMetadata(
 	const userSafetyIdentifier = typeof ir.userId === "string" && ir.userId.trim().length > 0
 		? ir.userId.trim()
 		: undefined;
-	const safetyIdentifier = explicitSafetyIdentifier ?? userSafetyIdentifier ?? requestId;
+	const workspaceSafetyIdentifier = typeof workspaceId === "string" && workspaceId.trim().length > 0
+		? workspaceId.trim()
+		: undefined;
+	const safetyIdentifier = normalizeOpenAISafetyIdentifier(
+		explicitSafetyIdentifier ?? userSafetyIdentifier ?? workspaceSafetyIdentifier,
+	);
 	if (!includeMetadata) {
 		delete next.metadata;
-		next.safetyIdentifier = safetyIdentifier;
+		if (safetyIdentifier) {
+			next.safetyIdentifier = safetyIdentifier;
+		} else {
+			delete next.safetyIdentifier;
+		}
 		return next;
 	}
 
@@ -566,8 +582,18 @@ function withOpenAIRequestMetadata(
 	}
 
 	next.metadata = metadata;
-	next.safetyIdentifier = safetyIdentifier;
+	if (safetyIdentifier) {
+		next.safetyIdentifier = safetyIdentifier;
+	} else {
+		delete next.safetyIdentifier;
+	}
 	return next;
+}
+
+function normalizeOpenAISafetyIdentifier(value: string | undefined): string | undefined {
+	const trimmed = value?.trim();
+	if (!trimmed) return undefined;
+	return trimmed.slice(0, 64);
 }
 
 function openAIRequestHeaders(
@@ -625,6 +651,7 @@ function cherryPickIRParams(
 			if (root === "reasoning") {
 				reasoning ??= {};
 				if (leaf === "effort") reasoning.effort = ir.reasoning?.effort;
+				if (leaf === "mode") reasoning.mode = ir.reasoning?.mode;
 				if (leaf === "summary") reasoning.summary = ir.reasoning?.summary;
 				if (leaf === "enabled") reasoning.enabled = ir.reasoning?.enabled;
 				if (leaf === "maxTokens" || leaf === "max_tokens") reasoning.maxTokens = ir.reasoning?.maxTokens;
@@ -736,6 +763,7 @@ async function executeOpenAIProvider(args: ExecutorExecuteArgs): Promise<Executo
 		args.ir as IRChatRequest,
 		args.providerId,
 		args.requestId,
+		args.workspaceId,
 		{ includeMetadata: !useNativeChatRoute },
 	);
 	const route = args.providerId === "openai"

--- a/apps/api/src/executors/openai/text-generate/index.ts
+++ b/apps/api/src/executors/openai/text-generate/index.ts
@@ -554,14 +554,11 @@ function withOpenAIRequestMetadata(
 	const explicitSafetyIdentifier = typeof ir.safetyIdentifier === "string" && ir.safetyIdentifier.trim().length > 0
 		? ir.safetyIdentifier.trim()
 		: undefined;
-	const userSafetyIdentifier = typeof ir.userId === "string" && ir.userId.trim().length > 0
-		? ir.userId.trim()
-		: undefined;
 	const workspaceSafetyIdentifier = typeof workspaceId === "string" && workspaceId.trim().length > 0
 		? workspaceId.trim()
 		: undefined;
 	const safetyIdentifier = normalizeOpenAISafetyIdentifier(
-		explicitSafetyIdentifier ?? userSafetyIdentifier ?? workspaceSafetyIdentifier,
+		explicitSafetyIdentifier ?? workspaceSafetyIdentifier,
 	);
 	if (!includeMetadata) {
 		delete next.metadata;

--- a/apps/api/src/executors/openai/text-generate/index.ts
+++ b/apps/api/src/executors/openai/text-generate/index.ts
@@ -551,15 +551,10 @@ function withOpenAIRequestMetadata(
 	if (providerId !== "openai") return ir;
 	const includeMetadata = options?.includeMetadata !== false;
 	const next: IRChatRequest = { ...ir };
-	const explicitSafetyIdentifier = typeof ir.safetyIdentifier === "string" && ir.safetyIdentifier.trim().length > 0
-		? ir.safetyIdentifier.trim()
-		: undefined;
 	const workspaceSafetyIdentifier = typeof workspaceId === "string" && workspaceId.trim().length > 0
 		? workspaceId.trim()
 		: undefined;
-	const safetyIdentifier = normalizeOpenAISafetyIdentifier(
-		explicitSafetyIdentifier ?? workspaceSafetyIdentifier,
-	);
+	const safetyIdentifier = normalizeOpenAISafetyIdentifier(workspaceSafetyIdentifier);
 	if (!includeMetadata) {
 		delete next.metadata;
 		if (safetyIdentifier) {

--- a/apps/api/src/pipeline/execute/normalize.test.ts
+++ b/apps/api/src/pipeline/execute/normalize.test.ts
@@ -64,6 +64,18 @@ describe("normalizeIRForProvider", () => {
 		expect(normalized.reasoning?.effort).toBe("minimal");
 	});
 
+	it("preserves OpenAI gpt-5.6 max effort before executor mapping", () => {
+		const ir = baseIr({
+			model: "openai/gpt-5.6-sol-pro",
+			reasoning: { effort: "max" },
+		});
+
+		const normalized = normalizeIRForProvider(ir, "openai", "openai.responses", {
+			modelForReasoning: "gpt-5.6-sol-pro",
+		});
+		expect(normalized.reasoning?.effort).toBe("max");
+	});
+
 	it("defaults OpenAI anthropic.messages requests to minimal reasoning", () => {
 		const ir = baseIr({
 			model: "openai/gpt-5-nano",

--- a/apps/api/src/providers/__tests__/textProfiles.test.ts
+++ b/apps/api/src/providers/__tests__/textProfiles.test.ts
@@ -32,6 +32,12 @@ describe("text provider profiles", () => {
 				model: "gpt-5-nano",
 			}),
 		).toEqual(["minimal", "low", "medium", "high"]);
+		expect(
+			getTextProviderReasoningEffortFallback({
+				providerId: "openai",
+				model: "gpt-5.6-sol-pro",
+			}),
+		).toEqual(["none", "low", "medium", "high", "xhigh", "max"]);
 	});
 
 	it("normalizes service tier aliases by provider", () => {

--- a/apps/api/src/providers/providerProfiles.ts
+++ b/apps/api/src/providers/providerProfiles.ts
@@ -47,6 +47,9 @@ function openAIReasoningFallback(model: string): TextReasoningEffort[] {
 	if (m.includes("gpt-5.1-codex-max")) {
 		return ["none", "minimal", "low", "medium", "high", "xhigh"];
 	}
+	if (m.includes("gpt-5.6")) {
+		return ["none", "low", "medium", "high", "xhigh", "max"];
+	}
 	if (m.includes("gpt-5.4-pro")) {
 		return ["medium", "high", "xhigh"];
 	}

--- a/apps/docs/openapi/v1/openapi.yaml
+++ b/apps/docs/openapi/v1/openapi.yaml
@@ -4003,7 +4003,13 @@ components:
             - medium
             - high
             - xhigh
+            - max
           default: medium
+        mode:
+          type: string
+          enum:
+            - standard
+            - pro
         summary:
           type: string
           enum:

--- a/packages/sdk/sdk-cpp/src/gen/models.hpp
+++ b/packages/sdk/sdk-cpp/src/gen/models.hpp
@@ -1032,6 +1032,7 @@ struct ReasoningConfig {
 	std::any effort;
 	std::optional<bool> enabled;
 	std::optional<int> max_tokens;
+	std::any mode;
 	std::any summary;
 };
 

--- a/packages/sdk/sdk-csharp/src/gen/Models.cs
+++ b/packages/sdk/sdk-csharp/src/gen/Models.cs
@@ -2519,6 +2519,9 @@ public sealed class ReasoningConfig
 	[JsonPropertyName("max_tokens")]
 	public int? MaxTokens { get; set; }
 
+	[JsonPropertyName("mode")]
+	public string? Mode { get; set; }
+
 	[JsonPropertyName("summary")]
 	public string? Summary { get; set; }
 

--- a/packages/sdk/sdk-go/src/gen/models.go
+++ b/packages/sdk/sdk-go/src/gen/models.go
@@ -2178,6 +2178,7 @@ type ReasoningConfig struct {
 	Effort *string `json:"effort,omitempty"`
 	Enabled *bool `json:"enabled,omitempty"`
 	MaxTokens *int `json:"max_tokens,omitempty"`
+	Mode *string `json:"mode,omitempty"`
 	Summary *string `json:"summary,omitempty"`
 }
 

--- a/packages/sdk/sdk-java/src/app/phaseo/gen/Models.java
+++ b/packages/sdk/sdk-java/src/app/phaseo/gen/Models.java
@@ -1037,6 +1037,7 @@ public final class Models {
 		public Object effort;
 		public Boolean enabled;
 		public Integer max_tokens;
+		public Object mode;
 		public Object summary;
 	}
 

--- a/packages/sdk/sdk-php/src/gen/Models.php
+++ b/packages/sdk/sdk-php/src/gen/Models.php
@@ -1828,6 +1828,8 @@ class ReasoningConfig
 	/** @var int|null */
 	public $max_tokens;
 	/** @var string|null */
+	public $mode;
+	/** @var string|null */
 	public $summary;
 }
 

--- a/packages/sdk/sdk-py/src/gen/models.py
+++ b/packages/sdk/sdk-py/src/gen/models.py
@@ -922,9 +922,10 @@ class ProvisioningKeyWithValue(TypedDict):
 	status: NotRequired[Literal["active", "disabled", "revoked"]]
 
 class ReasoningConfig(TypedDict):
-	effort: NotRequired[Literal["none", "minimal", "low", "medium", "high", "xhigh"]]
+	effort: NotRequired[Literal["none", "minimal", "low", "medium", "high", "xhigh", "max"]]
 	enabled: NotRequired[bool]
 	max_tokens: NotRequired[int]
+	mode: NotRequired[Literal["standard", "pro"]]
 	summary: NotRequired[Literal["auto", "concise", "detailed"]]
 
 RerankDocument = Union[str, Dict[str, Any]]

--- a/packages/sdk/sdk-ruby/lib/gen/models.rb
+++ b/packages/sdk/sdk-ruby/lib/gen/models.rb
@@ -1496,9 +1496,11 @@ module Phaseo
     #   @return [Boolean, nil]
     # @!attribute [rw] max_tokens
     #   @return [Integer, nil]
+    # @!attribute [rw] mode
+    #   @return [String, nil]
     # @!attribute [rw] summary
     #   @return [String, nil]
-    ReasoningConfig = Struct.new(:effort, :enabled, :max_tokens, :summary, keyword_init: true)
+    ReasoningConfig = Struct.new(:effort, :enabled, :max_tokens, :mode, :summary, keyword_init: true)
     RerankDocument = Object
     # @!attribute [rw] debug
     #   @return [Hash{String => Object}, nil]

--- a/packages/sdk/sdk-ruby/src/gen/models.rb
+++ b/packages/sdk/sdk-ruby/src/gen/models.rb
@@ -55,7 +55,7 @@ module Phaseo
     ProvisioningKey = Struct.new(:created_at, :id, :last_used_at, :name, :prefix, :scopes, :status, keyword_init: true)
     ProvisioningKeyDetail = Struct.new(:created_at, :created_by, :id, :last_used_at, :name, :prefix, :scopes, :soft_blocked, :status, :team_id, keyword_init: true)
     ProvisioningKeyWithValue = Struct.new(:created_at, :id, :key, :name, :prefix, :scopes, :status, keyword_init: true)
-    ReasoningConfig = Struct.new(:effort, :summary, keyword_init: true)
+    ReasoningConfig = Struct.new(:effort, :mode, :summary, keyword_init: true)
     ResponsesRequest = Struct.new(:background, :conversation, :include, :input, :input_items, :instructions, :max_output_tokens, :max_tool_calls, :meta, :metadata, :model, :parallel_tool_calls, :previous_response_id, :prompt, :prompt_cache_key, :prompt_cache_retention, :provider, :reasoning, :safety_identifier, :service_tier, :store, :stream, :stream_options, :temperature, :text, :tool_choice, :tools, :top_logprobs, :top_p, :truncation, :usage, :user, keyword_init: true)
     ResponsesResponse = Struct.new(:content, :created, :id, :model, :object, :role, :stop_reason, :type, :usage, keyword_init: true)
     TextContentPart = Struct.new(:text, :type, keyword_init: true)

--- a/packages/sdk/sdk-rust/src/gen/models.rs
+++ b/packages/sdk/sdk-rust/src/gen/models.rs
@@ -1028,6 +1028,7 @@ pub struct ReasoningConfig {
 	pub effort: Option<String>,
 	pub enabled: Option<bool>,
 	pub max_tokens: Option<i64>,
+	pub mode: Option<String>,
 	pub summary: Option<String>,
 }
 

--- a/packages/sdk/sdk-ts/src/oapi-gen/client/default.ts
+++ b/packages/sdk/sdk-ts/src/oapi-gen/client/default.ts
@@ -1176,9 +1176,10 @@ export type CreateAnthropicMessageParams = {
       };
     };
     reasoning?: {
-      effort?: "none" | "minimal" | "low" | "medium" | "high" | "xhigh";
+      effort?: "none" | "minimal" | "low" | "medium" | "high" | "xhigh" | "max";
       enabled?: boolean;
       max_tokens?: number;
+      mode?: "standard" | "pro";
       summary?: "auto" | "concise" | "detailed";
     };
     session_id?: string;
@@ -2167,9 +2168,10 @@ export type CreateChatCompletionParams = {
       };
     };
     reasoning?: {
-      effort?: "none" | "minimal" | "low" | "medium" | "high" | "xhigh";
+      effort?: "none" | "minimal" | "low" | "medium" | "high" | "xhigh" | "max";
       enabled?: boolean;
       max_tokens?: number;
+      mode?: "standard" | "pro";
       summary?: "auto" | "concise" | "detailed";
     };
     response_format?:
@@ -3287,9 +3289,10 @@ export type CreateResponseParams = {
       };
     };
     reasoning?: {
-      effort?: "none" | "minimal" | "low" | "medium" | "high" | "xhigh";
+      effort?: "none" | "minimal" | "low" | "medium" | "high" | "xhigh" | "max";
       enabled?: boolean;
       max_tokens?: number;
+      mode?: "standard" | "pro";
       summary?: "auto" | "concise" | "detailed";
     };
     safety_identifier?: string | null;

--- a/packages/sdk/sdk-ts/src/oapi-gen/models/AnthropicMessagesRequest.ts
+++ b/packages/sdk/sdk-ts/src/oapi-gen/models/AnthropicMessagesRequest.ts
@@ -104,9 +104,10 @@ export interface AnthropicMessagesRequest {
     };
   };
   reasoning?: {
-    effort?: "none" | "minimal" | "low" | "medium" | "high" | "xhigh";
+    effort?: "none" | "minimal" | "low" | "medium" | "high" | "xhigh" | "max";
     enabled?: boolean;
     max_tokens?: number;
+    mode?: "standard" | "pro";
     summary?: "auto" | "concise" | "detailed";
   };
   session_id?: string;

--- a/packages/sdk/sdk-ts/src/oapi-gen/models/ChatCompletionsRequest.ts
+++ b/packages/sdk/sdk-ts/src/oapi-gen/models/ChatCompletionsRequest.ts
@@ -164,9 +164,10 @@ export interface ChatCompletionsRequest {
     };
   };
   reasoning?: {
-    effort?: "none" | "minimal" | "low" | "medium" | "high" | "xhigh";
+    effort?: "none" | "minimal" | "low" | "medium" | "high" | "xhigh" | "max";
     enabled?: boolean;
     max_tokens?: number;
+    mode?: "standard" | "pro";
     summary?: "auto" | "concise" | "detailed";
   };
   response_format?:

--- a/packages/sdk/sdk-ts/src/oapi-gen/models/ReasoningConfig.ts
+++ b/packages/sdk/sdk-ts/src/oapi-gen/models/ReasoningConfig.ts
@@ -1,6 +1,7 @@
 export interface ReasoningConfig {
-  effort?: "none" | "minimal" | "low" | "medium" | "high" | "xhigh";
+  effort?: "none" | "minimal" | "low" | "medium" | "high" | "xhigh" | "max";
   enabled?: boolean;
   max_tokens?: number;
+  mode?: "standard" | "pro";
   summary?: "auto" | "concise" | "detailed";
 }

--- a/packages/sdk/sdk-ts/src/oapi-gen/models/ResponsesRequest.ts
+++ b/packages/sdk/sdk-ts/src/oapi-gen/models/ResponsesRequest.ts
@@ -107,9 +107,10 @@ export interface ResponsesRequest {
     };
   };
   reasoning?: {
-    effort?: "none" | "minimal" | "low" | "medium" | "high" | "xhigh";
+    effort?: "none" | "minimal" | "low" | "medium" | "high" | "xhigh" | "max";
     enabled?: boolean;
     max_tokens?: number;
+    mode?: "standard" | "pro";
     summary?: "auto" | "concise" | "detailed";
   };
   safety_identifier?: string | null;


### PR DESCRIPTION
## Summary
- Send OpenAI `safety_identifier` on Responses and Chat Completions requests using the workspace id as the stable internal safety scope.
- Ignore any request-provided safety identifier so callers cannot choose the upstream safety correlation key.
- Preserve `reasoning.effort: xhigh | max` for GPT-5.6 family slugs and forward `reasoning.mode` so Pro aliases reach OpenAI as Pro-mode requests.
- Add `reasoning.mode` and `reasoning.effort: max` to the OpenAPI schema and regenerated SDK request surfaces.

## Validation
- `pnpm run openapi:gen`
- `pnpm --filter @phaseo/gateway-api exec vitest run src/executors/openai/text-generate/index.test.ts`
- `pnpm --filter @phaseo/gateway-api typecheck`
- `pnpm run openapi:lint` (passes with existing 18 warnings)
- `pnpm run sdk:check-version-literals`
- `pnpm run changeset:validate-sdk-semver`
- `git diff --check` (passes; Git reports CRLF conversion warnings only)

Created with Codex