### PR TITLE
Fix titled model links database schema

### DIFF
--- a/supabase/migrations/20260710213000_add_titled_model_links.sql
+++ b/supabase/migrations/20260710213000_add_titled_model_links.sql
@@ -1,0 +1,38 @@
+-- Keep model-link storage in sync with the titled-link catalogue rollout.
+-- The web query selects kind/title, while platform remains for compatibility
+-- with older writers during deployment.
+alter table public.data_model_links
+  add column if not exists kind text,
+  add column if not exists title text;
+
+update public.data_model_links
+set kind = platform
+where kind is null or btrim(kind) = '';
+
+update public.data_model_links
+set title = initcap(replace(coalesce(nullif(btrim(kind), ''), platform), '_', ' '))
+where title is null or btrim(title) = '';
+
+-- The new catalogue permits multiple links of the same kind and identifies a
+-- link by URL. Remove exact per-model URL duplicates before changing the key.
+with ranked_links as (
+  select
+    id,
+    row_number() over (
+      partition by model_id, url
+      order by updated_at desc, created_at desc, id desc
+    ) as duplicate_rank
+  from public.data_model_links
+)
+delete from public.data_model_links links
+using ranked_links ranked
+where links.id = ranked.id
+  and ranked.duplicate_rank > 1;
+
+alter table public.data_model_links
+  drop constraint if exists data_model_links_model_id_platform_key;
+
+create unique index if not exists data_model_links_model_id_url_key
+  on public.data_model_links (model_id, url);
+
+notify pgrst, 'reload schema';

--- a/supabase/migrations/20260710213000_add_titled_model_links.sql
+++ b/supabase/migrations/20260710213000_add_titled_model_links.sql
@@ -29,8 +29,39 @@ using ranked_links ranked
 where links.id = ranked.id
   and ranked.duplicate_rank > 1;
 
-alter table public.data_model_links
-  drop constraint if exists data_model_links_model_id_platform_key;
+do $$
+declare
+  constraint_name text;
+begin
+  for constraint_name in
+    select c.conname
+    from pg_constraint c
+    join pg_class t on t.oid = c.conrelid
+    join pg_namespace n on n.oid = t.relnamespace
+    where n.nspname = 'public'
+      and t.relname = 'data_model_links'
+      and c.contype = 'u'
+      and pg_get_constraintdef(c.oid) = 'UNIQUE (model_id, platform)'
+  loop
+    execute format('alter table public.data_model_links drop constraint %I', constraint_name);
+  end loop;
+end $$;
+
+do $$
+declare
+  index_name text;
+begin
+  for index_name in
+    select i.indexname
+    from pg_indexes i
+    where i.schemaname = 'public'
+      and i.tablename = 'data_model_links'
+      and i.indexdef ilike 'CREATE UNIQUE INDEX%'
+      and i.indexdef like '%(model_id, platform)%'
+  loop
+    execute format('drop index if exists public.%I', index_name);
+  end loop;
+end $$;
 
 create unique index if not exists data_model_links_model_id_url_key
   on public.data_model_links (model_id, url);

--- a/supabase/migrations/20260710214500_require_titled_model_link_metadata.sql
+++ b/supabase/migrations/20260710214500_require_titled_model_link_metadata.sql
@@ -1,4 +1,42 @@
--- Match the canonical schema after all existing link rows have been backfilled.
+-- Reconcile legacy uniqueness even when the incident hotfix has already been
+-- recorded in migration history, then match the canonical column constraints.
+do $$
+declare
+  constraint_name text;
+begin
+  for constraint_name in
+    select c.conname
+    from pg_constraint c
+    join pg_class t on t.oid = c.conrelid
+    join pg_namespace n on n.oid = t.relnamespace
+    where n.nspname = 'public'
+      and t.relname = 'data_model_links'
+      and c.contype = 'u'
+      and pg_get_constraintdef(c.oid) = 'UNIQUE (model_id, platform)'
+  loop
+    execute format('alter table public.data_model_links drop constraint %I', constraint_name);
+  end loop;
+end $$;
+
+do $$
+declare
+  index_name text;
+begin
+  for index_name in
+    select i.indexname
+    from pg_indexes i
+    where i.schemaname = 'public'
+      and i.tablename = 'data_model_links'
+      and i.indexdef ilike 'CREATE UNIQUE INDEX%'
+      and i.indexdef like '%(model_id, platform)%'
+  loop
+    execute format('drop index if exists public.%I', index_name);
+  end loop;
+end $$;
+
+create unique index if not exists data_model_links_model_id_url_key
+  on public.data_model_links (model_id, url);
+
 alter table public.data_model_links
   alter column kind set not null,
   alter column title set not null;

--- a/supabase/migrations/20260710214500_require_titled_model_link_metadata.sql
+++ b/supabase/migrations/20260710214500_require_titled_model_link_metadata.sql
@@ -1,0 +1,6 @@
+-- Match the canonical schema after all existing link rows have been backfilled.
+alter table public.data_model_links
+  alter column kind set not null,
+  alter column title set not null;
+
+notify pgrst, 'reload schema';


### PR DESCRIPTION
## Summary

Adds the missing database migrations for the titled model-links rollout.

Individual model pages began failing because the deployed web query selected `data_model_links.kind` and `data_model_links.title`, while production had not received the corresponding table migration. This caused every affected server-rendered model request to fail with `column data_model_links_1.kind does not exist`.

## Changes

- add and backfill the `kind` and `title` columns
- deduplicate links by model and URL
- replace the legacy per-platform uniqueness constraint with `(model_id, url)` uniqueness
- enforce the canonical non-null constraints after backfill
- reload the PostgREST schema cache after each schema change

## Validation

- `git diff --check`
- applied the incident migration to the linked production Supabase project
- confirmed the migration is present in remote migration history
- confirmed HTTP 200 responses with expected rendered content and no database/application errors for:
  - `/models/openai/gpt-5.6-luna`
  - `/models/openai/gpt-5.5`
  - `/models/anthropic/claude-opus-4.8`

The linked Supabase schema lint still reports unrelated pre-existing errors in legacy functions. A full migration dry-run is also blocked by pre-existing remote-only migration-history entries; neither issue references `data_model_links` or these migrations.

Created with Codex
