### PR TITLE
Fix chat stream errors and model TOC

### DIFF
--- a/apps/web/src/components/(chat)/ChatPlayground.tsx
+++ b/apps/web/src/components/(chat)/ChatPlayground.tsx
@@ -1852,6 +1852,17 @@ function ChatPlaygroundContent({
 					}
 					await flushPromise;
 				};
+				const throwStreamError = async (
+					streamError: ChatErrorPayload,
+				): Promise<never> => {
+					if (flushTimer != null) {
+						window.clearTimeout(flushTimer);
+						flushTimer = null;
+						pendingMetaPartial = undefined;
+					}
+					await flushPromise;
+					throw streamError;
+				};
 				let reasoningContent = "";
 				const reasoningSummaries: Record<number, string> = {};
 				const buildStreamingMetaPartial = () => {
@@ -1909,10 +1920,12 @@ function ChatPlaygroundContent({
 							parsed = JSON.parse(data);
 						} catch {
 							if (frameEventType === "error") {
-								throw createChatStreamTextError(data, {
-									frame_event_type: frameEventType,
-									data,
-								});
+								await throwStreamError(
+									createChatStreamTextError(data, {
+										frame_event_type: frameEventType,
+										data,
+									}),
+								);
 							}
 							continue;
 						}
@@ -1921,7 +1934,7 @@ function ChatPlaygroundContent({
 							frameEventType,
 						);
 						if (streamError) {
-							throw streamError;
+							await throwStreamError(streamError);
 						}
 						try {
 								if (parsed?.usage || parsed?.response?.usage) {

--- a/apps/web/src/components/(chat)/ChatPlayground.tsx
+++ b/apps/web/src/components/(chat)/ChatPlayground.tsx
@@ -91,7 +91,9 @@ import {
 import { useChatAuth } from "@/components/(chat)/playground/use-chat-auth";
 import { useGroupedChatThreads } from "@/components/(chat)/playground/use-grouped-chat-threads";
 import {
+	createChatStreamTextError,
 	parseChatErrorResponse,
+	parseChatStreamErrorFrame,
 	type ChatErrorPayload,
 } from "@/components/(chat)/playground/chat-request-errors";
 import {
@@ -1902,8 +1904,26 @@ function ChatPlaygroundContent({
 						}
 						const data = frameDataLines.join("").trim();
 						if (!data || data === "[DONE]") continue;
+						let parsed: any;
 						try {
-							const parsed = JSON.parse(data);
+							parsed = JSON.parse(data);
+						} catch {
+							if (frameEventType === "error") {
+								throw createChatStreamTextError(data, {
+									frame_event_type: frameEventType,
+									data,
+								});
+							}
+							continue;
+						}
+						const streamError = parseChatStreamErrorFrame(
+							parsed,
+							frameEventType,
+						);
+						if (streamError) {
+							throw streamError;
+						}
+						try {
 								if (parsed?.usage || parsed?.response?.usage) {
 									finalUsage =
 										parsed?.usage ??

--- a/apps/web/src/components/(chat)/playground/chat-request-errors.test.ts
+++ b/apps/web/src/components/(chat)/playground/chat-request-errors.test.ts
@@ -44,6 +44,7 @@ describe("parseChatStreamErrorFrame", () => {
 		const error = parseChatStreamErrorFrame({
 			error: "upstream_error",
 			description: "Provider failed.",
+			generation_id: "gen_123",
 			routing_diagnostics: {
 				finalCandidateCount: 1,
 			},
@@ -52,6 +53,7 @@ describe("parseChatStreamErrorFrame", () => {
 		expect(error).not.toBeNull();
 		expect(error?.message).toBe("Provider failed.");
 		expect(error?.code).toBe("upstream_error");
+		expect(error?.requestId).toBe("gen_123");
 		expect(error?.routingDiagnostics).toEqual({
 			finalCandidateCount: 1,
 		});

--- a/apps/web/src/components/(chat)/playground/chat-request-errors.test.ts
+++ b/apps/web/src/components/(chat)/playground/chat-request-errors.test.ts
@@ -1,0 +1,73 @@
+import {
+	createChatStreamTextError,
+	parseChatStreamErrorFrame,
+} from "./chat-request-errors";
+
+describe("parseChatStreamErrorFrame", () => {
+	it("extracts OpenAI response.failed stream errors", () => {
+		const error = parseChatStreamErrorFrame(
+			{
+				type: "response.failed",
+				response: {
+					id: "resp_123",
+					error: {
+						code: "model_not_found",
+						message: "The requested model is not available.",
+					},
+				},
+			},
+			"response.failed",
+		);
+
+		expect(error).not.toBeNull();
+		expect(error?.message).toBe("The requested model is not available.");
+		expect(error?.code).toBe("model_not_found");
+		expect(error?.requestId).toBe("resp_123");
+		expect(error?.rawPayload).toMatchObject({
+			frame_event_type: "response.failed",
+			type: "response.failed",
+		});
+	});
+
+	it("extracts gateway object error stream frames", () => {
+		const error = parseChatStreamErrorFrame({
+			object: "error",
+			message: "openai_stream_failed",
+		});
+
+		expect(error).not.toBeNull();
+		expect(error?.message).toBe("openai_stream_failed");
+		expect(error?.code).toBe("stream_error");
+	});
+
+	it("keeps routing diagnostics from streamed gateway errors", () => {
+		const error = parseChatStreamErrorFrame({
+			error: "upstream_error",
+			description: "Provider failed.",
+			routing_diagnostics: {
+				finalCandidateCount: 1,
+			},
+		});
+
+		expect(error).not.toBeNull();
+		expect(error?.message).toBe("Provider failed.");
+		expect(error?.code).toBe("upstream_error");
+		expect(error?.routingDiagnostics).toEqual({
+			finalCandidateCount: 1,
+		});
+	});
+});
+
+describe("createChatStreamTextError", () => {
+	it("creates a structured error for non-json SSE error frames", () => {
+		const error = createChatStreamTextError("stream disconnected", {
+			frame_event_type: "error",
+		});
+
+		expect(error.message).toBe("stream disconnected");
+		expect(error.code).toBe("stream_error");
+		expect(error.rawPayload).toEqual({
+			frame_event_type: "error",
+		});
+	});
+});

--- a/apps/web/src/components/(chat)/playground/chat-request-errors.ts
+++ b/apps/web/src/components/(chat)/playground/chat-request-errors.ts
@@ -12,6 +12,10 @@ export type ChatErrorPayload = Error & {
 	rawPayload?: Record<string, unknown> | null;
 };
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return Boolean(value && typeof value === "object" && !Array.isArray(value));
+}
+
 function normalizeErrorDetails(details: unknown) {
 	if (!Array.isArray(details)) return undefined;
 
@@ -49,6 +53,136 @@ function normalizeRoutingDiagnostics(payload: Record<string, unknown>) {
 		return diagnostics as Record<string, unknown>;
 	}
 	return undefined;
+}
+
+function normalizeStatus(value: unknown) {
+	return typeof value === "number" && Number.isFinite(value)
+		? value
+		: undefined;
+}
+
+function firstString(...values: unknown[]) {
+	for (const value of values) {
+		if (typeof value === "string" && value.trim()) {
+			return value.trim();
+		}
+	}
+	return undefined;
+}
+
+function getNestedRecord(
+	payload: Record<string, unknown>,
+	key: string,
+): Record<string, unknown> | undefined {
+	const value = payload[key];
+	return isRecord(value) ? value : undefined;
+}
+
+function buildChatErrorPayload(args: {
+	message: string;
+	status?: number;
+	code?: string;
+	requestId?: string;
+	description?: string;
+	details?: ChatErrorPayload["details"];
+	routingDiagnostics?: Record<string, unknown> | null;
+	rawPayload?: Record<string, unknown> | null;
+}) {
+	const requestError = new Error(args.message) as ChatErrorPayload;
+	if (args.code) requestError.code = args.code;
+	if (args.status != null) requestError.status = args.status;
+	requestError.requestId = args.requestId;
+	requestError.description = args.description;
+	requestError.details = args.details;
+	requestError.routingDiagnostics = args.routingDiagnostics ?? null;
+	requestError.rawPayload = args.rawPayload ?? null;
+	return requestError;
+}
+
+export function createChatStreamTextError(
+	message: string,
+	rawPayload?: Record<string, unknown> | null,
+) {
+	return buildChatErrorPayload({
+		message: message.trim() || "The streamed response failed.",
+		code: "stream_error",
+		rawPayload,
+	});
+}
+
+export function parseChatStreamErrorFrame(
+	payload: unknown,
+	frameEventType?: string | null,
+): ChatErrorPayload | null {
+	if (!isRecord(payload)) return null;
+
+	const response = getNestedRecord(payload, "response");
+	const payloadError = payload.error;
+	const responseError = isRecord(response?.error)
+		? response.error
+		: undefined;
+	const errorObject = isRecord(payloadError)
+		? payloadError
+		: responseError;
+	const objectType = firstString(payload.object);
+	const frameType = firstString(payload.type, frameEventType);
+	const isErrorFrame =
+		frameEventType === "error" ||
+		frameType === "error" ||
+		frameType === "response.failed" ||
+		objectType === "error" ||
+		Boolean(errorObject) ||
+		typeof payloadError === "string";
+
+	if (!isErrorFrame) return null;
+
+	const rawPayload = {
+		...(frameEventType ? { frame_event_type: frameEventType } : {}),
+		...payload,
+	};
+	const message = firstString(
+		errorObject?.message,
+		responseError?.message,
+		payload.message,
+		payload.description,
+		typeof payloadError === "string" ? payloadError : undefined,
+	) ?? "The streamed response failed.";
+	const description = firstString(
+		payload.description,
+		errorObject?.description,
+		responseError?.description,
+	);
+	const code = firstString(
+		errorObject?.code,
+		errorObject?.type,
+		responseError?.code,
+		responseError?.type,
+		payload.code,
+		payload.error_code,
+		typeof payloadError === "string" ? payloadError : undefined,
+		objectType === "error" ? "stream_error" : undefined,
+		frameType === "response.failed" ? "response_failed" : undefined,
+	);
+	const status = normalizeStatus(payload.status) ??
+		normalizeStatus(payload.status_code) ??
+		normalizeStatus(errorObject?.status) ??
+		normalizeStatus(errorObject?.status_code);
+
+	return buildChatErrorPayload({
+		message,
+		status,
+		code,
+		requestId: firstString(
+			payload.request_id,
+			payload.requestId,
+			errorObject?.request_id,
+			response?.id,
+		),
+		description,
+		details: normalizeErrorDetails(payload.details),
+		routingDiagnostics: normalizeRoutingDiagnostics(payload) ?? null,
+		rawPayload,
+	});
 }
 
 export async function parseChatErrorResponse(response: Response) {
@@ -93,13 +227,14 @@ export async function parseChatErrorResponse(response: Response) {
 		if (text) errorMessage = text;
 	}
 
-	const requestError = new Error(errorMessage) as ChatErrorPayload;
-	if (errorCode) requestError.code = errorCode;
-	requestError.status = response.status;
-	requestError.requestId = errorRequestId;
-	requestError.description = errorDescription;
-	requestError.details = errorDetails;
-	requestError.routingDiagnostics = routingDiagnostics ?? null;
-	requestError.rawPayload = rawPayload;
-	return requestError;
+	return buildChatErrorPayload({
+		message: errorMessage,
+		status: response.status,
+		code: errorCode,
+		requestId: errorRequestId,
+		description: errorDescription,
+		details: errorDetails,
+		routingDiagnostics: routingDiagnostics ?? null,
+		rawPayload: rawPayload ?? null,
+	});
 }

--- a/apps/web/src/components/(chat)/playground/chat-request-errors.ts
+++ b/apps/web/src/components/(chat)/playground/chat-request-errors.ts
@@ -175,6 +175,8 @@ export function parseChatStreamErrorFrame(
 		requestId: firstString(
 			payload.request_id,
 			payload.requestId,
+			payload.generation_id,
+			payload.generationId,
 			errorObject?.request_id,
 			response?.id,
 		),

--- a/apps/web/src/components/(data)/model/ModelPageToc.tsx
+++ b/apps/web/src/components/(data)/model/ModelPageToc.tsx
@@ -298,7 +298,12 @@ export default function ModelPageToc({
 	);
 
 	return (
-		<div className={cn("min-w-0 lg:h-full lg:w-full", className)}>
+		<div
+			className={cn(
+				"min-w-0 lg:sticky lg:top-[calc(var(--site-notice-height,0px)+var(--site-header-height,3.75rem)+4.25rem)] lg:max-h-[calc(100dvh-var(--site-notice-height,0px)-var(--site-header-height,3.75rem)-5.25rem)] lg:w-full lg:self-start lg:overflow-y-auto",
+				className,
+			)}
+		>
 			<div className="lg:hidden">
 				<div id={mobileAnchorId}>{renderMobileSelect("inline")}</div>
 				<div
@@ -316,7 +321,7 @@ export default function ModelPageToc({
 			</div>
 
 			<aside className="hidden h-full min-w-0 lg:block lg:w-full">
-				<div className="sticky top-[calc(var(--site-header-height,3.75rem)+4.25rem)] w-full min-w-0">
+				<div className="w-full min-w-0">
 					<nav className="w-full min-w-0">
 						<div
 							className="relative flex w-full min-w-0 flex-col gap-1"


### PR DESCRIPTION
## Summary
- Surface streamed chat error frames through the existing chat request error UI instead of leaving blank responses.
- Preserve streamed error payloads, codes, request IDs, and routing diagnostics for copied diagnostics/reporting.
- Restore sticky behavior for the model page table of contents on desktop.

## Validation
- pnpm --filter @phaseo/web test -- chat-request-errors.test.ts
- pnpm --filter @phaseo/web typecheck
- pnpm --filter @phaseo/web exec eslint src/components/(chat)/ChatPlayground.tsx src/components/(chat)/playground/chat-request-errors.ts src/components/(chat)/playground/chat-request-errors.test.ts src/components/(data)/model/ModelPageToc.tsx
- Local model page request returned 200 for /models/openai/gpt-5-6-luna

Created with Codex