### PR TITLE
Gate product analytics behind consent

### DIFF
--- a/.changeset/calm-posthog-consent-events.md
+++ b/.changeset/calm-posthog-consent-events.md
@@ -1,0 +1,5 @@
+---
+"@phaseo/web": patch
+---
+
+Gate PostHog collection behind explicit analytics consent and add privacy-safe product milestone events for signup, onboarding, API keys, and credit purchases.

--- a/.changeset/calm-posthog-consent-events.md
+++ b/.changeset/calm-posthog-consent-events.md
@@ -2,4 +2,4 @@
 "@phaseo/web": patch
 ---
 
-Gate PostHog collection behind explicit analytics consent and add privacy-safe product milestone events for signup, onboarding, API keys, and credit purchases.
+Gate PostHog and Google Analytics collection behind explicit analytics consent and add privacy-safe product milestone events for signup, onboarding, API keys, and credit purchases.

--- a/apps/web/instrumentation-client.ts
+++ b/apps/web/instrumentation-client.ts
@@ -16,9 +16,14 @@ import {
 	type ClientErrorPayload,
 	isAnalyticsCaptureAllowed,
 } from "@/lib/clientErrorReporting";
+import {
+	PRODUCT_ANALYTICS_EVENT,
+	type ProductAnalyticsPayload,
+} from "@/lib/productAnalytics";
 
 let posthogInitialized = false;
 let listenersBound = false;
+let posthogCaptureEnabled = false;
 
 const RECENT_ERROR_WINDOW_MS = 15000;
 const RECENT_ERROR_MAX = 100;
@@ -89,7 +94,7 @@ function captureToGa(payload: ClientErrorPayload) {
 }
 
 function captureToPosthog(payload: ClientErrorPayload) {
-	if (!posthogInitialized) {
+	if (!posthogCaptureEnabled) {
 		return;
 	}
 
@@ -192,6 +197,12 @@ function bindGlobalErrorListeners() {
 		if (!customEvent.detail) return;
 		captureClientError(customEvent.detail);
 	});
+
+	window.addEventListener(PRODUCT_ANALYTICS_EVENT, (event) => {
+		const payload = (event as CustomEvent<ProductAnalyticsPayload>).detail;
+		if (!payload || !posthogCaptureEnabled) return;
+		posthog.capture(payload.event, payload.properties);
+	});
 }
 
 function initializePosthog() {
@@ -209,7 +220,6 @@ function initializePosthog() {
 		person_profiles: "identified_only",
 		disable_session_recording: true,
 		opt_out_capturing_by_default: true,
-		cookieless_mode: "on_reject",
 		debug: process.env.NODE_ENV === "development",
 	});
 
@@ -222,6 +232,7 @@ function enablePosthog() {
 	}
 
 	initializePosthog();
