### PR TITLE
Add synthetic gateway checks

### DIFF
--- a/apps/api/src/pipeline/before/index.ts
+++ b/apps/api/src/pipeline/before/index.ts
@@ -78,6 +78,15 @@ function hasItems(value: unknown): boolean {
     return Array.isArray(value) && value.length > 0;
 }
 
+function isSyntheticExecutionRequested(req: Request): boolean {
+    const headerValue =
+        req.headers.get("x-phaseo-synthetic-execution") ??
+        req.headers.get("x-phaseo-synthetic-check") ??
+        req.headers.get("x-phaseo-dry-run") ??
+        req.headers.get("x-aistats-synthetic-execution");
+    return normalizeReturnFlag(headerValue);
+}
+
 function classifyWorkspaceProviderFilterFailure(diagnostics: {
     providerAllowlist: string[];
     providerAllowlistConfigured?: boolean;
@@ -171,6 +180,17 @@ export async function beforeRequest(
     const debugBodyRaw = rawBody?.debug ?? null;
     const debugEnabled = debugHeaderEnabled || normalizeReturnFlag(debugBodyRaw?.enabled);
     const testingModeRequested = isTestingModeRequested(req, rawBody);
+    const syntheticExecutionRequested = isSyntheticExecutionRequested(req);
+    if (syntheticExecutionRequested && !internal) {
+        return {
+            ok: false,
+            response: err("unauthorised", {
+                reason: "synthetic_execution_requires_internal_token",
+                request_id: requestId,
+                workspace_id: workspaceId,
+            }),
+        };
+    }
 
     // 3) Zod (route schema: shape depends on request path)
     const v = await timer.span("guardZod", () => guardZod(zodSchema, rawBody, workspaceId, requestId));
@@ -224,7 +244,7 @@ export async function beforeRequest(
             requestId,
             internal,
             testingMode: testingModeEnabled,
-            disableCache: debugEnabled,
+            disableCache: debugEnabled || syntheticExecutionRequested,
         })
     );
     if (!c.ok) return c as { ok: false; response: Response };
@@ -715,6 +735,8 @@ export async function beforeRequest(
         },
         preset: presetInfo,
         internal,
+        syntheticExecution: syntheticExecutionRequested && Boolean(internal),
+        syntheticExecutionRequested,
         // Enrichment data for observability (wide events)
         teamEnrichment: context.teamEnrichment ?? null,
         keyEnrichment: context.keyEnrichment ?? null,

--- a/apps/api/src/pipeline/before/types.ts
+++ b/apps/api/src/pipeline/before/types.ts
@@ -619,6 +619,8 @@ export type PipelineContext = {
         config: PresetConfig;
     } | null;
     internal?: boolean;
+    syntheticExecution?: boolean;
+    syntheticExecutionRequested?: boolean;
     timing?: Record<string, number>;
     timer?: Timer;
     routingDiagnostics?: Record<string, any> | null;

--- a/apps/api/src/pipeline/execute/index.testing-mode.test.ts
+++ b/apps/api/src/pipeline/execute/index.testing-mode.test.ts
@@ -158,6 +158,95 @@ describe("doRequestWithIR pricing behavior in testing mode", () => {
 		]);
 	});
 
