### PR TITLE
fix(api): classify workspace errors correctly

### DIFF
--- a/apps/api/src/core/batch-finalization.ts
+++ b/apps/api/src/core/batch-finalization.ts
@@ -3,6 +3,7 @@
 // How: Reads output JSONL, prices successful responses, applies one idempotent charge, and marks billed.
 
 import { getBindings } from "@/runtime/env";
+import { emitGatewayOperationalFailure } from "@/observability/axiom";
 import { resolveCapabilityFromEndpoint } from "@/lib/config/capabilityToEndpoints";
 import { pickFirstFiniteNumber, resolveCanonicalTokenUsage } from "@core/usage-normalization";
 import {
@@ -904,6 +905,13 @@ export async function finalizeBatchJob(args: FinalizeBatchJobArgs): Promise<Fina
 			workspaceId: args.workspaceId,
 			batchId: args.batchId,
 			status,
+		});
+		await emitGatewayOperationalFailure({
+			workflow: "batch_finalization",
+			workspaceId: args.workspaceId,
+			resourceId: args.batchId,
+			reason: "batch_job_settlement_failed",
+			error,
 		});
 		return {
 			status,

--- a/apps/api/src/core/video-finalization.ts
+++ b/apps/api/src/core/video-finalization.ts
@@ -6,6 +6,7 @@ import { loadPriceCard } from "@pipeline/pricing/loader";
 import { recordUsageAndCharge } from "@pipeline/pricing/persist";
 import { applyByokServiceFee } from "@pipeline/pricing/byok-fee";
 import { getSupabaseAdmin } from "@/runtime/env";
+import { emitGatewayOperationalFailure } from "@/observability/axiom";
 import {
 	getVideoJobMeta,
 	getVideoJobRecord,
@@ -1086,6 +1087,13 @@ export async function finalizeVideoJob(args: FinalizeVideoJobArgs): Promise<Fina
 			error: captureErr,
 			workspaceId: args.workspaceId,
 			videoId: args.videoId,
+		});
+		await emitGatewayOperationalFailure({
+			workflow: "video_finalization",
+			workspaceId: args.workspaceId,
+			resourceId: args.videoId,
+			reason: "video_capture_reservation_failed",
+			error: captureErr,
 		});
 		return {
 			status: nextStatus,

--- a/apps/api/src/observability/axiom.ts
+++ b/apps/api/src/observability/axiom.ts
@@ -89,21 +89,25 @@ export async function emitGatewayOperationalFailure(args: {
     reason: string;
     error?: unknown;
 }) {
-    const message = args.error instanceof Error ? args.error.message : String(args.error ?? "");
-    await sendAxiomWideEvent({
-        event_type: "gateway.operational_failure",
-        event_emitted_at: new Date().toISOString(),
-        success: false,
-        error_type: "system",
-        error_origin: "gateway",
-        error_operational_kind: "finalization_failed",
-        error_action_owner: "gateway",
-        error_requires_investigation: true,
-        error_code: args.reason,
-        error_message: message.slice(0, 500) || null,
-        workspace_id: args.workspaceId,
-        finalization_workflow: args.workflow,
-        finalization_resource_id: args.resourceId,
-    });
+    try {
+        const message = args.error instanceof Error ? args.error.message : String(args.error ?? "");
+        await sendAxiomWideEvent({
+            event_type: "gateway.operational_failure",
+            event_emitted_at: new Date().toISOString(),
+            success: false,
+            error_type: "system",
+            error_origin: "gateway",
+            error_operational_kind: "finalization_failed",
+            error_action_owner: "gateway",
+            error_requires_investigation: true,
+            error_code: args.reason,
+            error_message: message.slice(0, 500) || null,
+            workspace_id: args.workspaceId,
+            finalization_workflow: args.workflow,
+            finalization_resource_id: args.resourceId,
+        });
+    } catch (error) {
+        console.error("[observability] finalization failure event emit failed", error);
+    }
 }
 

--- a/apps/api/src/observability/axiom.ts
+++ b/apps/api/src/observability/axiom.ts
@@ -82,3 +82,28 @@ export async function sendAxiomWideEvent(event: WideEvent) {
     }
 }
 
