### PR TITLE
Smooth provider table indicator

### DIFF
--- a/apps/web/src/components/(data)/model/pricing/ModelPricingClient.tsx
+++ b/apps/web/src/components/(data)/model/pricing/ModelPricingClient.tsx
@@ -42,7 +42,10 @@ import {
 import { type ProviderPricing } from "@/lib/fetchers/models/getModelPricing";
 import type { ProviderRuntimeStatsMap } from "@/lib/fetchers/models/getModelProviderRuntimeStats";
 import type { ProviderRoutingStatusMap } from "@/lib/fetchers/models/getModelProviderRoutingHealth";
-import ProviderCard from "@/components/(data)/model/pricing/ProviderCard";
+import ProviderCard, {
+    PROVIDER_INSPECTOR_CLOSE_EVENT,
+    PROVIDER_INSPECTOR_OPEN_EVENT,
+} from "@/components/(data)/model/pricing/ProviderCard";
 import { cn } from "@/lib/utils";
 import { normalizeProviderPromptTrainingPolicy } from "@/lib/providers/promptTrainingPolicy";
 import { mergeProviderPricingOffers } from "@/lib/providers/providerFamilyGroups";
@@ -74,6 +77,12 @@ type SortOption =
     | "latency"
     | "uptime";
 type SortDirection = "asc" | "desc";
+type ProviderTableIndicator = {
+    providerId: string;
+    x: number;
+    y: number;
+    height: number;
+};
 type WorkspacePrivacySettings = {
     isAuthenticated: boolean;
     privacyEnablePaidMayTrain: boolean;
@@ -643,9 +652,98 @@ export default function ModelPricingClient({
             return buildProviderTablePriceSummary(sections, "cached").primary !== null;
         });
     }, [visibleProviders]);
+    const providerTableContainerRef = useRef<HTMLDivElement>(null);
     const providerTableViewportRef = useRef<HTMLDivElement>(null);
     const [providerTableOverflows, setProviderTableOverflows] = useState<boolean | null>(null);
     const [providerTableThumbWidth, setProviderTableThumbWidth] = useState<number | null>(null);
