### PR TITLE
fix(chat): improve model filter contrast

### DIFF
--- a/apps/web/src/components/(chat)/ChatHeader.tsx
+++ b/apps/web/src/components/(chat)/ChatHeader.tsx
@@ -1285,11 +1285,13 @@ export function ChatHeader({
 								type="button"
 								variant="outline"
 								size="sm"
+								aria-pressed={quickFilters.free}
 								onClick={() => toggleQuickFilter("free")}
 								className={cn(
-									"h-7 rounded-md px-2.5 text-xs",
-									quickFilters.free &&
-										"border-foreground bg-foreground text-background hover:bg-foreground/90 hover:text-background",
+									"h-7 rounded-md px-2.5 text-xs font-medium transition-colors",
+									quickFilters.free
+										? "border-sky-600 bg-sky-600 text-white hover:border-sky-700 hover:bg-sky-700 hover:text-white dark:border-sky-300 dark:bg-sky-300 dark:text-slate-950 dark:hover:border-sky-200 dark:hover:bg-sky-200 dark:hover:text-slate-950"
+										: "border-border bg-transparent text-slate-900 hover:bg-slate-100 hover:text-slate-950 dark:border-white/25 dark:bg-transparent dark:text-slate-100 dark:hover:bg-white/10 dark:hover:text-white",
 								)}
 							>
 								Free
@@ -1298,11 +1300,13 @@ export function ChatHeader({
 								type="button"
 								variant="outline"
 								size="sm"
+								aria-pressed={quickFilters.new}
 								onClick={() => toggleQuickFilter("new")}
 								className={cn(
-									"h-7 rounded-md px-2.5 text-xs",
-									quickFilters.new &&
-										"border-foreground bg-foreground text-background hover:bg-foreground/90 hover:text-background",
+									"h-7 rounded-md px-2.5 text-xs font-medium transition-colors",
+									quickFilters.new
+										? "border-sky-600 bg-sky-600 text-white hover:border-sky-700 hover:bg-sky-700 hover:text-white dark:border-sky-300 dark:bg-sky-300 dark:text-slate-950 dark:hover:border-sky-200 dark:hover:bg-sky-200 dark:hover:text-slate-950"
+										: "border-border bg-transparent text-slate-900 hover:bg-slate-100 hover:text-slate-950 dark:border-white/25 dark:bg-transparent dark:text-slate-100 dark:hover:bg-white/10 dark:hover:text-white",
 								)}
 							>
 								New

--- a/apps/web/src/components/(chat)/RoomModelSelector.tsx
+++ b/apps/web/src/components/(chat)/RoomModelSelector.tsx
@@ -635,11 +635,13 @@ export function RoomModelSelector({
 							type="button"
 							variant="outline"
 							size="sm"
+							aria-pressed={quickFilters.free}
 							onClick={() => toggleQuickFilter("free")}
 							className={cn(
-								"h-7 rounded-md px-2.5 text-xs",
-								quickFilters.free &&
-									"border-foreground bg-foreground text-background hover:bg-foreground/90 hover:text-background",
+								"h-7 rounded-md px-2.5 text-xs font-medium transition-colors",
+								quickFilters.free
+									? "border-sky-600 bg-sky-600 text-white hover:border-sky-700 hover:bg-sky-700 hover:text-white dark:border-sky-300 dark:bg-sky-300 dark:text-slate-950 dark:hover:border-sky-200 dark:hover:bg-sky-200 dark:hover:text-slate-950"
+									: "border-border bg-transparent text-slate-900 hover:bg-slate-100 hover:text-slate-950 dark:border-white/25 dark:bg-transparent dark:text-slate-100 dark:hover:bg-white/10 dark:hover:text-white",
 							)}
 						>
 							Free
@@ -648,11 +650,13 @@ export function RoomModelSelector({
 							type="button"
 							variant="outline"
 							size="sm"
+							aria-pressed={quickFilters.new}
 							onClick={() => toggleQuickFilter("new")}
 							className={cn(
-								"h-7 rounded-md px-2.5 text-xs",
-								quickFilters.new &&
-									"border-foreground bg-foreground text-background hover:bg-foreground/90 hover:text-background",
+								"h-7 rounded-md px-2.5 text-xs font-medium transition-colors",
+								quickFilters.new
+									? "border-sky-600 bg-sky-600 text-white hover:border-sky-700 hover:bg-sky-700 hover:text-white dark:border-sky-300 dark:bg-sky-300 dark:text-slate-950 dark:hover:border-sky-200 dark:hover:bg-sky-200 dark:hover:text-slate-950"
+									: "border-border bg-transparent text-slate-900 hover:bg-slate-100 hover:text-slate-950 dark:border-white/25 dark:bg-transparent dark:text-slate-100 dark:hover:bg-white/10 dark:hover:text-white",
 							)}
 						>
 							New


### PR DESCRIPTION
## Summary

The Free and New quick filters in the chat model picker could retain a dark foreground when selected in dark mode, making their labels difficult to read.

This change gives active and inactive filter buttons explicit contrast-safe colours for both themes and adds `aria-pressed` to expose their toggle state to assistive technology. The same adjustment is applied to the shared room model selector.

## Validation

- `pnpm --filter @phaseo/web exec eslint 'src/components/(chat)/ChatHeader.tsx' 'src/components/(chat)/RoomModelSelector.tsx'` (passes with existing warnings)
- `pnpm --filter @phaseo/web typecheck`
- Manual browser verification of the dark-mode model picker with the Free filter selected

Created with Codex


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility**
  * Added state indicators to the “Free” and “New” quick-filter buttons for improved toggle accessibility.

* **Style**
  * Updated selected and inactive filter styling with clearer light- and dark-theme visual states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->