### PR TITLE
Improve rankings navigation

### DIFF
--- a/apps/web/src/app/(dashboard)/rankings/RankingsPageContent.tsx
+++ b/apps/web/src/app/(dashboard)/rankings/RankingsPageContent.tsx
@@ -16,7 +16,10 @@ import {
 	type ModalityLeaderboardEntry,
 	type ModalitySectionData,
 } from "@/components/(rankings)/ModalityLeaderboards";
-import { RankingsSideNav } from "@/components/(rankings)/RankingsSideNav";
+import { RankingsModalityTabs } from "@/components/(rankings)/RankingsModalityTabs";
+import ModelPageToc, {
+	type ModelPageTocItem,
+} from "@/components/(data)/model/ModelPageToc";
 import { ChartSkeleton, ListSkeleton } from "@/components/(rankings)/Skeletons";
 import { InlineInfoTooltip } from "@/components/(rankings)/InlineInfoTooltip";
 import {
@@ -59,6 +62,26 @@ export const RANKING_MODALITIES: RankingModality[] = [
 	"transcription",
 ];
 
+const rankingSectionLabels: Record<RankingModality, string> = {
+	text: "AI Model Rankings",
+	image: "Image Model Rankings",
+	embeddings: "Embedding Model Rankings",
+	rerank: "Rerank Model Rankings",
+	audio: "Audio Model Rankings",
+	video: "Video Model Rankings",
+	speech: "Speech Model Rankings",
+	transcription: "Transcription Model Rankings",
+};
+
+const textRankingTocItems: ModelPageTocItem[] = [
+	{ id: "text", label: "Leaderboard" },
+	{ id: "unique-users", label: "Unique Users" },
+	{ id: "market-share", label: "Market Share" },
+	{ id: "tool-calls", label: "Tool Calls" },
+	{ id: "images", label: "Images" },
+	{ id: "image-output", label: "Image Output" },
+];
+
 export function isRankingModality(value: string): value is RankingModality {
 	return RANKING_MODALITIES.includes(value as RankingModality);
 }
@@ -98,13 +121,22 @@ export default async function RankingsPageContent({
 	modality?: RankingModality;
 }) {
 	const isTextPage = modality === "text";
+	const tocItems = isTextPage
+		? textRankingTocItems
+		: [{ id: modality, label: rankingSectionLabels[modality] }];
 
     return (
         <div className="min-h-screen bg-background text-foreground">
-            <div className="mx-auto max-w-[1680px] px-4 py-8 sm:px-6 lg:px-10">
-                <div className="grid gap-8 lg:grid-cols-[220px_minmax(0,1fr)] xl:grid-cols-[240px_minmax(0,1fr)]">
-                    <RankingsSideNav currentModality={modality} className="lg:col-start-1 lg:h-full" />
-                    <main className="min-w-0 space-y-16 lg:col-start-2">
+            <div className="mx-auto max-w-[1680px] px-4 pb-8 pt-0 sm:px-6 lg:px-10">
+				<div className="sticky top-[calc(var(--site-notice-height,0px)+var(--site-header-height,3.75rem))] z-20 -mx-4 mb-4 border-b border-border/70 bg-background px-4 py-2 sm:-mx-6 sm:px-6 lg:-mx-10 lg:px-10">
+					<RankingsModalityTabs currentModality={modality} />
+				</div>
+				<div className="flex flex-col gap-8 lg:flex-row lg:items-start">
+					<ModelPageToc
+						items={tocItems}
+						className="lg:h-full lg:w-max lg:shrink-0"
+					/>
+					<main className="min-w-0 flex-1 space-y-16">
                     <Suspense fallback={<ListSkeleton />}>
                         <ModalityLeaderboardsServer modality={modality} />
                     </Suspense>
@@ -182,8 +214,8 @@ export default async function RankingsPageContent({
                     </>
                     ) : null}
 
-                    </main>
-                </div>
+					</main>
+				</div>
             </div>
         </div>
     );

--- a/apps/web/src/components/(data)/model/ModelPageToc.tsx
+++ b/apps/web/src/components/(data)/model/ModelPageToc.tsx
@@ -10,9 +10,14 @@ import {
 	CircleDollarSign,
 	CreditCard,
 	Gauge,
+	Image,
+	ImagePlus,
+	PieChart,
 	ScrollText,
 	Store,
 	Trophy,
+	Users,
+	Wrench,
 } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
@@ -39,6 +44,11 @@ const sectionIcons: Record<string, LucideIcon> = {
 	subscriptions: CreditCard,
 	quickstart: Bolt,
 	about: BadgeInfo,
+	"unique-users": Users,
+	"market-share": PieChart,
+	"tool-calls": Wrench,
+	images: Image,
+	"image-output": ImagePlus,
 };
 
 const activeSectionTopOffset = 212;

--- a/apps/web/src/components/(rankings)/RankingsModalityTabs.tsx
+++ b/apps/web/src/components/(rankings)/RankingsModalityTabs.tsx
@@ -1,0 +1,89 @@
+"use client";
+
+import Link from "next/link";
+import {
+	ArrowUpDown,
+	Binary,
+	Captions,
+	Headphones,
+	ImageIcon,
+	Speech,
+	Type as TypeIcon,
+	Video,
+	type LucideIcon,
+} from "lucide-react";
+import { cn } from "@/lib/utils";
+import { getModalityTone } from "@/lib/models/modalityStyles";
+
+type RankingsModalityItem = {
+	id: string;
+	label: string;
+	href: string;
+	icon: LucideIcon;
+};
+
+const ITEMS: RankingsModalityItem[] = [
+	{ id: "text", label: "Text", href: "/rankings", icon: TypeIcon },
+	{ id: "image", label: "Image", href: "/rankings/image", icon: ImageIcon },
+	{ id: "embeddings", label: "Embeddings", href: "/rankings/embeddings", icon: Binary },
+	{ id: "rerank", label: "Rerank", href: "/rankings/rerank", icon: ArrowUpDown },
+	{ id: "audio", label: "Audio", href: "/rankings/audio", icon: Headphones },
+	{ id: "video", label: "Video", href: "/rankings/video", icon: Video },
+	{ id: "speech", label: "Speech", href: "/rankings/speech", icon: Speech },
+	{
+		id: "transcription",
+		label: "Transcription",
+		href: "/rankings/transcription",
+		icon: Captions,
+	},
+];
+
+export function RankingsModalityTabs({
+	currentModality,
+}: {
+	currentModality: string;
+}) {
+	return (
+		<div className="w-full touch-pan-x overflow-x-auto overscroll-x-contain [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
+			<nav
+				aria-label="Ranking modalities"
+				className="flex min-w-max items-center gap-1.5 pr-4"
+			>
+				{ITEMS.map((item) => {
+					const isActive = item.id === currentModality;
+					const Icon = item.icon;
+					const tone = getModalityTone(item.id);
+
+					return (
+						<Link
+							key={item.id}
+							href={item.href}
+							aria-current={isActive ? "page" : undefined}
+							className={cn(
+								"group inline-flex h-9 shrink-0 items-center gap-1.5 rounded-md px-2 text-sm transition-colors",
+								isActive
+									? cn("bg-muted text-foreground", tone.badgeClassName)
+									: "text-muted-foreground hover:bg-muted/70 hover:text-foreground",
+							)}
+						>
+							<span
+								className={cn(
+									"inline-flex size-5 shrink-0 items-center justify-center rounded-sm",
+									isActive
+										? tone.iconClassName
+										: cn(
+											"text-muted-foreground transition-colors",
+											tone.ghostIconHoverClassName,
+										),
+								)}
+							>
+								<Icon className="size-3.5" />
+							</span>
+							<span>{item.label}</span>
+						</Link>
+					);
+				})}
+			</nav>
+		</div>
+	);
+}

--- a/apps/web/src/components/(rankings)/UsageStackedBar.tsx
+++ b/apps/web/src/components/(rankings)/UsageStackedBar.tsx
@@ -634,8 +634,8 @@ export function UsageStackedBar({
 			<div className="space-y-8 pt-3">
 				<div className="flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
 					<div className="min-w-0 max-w-xl space-y-1">
-						<h3 className="text-xl font-semibold">{leaderboardTitle}</h3>
-						<p className="text-sm text-muted-foreground">
+						<h3 className="text-lg font-semibold lg:text-xl">{leaderboardTitle}</h3>
+						<p className="text-xs text-muted-foreground lg:text-sm">
 							{leaderboardDescription}
 						</p>
 					</div>
@@ -645,7 +645,7 @@ export function UsageStackedBar({
 									type="button"
 									variant="outline"
 									size="sm"
-									className="h-9 w-36 justify-between rounded-lg px-4 font-normal text-muted-foreground" />}>
+									className="h-8 w-32 justify-between rounded-lg px-3 text-xs font-normal text-muted-foreground lg:h-9 lg:w-36 lg:px-4 lg:text-sm" />}>
 
 									{optionLabel(MODEL_FILTER_OPTIONS, modelFilter)}
 									<ChevronDown className="ml-2 h-4 w-4 opacity-60" />
@@ -676,7 +676,7 @@ export function UsageStackedBar({
 									type="button"
 									variant="outline"
 									size="sm"
-									className="h-9 w-32 justify-between rounded-lg px-4 font-normal text-muted-foreground" />}>
+									className="h-8 w-28 justify-between rounded-lg px-3 text-xs font-normal text-muted-foreground lg:h-9 lg:w-32 lg:px-4 lg:text-sm" />}>
 
 									{optionLabel(PERIOD_OPTIONS, leaderboardPeriod)}
 									<ChevronDown className="ml-2 h-4 w-4 opacity-60" />
@@ -731,18 +731,18 @@ export function UsageStackedBar({
 								return (
 									<div
 										key={model}
-										className="grid min-h-16 grid-cols-[2.25rem_2rem_minmax(0,1fr)_auto] items-center gap-3 py-2"
+										className="grid min-h-14 grid-cols-[2rem_1.75rem_minmax(0,1fr)_auto] items-center gap-2 py-1.5 lg:min-h-16 lg:grid-cols-[2.25rem_2rem_minmax(0,1fr)_auto] lg:gap-3 lg:py-2"
 									>
-										<div className="text-base tabular-nums text-muted-foreground">
+										<div className="text-sm tabular-nums text-muted-foreground lg:text-base">
 											{index + 1}.
 										</div>
 										{logoHref ? (
 											<Link
 												href={logoHref}
 												aria-label={`${modelName} organization`}
-												className="flex h-7 w-7 items-center justify-center rounded-lg border border-zinc-200/80 bg-transparent dark:border-zinc-800"
+												className="flex h-6 w-6 items-center justify-center rounded-lg border border-zinc-200/80 bg-transparent dark:border-zinc-800 lg:h-7 lg:w-7"
 											>
-												<span className="relative h-4 w-4">
+												<span className="relative h-3 w-3 lg:h-4 lg:w-4">
 													<Logo
 														id={logoId}
 														alt={modelName}
@@ -752,8 +752,8 @@ export function UsageStackedBar({
 												</span>
 											</Link>
 										) : (
-											<span className="flex h-7 w-7 items-center justify-center rounded-lg border border-zinc-200/80 bg-transparent dark:border-zinc-800">
-												<span className="relative h-4 w-4">
+											<span className="flex h-6 w-6 items-center justify-center rounded-lg border border-zinc-200/80 bg-transparent dark:border-zinc-800 lg:h-7 lg:w-7">
+												<span className="relative h-3 w-3 lg:h-4 lg:w-4">
 													<Logo
 														id={logoId}
 														alt={modelName}
@@ -767,12 +767,12 @@ export function UsageStackedBar({
 											<div className="min-w-0">
 												<Link
 													href={modelHref}
-													className="block truncate text-base font-semibold underline decoration-transparent underline-offset-2 hover:decoration-current"
+													className="block truncate text-sm font-semibold underline decoration-transparent underline-offset-2 hover:decoration-current lg:text-base"
 												>
 													{modelName}
 												</Link>
 												{organisationId ? (
-													<div className="text-sm text-muted-foreground">
+													<div className="text-xs text-muted-foreground lg:text-sm">
 														by{" "}
 														<Link
 															href={`/organisations/${encodeURIComponent(organisationId)}`}
@@ -785,18 +785,18 @@ export function UsageStackedBar({
 											</div>
 										) : (
 											<div className="min-w-0">
-												<div className="truncate text-base font-semibold">
+												<div className="truncate text-sm font-semibold lg:text-base">
 													{modelName}
 												</div>
 												{organisationId ? (
-													<div className="text-sm text-muted-foreground">
+													<div className="text-xs text-muted-foreground lg:text-sm">
 														by {organisationName}
 													</div>
 												) : null}
 											</div>
 										)}
 										<div className="text-right">
-											<div className="whitespace-nowrap text-sm tabular-nums text-muted-foreground">
+											<div className="whitespace-nowrap text-xs tabular-nums text-muted-foreground lg:text-sm">
 												{formatNumber(entry.current)} {leaderboardUnit}
 											</div>
 											<div className={changeClassName(entry.changePct)}>


### PR DESCRIPTION
## Summary

The rankings page previously used its left rail exclusively for modality navigation, which left the page sections without an in-page navigation pattern and made modality switching less consistent with the models page.

This change moves modality switching into a compact, sticky selector row and repurposes the left rail as an active section table of contents. The selector remains available while scrolling, while the table of contents follows the current leaderboard section.

## User impact

Visitors can switch modalities without leaving their reading position, jump directly between leaderboard sections, and use a more compact leaderboard layout on narrower screens.

## Implementation details

- Added a modality selector styled to match the models page controls.
- Reused the model detail table-of-contents behavior for rankings sections and added appropriate section icons.
- Made the selector sticky, flush with the site header, and removed the visible horizontal scrollbar and mismatched background treatment.
- Reduced leaderboard row typography, logo sizing, and filter-control density below the large breakpoint while retaining desktop sizing.

## Validation

- `pnpm --filter @phaseo/web typecheck`
- Focused ESLint checks for the changed rankings and table-of-contents components

Created with Codex