+export async function emitGatewayOperationalFailure(args: {
+    workflow: "batch_finalization" | "video_finalization";
+    workspaceId: string;
+    resourceId: string;
+    reason: string;
+    error?: unknown;
+}) {
+    const message = args.error instanceof Error ? args.error.message : String(args.error ?? "");
+    await sendAxiomWideEvent({
+        event_type: "gateway.operational_failure",
+        event_emitted_at: new Date().toISOString(),
+        success: false,
+        error_type: "system",
+        error_origin: "gateway",
+        error_operational_kind: "finalization_failed",
+        error_action_owner: "gateway",
+        error_requires_investigation: true,
+        error_code: args.reason,
+        error_message: message.slice(0, 500) || null,
+        workspace_id: args.workspaceId,
+        finalization_workflow: args.workflow,
+        finalization_resource_id: args.resourceId,
+    });
+}
+

--- a/apps/api/src/pipeline/before/http.test.ts
+++ b/apps/api/src/pipeline/before/http.test.ts
@@ -43,6 +43,20 @@ describe("before/http err", () => {
 		});
 	});
 
+	it.each(["insufficient_funds", "key_limit_exceeded"] as const)(
+		"classifies %s as a user/workspace error",
+		async (code) => {
+			const response = err(code, { reason: code });
+			expect(response.status).toBe(code === "insufficient_funds" ? 402 : 429);
+			const payload = await response.json();
+			expect(payload).toMatchObject({
+				error: code,
+				error_type: "user",
+				error_origin: "user",
+			});
+		},
+	);
+
 	it("adds structured route-level upstream diagnostics for provider timeouts", async () => {
 		const response = err("upstream_error", {
 			reason: "video_provider_timeout",

--- a/apps/api/src/pipeline/before/http.ts
+++ b/apps/api/src/pipeline/before/http.ts
@@ -29,9 +29,7 @@ export function json(data: unknown, status = 200) {
 function defaultErrorType(code: ErrorCode): "user" | "system" {
     if (
         code === "upstream_error" ||
-        code === "gateway_error" ||
-        code === "key_limit_exceeded" ||
-        code === "insufficient_funds"
+        code === "gateway_error"
     ) {
         return "system";
     }

--- a/apps/web/src/components/(gateway)/settings/authorized-apps/AuthorizationCard.tsx
+++ b/apps/web/src/components/(gateway)/settings/authorized-apps/AuthorizationCard.tsx
@@ -15,7 +15,7 @@ interface AuthorizationCardProps {
 }
 
 export default function AuthorizationCard({ authorization }: AuthorizationCardProps) {
-	const additionalScopes = Array.isArray(authorization.additional_scopes)
+	const additionalScopes: string[] = Array.isArray(authorization.additional_scopes)
 		? authorization.additional_scopes.filter((scope: unknown): scope is string => typeof scope === "string")
 		: [];
 


### PR DESCRIPTION
## Summary

Corrects the gateway error taxonomy so credit and key-limit rejections are reported as user/workspace errors rather than upstream system failures. Adds structured Axiom operational-failure events for batch settlement and video reservation-capture finalisation failures.

## Cause and effect

`insufficient_funds` and `key_limit_exceeded` were assigned `error_type: system` by the shared HTTP error constructor. The error handler consequently prefixed them as `upstream:`, which made user balance and workspace-limit issues appear as provider incidents in Supabase and Axiom.

## Changes

- classify insufficient-credit and key-limit responses as user-originated errors;
- add regression coverage for both response contracts;
- emit `gateway.operational_failure` Axiom events for batch settlement and video reservation-capture failures, including an explicit gateway owner and investigation flag.

## Validation

- `pnpm --filter @phaseo/gateway-api exec vitest run src/pipeline/before/http.test.ts src/core/error-handler.test.ts src/observability/axiom.test.ts`

Created with Codex
