### PR TITLE
fix(web): link Monthly Tokens card to rankings

### DIFF
--- a/apps/web/src/components/landingPage/DatabaseStatistics.test.tsx
+++ b/apps/web/src/components/landingPage/DatabaseStatistics.test.tsx
@@ -1,0 +1,43 @@
+import React from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+
+import { fetchFrontendLandingStats } from "@/lib/fetchers/frontend/fetchPublicCatalog";
+import DatabaseStats from "./DatabaseStatistics";
+
+jest.mock("@/lib/fetchers/frontend/fetchPublicCatalog", () => ({
+	fetchFrontendLandingStats: jest.fn(),
+}));
+
+jest.mock("next/link", () => ({
+	__esModule: true,
+	default: ({
+		href,
+		children,
+		...props
+	}: {
+		href: string;
+		children: React.ReactNode;
+		className?: string;
+	}) => React.createElement("a", { ...props, href }, children),
+}));
+
+const mockFetchFrontendLandingStats = jest.mocked(fetchFrontendLandingStats);
+
+describe("DatabaseStats", () => {
+	it("links Monthly Tokens to the rankings page", async () => {
+		mockFetchFrontendLandingStats.mockResolvedValue({
+			db: {
+				models: 100,
+				organisations: 0,
+				benchmarks: 0,
+				benchmark_results: 0,
+				api_providers: 10,
+			},
+			monthlyTokenTotal: 1_234,
+		});
+
+		const html = renderToStaticMarkup(await DatabaseStats());
+
+		expect(html).toMatch(/<a[^>]*href="\/rankings"[^>]*>.*Monthly Tokens/);
+	});
+});

--- a/apps/web/src/components/landingPage/DatabaseStatistics.tsx
+++ b/apps/web/src/components/landingPage/DatabaseStatistics.tsx
@@ -43,7 +43,7 @@ export default async function DatabaseStats() {
 		{
 			label: "Monthly Tokens",
 			value: `${formatCompact(monthlyTokenTotal ?? 0)}+`,
-			route: "/",
+			route: "/rankings",
 		},
 	] as const;
 


### PR DESCRIPTION
## Summary

The landing page's Monthly Tokens statistics card linked back to `/` instead of taking users to the rankings page. This made the card's call to action ineffective for users looking for token usage rankings.

## Cause and fix

The card data in `DatabaseStatistics` assigned the Monthly Tokens stat a root route while the other landing-page statistics cards use their destination routes. The route is now `/rankings`, and a colocated regression test renders the server component and verifies that the Monthly Tokens link targets that path.

## Validation

- `pnpm --filter @phaseo/web test -- DatabaseStatistics.test.tsx`
- `pnpm --filter @phaseo/web exec eslint src/components/landingPage/DatabaseStatistics.tsx src/components/landingPage/DatabaseStatistics.test.tsx`
- `pnpm --filter @phaseo/web typecheck`
- `git diff --check`