+	if (posthogCaptureEnabled) return;
 
 	posthog.set_config({
 		autocapture: true,
@@ -233,6 +244,11 @@ function enablePosthog() {
 		disable_session_recording: false,
 	});
 	posthog.opt_in_capturing({ captureEventName: false });
+	posthogCaptureEnabled = true;
+	posthog.capture("$pageview", {
+		$current_url: window.location.href,
+		$pathname: window.location.pathname,
+	});
 }
 
 function disablePosthog() {
@@ -240,14 +256,15 @@ function disablePosthog() {
 		return;
 	}
 
+	posthogCaptureEnabled = false;
 	posthog.set_config({
 		autocapture: false,
 		capture_pageview: false,
 		capture_pageleave: false,
 		disable_session_recording: true,
 	});
-	posthog.opt_out_capturing();
 	posthog.reset();
+	posthog.opt_out_capturing();
 }
 
 function applyPosthogConsent(consent: AnalyticsConsent | null) {

--- a/apps/web/instrumentation-client.ts
+++ b/apps/web/instrumentation-client.ts
@@ -200,8 +200,15 @@ function bindGlobalErrorListeners() {
 
 	window.addEventListener(PRODUCT_ANALYTICS_EVENT, (event) => {
 		const payload = (event as CustomEvent<ProductAnalyticsPayload>).detail;
-		if (!payload || !posthogCaptureEnabled) return;
-		posthog.capture(payload.event, payload.properties);
+		if (!payload || !isAnalyticsCaptureAllowed()) return;
+
+		if (typeof window.gtag === "function") {
+			window.gtag("event", payload.event, payload.properties);
+		}
+
+		if (posthogCaptureEnabled) {
+			posthog.capture(payload.event, payload.properties);
+		}
 	});
 }
 

--- a/apps/web/src/components/(gateway)/auth/sign-up/EmailPassword.tsx
+++ b/apps/web/src/components/(gateway)/auth/sign-up/EmailPassword.tsx
@@ -8,6 +8,7 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { handleEmailSignup } from "@/app/(auth)/sign-up/actions";
 import { Check, Eye, EyeOff, X } from "lucide-react";
+import { captureProductEvent } from "@/lib/productAnalytics";
 
 const SYMBOL_REGEX = /[!@#$%^&*()_+\-=[\]{};':"|<>?,./`~]/;
 const LAST_AUTH_PROVIDER_STORAGE_KEY = "phaseo:last-auth-provider";
@@ -90,6 +91,7 @@ export default function EmailPassword({
 		} catch {
 			// Ignore storage failures; auth still proceeds.
 		}
+		captureProductEvent("account_signup_started", { method: "email" });
 		setFormError(null);
 	};
 

--- a/apps/web/src/components/(gateway)/auth/sign-up/OAuthButtons.tsx
+++ b/apps/web/src/components/(gateway)/auth/sign-up/OAuthButtons.tsx
@@ -4,6 +4,7 @@ import Image from "next/image";
 import { Button } from "@/components/ui/button";
 import { handleOAuthRedirect } from "@/app/(auth)/sign-in/actions";
 import { Logo } from "@/components/Logo";
+import { captureProductEvent } from "@/lib/productAnalytics";
 
 type SocialProviderId = "google" | "github" | "gitlab";
 
@@ -56,6 +57,9 @@ export default function OAuthButtons({
 								} catch {
 									// Ignore storage failures; auth still proceeds.
 								}
+								captureProductEvent("account_signup_started", {
+									method: id,
+								});
 							}}
 						>
 							<input type="hidden" name="authFlow" value="signup" />

--- a/apps/web/src/components/(gateway)/credits/CreditPurchases/TopUp/CreditsPurchaseDialog.tsx
+++ b/apps/web/src/components/(gateway)/credits/CreditPurchases/TopUp/CreditsPurchaseDialog.tsx
@@ -48,19 +48,6 @@ function trackFirstPaymentSaveCardClick(payload: {
 		return;
 	}
 
-	const eventPayload = {
-		source: "credits_top_up_dialog",
-		credits_amount_usd: payload.creditsAmountUsd,
-		fee_usd: payload.feeUsd,
-		total_usd: payload.totalUsd,
-		currency: "usd",
-	};
-
-	const gtag = (window as any).gtag;
-	if (typeof gtag === "function") {
-		gtag("event", "first_payment_save_card_click", eventPayload);
-	}
-
 	captureProductEvent("first_payment_save_card_click", {
 		amount_usd: payload.creditsAmountUsd,
 		currency: "usd",

--- a/apps/web/src/components/(gateway)/credits/CreditPurchases/TopUp/CreditsPurchaseDialog.tsx
+++ b/apps/web/src/components/(gateway)/credits/CreditPurchases/TopUp/CreditsPurchaseDialog.tsx
@@ -25,8 +25,8 @@ import { toast } from "sonner";
 import { loadStripe } from "@stripe/stripe-js";
 import { Spinner } from "@/components/ui/spinner";
 import { ChargeSavedPayment } from "@/app/(dashboard)/settings/credits/actions";
-import posthog from "posthog-js";
 import { isAnalyticsCaptureAllowed } from "@/lib/clientErrorReporting";
+import { captureProductEvent } from "@/lib/productAnalytics";
 
 /* Helpers */
 const formatUSD = (v: number) =>
@@ -61,11 +61,13 @@ function trackFirstPaymentSaveCardClick(payload: {
 		gtag("event", "first_payment_save_card_click", eventPayload);
 	}
 
-	try {
-		posthog.capture("first_payment_save_card_click", eventPayload);
-	} catch {
-		// no-op; analytics should never block checkout
-	}
+	captureProductEvent("first_payment_save_card_click", {
+		amount_usd: payload.creditsAmountUsd,
+		currency: "usd",
+		fee_usd: payload.feeUsd,
+		surface: "credits_top_up_dialog",
+		total_usd: payload.totalUsd,
+	});
 }
 
 export default function CreditsPurchaseDialog({
@@ -212,6 +214,12 @@ export default function CreditsPurchaseDialog({
 				totalUsd: total,
 			});
 		}
+		captureProductEvent("credits_checkout_started", {
+			amount_usd: total,
+			currency: "usd",
+			mode,
+			payment_method: selectedPm === "new" ? "new" : "saved",
+		});
 
 		// Update URL to indicate a payment attempt is in progress so the
 		// parent page can show a processing banner. Use a short unique-ish
@@ -289,6 +297,12 @@ export default function CreditsPurchaseDialog({
 				if (ok) {
 					const status = (data?.status || "").toLowerCase();
 					if (status === "succeeded") {
+						captureProductEvent("credits_payment_succeeded", {
+							amount_usd: total,
+							currency: "usd",
+							mode,
+							payment_method: "saved",
+						});
 						toast.success("Payment successful");
 						onClose();
 						return; // don't fall through

--- a/apps/web/src/components/(gateway)/credits/ZeroCreditPurchaseBlockerSurveyCard.tsx
+++ b/apps/web/src/components/(gateway)/credits/ZeroCreditPurchaseBlockerSurveyCard.tsx
@@ -1,14 +1,13 @@
 "use client";
 
 import * as React from "react";
-import posthog from "posthog-js";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Textarea } from "@/components/ui/textarea";
 import { Badge } from "@/components/ui/badge";
 import { cn } from "@/lib/utils";
-import { isAnalyticsCaptureAllowed } from "@/lib/clientErrorReporting";
+import { captureProductEvent } from "@/lib/productAnalytics";
 
 const REASON_OPTIONS = [
 	{ key: "setup_unclear", label: "Setup is unclear" },
@@ -63,15 +62,10 @@ export default function ZeroCreditPurchaseBlockerSurveyCard(props: {
 	}, [props.workspaceId]);
 
 	React.useEffect(() => {
-		if (!cooldownChecked || submitted || !isAnalyticsCaptureAllowed()) return;
-		try {
-			posthog.capture("credits_purchase_blocker_survey_viewed", {
-				surface: "settings_credits_zero_balance",
-				workspace_id: props.workspaceId ?? null,
-			});
-		} catch {
-			// no-op; analytics should never block the credits page
-		}
+		if (!cooldownChecked || submitted) return;
+		captureProductEvent("credits_purchase_blocker_survey_viewed", {
+			surface: "settings_credits_zero_balance",
+		});
 	}, [cooldownChecked, props.workspaceId, submitted]);
 
 	async function handleSubmit() {
@@ -79,18 +73,11 @@ export default function ZeroCreditPurchaseBlockerSurveyCard(props: {
 
 		setIsSubmitting(true);
 		try {
-			try {
-				posthog.capture("credits_purchase_blocker_feedback_submitted", {
-					surface: "settings_credits_zero_balance",
-					workspace_id: props.workspaceId ?? null,
-					reason_key: reasonKey,
-					details: details.trim() || null,
-					has_details: details.trim().length > 0,
-					details_length: details.trim().length,
-				});
-			} catch {
-				// no-op; explicit survey submission should still complete locally
-			}
+			captureProductEvent("credits_purchase_blocker_feedback_submitted", {
+				has_details: details.trim().length > 0,
+				reason_key: reasonKey,
+				surface: "settings_credits_zero_balance",
+			});
 
 			if (typeof window !== "undefined") {
 				window.localStorage.setItem(

--- a/apps/web/src/components/(gateway)/onboarding/InteractiveOnboarding.tsx
+++ b/apps/web/src/components/(gateway)/onboarding/InteractiveOnboarding.tsx
@@ -30,6 +30,7 @@ import {
 	DrawerTrigger,
 } from "@/components/ui/drawer";
 import { cn } from "@/lib/utils";
+import { captureProductEvent } from "@/lib/productAnalytics";
 
 export type OnboardingWorkspace = {
 	id: string;
@@ -540,6 +541,10 @@ export default function InteractiveOnboarding({
 			setCreatedPlaintextKey(result.plaintext ?? "");
 			setCreatedKeyPrefix(result.prefix ?? "");
 			if (result.id) setSelectedKeyId(result.id);
+			captureProductEvent("api_key_created", {
+				preset: "development",
+				surface: "onboarding",
+			});
 
 			const nextCompleted = new Set(completedSteps);
 			nextCompleted.add("api-key");
@@ -598,6 +603,11 @@ export default function InteractiveOnboarding({
 						? ["api-key", "models", "request"]
 						: Array.from(completedSteps),
 				status,
+			});
+			captureProductEvent("onboarding_finished", {
+				completed_step_count:
+					status === "completed" ? 3 : completedSteps.size,
+				outcome: status,
 			});
 			toast.success(
 				status === "completed" ? "Onboarding complete" : "Onboarding skipped",

--- a/apps/web/src/components/(gateway)/settings/keys/CreateKeyDialog.tsx
+++ b/apps/web/src/components/(gateway)/settings/keys/CreateKeyDialog.tsx
@@ -28,6 +28,7 @@ import {
 	type ApiKeyPresetId,
 } from "@/lib/gateway/secretReveal";
 import { SecretRevealActions } from "./SecretRevealActions";
+import { captureProductEvent } from "@/lib/productAnalytics";
 
 export default function CreateKeyDialog({
 	currentUserId,
@@ -81,6 +82,10 @@ export default function CreateKeyDialog({
 				getApiKeyPreset(selectedPresetId).limits
 			);
 			setPlainKey(res?.plaintext ?? null);
+			captureProductEvent("api_key_created", {
+				preset: selectedPresetId,
+				surface: "settings",
+			});
 		} catch (err: any) {
 			const message =
 				err?.message ?? "Could not create API key right now. Please try again.";

--- a/apps/web/src/components/analytics/CookieConsentManager.tsx
+++ b/apps/web/src/components/analytics/CookieConsentManager.tsx
@@ -61,9 +61,9 @@ export function CookieConsentManager({
     message: string
     title: string
   } | null>(null)
-  // Load GA with denied-by-default consent mode so we can still verify install
-  // health and collect modeled/cookieless signals until explicit consent.
-  const shouldLoadGa = Boolean(gaMeasurementId)
+  // Do not load third-party analytics until consent is explicit. This keeps
+  // pending and declined visits free of analytics network requests.
+  const shouldLoadGa = Boolean(gaMeasurementId) && consent === "accepted"
 
   useEffect(() => {
     if (consent !== "pending") return
@@ -136,7 +136,7 @@ export function CookieConsentManager({
             function gtag(){window.dataLayer.push(arguments);}
             window.gtag = window.gtag || gtag;
             gtag('js', new Date());
-            gtag('consent', 'default', ${JSON.stringify(GA_DENIED_CONSENT)});
+            gtag('consent', 'default', ${JSON.stringify(GA_GRANTED_CONSENT)});
             gtag('config', '${gaMeasurementId}', { anonymize_ip: true });
           `}</Script>
         </>

--- a/apps/web/src/lib/productAnalytics.test.ts
+++ b/apps/web/src/lib/productAnalytics.test.ts
@@ -1,0 +1,44 @@
+import {
+	PRODUCT_ANALYTICS_EVENT,
+	captureProductEvent,
+	type ProductAnalyticsPayload,
+} from "./productAnalytics";
+
+describe("captureProductEvent", () => {
+	it("is a no-op during server rendering", () => {
+		expect(() =>
+			captureProductEvent("onboarding_finished", {
+				completed_step_count: 3,
+				outcome: "completed",
+			}),
+		).not.toThrow();
+	});
+
+	it("dispatches a typed browser event without identifiers or free text", () => {
+		const browserWindow = new EventTarget();
+		Object.defineProperty(globalThis, "window", {
+			configurable: true,
+			value: browserWindow,
+		});
+
+		let received: ProductAnalyticsPayload | null = null;
+		browserWindow.addEventListener(PRODUCT_ANALYTICS_EVENT, (event) => {
+			received = (event as CustomEvent<ProductAnalyticsPayload>).detail;
+		});
+
+		captureProductEvent("api_key_created", {
+			preset: "production",
+			surface: "settings",
+		});
+
+		expect(received).toEqual({
+			event: "api_key_created",
+			properties: {
+				preset: "production",
+				surface: "settings",
+			},
+		});
+
+		Reflect.deleteProperty(globalThis, "window");
+	});
+});

--- a/apps/web/src/lib/productAnalytics.ts
+++ b/apps/web/src/lib/productAnalytics.ts
@@ -1,0 +1,60 @@
+export const PRODUCT_ANALYTICS_EVENT = "phaseo:product-analytics";
+
+export type ProductAnalyticsEventMap = {
+	account_signup_started: { method: "email" | "github" | "gitlab" | "google" };
+	api_key_created: {
+		preset: "ci" | "development" | "production" | "sandbox";
+		surface: "onboarding" | "settings";
+	};
+	credits_checkout_started: {
+		amount_usd: number;
+		currency: "usd";
+		mode: "oneoff" | "pay_and_save";
+		payment_method: "new" | "saved";
+	};
+	credits_payment_succeeded: {
+		amount_usd: number;
+		currency: "usd";
+		mode: "oneoff" | "pay_and_save";
+		payment_method: "saved";
+	};
+	credits_purchase_blocker_feedback_submitted: {
+		has_details: boolean;
+		reason_key: string;
+		surface: "settings_credits_zero_balance";
+	};
+	credits_purchase_blocker_survey_viewed: {
+		surface: "settings_credits_zero_balance";
+	};
+	first_payment_save_card_click: {
+		amount_usd: number;
+		currency: "usd";
+		fee_usd: number;
+		surface: "credits_top_up_dialog";
+		total_usd: number;
+	};
+	onboarding_finished: {
+		completed_step_count: number;
+		outcome: "completed" | "skipped";
+	};
+};
+
+export type ProductAnalyticsPayload = {
+	[K in keyof ProductAnalyticsEventMap]: {
+		event: K;
+		properties: ProductAnalyticsEventMap[K];
+	};
+}[keyof ProductAnalyticsEventMap];
+
+export function captureProductEvent<K extends keyof ProductAnalyticsEventMap>(
+	event: K,
+	properties: ProductAnalyticsEventMap[K],
+) {
+	if (typeof window === "undefined") return;
+
+	window.dispatchEvent(
+		new CustomEvent<ProductAnalyticsPayload>(PRODUCT_ANALYTICS_EVENT, {
+			detail: { event, properties } as ProductAnalyticsPayload,
+		}),
+	);
+}


### PR DESCRIPTION
## Summary

Fixes the PostHog and Google Analytics consent lifecycle and adds a typed, privacy-safe product analytics event layer for the web application.

## Problem

PostHog was configured to start opted out, but it was only initialized after analytics consent had already been accepted. This meant the initial pageview was missed and the intended consent state was difficult to reason about. Several components also imported `posthog-js` directly, allowing product events to bypass the central consent lifecycle. One feedback event included free-text and workspace identifiers.

Google Analytics was loaded before consent using denied consent mode. Although this suppressed analytics storage, it still allowed pre-consent analytics network activity. Product milestones were not consistently forwarded to GA, leaving key-event and funnel reporting incomplete.

## Changes

- Keep PostHog uninitialized while consent is pending or denied.
- Initialize PostHog only after explicit analytics consent and capture the initial pageview manually.
- Disable autocapture, pageviews, page-leave capture, session recording, and product-event delivery after consent withdrawal.
- Load Google Analytics only after explicit acceptance.
- Add a typed `captureProductEvent` event bus that forwards consented, allowlisted milestones to PostHog and GA.
- Add privacy-limited milestones for signup intent, onboarding completion, API-key creation, checkout start, saved-card payment success, and credit-purchase friction.
- Remove workspace IDs, user/customer IDs, key data, payment identifiers, and free-text feedback from analytics payloads.
- Add a web package changeset.

## Compliance posture

This change intentionally does not use cookieless tracking for pending or declined visitors. The product analytics data retains individual journeys and may enable session recording after consent, so it is not treated as aggregate-only analytics under the narrow UK statistical-purpose exception. This is a conservative engineering posture and is not a substitute for legal advice or a documented DPIA/LIA.

## Validation

- `pnpm test -- --runInBand src/lib/productAnalytics.test.ts`
- Targeted ESLint for modified TypeScript and TSX files (no errors; existing warnings remain in the credits dialog)
- `git diff --check`
- CI runs the clean dependency-graph typecheck; a local linked-dependency rerun was blocked by duplicate React type trees unrelated to this diff

Created with Codex
