### PR TITLE
chore(raycast): clarify Store title

### DIFF
--- a/packages/devtools/raycast-extension/package.json
+++ b/packages/devtools/raycast-extension/package.json
@@ -3,7 +3,7 @@
   "name": "phaseo",
   "version": "0.4.0",
   "private": true,
-  "title": "Phaseo",
+  "title": "Phaseo Models",
   "description": "Search Phaseo's AI model catalogue",
   "icon": "icon.png",
   "author": "danielbutler1",


### PR DESCRIPTION
## Summary

- Rename the Store-facing extension title to **Phaseo Models**.
- Keep the existing `phaseo` extension identifier unchanged.

## Validation

- `pnpm run lint`
- `pnpm run build`

Created with Codex