### PR TITLE
Update KwaiKAT model metadata

### DIFF
--- a/packages/data/catalog/src/data/models/kwaipilot/kat-coder-pro-v2.5/model.json
+++ b/packages/data/catalog/src/data/models/kwaipilot/kat-coder-pro-v2.5/model.json
@@ -1,11 +1,11 @@
 {
   "model_id": "kwaipilot/kat-coder-pro-v2.5",
   "organisation_id": "kwaipilot",
-  "name": "Kat Coder Pro V2.5",
+  "name": "KAT-Coder-Pro V2.5",
   "status": "Available",
   "previous_model_id": "kwaipilot/kat-coder-pro-v2",
-  "description": "Kat Coder Pro V2.5 is a high-end coding agent model in KwaiKAT's KAT-Coder series, built for complex software engineering, repository-scale tasks, and autonomous development workflows.",
-  "announced_date": null,
+  "description": "KAT-Coder-Pro V2.5 is a high-end coding agent model in KwaiKAT's KAT-Coder series, built for complex software engineering, repository-scale tasks, and autonomous development workflows.",
+  "announced_date": "2026-07-10T00:00:00",
   "release_date": "2026-07-08T00:00:00",
   "deprecation_date": null,
   "retirement_date": null,
@@ -17,7 +17,12 @@
     "text"
   ],
   "api_model_id": "kwaipilot/kat-coder-pro-v2.5",
-  "links": [],
+  "links": [
+    {
+      "platform": "announcement",
+      "url": "https://x.com/KwaiAICoder/status/2075430060245631055?s=20"
+    }
+  ],
   "details": [
     {
       "name": "api_model_id",

--- a/packages/data/catalog/src/data/models/kwaipilot/kat-coder-pro-v2.5/model.json
+++ b/packages/data/catalog/src/data/models/kwaipilot/kat-coder-pro-v2.5/model.json
@@ -6,7 +6,7 @@
   "previous_model_id": "kwaipilot/kat-coder-pro-v2",
   "description": "KAT-Coder-Pro V2.5 is a high-end coding agent model in KwaiKAT's KAT-Coder series, built for complex software engineering, repository-scale tasks, and autonomous development workflows.",
   "announced_date": "2026-07-10T00:00:00",
-  "release_date": "2026-07-08T00:00:00",
+  "release_date": "2026-07-10T00:00:00",
   "deprecation_date": null,
   "retirement_date": null,
   "license": null,

--- a/packages/data/catalog/src/data/organisations/kwaipilot/organisation.json
+++ b/packages/data/catalog/src/data/organisations/kwaipilot/organisation.json
@@ -1,8 +1,21 @@
 {
   "organisation_id": "kwaipilot",
-  "name": "Kwaipilot",
+  "name": "KwaiKAT",
   "country_code": "CN",
-  "description": null,
+  "description": "KwaiKAT is Kuaishou's coding-model team behind the KAT-Coder family. Its public model IDs use the kwaipilot namespace.",
   "colour": null,
-  "organisation_links": []
+  "organisation_links": [
+    {
+      "platform": "x",
+      "url": "https://x.com/KwaiAICoder"
+    },
+    {
+      "platform": "hugging_face",
+      "url": "https://huggingface.co/Kwaipilot"
+    },
+    {
+      "platform": "website",
+      "url": "https://kwaipilot.ai/"
+    }
+  ]
 }


### PR DESCRIPTION
## Summary
- Update the shared `kwaipilot` organisation display metadata to `KwaiKAT` while preserving stable `kwaipilot/...` model IDs.
- Add the KAT-Coder-Pro V2.5 launch announcement metadata and normalize the model display name.
- Confirmed existing AtlasCloud pricing for KAT-Coder-Pro V2.5 remains present: $0.74/M input, $0.15/M cache read, $2.96/M output.

## Validation
- `pnpm validate:data`
- `pnpm validate:pricing`
- `pnpm validate:gateway`

Created with Codex

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the KAT-Coder-Pro V2.5 model to the catalog with updated naming, description, and announcement date.
  * Added an announcement link for the model.
  * Updated KwaiKAT’s catalog profile with new descriptive information and links to its website, X, and Hugging Face pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->