### PR TITLE
Fix Next 16 benchmarks layout build

### DIFF
--- a/apps/web/src/app/(dashboard)/benchmarks/layout.tsx
+++ b/apps/web/src/app/(dashboard)/benchmarks/layout.tsx
@@ -1,5 +1,3 @@
-import type { ReactNode } from "react";
-
-export default function BenchmarksLayout({ children }: { children: ReactNode }) {
+export default function BenchmarksLayout({ children }: LayoutProps<"/benchmarks">) {
 	return children;
 }


### PR DESCRIPTION
## Summary
- use Next's route-aware LayoutProps for the benchmarks layout
- unblock the production web build that contains the Cloudflare favicon and search migration

## Root cause
The layout used ReactNode from a React type instance that does not satisfy Next 16's generated route contract.

## Validation
- pnpm --filter @phaseo/web exec tsc --noEmit --pretty false
- confirmed the preceding production failure at the same generated layout check

Created with Codex