### PR TITLE
fix(chat): render LaTeX responses

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -74,6 +74,7 @@
 		"@statsig/react-bindings": "^3.33.2",
 		"@statsig/session-replay": "^3.33.2",
 		"@statsig/web-analytics": "^3.33.2",
+		"@streamdown/math": "^1.0.2",
 		"@stripe/react-stripe-js": "^6.3.0",
 		"@stripe/stripe-js": "^9.7.0",
 		"@supabase/ssr": "^0.10.3",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -108,6 +108,7 @@
 		"jspdf": "^4.2.1",
 		"jspdf-autotable": "^5.0.8",
 		"jszip": "^3.10.1",
+		"katex": "0.16.47",
 		"lucide-react": "^1.17.0",
 		"motion": "^12.40.0",
 		"nanoid": "^5.1.9",

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -1,3 +1,4 @@
+@import "katex/dist/katex.min.css";
 @import "tailwindcss";
 @import "tw-animate-css";
 @import "shadcn/tailwind.css";

--- a/apps/web/src/components/(chat)/ChatConversationMessages.tsx
+++ b/apps/web/src/components/(chat)/ChatConversationMessages.tsx
@@ -87,6 +87,10 @@ import { ChatMessagesEmptyState } from "@/components/(chat)/ChatMessagesEmptySta
 import { ChatVirtualMessageList } from "@/components/(chat)/ChatVirtualMessageList";
 import { markChatUserMessageRendered } from "@/components/(chat)/playground/chat-performance";
 import {
+	chatMarkdownPlugins,
+	normalizeChatMarkdown,
+} from "@/components/(chat)/chatMarkdown";
+import {
 	buildModelLink,
 	ensureVariants,
 	extractGeneratedAudioUrl,
@@ -959,7 +963,9 @@ export function ChatConversationMessages({
 													key={event.id}
 													className="prose prose-sm max-w-none text-foreground dark:prose-invert prose-p:my-0"
 												>
-													<Streamdown>{eventText}</Streamdown>
+											<Streamdown plugins={chatMarkdownPlugins}>
+												{normalizeChatMarkdown(eventText)}
+											</Streamdown>
 												</div>
 											);
 										})}
