### PR TITLE
Surface chat stream errors

### DIFF
--- a/apps/web/src/components/(chat)/ChatPlayground.tsx
+++ b/apps/web/src/components/(chat)/ChatPlayground.tsx
@@ -2211,6 +2211,15 @@ function ChatPlaygroundContent({
 									if (typeof partText === "string") {
 										responseText = partText;
 									}
+								} else if (
+									frameType === "error" ||
+									frameType === "response.failed"
+								) {
+									const streamError = parseChatStreamErrorFrame(
+										parsed,
+										frameType,
+									);
+									if (streamError) throw streamError;
 								} else if (frameType === "response.completed") {
 									responseText = extractResponseText(
 										parsed?.response ?? parsed,
@@ -2325,8 +2334,9 @@ function ChatPlaygroundContent({
 								} else if (toolCallUpdated) {
 									scheduleUpdate(buildStreamingMetaPartial());
 								}
-						} catch {
-							// ignore malformed chunks
+						} catch (error) {
+							if (error instanceof SyntaxError) continue;
+							throw error;
 						}
 					}
 				}


### PR DESCRIPTION
## Summary
- surface OpenAI/Responses stream error frames in the chat playground instead of saving blank assistant messages
- add a shared response-error extractor for `event: error` and `response.failed` payloads
- cover both stream error shapes with focused tests

## Validation
- pnpm --filter @phaseo/web test -- chatPayload
- pnpm --filter @phaseo/web typecheck
- production deploy: dpl_D7W5PsmdTvRv4SoceGjLMAjSDUgo
- browser smoke on https://phaseo.app/chat with OpenAI GPT 5.6 Luna now shows `Request failed (400)` instead of a blank response

Created with Codex

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved chat error handling for provider streaming failures.
  * Displays clearer error messages and available error details when requests fail.
  * Correctly handles both standard provider errors and failed response events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->