### PR TITLE
Fix chat GPT-5.6 reasoning summaries

### DIFF
--- a/apps/web/src/components/(chat)/ChatPlayground.tsx
+++ b/apps/web/src/components/(chat)/ChatPlayground.tsx
@@ -45,6 +45,7 @@ import {
 	coerceResponseText,
 	appendImagesToText,
 	extractResponseImages,
+	resolveChatReasoningSummary,
 	extractReasoningText,
 	extractResponseToolCalls,
 	extractResponseText,
@@ -1254,7 +1255,7 @@ function ChatPlaygroundContent({
 			if (endpoint === "responses" && effectiveModelSettings.reasoningEnabled) {
 				requestBody.reasoning = {
 					effort: effectiveModelSettings.reasoningEffort ?? "medium",
-					summary: "auto",
+					summary: resolveChatReasoningSummary(selectedModelId),
 				};
 			}
 

--- a/apps/web/src/components/(chat)/chatPayload.test.ts
+++ b/apps/web/src/components/(chat)/chatPayload.test.ts
@@ -1,8 +1,21 @@
 import {
 	extractOutputText,
+	resolveChatReasoningSummary,
 	extractResponseText,
 	extractResponseToolCalls,
 } from "./chatPayload";
+
+describe("resolveChatReasoningSummary", () => {
+	it("uses detailed summaries for OpenAI GPT-5.6 chat models", () => {
+		expect(resolveChatReasoningSummary("openai/gpt-5.6-luna-pro")).toBe(
+			"detailed",
+		);
+	});
+
+	it("keeps auto summaries for other chat models", () => {
+		expect(resolveChatReasoningSummary("openai/gpt-5.4-nano")).toBe("auto");
+	});
+});
 
 describe("extractResponseToolCalls", () => {
 	it("extracts Responses function calls", () => {

--- a/apps/web/src/components/(chat)/chatPayload.ts
+++ b/apps/web/src/components/(chat)/chatPayload.ts
@@ -25,6 +25,11 @@ export const coerceResponseText = (value: unknown) => {
     return "";
 };
 
+export const resolveChatReasoningSummary = (modelId: string): "auto" | "detailed" =>
+    modelId.trim().toLowerCase().startsWith("openai/gpt-5.6")
+        ? "detailed"
+        : "auto";
+
 export const extractOutputText = (output: unknown) => {
     if (!Array.isArray(output)) return "";
     const candidates: string[] = [];


### PR DESCRIPTION
## Summary
- Request `reasoning.summary: detailed` from the Phaseo Chat UI for OpenAI GPT-5.6 models.
- Preserve gateway/API defaults and all explicit API caller settings.
- Cover the chat-only summary mode selection with unit tests.

## Validation
- `pnpm --filter @phaseo/web exec jest --runInBand --runTestsByPath E:\ai-stats-public-worktrees\openai-gpt56-detailed-reasoning-summaries-20260710\apps\web\src\components\(chat)\chatPayload.test.ts`
- `pnpm --filter @phaseo/web typecheck`
- `pnpm --filter @phaseo/web exec eslint src/components/(chat)/ChatPlayground.tsx src/components/(chat)/chatPayload.ts src/components/(chat)/chatPayload.test.ts`
- Production Phaseo Responses API smoke: `openai/gpt-5.6-luna-pro`, provider locked to OpenAI, returned a reasoning item and a 445-character summary with `reasoning.summary: detailed`.

Created with Codex