@@ -988,8 +994,8 @@ export function ChatConversationMessages({
 										!showRequestError &&
 										contentWithoutMediaLinks ? (
 											<div className="prose prose-sm max-w-none text-foreground dark:prose-invert prose-p:my-0">
-												<Streamdown>
-													{contentWithoutMediaLinks}
+												<Streamdown plugins={chatMarkdownPlugins}>
+													{normalizeChatMarkdown(contentWithoutMediaLinks)}
 												</Streamdown>
 											</div>
 										) : null}
@@ -1016,8 +1022,8 @@ export function ChatConversationMessages({
 										) : null}
 										{!showRequestError &&
 										contentWithoutMediaLinks ? (
-											<Streamdown>
-												{contentWithoutMediaLinks}
+											<Streamdown plugins={chatMarkdownPlugins}>
+												{normalizeChatMarkdown(contentWithoutMediaLinks)}
 											</Streamdown>
 										) : null}
 									</>

--- a/apps/web/src/components/(chat)/ChatPlayground.tsx
+++ b/apps/web/src/components/(chat)/ChatPlayground.tsx
@@ -873,6 +873,10 @@ function ChatPlaygroundContent({
 					if (thread.id !== nextThread.id) {
 						return thread;
 					}
+					if (thread.messages === nextThread.messages) {
+						threadToPersist = { ...thread, ...nextThread };
+						return threadToPersist;
+					}
 					const currentById = new Map(
 						thread.messages.map((message) => [message.id, message]),
 					);

--- a/apps/web/src/components/(chat)/ModelSettingsDialog.tsx
+++ b/apps/web/src/components/(chat)/ModelSettingsDialog.tsx
@@ -96,6 +96,11 @@ type SamplingNumberKey =
     | "repetitionPenalty"
     | "seed";
 
+type TextSettingKey = "displayName" | "systemPrompt";
+
+const TEXT_SETTING_KEYS: TextSettingKey[] = ["displayName", "systemPrompt"];
+const TEXT_COMMIT_DELAY_MS = 350;
+
 const SAMPLING_NUMBER_KEYS: SamplingNumberKey[] = [
     "temperature",
     "maxOutputTokens",
@@ -128,6 +133,13 @@ function samplingDraftFromSettings(settings: ChatModelSettings) {
         repetitionPenalty: samplingValueToInput(settings.repetitionPenalty),
         seed: samplingValueToInput(settings.seed),
     } satisfies Record<SamplingNumberKey, string>;
+}
+
+function textDraftFromSettings(settings: ChatModelSettings) {
+    return {
+        displayName: settings.displayName ?? "",
+        systemPrompt: settings.systemPrompt ?? "",
+    } satisfies Record<TextSettingKey, string>;
 }
 
 export function ModelSettingsDialog({
@@ -166,8 +178,14 @@ export function ModelSettingsDialog({
     const [samplingDraft, setSamplingDraft] = useState<
         Record<SamplingNumberKey, string>
     >(() => samplingDraftFromSettings(settings));
+    const [textDraft, setTextDraft] = useState<Record<TextSettingKey, string>>(
+        () => textDraftFromSettings(settings)
+    );
     const samplingCommitTimersRef = useRef<
         Partial<Record<SamplingNumberKey, ReturnType<typeof setTimeout>>>
+    >({});
+    const textCommitTimersRef = useRef<
+        Partial<Record<TextSettingKey, ReturnType<typeof setTimeout>>>
     >({});
     const pageTransition = reduceMotion
         ? { duration: 0 }
@@ -213,6 +231,41 @@ export function ModelSettingsDialog({
         },
         [scheduleSamplingCommit]
     );
+    const commitTextDraft = useCallback(
+        (key: TextSettingKey, value: string) => {
+            const timer = textCommitTimersRef.current[key];
+            if (timer) {
+                clearTimeout(timer);
+                delete textCommitTimersRef.current[key];
+            }
+            if ((settings[key] ?? "") === value) return;
+            onUpdate({ [key]: value });
+        },
+        [onUpdate, settings]
+    );
+    const scheduleTextCommit = useCallback(
+        (key: TextSettingKey, value: string) => {
+            const timer = textCommitTimersRef.current[key];
+            if (timer) clearTimeout(timer);
+            textCommitTimersRef.current[key] = setTimeout(() => {
+                commitTextDraft(key, value);
+            }, TEXT_COMMIT_DELAY_MS);
+        },
+        [commitTextDraft]
+    );
+    const updateTextDraft = useCallback(
+        (key: TextSettingKey, value: string) => {
+            setTextDraft((current) => ({ ...current, [key]: value }));
+            scheduleTextCommit(key, value);
+        },
+        [scheduleTextCommit]
+    );
+    const flushTextDraft = useCallback(
+        (key: TextSettingKey) => {
+            commitTextDraft(key, textDraft[key]);
+        },
+        [commitTextDraft, textDraft]
+    );
     const getSamplingSliderValue = useCallback(
         (key: SamplingNumberKey, fallbackValue: number) => {
             const parsed = Number(samplingDraft[key]);
@@ -238,13 +291,33 @@ export function ModelSettingsDialog({
         settings.seed,
     ]);
     useEffect(() => {
+        for (const key of TEXT_SETTING_KEYS) {
+            const timer = textCommitTimersRef.current[key];
+            if (timer) {
+                clearTimeout(timer);
+                delete textCommitTimersRef.current[key];
+            }
+        }
+        setTextDraft(textDraftFromSettings(settings));
+    }, [selectedModelId, settings.displayName, settings.systemPrompt]);
+    useEffect(() => {
         return () => {
             for (const key of SAMPLING_NUMBER_KEYS) {
                 const timer = samplingCommitTimersRef.current[key];
                 if (timer) clearTimeout(timer);
             }
+
+            for (const key of TEXT_SETTING_KEYS) {
+                const timer = textCommitTimersRef.current[key];
+                if (timer) clearTimeout(timer);
+            }
         };
     }, []);
+    useEffect(() => {
+        if (!open) {
+            for (const key of TEXT_SETTING_KEYS) flushTextDraft(key);
+        }
+    }, [flushTextDraft, open]);
     const filteredProviderOptions = supportedProvidersForModel
         ? providerOptions.filter((provider) =>
               supportedProvidersForModel.includes(provider.id)
@@ -532,10 +605,11 @@ export function ModelSettingsDialog({
                                 <Label htmlFor="chat-display-name">Chat display name</Label>
                                 <Input
                                     id="chat-display-name"
-                                    value={settings.displayName ?? ""}
+                                    value={textDraft.displayName}
                                     onChange={(event) =>
-                                        onUpdate({ displayName: event.target.value })
+                                        updateTextDraft("displayName", event.target.value)
                                     }
+                                    onBlur={() => flushTextDraft("displayName")}
                                     placeholder="Optional model alias for this chat"
                                 />
                             </div>
@@ -655,10 +729,11 @@ export function ModelSettingsDialog({
                         </div>
                         <Textarea
                             id="system-prompt"
-                            value={settings.systemPrompt ?? ""}
+                            value={textDraft.systemPrompt}
                             onChange={(event) =>
-                                onUpdate({ systemPrompt: event.target.value })
+                                updateTextDraft("systemPrompt", event.target.value)
                             }
+                            onBlur={() => flushTextDraft("systemPrompt")}
                             rows={3}
                         />
                     </div>

--- a/apps/web/src/components/(chat)/ModelSettingsDialog.tsx
+++ b/apps/web/src/components/(chat)/ModelSettingsDialog.tsx
@@ -33,6 +33,7 @@ import {
     MODEL_SELECTOR_FAVORITES_STORAGE_KEY,
     normalizeFavoriteModelId,
 } from "@/components/(chat)/playgroundConfig";
+import { estimatePromptTokenCount } from "@/components/(chat)/playground/chat-playground-core";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -646,7 +647,12 @@ export function ModelSettingsDialog({
                     </div>
                     <Separator />
                     <div className="grid gap-1.5">
-                        <Label htmlFor="system-prompt">System prompt</Label>
+                        <div className="flex items-center justify-between gap-3">
+                            <Label htmlFor="system-prompt">System prompt</Label>
+                            <span className="shrink-0 text-xs tabular-nums text-muted-foreground">
+                                ~{estimatePromptTokenCount(settings.systemPrompt).toLocaleString()} tokens
+                            </span>
+                        </div>
                         <Textarea
                             id="system-prompt"
                             value={settings.systemPrompt ?? ""}

--- a/apps/web/src/components/(chat)/ModelSettingsDialog.tsx
+++ b/apps/web/src/components/(chat)/ModelSettingsDialog.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { startTransition, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { AnimatePresence, motion, useReducedMotion } from "motion/react";
 import { Logo } from "@/components/Logo";
 import {
@@ -248,7 +248,9 @@ export function ModelSettingsDialog({
             const timer = textCommitTimersRef.current[key];
             if (timer) clearTimeout(timer);
             textCommitTimersRef.current[key] = setTimeout(() => {
-                commitTextDraft(key, value);
+                startTransition(() => {
+                    commitTextDraft(key, value);
+                });
             }, TEXT_COMMIT_DELAY_MS);
         },
         [commitTextDraft]
@@ -418,8 +420,10 @@ export function ModelSettingsDialog({
     }, [favoriteModelIdSet, filteredModelChoices]);
     const modelPickerHasResults =
         featuredModelChoices.length > 0 || groupedModelChoices.length > 0;
-    const selectedChoice =
-        modelChoices.find((choice) => choice.id === selectedModelId) ?? null;
+    const selectedChoice = useMemo(
+        () => modelChoices.find((choice) => choice.id === selectedModelId) ?? null,
+        [modelChoices, selectedModelId]
+    );
 
     return (
         <Dialog open={open} onOpenChange={onOpenChange}>

--- a/apps/web/src/components/(chat)/chatMarkdown.test.tsx
+++ b/apps/web/src/components/(chat)/chatMarkdown.test.tsx
@@ -24,4 +24,20 @@ describe("chatMarkdownPlugins", () => {
 			"After 20% off, you pay $80\\%$.\n\n$$\n0.80 \\times 0.90 = 72\\%\n$$",
 		);
 	});
+
+	it("preserves dollar-prefixed monetary amounts alongside inline math", () => {
+		expect(
+			normalizeChatMarkdown(
+				"The final price is $72, so the discount is $28 = $28\\%$.",
+			),
+		).toBe(
+			"The final price is &#36;72, so the discount is &#36;28 = $28\\%$.",
+		);
+	});
+
+	it("does not treat inline math expressions as monetary amounts", () => {
+		expect(normalizeChatMarkdown("$2 + 2$ = $4$")).toBe(
+			"$2 + 2$ = $4$",
+		);
+	});
 });

--- a/apps/web/src/components/(chat)/chatMarkdown.test.tsx
+++ b/apps/web/src/components/(chat)/chatMarkdown.test.tsx
@@ -1,0 +1,27 @@
+jest.mock("@streamdown/math", () => ({
+	createMathPlugin: jest.fn((options) => options),
+}), { virtual: true });
+
+import { createMathPlugin } from "@streamdown/math";
+import { chatMarkdownPlugins, normalizeChatMarkdown } from "./chatMarkdown";
+
+describe("chatMarkdownPlugins", () => {
+	it("enables single-dollar inline math for assistant messages", () => {
+		expect(createMathPlugin).toHaveBeenCalledWith({
+			singleDollarTextMath: true,
+		});
+		expect(chatMarkdownPlugins.math).toEqual({
+			singleDollarTextMath: true,
+		});
+	});
+
+	it("escapes percentage signs inside math delimiters", () => {
+		expect(
+			normalizeChatMarkdown(
+				"After 20% off, you pay $80%$.\n\n$$0.80 \\times 0.90 = 72%$$",
+			),
+		).toBe(
+			"After 20% off, you pay $80\\%$.\n\n$$\n0.80 \\times 0.90 = 72\\%\n$$",
+		);
+	});
+});

--- a/apps/web/src/components/(chat)/chatMarkdown.test.tsx
+++ b/apps/web/src/components/(chat)/chatMarkdown.test.tsx
@@ -25,6 +25,20 @@ describe("chatMarkdownPlugins", () => {
 		);
 	});
 
+	it("escapes each consecutive percentage sign inside math delimiters", () => {
+		expect(normalizeChatMarkdown("$a%%b$")).toBe("$a\\%\\%b$");
+	});
+
+	it("does not normalize currency or math syntax inside code", () => {
+		expect(
+			normalizeChatMarkdown(
+				"Inline `const price = '$80%$'` and $80%$.\n\n```ts\nconst price = '$80%$';\n```",
+			),
+		).toBe(
+			"Inline `const price = '$80%$'` and $80\\%$.\n\n```ts\nconst price = '$80%$';\n```",
+		);
+	});
+
 	it("preserves dollar-prefixed monetary amounts alongside inline math", () => {
 		expect(
 			normalizeChatMarkdown(
@@ -32,6 +46,12 @@ describe("chatMarkdownPlugins", () => {
 			),
 		).toBe(
 			"The final price is &#36;72, so the discount is &#36;28 = $28\\%$.",
+		);
+	});
+
+	it("preserves multiple plain currency amounts", () => {
+		expect(normalizeChatMarkdown("Prices are $5 and $7.")).toBe(
+			"Prices are &#36;5 and &#36;7.",
 		);
 	});
 

--- a/apps/web/src/components/(chat)/chatMarkdown.ts
+++ b/apps/web/src/components/(chat)/chatMarkdown.ts
@@ -1,0 +1,19 @@
+import { createMathPlugin } from "@streamdown/math";
+
+export const chatMarkdownPlugins = {
+	math: createMathPlugin({ singleDollarTextMath: true }),
+};
+
+function escapeMathPercentages(value: string) {
+	return value.replace(/(^|[^\\])%/g, "$1\\%");
+}
+
+export function normalizeChatMarkdown(value: string) {
+	return value
+		.replace(/\$\$([\s\S]*?)\$\$/g, (_, math: string) => {
+			return `$$\n${escapeMathPercentages(math).trim()}\n$$`;
+		})
+		.replace(/(?<!\$)\$([^$\r\n]+?)\$(?!\$)/g, (_, math: string) => {
+			return `$${escapeMathPercentages(math)}$`;
+		});
+}

--- a/apps/web/src/components/(chat)/chatMarkdown.ts
+++ b/apps/web/src/components/(chat)/chatMarkdown.ts
@@ -5,7 +5,7 @@ export const chatMarkdownPlugins = {
 };
 
 function escapeMathPercentages(value: string) {
-	return value.replace(/(^|[^\\])%/g, "$1\\%");
+	return value.replace(/(?<!\\)%/g, "\\%");
 }
 
 function isSingleDollar(value: string, index: number) {
@@ -52,7 +52,7 @@ function escapeCurrencyDollarSigns(value: string) {
 	);
 }
 
-export function normalizeChatMarkdown(value: string) {
+function normalizeMathSegment(value: string) {
 	return escapeCurrencyDollarSigns(value)
 		.replace(/\$\$([\s\S]*?)\$\$/g, (_, math: string) => {
 			return `$$\n${escapeMathPercentages(math).trim()}\n$$`;
@@ -60,4 +60,78 @@ export function normalizeChatMarkdown(value: string) {
 		.replace(/(?<!\$)\$([^$\r\n]+?)\$(?!\$)/g, (_, math: string) => {
 			return `$${escapeMathPercentages(math)}$`;
 		});
+}
+
+function findCodeFenceEnd(
+	value: string,
+	start: number,
+	delimiter: string,
+) {
+	let lineStart = value.indexOf("\n", start + delimiter.length);
+	while (lineStart !== -1) {
+		lineStart += 1;
+		const lineEnd = value.indexOf("\n", lineStart);
+		const line = value.slice(lineStart, lineEnd === -1 ? value.length : lineEnd);
+		if (new RegExp(`^ {0,3}${delimiter[0]}{${delimiter.length},}`).test(line)) {
+			return lineEnd === -1 ? value.length : lineEnd + 1;
+		}
+		lineStart = lineEnd;
+	}
+	return null;
+}
+
+function findInlineCodeEnd(value: string, start: number, delimiter: string) {
+	let index = start + delimiter.length;
+	while (index < value.length) {
+		const closingIndex = value.indexOf(delimiter, index);
+		if (closingIndex === -1 || value.slice(index, closingIndex).includes("\n")) {
+			return null;
+		}
+		const before = value[closingIndex - 1];
+		const after = value[closingIndex + delimiter.length];
+		if (before !== "`" && after !== "`") {
+			return closingIndex + delimiter.length;
+		}
+		index = closingIndex + delimiter.length;
+	}
+	return null;
+}
+
+export function normalizeChatMarkdown(value: string) {
+	let normalized = "";
+	let textStart = 0;
+	let index = 0;
+
+	while (index < value.length) {
+		const character = value[index];
+		if (character !== "`" && character !== "~") {
+			index += 1;
+			continue;
+		}
+
+		let delimiterLength = 1;
+		while (value[index + delimiterLength] === character) {
+			delimiterLength += 1;
+		}
+		const delimiter = character.repeat(delimiterLength);
+		const isFence =
+			delimiterLength >= 3 &&
+			(index === 0 || value[index - 1] === "\n");
+		const codeEnd = isFence
+			? findCodeFenceEnd(value, index, delimiter)
+			: character === "`"
+				? findInlineCodeEnd(value, index, delimiter)
+				: null;
+		if (codeEnd === null) {
+			index += delimiterLength;
+			continue;
+		}
+
+		normalized += normalizeMathSegment(value.slice(textStart, index));
+		normalized += value.slice(index, codeEnd);
+		textStart = codeEnd;
+		index = codeEnd;
+	}
+
+	return normalized + normalizeMathSegment(value.slice(textStart));
 }

--- a/apps/web/src/components/(chat)/chatMarkdown.ts
+++ b/apps/web/src/components/(chat)/chatMarkdown.ts
@@ -8,8 +8,52 @@ function escapeMathPercentages(value: string) {
 	return value.replace(/(^|[^\\])%/g, "$1\\%");
 }
 
+function isSingleDollar(value: string, index: number) {
+	return (
+		value[index] === "$" &&
+		value[index - 1] !== "$" &&
+		value[index + 1] !== "$" &&
+		value[index - 1] !== "\\"
+	);
+}
+
+function findClosingDollar(value: string, start: number) {
+	for (let index = start; index < value.length; index += 1) {
+		if (value[index] === "\n" || value[index] === "\r") return null;
+		if (!isSingleDollar(value, index)) continue;
+		if (/\d/.test(value[index + 1] ?? "")) return null;
+		return index;
+	}
+	return null;
+}
+
+function isMathExpression(value: string) {
+	return /[\\=+*^_()[\]{}%]/.test(value);
+}
+
+function escapeCurrencyDollarSigns(value: string) {
+	return value.replace(
+		/\$(\d+(?:,\d{3})*(?:\.\d+)?)(?=$|[\s,.;:!?)]|\$)/g,
+		(match, amount: string, offset: number, source: string) => {
+			if (!isSingleDollar(source, offset)) return match;
+
+			const amountEnd = offset + match.length;
+			const closingDollar = findClosingDollar(source, amountEnd);
+			if (
+				closingDollar !== null &&
+				(closingDollar === amountEnd ||
+					isMathExpression(source.slice(offset + 1, closingDollar)))
+			) {
+				return match;
+			}
+
+			return `&#36;${amount}`;
+		},
+	);
+}
+
 export function normalizeChatMarkdown(value: string) {
-	return value
+	return escapeCurrencyDollarSigns(value)
 		.replace(/\$\$([\s\S]*?)\$\$/g, (_, math: string) => {
 			return `$$\n${escapeMathPercentages(math).trim()}\n$$`;
 		})

--- a/apps/web/src/components/(chat)/playground/chat-playground-core.test.ts
+++ b/apps/web/src/components/(chat)/playground/chat-playground-core.test.ts
@@ -1,6 +1,7 @@
 import {
 	buildDefaultSystemPrompt,
 	buildServerToolDefinitions,
+	estimatePromptTokenCount,
 	normalizeServerTools,
 } from "./chat-playground-core";
 
@@ -22,6 +23,15 @@ describe("buildDefaultSystemPrompt", () => {
 		);
 		expect(prompt).toContain("no \\(...\\) or \\[...\\].");
 		expect(prompt).not.toContain("Formatting Rules:");
+	});
+});
+
+describe("estimatePromptTokenCount", () => {
+	it("uses a four-character approximation without rounding nonempty prompts to zero", () => {
+		expect(estimatePromptTokenCount("")).toBe(0);
+		expect(estimatePromptTokenCount("a")).toBe(1);
+		expect(estimatePromptTokenCount("abcd")).toBe(1);
+		expect(estimatePromptTokenCount("abcde")).toBe(2);
 	});
 });
 

--- a/apps/web/src/components/(chat)/playground/chat-playground-core.test.ts
+++ b/apps/web/src/components/(chat)/playground/chat-playground-core.test.ts
@@ -9,17 +9,19 @@ describe("buildDefaultSystemPrompt", () => {
 		const prompt = buildDefaultSystemPrompt("openai/gpt-5.6-luna-pro");
 
 		expect(prompt).toContain(
-			"Use dollar-sign delimiters only for mathematical expressions that need notation or layout",
+			"Markdown; ```code fences```; `backticks` for code, filenames, paths, and functions.",
 		);
 		expect(prompt).toContain(
-			"Keep ordinary numbers, percentages, and currency as plain text",
+			"Use $...$ or $$...$$ only for typeset math",
 		);
-		expect(prompt).toContain("Put the $$ block-math delimiters on their own lines.");
 		expect(prompt).toContain(
-			"write percentages as $80\\%$, never $80%$.",
+			"Keep numbers, percentages, and currency plain.",
 		);
-		expect(prompt).not.toContain("Write monetary amounts with a currency label");
-		expect(prompt).toContain("Do not use \\(...\\) or \\[...\\] delimiters.");
+		expect(prompt).toContain(
+			"escape % in math (e.g. $80\\%$)",
+		);
+		expect(prompt).toContain("no \\(...\\) or \\[...\\].");
+		expect(prompt).not.toContain("Formatting Rules:");
 	});
 });
 

--- a/apps/web/src/components/(chat)/playground/chat-playground-core.test.ts
+++ b/apps/web/src/components/(chat)/playground/chat-playground-core.test.ts
@@ -15,6 +15,9 @@ describe("buildDefaultSystemPrompt", () => {
 		expect(prompt).toContain(
 			"write percentages as $80\\%$, never $80%$.",
 		);
+		expect(prompt).toContain(
+			"Write monetary amounts with a currency label, for example USD 72, never $72.",
+		);
 		expect(prompt).toContain("Do not use \\(...\\) or \\[...\\] delimiters.");
 	});
 });

--- a/apps/web/src/components/(chat)/playground/chat-playground-core.test.ts
+++ b/apps/web/src/components/(chat)/playground/chat-playground-core.test.ts
@@ -2,6 +2,7 @@ import {
 	buildDefaultSystemPrompt,
 	buildServerToolDefinitions,
 	estimatePromptTokenCount,
+	isGeneratedDefaultSystemPrompt,
 	normalizeServerTools,
 } from "./chat-playground-core";
 
@@ -32,6 +33,28 @@ describe("estimatePromptTokenCount", () => {
 		expect(estimatePromptTokenCount("a")).toBe(1);
 		expect(estimatePromptTokenCount("abcd")).toBe(1);
 		expect(estimatePromptTokenCount("abcde")).toBe(2);
+	});
+});
+
+describe("isGeneratedDefaultSystemPrompt", () => {
+	const modelId = "openai/gpt-5.6-luna";
+	const nickname = "Luna";
+	const identity = `You are ${modelId}, known as: ${nickname}, a large language model from openai.`;
+
+	it("recognizes the current compact default prompt", () => {
+		expect(isGeneratedDefaultSystemPrompt(buildDefaultSystemPrompt(modelId, nickname), modelId, nickname)).toBe(true);
+	});
+
+	it("recognizes the prior and legacy formatting suffixes", () => {
+		const previous = `${identity}\n\nFormatting Rules:\n- Do not use \\(...\\) or \\[...\\] delimiters.`;
+		const legacy = `${identity}\n\nFormatting Rules:\n- **For all mathematical expressions, you must use dollar-sign delimiters. Use $...$ for inline math and $$...$$ for block math. Do not use (...) or [...] delimiters.**`;
+
+		expect(isGeneratedDefaultSystemPrompt(previous, modelId, nickname)).toBe(true);
+		expect(isGeneratedDefaultSystemPrompt(legacy, modelId, nickname)).toBe(true);
+	});
+
+	it("does not classify a custom prompt as generated", () => {
+		expect(isGeneratedDefaultSystemPrompt("Always answer in haiku.", modelId, nickname)).toBe(false);
 	});
 });
 

--- a/apps/web/src/components/(chat)/playground/chat-playground-core.test.ts
+++ b/apps/web/src/components/(chat)/playground/chat-playground-core.test.ts
@@ -9,7 +9,10 @@ describe("buildDefaultSystemPrompt", () => {
 		const prompt = buildDefaultSystemPrompt("openai/gpt-5.6-luna-pro");
 
 		expect(prompt).toContain(
-			"Use dollar-sign delimiters for all mathematical expressions",
+			"Use dollar-sign delimiters only for mathematical expressions that need notation or layout",
+		);
+		expect(prompt).toContain(
+			"Keep ordinary numbers, percentages, and currency as plain text",
 		);
 		expect(prompt).toContain("Put the $$ block-math delimiters on their own lines.");
 		expect(prompt).toContain(

--- a/apps/web/src/components/(chat)/playground/chat-playground-core.test.ts
+++ b/apps/web/src/components/(chat)/playground/chat-playground-core.test.ts
@@ -1,7 +1,23 @@
 import {
+	buildDefaultSystemPrompt,
 	buildServerToolDefinitions,
 	normalizeServerTools,
 } from "./chat-playground-core";
+
+describe("buildDefaultSystemPrompt", () => {
+	it("instructs models to produce valid Streamdown-compatible LaTeX", () => {
+		const prompt = buildDefaultSystemPrompt("openai/gpt-5.6-luna-pro");
+
+		expect(prompt).toContain(
+			"Use dollar-sign delimiters for all mathematical expressions",
+		);
+		expect(prompt).toContain("Put the $$ block-math delimiters on their own lines.");
+		expect(prompt).toContain(
+			"write percentages as $80\\%$, never $80%$.",
+		);
+		expect(prompt).toContain("Do not use \\(...\\) or \\[...\\] delimiters.");
+	});
+});
 
 describe("buildServerToolDefinitions", () => {
 	it("caps and validates datetime timezone parameters", () => {

--- a/apps/web/src/components/(chat)/playground/chat-playground-core.test.ts
+++ b/apps/web/src/components/(chat)/playground/chat-playground-core.test.ts
@@ -15,9 +15,7 @@ describe("buildDefaultSystemPrompt", () => {
 		expect(prompt).toContain(
 			"write percentages as $80\\%$, never $80%$.",
 		);
-		expect(prompt).toContain(
-			"Write monetary amounts with a currency label, for example USD 72, never $72.",
-		);
+		expect(prompt).not.toContain("Write monetary amounts with a currency label");
 		expect(prompt).toContain("Do not use \\(...\\) or \\[...\\] delimiters.");
 	});
 });

--- a/apps/web/src/components/(chat)/playground/chat-playground-core.ts
+++ b/apps/web/src/components/(chat)/playground/chat-playground-core.ts
@@ -16,6 +16,7 @@ import type {
 } from "@/lib/indexeddb/chats";
 
 export const DEFAULT_SERVER_TOOLS: ChatServerToolType[] = ["gateway:datetime"];
+const CHARS_PER_APPROXIMATE_TOKEN = 4;
 const MAX_DATETIME_TIMEZONES = 5;
 const MAX_ADVISOR_TOOLS = 5;
 const TIMEZONE_NAME_PATTERN = /^[A-Za-z0-9_+\-/]+$/;
@@ -38,6 +39,10 @@ export function normalizeServerTools(
 	return Array.from(new Set(serverTools)).filter((toolType) =>
 		SUPPORTED_CHAT_SERVER_TOOLS.has(toolType),
 	);
+}
+
+export function estimatePromptTokenCount(prompt?: string | null) {
+	return Math.ceil((prompt?.length ?? 0) / CHARS_PER_APPROXIMATE_TOKEN);
 }
 
 export const DEFAULT_SETTINGS: ChatSettings = {

--- a/apps/web/src/components/(chat)/playground/chat-playground-core.ts
+++ b/apps/web/src/components/(chat)/playground/chat-playground-core.ts
@@ -314,6 +314,16 @@ function normalizeNickname(nickname?: string | null) {
 	return nickname.trim();
 }
 
+const LEGACY_MATH_FORMATTING_RULE =
+	"- **For all mathematical expressions, you must use dollar-sign delimiters. Use $...$ for inline math and $$...$$ for block math. Do not use (...) or [...] delimiters.**";
+
+const MATH_FORMATTING_RULES = [
+	"- Use dollar-sign delimiters for all mathematical expressions: $...$ for inline math and $$...$$ for block math.",
+	"- Put the $$ block-math delimiters on their own lines.",
+	"- Use valid LaTeX inside delimiters. Escape special characters: write percentages as $80\\%$, never $80%$.",
+	"- Do not use \\(...\\) or \\[...\\] delimiters.",
+] as const;
+
 export function buildDefaultSystemPrompt(
 	modelId: string,
 	nickname?: string | null,
@@ -331,7 +341,7 @@ export function buildDefaultSystemPrompt(
 		"- Use Markdown for lists, tables, and styling.",
 		"- Use ```code fences``` for all code blocks.",
 		"- Format file names, paths, and function names with `inline code` backticks.",
-		"- **For all mathematical expressions, you must use dollar-sign delimiters. Use $...$ for inline math and $$...$$ for block math. Do not use (...) or [...] delimiters.**",
+		...MATH_FORMATTING_RULES,
 	].join("\n");
 }
 
@@ -360,9 +370,10 @@ function isGeneratedDefaultSystemPrompt(
 	return (
 		normalizedPrompt.startsWith(generatedPrefix) &&
 		normalizedPrompt.includes(generatedSuffix) &&
-		normalizedPrompt.endsWith(
-			"- **For all mathematical expressions, you must use dollar-sign delimiters. Use $...$ for inline math and $$...$$ for block math. Do not use (...) or [...] delimiters.**",
-		)
+		(MATH_FORMATTING_RULES.some((rule) =>
+			normalizedPrompt.endsWith(rule),
+		) ||
+			normalizedPrompt.endsWith(LEGACY_MATH_FORMATTING_RULE))
 	);
 }
 

--- a/apps/web/src/components/(chat)/playground/chat-playground-core.ts
+++ b/apps/web/src/components/(chat)/playground/chat-playground-core.ts
@@ -318,7 +318,8 @@ const LEGACY_MATH_FORMATTING_RULE =
 	"- **For all mathematical expressions, you must use dollar-sign delimiters. Use $...$ for inline math and $$...$$ for block math. Do not use (...) or [...] delimiters.**";
 
 const MATH_FORMATTING_RULES = [
-	"- Use dollar-sign delimiters for all mathematical expressions: $...$ for inline math and $$...$$ for block math.",
+	"- Use dollar-sign delimiters only for mathematical expressions that need notation or layout: $...$ for inline math and $$...$$ for block math.",
+	"- Keep ordinary numbers, percentages, and currency as plain text (for example: 28%, $28, and $72).",
 	"- Put the $$ block-math delimiters on their own lines.",
 	"- Use valid LaTeX inside delimiters. Escape special characters: write percentages as $80\\%$, never $80%$.",
 	"- Do not use \\(...\\) or \\[...\\] delimiters.",

--- a/apps/web/src/components/(chat)/playground/chat-playground-core.ts
+++ b/apps/web/src/components/(chat)/playground/chat-playground-core.ts
@@ -321,6 +321,7 @@ const MATH_FORMATTING_RULES = [
 	"- Use dollar-sign delimiters for all mathematical expressions: $...$ for inline math and $$...$$ for block math.",
 	"- Put the $$ block-math delimiters on their own lines.",
 	"- Use valid LaTeX inside delimiters. Escape special characters: write percentages as $80\\%$, never $80%$.",
+	"- Reserve dollar signs for LaTeX delimiters. Write monetary amounts with a currency label, for example USD 72, never $72.",
 	"- Do not use \\(...\\) or \\[...\\] delimiters.",
 ] as const;
 

--- a/apps/web/src/components/(chat)/playground/chat-playground-core.ts
+++ b/apps/web/src/components/(chat)/playground/chat-playground-core.ts
@@ -321,7 +321,6 @@ const MATH_FORMATTING_RULES = [
 	"- Use dollar-sign delimiters for all mathematical expressions: $...$ for inline math and $$...$$ for block math.",
 	"- Put the $$ block-math delimiters on their own lines.",
 	"- Use valid LaTeX inside delimiters. Escape special characters: write percentages as $80\\%$, never $80%$.",
-	"- Reserve dollar signs for LaTeX delimiters. Write monetary amounts with a currency label, for example USD 72, never $72.",
 	"- Do not use \\(...\\) or \\[...\\] delimiters.",
 ] as const;
 

--- a/apps/web/src/components/(chat)/playground/chat-playground-core.ts
+++ b/apps/web/src/components/(chat)/playground/chat-playground-core.ts
@@ -317,13 +317,11 @@ function normalizeNickname(nickname?: string | null) {
 const LEGACY_MATH_FORMATTING_RULE =
 	"- **For all mathematical expressions, you must use dollar-sign delimiters. Use $...$ for inline math and $$...$$ for block math. Do not use (...) or [...] delimiters.**";
 
-const MATH_FORMATTING_RULES = [
-	"- Use dollar-sign delimiters only for mathematical expressions that need notation or layout: $...$ for inline math and $$...$$ for block math.",
-	"- Keep ordinary numbers, percentages, and currency as plain text (for example: 28%, $28, and $72).",
-	"- Put the $$ block-math delimiters on their own lines.",
-	"- Use valid LaTeX inside delimiters. Escape special characters: write percentages as $80\\%$, never $80%$.",
-	"- Do not use \\(...\\) or \\[...\\] delimiters.",
-] as const;
+const PREVIOUS_MATH_FORMATTING_RULE =
+	"- Do not use \\(...\\) or \\[...\\] delimiters.";
+
+const COMPACT_FORMATTING_RULE =
+	"Markdown; ```code fences```; `backticks` for code, filenames, paths, and functions. Use $...$ or $$...$$ only for typeset math; put $$ delimiters on their own lines. Keep numbers, percentages, and currency plain. Use valid LaTeX: escape % in math (e.g. $80\\%$); no \\(...\\) or \\[...\\].";
 
 export function buildDefaultSystemPrompt(
 	modelId: string,
@@ -338,11 +336,7 @@ export function buildDefaultSystemPrompt(
 	return [
 		identityLine,
 		"",
-		"Formatting Rules:",
-		"- Use Markdown for lists, tables, and styling.",
-		"- Use ```code fences``` for all code blocks.",
-		"- Format file names, paths, and function names with `inline code` backticks.",
-		...MATH_FORMATTING_RULES,
+		`Formatting: ${COMPACT_FORMATTING_RULE}`,
 	].join("\n");
 }
 
@@ -367,13 +361,15 @@ function isGeneratedDefaultSystemPrompt(
 	const safeModelId = modelId || "AI model";
 	const orgLabel = formatOrgLabel(getOrgId(safeModelId));
 	const generatedPrefix = `You are ${safeModelId}, known as: `;
-	const generatedSuffix = `, a large language model from ${orgLabel}.\n\nFormatting Rules:`;
+	const generatedSuffixes = [
+		`, a large language model from ${orgLabel}.\n\nFormatting:`,
+		`, a large language model from ${orgLabel}.\n\nFormatting Rules:`,
+	];
 	return (
 		normalizedPrompt.startsWith(generatedPrefix) &&
-		normalizedPrompt.includes(generatedSuffix) &&
-		(MATH_FORMATTING_RULES.some((rule) =>
-			normalizedPrompt.endsWith(rule),
-		) ||
+		generatedSuffixes.some((suffix) => normalizedPrompt.includes(suffix)) &&
+		(normalizedPrompt.endsWith(COMPACT_FORMATTING_RULE) ||
+			normalizedPrompt.endsWith(PREVIOUS_MATH_FORMATTING_RULE) ||
 			normalizedPrompt.endsWith(LEGACY_MATH_FORMATTING_RULE))
 	);
 }

--- a/apps/web/src/components/(chat)/playground/chat-playground-core.ts
+++ b/apps/web/src/components/(chat)/playground/chat-playground-core.ts
@@ -348,7 +348,7 @@ export function buildDefaultSystemPrompt(
 const normalizeSystemPromptForComparison = (prompt?: string | null) =>
 	(prompt ?? "").replace(/\r\n/g, "\n").trim();
 
-function isGeneratedDefaultSystemPrompt(
+export function isGeneratedDefaultSystemPrompt(
 	prompt: string | undefined,
 	modelId: string,
 	modelDisplayName?: string,

--- a/apps/web/src/components/(chat)/playground/use-grouped-chat-threads.test.ts
+++ b/apps/web/src/components/(chat)/playground/use-grouped-chat-threads.test.ts
@@ -1,0 +1,48 @@
+import { getChatThreadActivityTime } from "./use-grouped-chat-threads";
+import type { ChatThread } from "@/lib/indexeddb/chats";
+
+function createThread(messages: ChatThread["messages"]): ChatThread {
+	return {
+		id: "thread-1",
+		title: "Thread",
+		modelId: "openai/gpt-5.6-luna",
+		createdAt: "2026-07-11T09:00:00.000Z",
+		updatedAt: "2026-07-11T09:00:00.000Z",
+		messages,
+		settings: {
+			temperature: null,
+			maxOutputTokens: null,
+			systemPrompt: "",
+			stream: true,
+		},
+	};
+}
+
+describe("getChatThreadActivityTime", () => {
+	it("uses the newest message timestamp when messages are present", () => {
+		const thread = createThread([
+			{
+				id: "message-1",
+				role: "user",
+				content: "First",
+				createdAt: "2026-07-11T09:15:00.000Z",
+			},
+			{
+				id: "message-2",
+				role: "assistant",
+				content: "Second",
+				createdAt: "2026-07-11T09:30:00.000Z",
+			},
+		]);
+
+		expect(getChatThreadActivityTime(thread)).toBe(
+			Date.parse("2026-07-11T09:30:00.000Z"),
+		);
+	});
+
+	it("uses the creation time for an empty thread", () => {
+		expect(getChatThreadActivityTime(createThread([]))).toBe(
+			Date.parse("2026-07-11T09:00:00.000Z"),
+		);
+	});
+});

--- a/apps/web/src/components/(chat)/playground/use-grouped-chat-threads.ts
+++ b/apps/web/src/components/(chat)/playground/use-grouped-chat-threads.ts
@@ -1,16 +1,26 @@
 import { useMemo } from "react";
-import type { ChatThread } from "@/lib/indexeddb/chats";
+import type { ChatMessage, ChatThread } from "@/lib/indexeddb/chats";
 import type { GroupedThreads } from "@/components/(chat)/ChatSidebar";
 
+const activityTimeByMessages = new WeakMap<ChatMessage[], number | null>();
+
 export function getChatThreadActivityTime(thread: ChatThread) {
+	const cachedActivityTime = activityTimeByMessages.get(thread.messages);
+	if (cachedActivityTime !== undefined) return cachedActivityTime;
+
 	const messageTimes = thread.messages
 		.map((message) => Date.parse(message.createdAt))
 		.filter(Number.isFinite);
 	if (messageTimes.length > 0) {
-		return Math.max(...messageTimes);
+		const activityTime = Math.max(...messageTimes);
+		activityTimeByMessages.set(thread.messages, activityTime);
+		return activityTime;
 	}
 	const createdMs = Date.parse(thread.createdAt);
-	if (Number.isFinite(createdMs)) return createdMs;
+	if (Number.isFinite(createdMs)) {
+		activityTimeByMessages.set(thread.messages, createdMs);
+		return createdMs;
+	}
 	const updatedMs = Date.parse(thread.updatedAt);
 	return Number.isFinite(updatedMs) ? updatedMs : null;
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -275,6 +275,9 @@ importers:
       '@statsig/web-analytics':
         specifier: ^3.33.2
         version: 3.33.2
+      '@streamdown/math':
+        specifier: ^1.0.2
+        version: 1.0.2(react@19.2.7)
       '@stripe/react-stripe-js':
         specifier: ^6.3.0
         version: 6.3.0(@stripe/stripe-js@9.7.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -4620,6 +4623,11 @@ packages:
   '@stoplight/yaml@4.3.0':
     resolution: {integrity: sha512-JZlVFE6/dYpP9tQmV0/ADfn32L9uFarHWxfcRhReKUnljz1ZiUM5zpX+PH8h5CJs6lao3TuFqnPm9IJJCEkE2w==}
     engines: {node: '>=10.8'}
+
+  '@streamdown/math@1.0.2':
+    resolution: {integrity: sha512-r8Ur9/lBuFnzZAFdEWrLUF2s/gRwRRRwruqltdZibyjbCBnuW7SJbFm26nXqvpJPW/gzpBUMrBVBzd88z05D5g==}
+    peerDependencies:
+      react: ^18.0.0 || ^19.0.0
 
   '@stripe/react-stripe-js@6.3.0':
     resolution: {integrity: sha512-N1FTRNCMKySElDz1lAsf/m6Oy5vcl6LRVXcW29t0Y3U3HYOAqCBlk6nuDsR2x7SAuaXkVCjnpCqrNbA/7l74jg==}
@@ -13883,7 +13891,7 @@ snapshots:
       remark-smartypants: 3.0.2
       shiki: 3.23.0
       unified: 11.0.5
-      unist-util-visit: 5.0.0
+      unist-util-visit: 5.1.0
     transitivePeerDependencies:
       - '@types/react'
       - supports-color
@@ -16486,6 +16494,15 @@ snapshots:
       '@stoplight/types': 14.1.1
       '@stoplight/yaml-ast-parser': 0.0.50
       tslib: 2.8.1
+
+  '@streamdown/math@1.0.2(react@19.2.7)':
+    dependencies:
+      katex: 0.16.47
+      react: 19.2.7
+      rehype-katex: 7.0.1
+      remark-math: 6.0.0
+    transitivePeerDependencies:
+      - supports-color
 
   '@stripe/react-stripe-js@6.3.0(@stripe/stripe-js@9.7.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
@@ -20228,7 +20245,7 @@ snapshots:
       rehype-minify-whitespace: 6.0.2
       trim-trailing-lines: 2.1.0
       unist-util-position: 5.0.0
-      unist-util-visit: 5.0.0
+      unist-util-visit: 5.1.0
 
   hast-util-to-parse5@8.0.1:
     dependencies:
@@ -21584,7 +21601,7 @@ snapshots:
       '@types/mdast': 4.0.4
       escape-string-regexp: 5.0.0
       unist-util-is: 6.0.1
-      unist-util-visit-parents: 6.0.1
+      unist-util-visit-parents: 6.0.2
 
   mdast-util-from-markdown@2.0.2:
     dependencies:
@@ -21625,7 +21642,7 @@ snapshots:
       '@types/mdast': 4.0.4
       devlop: 1.1.0
       escape-string-regexp: 5.0.0
-      mdast-util-from-markdown: 2.0.2
+      mdast-util-from-markdown: 2.0.3
       mdast-util-to-markdown: 2.1.2
       micromark-extension-frontmatter: 2.0.0
     transitivePeerDependencies:
@@ -21643,7 +21660,7 @@ snapshots:
     dependencies:
       '@types/mdast': 4.0.4
       devlop: 1.1.0
-      mdast-util-from-markdown: 2.0.2
+      mdast-util-from-markdown: 2.0.3
       mdast-util-to-markdown: 2.1.2
       micromark-util-normalize-identifier: 2.0.1
     transitivePeerDependencies:
@@ -21652,7 +21669,7 @@ snapshots:
   mdast-util-gfm-strikethrough@2.0.0:
     dependencies:
       '@types/mdast': 4.0.4
-      mdast-util-from-markdown: 2.0.2
+      mdast-util-from-markdown: 2.0.3
       mdast-util-to-markdown: 2.1.2
     transitivePeerDependencies:
       - supports-color
@@ -21662,7 +21679,7 @@ snapshots:
       '@types/mdast': 4.0.4
       devlop: 1.1.0
       markdown-table: 3.0.4
-      mdast-util-from-markdown: 2.0.2
+      mdast-util-from-markdown: 2.0.3
       mdast-util-to-markdown: 2.1.2
     transitivePeerDependencies:
       - supports-color
@@ -21671,14 +21688,14 @@ snapshots:
     dependencies:
       '@types/mdast': 4.0.4
       devlop: 1.1.0
-      mdast-util-from-markdown: 2.0.2
+      mdast-util-from-markdown: 2.0.3
       mdast-util-to-markdown: 2.1.2
     transitivePeerDependencies:
       - supports-color
 
   mdast-util-gfm@3.0.0:
     dependencies:
-      mdast-util-from-markdown: 2.0.2
+      mdast-util-from-markdown: 2.0.3
       mdast-util-gfm-autolink-literal: 2.0.1
       mdast-util-gfm-footnote: 2.1.0
       mdast-util-gfm-strikethrough: 2.0.0
@@ -21706,7 +21723,7 @@ snapshots:
       '@types/mdast': 4.0.4
       devlop: 1.1.0
       longest-streak: 3.1.0
-      mdast-util-from-markdown: 2.0.2
+      mdast-util-from-markdown: 2.0.3
       mdast-util-to-markdown: 2.1.2
       unist-util-remove-position: 5.0.0
     transitivePeerDependencies:
@@ -21718,7 +21735,7 @@ snapshots:
       '@types/hast': 3.0.4
       '@types/mdast': 4.0.4
       devlop: 1.1.0
-      mdast-util-from-markdown: 2.0.2
+      mdast-util-from-markdown: 2.0.3
       mdast-util-to-markdown: 2.1.2
     transitivePeerDependencies:
       - supports-color
@@ -21731,7 +21748,7 @@ snapshots:
       '@types/unist': 3.0.3
       ccount: 2.0.1
       devlop: 1.1.0
-      mdast-util-from-markdown: 2.0.2
+      mdast-util-from-markdown: 2.0.3
       mdast-util-to-markdown: 2.1.2
       parse-entities: 4.0.2
       stringify-entities: 4.0.4
@@ -21759,7 +21776,7 @@ snapshots:
 
   mdast-util-mdx@3.0.0:
     dependencies:
-      mdast-util-from-markdown: 2.0.2
+      mdast-util-from-markdown: 2.0.3
       mdast-util-mdx-expression: 2.0.1
       mdast-util-mdx-jsx: 3.2.0
       mdast-util-mdxjs-esm: 2.0.1
@@ -21773,7 +21790,7 @@ snapshots:
       '@types/hast': 3.0.4
       '@types/mdast': 4.0.4
       devlop: 1.1.0
-      mdast-util-from-markdown: 2.0.2
+      mdast-util-from-markdown: 2.0.3
       mdast-util-to-markdown: 2.1.2
     transitivePeerDependencies:
       - supports-color
@@ -21797,7 +21814,7 @@ snapshots:
       micromark-util-sanitize-uri: 2.0.1
       trim-lines: 3.0.1
       unist-util-position: 5.0.0
-      unist-util-visit: 5.0.0
+      unist-util-visit: 5.1.0
       vfile: 6.0.3
 
   mdast-util-to-markdown@2.1.2:
@@ -21809,7 +21826,7 @@ snapshots:
       mdast-util-to-string: 4.0.0
       micromark-util-classify-character: 2.0.1
       micromark-util-decode-string: 2.0.1
-      unist-util-visit: 5.0.0
+      unist-util-visit: 5.1.0
       zwitch: 2.0.4
 
   mdast-util-to-string@4.0.0:
@@ -23612,7 +23629,7 @@ snapshots:
   remark-parse@11.0.0:
     dependencies:
       '@types/mdast': 4.0.4
-      mdast-util-from-markdown: 2.0.2
+      mdast-util-from-markdown: 2.0.3
       micromark-util-types: 2.0.2
       unified: 11.0.5
     transitivePeerDependencies:
@@ -23639,7 +23656,7 @@ snapshots:
       retext: 9.0.0
       retext-smartypants: 6.2.0
       unified: 11.0.5
-      unist-util-visit: 5.0.0
+      unist-util-visit: 5.1.0
 
   remark-stringify@11.0.0:
     dependencies:
@@ -23735,7 +23752,7 @@ snapshots:
     dependencies:
       '@types/nlcst': 2.0.3
       nlcst-to-string: 4.0.0
-      unist-util-visit: 5.0.0
+      unist-util-visit: 5.1.0
 
   retext-stringify@4.0.0:
     dependencies:
@@ -25110,13 +25127,13 @@ snapshots:
   unist-util-remove-position@5.0.0:
     dependencies:
       '@types/unist': 3.0.3
-      unist-util-visit: 5.0.0
+      unist-util-visit: 5.1.0
 
   unist-util-remove@4.0.0:
     dependencies:
       '@types/unist': 3.0.3
       unist-util-is: 6.0.1
-      unist-util-visit-parents: 6.0.1
+      unist-util-visit-parents: 6.0.2
 
   unist-util-stringify-position@4.0.0:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -377,6 +377,9 @@ importers:
       jszip:
         specifier: ^3.10.1
         version: 3.10.1
+      katex:
+        specifier: 0.16.47
+        version: 0.16.47
       lucide-react:
         specifier: ^1.17.0
         version: 1.17.0(react@19.2.7)


### PR DESCRIPTION
## Summary
- Render assistant-message inline and display LaTeX with Streamdown's KaTeX math plugin.
- Normalize model-generated percent signs and single-line display delimiters so responses such as `$80%$` and `$$0.80 \\times 0.90 = 0.72$$` render correctly.
- Update the generated chat system prompt to request valid LaTeX: escaped percentage signs and block delimiters on their own lines.
- Add coverage for chat Markdown rendering and prompt guidance.

## Validation
- `pnpm --filter @phaseo/web exec jest --runInBand --runTestsByPath ./src/components/(chat)/playground/chat-playground-core.test.ts ./src/components/(chat)/chatMarkdown.test.tsx`
- KaTeX server-render smoke test for inline and display math
- `pnpm --filter @phaseo/web typecheck`
- `pnpm install --frozen-lockfile --offline`
- Scoped ESLint (passes with four existing warnings in `ChatConversationMessages.tsx`)

Created with Codex

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added math-capable markdown rendering for chat messages, including inline and block expressions.
  * Included global KaTeX styling to support consistent math appearance.
  * Updated default system prompt formatting guidance for math (using supported delimiter styles).

* **Bug Fixes**
  * Improved normalization of math markdown to handle percent signs and dollar-prefixed monetary amounts correctly during display.

* **Tests**
  * Expanded Jest coverage for math/markdown normalization and system prompt formatting guidance.

* **Chores**
  * Added an additional runtime dependency to support math rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->