### PR TITLE
Use custom status domain

### DIFF
--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -95,7 +95,7 @@ const nextConfig = {
       },
       {
         source: "/status",
-        destination: "https://statuspage.incident.io/phaseo",
+        destination: "https://status.phaseo.app",
         permanent: true,
       },
     ];

--- a/apps/web/src/app/api/status/summary/route.ts
+++ b/apps/web/src/app/api/status/summary/route.ts
@@ -8,8 +8,8 @@ type StatusState =
 	| "maintenance"
 	| "unknown";
 
-const STATUS_PAGE_HREF = "https://statuspage.incident.io/phaseo";
-const DEFAULT_STATUS_PAGE_URL = "https://statuspage.incident.io/phaseo";
+const STATUS_PAGE_HREF = "https://status.phaseo.app";
+const DEFAULT_STATUS_PAGE_URL = "https://status.phaseo.app";
 const DEFAULT_WIDGET_API_URL =
 	"https://statuspage.incident.io/phaseo/api/v1/summary";
 const STATUS_PAGE_CACHE_TTL_MS = 30_000;

--- a/apps/web/src/app/api/status/summary/route.ts
+++ b/apps/web/src/app/api/status/summary/route.ts
@@ -419,9 +419,7 @@ async function fetchIncidentStatus(signal: AbortSignal) {
 	};
 	const value = {
 		components: flattenIncidentComponents(summary),
-		href: String(
-			widgetSummary?.page_url ?? pageSummary?.public_url ?? STATUS_PAGE_HREF,
-		),
+		href: STATUS_PAGE_HREF,
 		status: pickIncidentStatus(liveSummary),
 	};
 

--- a/apps/web/src/components/FooterStatusIndicator.tsx
+++ b/apps/web/src/components/FooterStatusIndicator.tsx
@@ -26,7 +26,7 @@ type StatusSummary = {
 	}>;
 };
 
-const STATUS_PAGE_HREF = "https://statuspage.incident.io/phaseo";
+const STATUS_PAGE_HREF = "https://status.phaseo.app";
 
 const STATUS_STYLES: Record<StatusState, { dot: string; text: string }> = {
 	operational: {


### PR DESCRIPTION
## Summary

Phaseo's Incident.io status page is now available and verified at `https://status.phaseo.app`, but the web app still directed users to the original `statuspage.incident.io` URL.

This updates the permanent `/status` redirect, footer fallback link, API response href, and public status-page fetch to use the branded custom domain. The Incident.io Widget API remains on its service hostname because it is the stable backend endpoint used to retrieve live incident and maintenance data.

## User impact

Status links now keep users on the Phaseo-branded domain while preserving the existing live status indicator and component data.

## Validation

- `pnpm --filter @phaseo/web typecheck`
- `pnpm --filter @phaseo/web exec eslint src/app/api/status/summary/route.ts src/components/FooterStatusIndicator.tsx`
- Local `/status` smoke test returned `308` with `Location: https://status.phaseo.app/`
- Local `/api/status/summary` smoke test returned `200`, `operational`, five components, and `href: https://status.phaseo.app/`
- Live `https://status.phaseo.app/` returned `200`

Created with Codex


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Updated the status page destination across redirects, status summaries, and the footer status indicator.
  * Status links now direct to `https://status.phaseo.app`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->