### PR TITLE
Fix dashboard layout types

### DIFF
--- a/apps/web/src/app/(dashboard)/benchmarks/layout.tsx
+++ b/apps/web/src/app/(dashboard)/benchmarks/layout.tsx
@@ -1,5 +1,3 @@
-import type { ReactNode } from "react";
-
-export default function BenchmarksLayout({ children }: { children: ReactNode }) {
-	return children;
+export default function BenchmarksLayout({ children }: LayoutProps<"/benchmarks">) {
+	return <>{children}</>;
 }

--- a/apps/web/src/app/(dashboard)/collections/layout.tsx
+++ b/apps/web/src/app/(dashboard)/collections/layout.tsx
@@ -1,5 +1,3 @@
-import type { ReactNode } from "react";
-
-export default function CollectionsLayout({ children }: { children: ReactNode }) {
-	return children;
+export default function CollectionsLayout({ children }: LayoutProps<"/collections">) {
+	return <>{children}</>;
 }

--- a/apps/web/src/app/(dashboard)/countries/layout.tsx
+++ b/apps/web/src/app/(dashboard)/countries/layout.tsx
@@ -1,5 +1,3 @@
-import type { ReactNode } from "react";
-
-export default function CountriesLayout({ children }: { children: ReactNode }) {
-	return children;
+export default function CountriesLayout({ children }: LayoutProps<"/countries">) {
+	return <>{children}</>;
 }

--- a/apps/web/src/app/(dashboard)/families/layout.tsx
+++ b/apps/web/src/app/(dashboard)/families/layout.tsx
@@ -1,5 +1,3 @@
-import type { ReactNode } from "react";
-
-export default function FamiliesLayout({ children }: { children: ReactNode }) {
-	return children;
+export default function FamiliesLayout({ children }: LayoutProps<"/families">) {
+	return <>{children}</>;
 }

--- a/apps/web/src/app/(dashboard)/models/layout.tsx
+++ b/apps/web/src/app/(dashboard)/models/layout.tsx
@@ -1,7 +1,6 @@
-import type { ReactNode } from "react";
 import NoFooterStyle from "@/components/layout/NoFooterStyle";
 
-export default function ModelsLayout({ children }: { children: ReactNode }) {
+export default function ModelsLayout({ children }: LayoutProps<"/models">) {
 	return (
 		<>
 			<NoFooterStyle />

--- a/apps/web/src/app/(dashboard)/organisations/layout.tsx
+++ b/apps/web/src/app/(dashboard)/organisations/layout.tsx
@@ -1,9 +1,5 @@
-import type { ReactNode } from "react";
-
 export default function OrganisationsLayout({
 	children,
-}: {
-	children: ReactNode;
-}) {
-	return children;
+}: LayoutProps<"/organisations">) {
+	return <>{children}</>;
 }

--- a/apps/web/src/app/(dashboard)/rankings/layout.tsx
+++ b/apps/web/src/app/(dashboard)/rankings/layout.tsx
@@ -1,5 +1,3 @@
-import type { ReactNode } from "react";
-
-export default function RankingsLayout({ children }: { children: ReactNode }) {
-	return children;
+export default function RankingsLayout({ children }: LayoutProps<"/rankings">) {
+	return <>{children}</>;
 }

--- a/apps/web/src/app/(dashboard)/subscription-plans/layout.tsx
+++ b/apps/web/src/app/(dashboard)/subscription-plans/layout.tsx
@@ -1,9 +1,5 @@
-import type { ReactNode } from "react";
-
 export default function SubscriptionPlansLayout({
 	children,
-}: {
-	children: ReactNode;
-}) {
-	return children;
+}: LayoutProps<"/subscription-plans">) {
+	return <>{children}</>;
 }

--- a/apps/web/src/app/(dashboard)/works-with/layout.tsx
+++ b/apps/web/src/app/(dashboard)/works-with/layout.tsx
@@ -1,5 +1,3 @@
-import type { ReactNode } from "react";
-
-export default function WorksWithLayout({ children }: { children: ReactNode }) {
-	return children;
+export default function WorksWithLayout({ children }: LayoutProps<"/works-with">) {
+	return <>{children}</>;
 }


### PR DESCRIPTION
## Summary
- align dashboard route layouts with Next 16 generated LayoutProps types
- remove incompatible ReactNode imports from simple layout boundaries
- unblock the production web build so CLI activation can use the deployed API origin

## Validation
- git diff --check`n
Created with Codex