### PR TITLE
Show goodwill credits in transaction history

### DIFF
--- a/apps/web/src/components/(gateway)/credits/RecentTransactions.tsx
+++ b/apps/web/src/components/(gateway)/credits/RecentTransactions.tsx
@@ -22,6 +22,7 @@ import {
 	DollarSign,
 	Repeat,
 	CreditCard,
+	Gift,
 	Zap,
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
@@ -231,6 +232,17 @@ function kindBadge(kind?: string | null) {
 			>
 				<Zap className="h-3 w-3" aria-hidden />
 				{label ?? "Promo"}
+			</Badge>
+		);
+
+	if (kind === "goodwill_credit")
+		return (
+			<Badge
+				variant="outline"
+				className={cn(TRANSACTION_CHIP_BASE, TRANSACTION_CHIP_TONES.teal)}
+			>
+				<Gift className="h-3 w-3" aria-hidden />
+				{label ?? "Goodwill Credit"}
 			</Badge>
 		);
 

--- a/apps/web/src/lib/credits/promoCodes.test.ts
+++ b/apps/web/src/lib/credits/promoCodes.test.ts
@@ -44,5 +44,8 @@ describe("promo code helpers", () => {
 
 	it("maps promo_code transactions to Promo Credit", () => {
 		expect(getCreditTransactionKindLabel("promo_code")).toBe("Promo Credit");
+		expect(getCreditTransactionKindLabel("goodwill_credit")).toBe(
+			"Goodwill Credit",
+		);
 	});
 });

--- a/apps/web/src/lib/credits/promoCodes.ts
+++ b/apps/web/src/lib/credits/promoCodes.ts
@@ -76,6 +76,7 @@ export function getCreditTransactionKindLabel(
 	const normalized = String(kind ?? "").toLowerCase();
 	if (!normalized) return null;
 	if (normalized === "promo_code") return "Promo Credit";
+	if (normalized === "goodwill_credit") return "Goodwill Credit";
 	if (normalized === "top_up_one_off") return "One-Off Top Up";
 	if (normalized === "top_up") return "Top Up";
 	if (normalized === "auto_top_up") return "Auto Top Up";


### PR DESCRIPTION
## Summary

Goodwill credits now render as a first-class positive transaction in the credits history.

When support applies a `goodwill_credit` ledger entry, customers see a teal gift badge labelled **Goodwill Credit**, rather than the raw database value. The existing signed amount and paid-status presentation remain intact.

## Validation

- Passed: `pnpm --filter @phaseo/web test -- promoCodes.test.ts` in the existing workspace.
- Passed: `pnpm --filter @phaseo/web lint -- 'src/lib/credits/promoCodes.ts' 'src/components/(gateway)/credits/RecentTransactions.tsx'` in the existing workspace.
- The isolated PR worktree did not have usable dependency executables after its install attempt, so those same focused checks could not be repeated there.

Created with Codex


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added clear “Goodwill Credit” labeling for applicable credit transactions.
  * Added a dedicated gift icon and teal badge styling to make goodwill credits easier to identify in recent transactions.

* **Tests**
  * Added coverage verifying the new transaction label.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->