+	it("builds a synthetic execution result without calling the provider executor", async () => {
+		const candidate = {
+			providerId: "openai",
+			apiModelId: "gpt-5-mini",
+			pricingKey: "openai:gpt-5-mini",
+			pricingCard: {
+				provider: "openai",
+				model: "gpt-5-mini",
+				endpoint: "text.generate",
+				currency: "USD",
+				rules: [{ pricing_plan: "token", price_per_unit: "0.000001" }],
+			},
+			byokMeta: [],
+			providerModelSlug: "gpt-5-mini",
+			capabilityParams: {},
+			maxInputTokens: null,
+			maxOutputTokens: 4096,
+		};
+		guardCandidatesMock.mockResolvedValue({ ok: true, value: [candidate] });
+		rankProvidersMock.mockResolvedValue([{ candidate, health: {} }]);
+
+		const executor = vi.fn().mockResolvedValue({
+			kind: "completed",
+			ir: {},
+			upstream: new Response(JSON.stringify({ ok: true }), { status: 200 }),
+			bill: { cost_cents: 0, currency: "USD" },
+		});
+		resolveProviderExecutorMock.mockReturnValue(executor);
+		const ctx = createCtx({
+			endpoint: "responses",
+			capability: "text.generate",
+			model: "openai/gpt-5-mini",
+			requestedModel: "openai/gpt-5-mini",
+			requestPath: "/v1/responses",
+			protocol: "openai.responses",
+			syntheticExecution: true,
+			body: { model: "openai/gpt-5-mini" },
+			rawBody: { model: "openai/gpt-5-mini" },
+		});
+
+		const result = await doRequestWithIR(
+			ctx,
+			{
+				model: "openai/gpt-5-mini",
+				stream: false,
+				messages: [{ role: "user", content: [{ type: "text", text: "ping" }] }],
+				tools: [],
+			} as any,
+			createTiming(),
+		);
+
+		expect((result as any).ok).toBe(true);
+		const synthetic = (result as any).result.synthetic;
+		expect(synthetic).toMatchObject({
+			object: "phaseo.synthetic_execution",
+			synthetic: true,
+			upstream_request_attempted: false,
+			endpoint: "responses",
+			endpoint_url: "/v1/responses",
+			protocol: "openai.responses",
+			selected_provider: "openai",
+			selected_api_model_id: "gpt-5-mini",
+			checks: expect.objectContaining({
+				routing: "passed",
+				executor_resolution: "passed",
+				ir_normalization: "passed",
+				upstream: "skipped",
+			}),
+			meta: expect.objectContaining({
+				response_cache: "bypassed",
+				billing: "skipped",
+				audit_success_event: "skipped",
+			}),
+		});
+		expect(resolveProviderExecutorMock).toHaveBeenCalledWith("openai", "text.generate");
+		expect(executor).not.toHaveBeenCalled();
+		expect(onCallStartMock).not.toHaveBeenCalled();
+		expect(onCallEndMock).not.toHaveBeenCalled();
+		expect(ctx.providerAttempts).toEqual([
+			expect.objectContaining({
+				attempt_number: 1,
+				provider: "openai",
+				outcome: "success",
+				type: "synthetic",
+				status: 200,
+			}),
+		]);
+	});
+
 	it("still returns pricing guard failure on non-testing traffic when no pricing is preloaded", async () => {
 		const candidate = {
 			providerId: "openai",

--- a/apps/api/src/pipeline/execute/index.ts
+++ b/apps/api/src/pipeline/execute/index.ts
@@ -37,6 +37,72 @@ export type Bill = {
 	finish_reason?: string | null;
 };
 
+type SupportedIRRequest =
+	| IRChatRequest
+	| IREmbeddingsRequest
+	| IRModerationsRequest
+	| IRRerankRequest
+	| IRImageGenerationRequest
+	| IRAudioSpeechRequest
+	| IRAudioTranscriptionRequest
+	| IRAudioTranslationRequest
+	| IRVideoGenerationRequest
+	| IROcrRequest
+	| IRMusicGenerateRequest;
+
+export type SyntheticExecutionPayload = {
+	object: "phaseo.synthetic_execution";
+	synthetic: true;
+	upstream_request_attempted: false;
+	request_id: string;
+	endpoint: string;
+	endpoint_url: string | null;
+	protocol: string | null;
+	capability: string;
+	model: string;
+	requested_model: string;
+	stream_requested: boolean;
+	selected_provider: string;
+	selected_api_model_id: string | null;
+	selected_provider_model_slug: string | null;
+	pricing_key: string | null;
+	provider_count: number;
+	ranked_providers: Array<{
+		provider: string;
+		api_model_id: string | null;
+		provider_model_slug: string | null;
+		pricing_configured: boolean;
+		key_sources: Array<"gateway" | "byok">;
+	}>;
+	checks: {
+		authentication: "passed";
+		schema_validation: "passed";
+		context_resolution: "passed";
+		guardrails: "passed";
+		routing: "passed";
+		breaker_admission: "passed";
+		pricing: "passed";
+		executor_resolution: "passed";
+		ir_normalization: "passed";
+		upstream: "skipped";
+	};
+	request_summary: {
+		message_count: number | null;
+		tool_count: number;
+		input_modalities: string[];
+		output_modalities: string[];
+		max_output_tokens: number | null;
+		temperature: number | null;
+	};
+	meta: {
+		testing_mode: boolean;
+		response_cache: "bypassed";
+		billing: "skipped";
+		audit_success_event: "skipped";
+	};
+	timing_ms: Record<string, number>;
+};
+
 // NOTE: Legacy RequestResult removed. Use IRRequestResult everywhere.
 
 // ============================================================================
@@ -308,9 +374,312 @@ export type IRRequestResult = {
 	byokKeyId?: string | null;
 	mappedRequest?: string;
 	rawResponse?: any;
+	synthetic?: SyntheticExecutionPayload;
 };
 
 export type RequestResult = IRRequestResult;
+
+function defaultEndpointPath(endpoint: PipelineContext["endpoint"]): string | null {
+	switch (endpoint) {
+		case "responses":
+			return "/v1/responses";
+		case "chat.completions":
+			return "/v1/chat/completions";
+		case "messages":
+			return "/v1/messages";
+		case "embeddings":
+			return "/v1/embeddings";
+		case "moderations":
+			return "/v1/moderations";
+		case "rerank":
+			return "/v1/rerank";
+		default:
+			return null;
+	}
+}
+
+function summarizeIRRequest(ir: SupportedIRRequest): SyntheticExecutionPayload["request_summary"] {
+	const record = ir as Record<string, any>;
+	const messages = Array.isArray(record.messages) ? record.messages : null;
+	const tools = Array.isArray(record.tools) ? record.tools : [];
+	const inputModalities = Array.isArray(record.modalities)
+		? record.modalities.filter((value): value is string => typeof value === "string")
+		: [];
+	const outputModalities = Array.isArray(record.outputModalities)
+		? record.outputModalities.filter((value): value is string => typeof value === "string")
+		: [];
+	const maxOutputTokens = Number(record.maxTokens ?? record.maxOutputTokens);
+	const temperature = Number(record.temperature);
+	return {
+		message_count: messages ? messages.length : null,
+		tool_count: tools.length,
+		input_modalities: inputModalities,
+		output_modalities: outputModalities,
+		max_output_tokens: Number.isFinite(maxOutputTokens) ? maxOutputTokens : null,
+		temperature: Number.isFinite(temperature) ? temperature : null,
+	};
+}
+
+function summarizeRankedProviders(ranked: any[]): SyntheticExecutionPayload["ranked_providers"] {
+	return ranked.map((entry) => {
+		const candidate = entry?.candidate ?? {};
+		const hasByok = Array.isArray(candidate.byokMeta) && candidate.byokMeta.length > 0;
+		return {
+			provider: String(candidate.providerId ?? "unknown"),
+			api_model_id:
+				typeof candidate.apiModelId === "string" && candidate.apiModelId.trim().length > 0
+					? candidate.apiModelId.trim()
+					: null,
+			provider_model_slug:
+				typeof candidate.providerModelSlug === "string" && candidate.providerModelSlug.trim().length > 0
+					? candidate.providerModelSlug.trim()
+					: null,
+			pricing_configured: Boolean(candidate.pricingCard),
+			key_sources: hasByok ? ["gateway", "byok"] : ["gateway"],
+		};
+	});
+}
+
+async function buildSyntheticExecutionResult(args: {
+	ctx: PipelineContext;
+	ir: SupportedIRRequest;
+	timing: PipelineTiming;
+	baseModel: string;
+	ranked: any[];
+}): Promise<Response | { ok: true; result: IRRequestResult }> {
+	const { ctx, ir, timing, baseModel, ranked } = args;
+	const attemptErrors: Array<Record<string, unknown>> = (ctx.attemptErrors ??= []);
+	const rankedProviders = summarizeRankedProviders(ranked);
+
+	for (let index = 0; index < ranked.length; index += 1) {
+		const routed = ranked[index];
+		const candidate = routed?.candidate;
+		if (!candidate) continue;
+		const attemptNumber = index + 1;
+		const attemptStartedAt = performance.now();
+		const candidateApiModelId =
+			typeof candidate.apiModelId === "string" && candidate.apiModelId.trim().length > 0
+				? candidate.apiModelId.trim()
+				: null;
+		const providerModelSlug = typeof candidate.providerModelSlug === "string"
+			? candidate.providerModelSlug.trim()
+			: candidate.providerModelSlug;
+
+		const admission = await timing.timer.span(`synthetic_${attemptNumber}_breaker`, () =>
+			admitThroughBreaker(
+				ctx.endpoint,
+				candidate.providerId,
+				baseModel,
+				ctx.workspaceId,
+				ctx.requestId,
+				routed.health,
+			),
+		);
+		if (admission === "blocked") {
+			attemptErrors.push({
+				provider: candidate.providerId,
+				endpoint: ctx.endpoint,
+				attempt_number: attemptNumber,
+				type: "blocked",
+				synthetic: true,
+			});
+			recordProviderAttempt(ctx, {
+				attempt_number: attemptNumber,
+				provider: candidate.providerId,
+				endpoint: ctx.endpoint,
+				model: baseModel,
+				api_model_id: candidateApiModelId,
+				provider_model_slug: providerModelSlug ?? null,
+				outcome: "blocked",
+				type: "blocked",
+				duration_ms: Math.round(performance.now() - attemptStartedAt),
+				was_probe: false,
+			});
+			continue;
+		}
+
+		let pricingCard = candidate.pricingCard ?? null;
+		if (!pricingCard) {
+			pricingCard = await timing.timer.span(`synthetic_${attemptNumber}_load_pricecard`, () =>
+				loadPriceCard(
+					candidate.providerId,
+					candidateApiModelId ?? baseModel,
+					ctx.capability,
+				),
+			);
+			if (pricingCard) {
+				candidate.pricingCard = pricingCard;
+			}
+		}
+		if (!pricingCard) {
+			attemptErrors.push({
+				provider: candidate.providerId,
+				endpoint: ctx.endpoint,
+				attempt_number: attemptNumber,
+				type: "no_pricing",
+				synthetic: true,
+			});
+			recordProviderAttempt(ctx, {
+				attempt_number: attemptNumber,
+				provider: candidate.providerId,
+				endpoint: ctx.endpoint,
+				model: baseModel,
+				api_model_id: candidateApiModelId,
+				provider_model_slug: providerModelSlug ?? null,
+				outcome: "no_pricing",
+				type: "no_pricing",
+				duration_ms: Math.round(performance.now() - attemptStartedAt),
+				was_probe: admission === "probe",
+			});
+			continue;
+		}
+
+		const executorResolveStart = performance.now();
+		const executor = resolveProviderExecutor(candidate.providerId, ctx.capability);
+		timing.timer.record(
+			`synthetic_${attemptNumber}_resolve_executor`,
+			performance.now() - executorResolveStart,
+		);
+		if (!executor) {
+			attemptErrors.push({
+				provider: candidate.providerId,
+				endpoint: ctx.endpoint,
+				attempt_number: attemptNumber,
+				type: "unsupported_executor",
+				synthetic: true,
+			});
+			recordProviderAttempt(ctx, {
+				attempt_number: attemptNumber,
+				provider: candidate.providerId,
+				endpoint: ctx.endpoint,
+				model: baseModel,
+				api_model_id: candidateApiModelId,
+				provider_model_slug: providerModelSlug ?? null,
+				outcome: "unsupported_executor",
+				type: "unsupported_executor",
+				duration_ms: Math.round(performance.now() - attemptStartedAt),
+				was_probe: admission === "probe",
+			});
+			continue;
+		}
+
+		const normalizedCapability = normalizeCapability(ctx.capability);
+		const isTextGenerate = normalizedCapability === "text.generate";
+		const modelForReasoning = providerModelSlug?.trim() || baseModel;
+		await timing.timer.span(`synthetic_${attemptNumber}_normalize_ir`, () =>
+			isTextGenerate
+				? normalizeIRForProvider(
+					ir as IRChatRequest,
+					candidate.providerId,
+					ctx.protocol as any,
+					{
+						capabilityParams: candidate.capabilityParams,
+						providerMaxOutputTokens: candidate.maxOutputTokens,
+						modelForReasoning,
+					},
+				)
+				: ir,
+		);
+
+		const selectedPricingKey =
+			candidate.pricingKey ??
+			(candidateApiModelId
+				? `${candidate.providerId}:${candidateApiModelId}`
+				: candidate.providerId);
+		const payload: SyntheticExecutionPayload = {
+			object: "phaseo.synthetic_execution",
+			synthetic: true,
+			upstream_request_attempted: false,
+			request_id: ctx.requestId,
+			endpoint: ctx.endpoint,
+			endpoint_url: ctx.requestPath ?? ctx.meta?.requestPath ?? defaultEndpointPath(ctx.endpoint),
+			protocol: ctx.protocol ?? null,
+			capability: ctx.capability,
+			model: ctx.model,
+			requested_model: ctx.requestedModel,
+			stream_requested: Boolean(ctx.stream),
+			selected_provider: candidate.providerId,
+			selected_api_model_id: candidateApiModelId,
+			selected_provider_model_slug: providerModelSlug ?? null,
+			pricing_key: selectedPricingKey,
+			provider_count: ranked.length,
+			ranked_providers: rankedProviders,
+			checks: {
+				authentication: "passed",
+				schema_validation: "passed",
+				context_resolution: "passed",
+				guardrails: "passed",
+				routing: "passed",
+				breaker_admission: "passed",
+				pricing: "passed",
+				executor_resolution: "passed",
+				ir_normalization: "passed",
+				upstream: "skipped",
+			},
+			request_summary: summarizeIRRequest(ir),
+			meta: {
+				testing_mode: Boolean(ctx.testingMode),
+				response_cache: "bypassed",
+				billing: "skipped",
+				audit_success_event: "skipped",
+			},
+			timing_ms: timing.timer.snapshot(),
+		};
+
+		recordProviderAttempt(ctx, {
+			attempt_number: attemptNumber,
+			provider: candidate.providerId,
+			endpoint: ctx.endpoint,
+			model: baseModel,
+			api_model_id: candidateApiModelId,
+			provider_model_slug: providerModelSlug ?? null,
+			outcome: "success",
+			type: "synthetic",
+			duration_ms: Math.round(performance.now() - attemptStartedAt),
+			status: 200,
+			status_text: "Synthetic Execution",
+			response_kind: "completed",
+			was_probe: admission === "probe",
+		});
+
+		return {
+			ok: true,
+			result: {
+				kind: "completed",
+				upstream: new Response(null, {
+					status: 200,
+					statusText: "Synthetic Execution",
+					headers: {
+						"Content-Type": "application/json",
+						"X-Phaseo-Synthetic-Execution": "true",
+						"X-Phaseo-Upstream-Attempted": "false",
+					},
+				}),
+				provider: candidate.providerId,
+				apiModelId: candidateApiModelId,
+				pricingKey: selectedPricingKey,
+				providerModelSlug: providerModelSlug ?? null,
+				generationTimeMs: 0,
+				bill: {
+					cost_cents: 0,
+					currency: pricingCard.currency ?? "USD",
+					usage: {
+						input_tokens: 0,
+						output_tokens: 0,
+						total_tokens: 0,
+					},
+				},
+				keySource: "gateway",
+				synthetic: payload,
+			},
+		};
+	}
+
+	const failureGuard = await timing.timer.span("execute_guard_all_failed", () =>
+		guardAllFailed(ctx, timing),
+	);
+	return (failureGuard as { ok: false; response: Response }).response;
+}
 
 /**
  * Execute request using IR pipeline
@@ -321,18 +690,7 @@ export type RequestResult = IRRequestResult;
  */
 export async function doRequestWithIR(
 	ctx: PipelineContext,
-	ir:
-		| IRChatRequest
-		| IREmbeddingsRequest
-		| IRModerationsRequest
-		| IRRerankRequest
-		| IRImageGenerationRequest
-		| IRAudioSpeechRequest
-		| IRAudioTranscriptionRequest
-		| IRAudioTranslationRequest
-		| IRVideoGenerationRequest
-		| IROcrRequest
-		| IRMusicGenerateRequest,
+	ir: SupportedIRRequest,
 	timing: PipelineTiming,
 ): Promise<Response | { ok: true; result: IRRequestResult }> {
 	const baseModel = getBaseModel(ctx.model);
@@ -389,6 +747,16 @@ export async function doRequestWithIR(
 		rankProviders(candidates, ctx),
 	);
 
+	if (ctx.syntheticExecution) {
+		return buildSyntheticExecutionResult({
+			ctx,
+			ir,
+			timing,
+			baseModel,
+			ranked,
+		});
+	}
+
 	// 3) Try providers in order (failover up to 5)
 	const allowFallbacks = getEffectiveRoutingHints(ctx.body).allowFallbacks;
 	const maxTries = calculateMaxTries(ranked.length, allowFallbacks);
@@ -443,18 +811,7 @@ export async function doRequestWithIR(
 async function attemptProviderWithIR(
 	routed: any, // RoutedCandidate type
 	ctx: PipelineContext,
-	ir:
-		| IRChatRequest
-		| IREmbeddingsRequest
-		| IRModerationsRequest
-		| IRRerankRequest
-		| IRImageGenerationRequest
-		| IRAudioSpeechRequest
-		| IRAudioTranscriptionRequest
-		| IRAudioTranslationRequest
-		| IRVideoGenerationRequest
-		| IROcrRequest
-		| IRMusicGenerateRequest,
+	ir: SupportedIRRequest,
 	timing: PipelineTiming,
 	baseModel: string,
 	allowSingleProviderRetry: boolean,

--- a/apps/api/src/pipeline/surfaces/text-generate.ts
+++ b/apps/api/src/pipeline/surfaces/text-generate.ts
@@ -622,14 +622,14 @@ export async function runTextGeneratePipeline(args: PipelineRunnerArgs): Promise
 		const responseCacheEligibility = isResponseCacheEligible({
 			endpoint,
 			stream: requestedStream,
-			debugEnabled: Boolean(pre.ctx.meta?.debug?.enabled),
+			debugEnabled: Boolean(pre.ctx.meta?.debug?.enabled || pre.ctx.syntheticExecution),
 			hasTools: Array.isArray(pre.ctx.body?.tools) && pre.ctx.body.tools.length > 0,
 			serverToolsEnabled: preparedServerTools.config.enabled,
 		});
 		pre.ctx.responseCache = {
 			enabled: false,
 			status: "bypass",
-			reason: responseCacheEligibility.reason,
+			reason: pre.ctx.syntheticExecution ? "synthetic_execution" : responseCacheEligibility.reason,
 			key: null,
 			fingerprint: null,
 			ttlSeconds: null,
@@ -637,7 +637,7 @@ export async function runTextGeneratePipeline(args: PipelineRunnerArgs): Promise
 		};
 
 		const responseCacheStore = getResponseCache();
-		if (responseCacheEligibility.eligible && responseCacheStore) {
+		if (!pre.ctx.syntheticExecution && responseCacheEligibility.eligible && responseCacheStore) {
 			const presetResponseCaching = pre.ctx.preset?.config?.responseCaching ?? null;
 			const responseCachePolicy = resolveResponseCachePolicy({
 				presetTtlSeconds: presetResponseCaching?.ttlSeconds ?? null,
@@ -712,7 +712,7 @@ export async function runTextGeneratePipeline(args: PipelineRunnerArgs): Promise
 					});
 				}
 			}
-		} else if (responseCacheEligibility.eligible && !responseCacheStore) {
+		} else if (!pre.ctx.syntheticExecution && responseCacheEligibility.eligible && !responseCacheStore) {
 			pre.ctx.responseCache = {
 				enabled: false,
 				status: "bypass",
@@ -756,6 +756,24 @@ export async function runTextGeneratePipeline(args: PipelineRunnerArgs): Promise
 				auditFailure,
 				req,
 			});
+		}
+
+		if (exec.result.synthetic) {
+			timing.timer.end("execute_total", "execute_start");
+			const header = timing.timer.header();
+			pre.ctx.timing = timing.timer.snapshot();
+			pre.ctx.timer = timing.timer;
+			const headers = makeHeaders(header || undefined);
+			headers.set("X-Phaseo-Synthetic-Execution", "true");
+			headers.set("X-Phaseo-Upstream-Attempted", "false");
+			return createResponse(
+				{
+					...exec.result.synthetic,
+					timing_ms: timing.timer.snapshot(),
+				},
+				200,
+				headers,
+			);
 		}
 
 		const shouldMaterializeInitialStream = !requestedStream || preparedServerTools.config.enabled;

--- a/apps/api/src/routes/utils.ts
+++ b/apps/api/src/routes/utils.ts
@@ -384,7 +384,7 @@ export function withCors(
         "Access-Control-Allow-Origin": "*",
         "Access-Control-Allow-Methods": "GET,POST,OPTIONS",
         "Access-Control-Allow-Headers":
-            "Authorization,Content-Type,x-title,http-referer,x-app-id,x-app-name,x-gateway-debug,x-phaseo-debug,X-Phaseo-Strictness,x-phaseo-cache-revalidate",
+            "Authorization,Content-Type,x-title,http-referer,x-app-id,x-app-name,x-gateway-debug,x-phaseo-debug,X-Phaseo-Strictness,x-phaseo-cache-revalidate,x-phaseo-synthetic-execution,x-phaseo-synthetic-check,x-phaseo-dry-run,x-phaseo-internal-token",
         "Access-Control-Max-Age": "86400",
     };
 

--- a/apps/api/src/routes/v1/index.ts
+++ b/apps/api/src/routes/v1/index.ts
@@ -17,7 +17,7 @@ const CORS_HEADERS: Record<string, string> = {
     "Access-Control-Allow-Origin": "*",
     "Access-Control-Allow-Methods": "GET, POST, PUT, PATCH, DELETE, OPTIONS",
     "Access-Control-Allow-Headers":
-        "Authorization, Content-Type, x-title, http-referer, x-app-id, x-app-name, x-gateway-debug, x-phaseo-debug, X-Phaseo-Strictness, x-phaseo-cache-revalidate",
+        "Authorization, Content-Type, x-title, http-referer, x-app-id, x-app-name, x-gateway-debug, x-phaseo-debug, X-Phaseo-Strictness, x-phaseo-cache-revalidate, x-phaseo-synthetic-execution, x-phaseo-synthetic-check, x-phaseo-dry-run, x-phaseo-internal-token",
     "Access-Control-Max-Age": "86400",
 };
 


### PR DESCRIPTION
## Summary
- Add guarded synthetic execution mode for text-generation gateway endpoints.
- Require an internal token plus `x-phaseo-synthetic-execution: true` before synthetic checks are allowed.
- Exercise schema validation, context resolution, guardrails, routing, breaker admission, pricing, executor resolution, and provider IR normalization, then stop before the upstream executor call.
- Return a Phaseo diagnostic payload with `upstream_request_attempted: false`, endpoint path, selected provider, ranked providers, and skipped billing/audit metadata.
- Bypass response cache and after-stage billing/audit/cache side effects for synthetic checks.
- Allow synthetic/internal headers through API CORS.

## Validation
- `pnpm --filter @phaseo/gateway-api test -- --run src/pipeline/execute/index.testing-mode.test.ts`
- `pnpm --filter @phaseo/gateway-api typecheck`

Created with Codex

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added authorized synthetic execution support for internal requests.
  * Synthetic runs now return successful simulated results without contacting providers.
  * Responses include synthetic execution metadata, timing information, and provider details.
  * Added support for synthetic execution across supported request types.

* **Bug Fixes**
  * Synthetic executions now bypass response caching appropriately.
  * Expanded CORS support for synthetic execution and related request headers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->