+    const [providerTableIndicator, setProviderTableIndicator] =
+        useState<ProviderTableIndicator | null>(null);
+    const activeProviderIndicatorId = providerTableIndicator?.providerId ?? null;
+
+    const updateProviderTableIndicator = useCallback((providerId: string) => {
+        const container = providerTableContainerRef.current;
+        if (!container) return;
+        const row = Array.from(
+            container.querySelectorAll<HTMLTableRowElement>("[data-provider-inspector-id]")
+        ).find((element) => element.dataset.providerInspectorId === providerId);
+        if (!row) return;
+
+        const containerRect = container.getBoundingClientRect();
+        const rowRect = row.getBoundingClientRect();
+        const next = {
+            providerId,
+            x: rowRect.left - containerRect.left,
+            y: rowRect.top - containerRect.top,
+            height: rowRect.height,
+        };
+        setProviderTableIndicator((current) =>
+            current &&
+            current.providerId === next.providerId &&
+            current.x === next.x &&
+            current.y === next.y &&
+            current.height === next.height
+                ? current
+                : next
+        );
+    }, []);
+
+    useEffect(() => {
+        let frame = 0;
+        const requestIndicatorUpdate = (providerId: string) => {
+            if (frame) window.cancelAnimationFrame(frame);
+            frame = window.requestAnimationFrame(() => {
+                updateProviderTableIndicator(providerId);
+                frame = 0;
+            });
+        };
+        const handleOpen = (event: Event) => {
+            const providerId = (event as CustomEvent<{ providerId?: string }>).detail?.providerId;
+            if (providerId) requestIndicatorUpdate(providerId);
+        };
+        const handleClose = (event: Event) => {
+            const providerId = (event as CustomEvent<{ providerId?: string }>).detail?.providerId;
+            if (!providerId) return;
+            window.requestAnimationFrame(() => {
+                setProviderTableIndicator((current) =>
+                    current?.providerId === providerId ? null : current
+                );
+            });
+        };
+
+        window.addEventListener(PROVIDER_INSPECTOR_OPEN_EVENT, handleOpen);
+        window.addEventListener(PROVIDER_INSPECTOR_CLOSE_EVENT, handleClose);
+        return () => {
+            if (frame) window.cancelAnimationFrame(frame);
+            window.removeEventListener(PROVIDER_INSPECTOR_OPEN_EVENT, handleOpen);
+            window.removeEventListener(PROVIDER_INSPECTOR_CLOSE_EVENT, handleClose);
+        };
+    }, [updateProviderTableIndicator]);
+
+    useLayoutEffect(() => {
+        if (!activeProviderIndicatorId) return;
+        const frame = window.requestAnimationFrame(() => {
+            updateProviderTableIndicator(activeProviderIndicatorId);
+        });
+        return () => window.cancelAnimationFrame(frame);
+    }, [
+        activeProviderIndicatorId,
+        updateProviderTableIndicator,
+        visibleProviders,
+    ]);
+
+    useEffect(() => {
+        const viewport = providerTableViewportRef.current;
+        if (!viewport || !activeProviderIndicatorId) return;
+        const handleScroll = () => {
+            updateProviderTableIndicator(activeProviderIndicatorId);
+        };
+        viewport.addEventListener("scroll", handleScroll, { passive: true });
+        window.addEventListener("resize", handleScroll);
+        return () => {
+            viewport.removeEventListener("scroll", handleScroll);
+            window.removeEventListener("resize", handleScroll);
+        };
+    }, [activeProviderIndicatorId, updateProviderTableIndicator]);
 
     useLayoutEffect(() => {
         const viewport = providerTableViewportRef.current;
@@ -852,7 +950,20 @@ export default function ModelPricingClient({
                 ) : null}
                 {filteredProviders.length > 0 ? (
                     <div className="space-y-2">
-                        <div className="overflow-hidden rounded-md border border-zinc-200/80 bg-background dark:border-zinc-800">
+                        <div
+                            ref={providerTableContainerRef}
+                            className="relative overflow-hidden rounded-md border border-zinc-200/80 bg-background dark:border-zinc-800"
+                        >
+							{providerTableIndicator ? (
+								<span
+									aria-hidden="true"
+									className="pointer-events-none absolute left-0 top-0 z-10 w-0.5 bg-primary will-change-transform transition-transform duration-200 ease-out motion-reduce:transition-none"
+									style={{
+										height: providerTableIndicator.height,
+										transform: `translate3d(${providerTableIndicator.x}px, ${providerTableIndicator.y}px, 0)`,
+									}}
+								/>
+							) : null}
                             <ScrollArea
                                 className={cn(
                                     "w-full",

--- a/apps/web/src/components/(data)/model/pricing/ProviderCard.tsx
+++ b/apps/web/src/components/(data)/model/pricing/ProviderCard.tsx
@@ -2,7 +2,6 @@
 
 import React, { useEffect, useMemo, useRef, useState } from "react";
 import Link from "next/link";
-import { motion, useReducedMotion } from "motion/react";
 import {
 	AlertTriangle,
 	ArrowUpRight,
@@ -94,7 +93,8 @@ const PROVIDER_SHEET_DOCS = {
 	dataRetention:
 		"https://phaseo.app/docs/v1/cookbook/route-only-to-eu-or-zdr-providers",
 } as const;
-const PROVIDER_INSPECTOR_OPEN_EVENT = "ai-stats-provider-inspector-open";
+export const PROVIDER_INSPECTOR_OPEN_EVENT = "ai-stats-provider-inspector-open";
+export const PROVIDER_INSPECTOR_CLOSE_EVENT = "ai-stats-provider-inspector-close";
 const PROVIDER_INSPECTOR_STATE_KEY = "__aiStatsOpenProviderInspectorId";
 const PROVIDER_INSPECTOR_SUPPRESS_ANIMATION_KEY =
 	"__aiStatsSuppressProviderInspectorAnimationForId";
@@ -1326,7 +1326,6 @@ export default function ProviderCard({
 }) {
 	const [selectedPlan, setSelectedPlan] = useState(defaultPlan);
 	const [expanded, setExpanded] = useState(false);
-	const reduceMotion = useReducedMotion();
 	const [disableInspectorAnimation, setDisableInspectorAnimation] = useState(false);
 	const [copiedInspectorValue, setCopiedInspectorValue] = useState<string | null>(null);
 	const inspectorAnimationResetRef = useRef<number | null>(null);
@@ -2010,6 +2009,11 @@ export default function ProviderCard({
 	const handleInspectorOpenChange = (open: boolean) => {
 		if (!open && expanded) {
 			const closingProviderId = inspectorProviderId;
+			window.dispatchEvent(
+				new CustomEvent(PROVIDER_INSPECTOR_CLOSE_EVENT, {
+					detail: { providerId: closingProviderId },
+				}),
+			);
 			window[PROVIDER_INSPECTOR_RECENTLY_CLOSED_ID_KEY] = closingProviderId;
 			window[PROVIDER_INSPECTOR_RECENTLY_CLOSED_AT_KEY] = Date.now();
 			if (inspectorStateClearRef.current !== null) {
@@ -2446,6 +2450,7 @@ export default function ProviderCard({
 				tabIndex={0}
 				aria-selected={expanded}
 				aria-expanded={expanded}
+				data-provider-inspector-id={inspectorProviderId}
 				data-provider-inspector-open={expanded ? "true" : undefined}
 				onPointerDownCapture={handleSummaryRowPointerDownCapture}
 				onClick={handleSummaryRowClick}
@@ -2456,19 +2461,6 @@ export default function ProviderCard({
 				)}
 			>
 				<TableCell className="relative min-w-[280px] py-1 pl-3 pr-2">
-					{expanded ? (
-						<motion.span
-							aria-hidden="true"
-							className="absolute inset-y-0 left-0 w-0.5 bg-primary"
-							initial={reduceMotion ? false : { opacity: 0 }}
-							animate={{ opacity: 1 }}
-							transition={
-								reduceMotion
-									? { duration: 0 }
-									: { duration: 0.12, ease: "easeOut" }
-							}
-						/>
-					) : null}
 					<div>
 						<div className="flex items-center gap-2.5">
 							<Link


### PR DESCRIPTION
## Summary
- Restore animated provider selection using one table-level indicator.
- Animate only a compositor `translate3d` transform when the selected provider changes.
- Retain immediate row interactions and clear the indicator when the sheet closes.

## Validation
- `pnpm exec eslint 'src/components/(data)/model/pricing/ModelPricingClient.tsx' 'src/components/(data)/model/pricing/ProviderCard.tsx'`
- `pnpm exec tsc --noEmit --pretty false --incremental false --project tsconfig.json`
- `pnpm --filter @phaseo/web test -- --runInBand`
- Local Playwright verification on `http://localhost:3102/models/z-ai/glm-5.2`, including a multi-row provider jump with no console errors.

Created with Codex

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a visual indicator to the pricing table that highlights the provider currently being inspected.
  * The indicator remains aligned with the selected provider while the table layout changes or is horizontally scrolled.
* **Bug Fixes**
  * Improved synchronization between opening and closing the provider inspector and the highlighted pricing-table row.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->