### PR TITLE
Fix remaining Next 16 layout types

### DIFF
--- a/apps/web/src/app/(dashboard)/collections/layout.tsx
+++ b/apps/web/src/app/(dashboard)/collections/layout.tsx
@@ -1,5 +1,3 @@
-import type { ReactNode } from "react";
-
-export default function CollectionsLayout({ children }: { children: ReactNode }) {
+export default function CollectionsLayout({ children }: LayoutProps<"/collections">) {
 	return children;
 }

--- a/apps/web/src/app/(dashboard)/countries/layout.tsx
+++ b/apps/web/src/app/(dashboard)/countries/layout.tsx
@@ -1,5 +1,3 @@
-import type { ReactNode } from "react";
-
-export default function CountriesLayout({ children }: { children: ReactNode }) {
+export default function CountriesLayout({ children }: LayoutProps<"/countries">) {
 	return children;
 }

--- a/apps/web/src/app/(dashboard)/families/layout.tsx
+++ b/apps/web/src/app/(dashboard)/families/layout.tsx
@@ -1,5 +1,3 @@
-import type { ReactNode } from "react";
-
-export default function FamiliesLayout({ children }: { children: ReactNode }) {
+export default function FamiliesLayout({ children }: LayoutProps<"/families">) {
 	return children;
 }

--- a/apps/web/src/app/(dashboard)/models/layout.tsx
+++ b/apps/web/src/app/(dashboard)/models/layout.tsx
@@ -1,7 +1,6 @@
-import type { ReactNode } from "react";
 import NoFooterStyle from "@/components/layout/NoFooterStyle";
 
-export default function ModelsLayout({ children }: { children: ReactNode }) {
+export default function ModelsLayout({ children }: LayoutProps<"/models">) {
 	return (
 		<>
 			<NoFooterStyle />

--- a/apps/web/src/app/(dashboard)/organisations/layout.tsx
+++ b/apps/web/src/app/(dashboard)/organisations/layout.tsx
@@ -1,9 +1,5 @@
-import type { ReactNode } from "react";
-
 export default function OrganisationsLayout({
 	children,
-}: {
-	children: ReactNode;
-}) {
+}: LayoutProps<"/organisations">) {
 	return children;
 }

--- a/apps/web/src/app/(dashboard)/rankings/layout.tsx
+++ b/apps/web/src/app/(dashboard)/rankings/layout.tsx
@@ -1,5 +1,3 @@
-import type { ReactNode } from "react";
-
-export default function RankingsLayout({ children }: { children: ReactNode }) {
+export default function RankingsLayout({ children }: LayoutProps<"/rankings">) {
 	return children;
 }

--- a/apps/web/src/app/(dashboard)/subscription-plans/layout.tsx
+++ b/apps/web/src/app/(dashboard)/subscription-plans/layout.tsx
@@ -1,9 +1,5 @@
-import type { ReactNode } from "react";
-
 export default function SubscriptionPlansLayout({
 	children,
-}: {
-	children: ReactNode;
-}) {
+}: LayoutProps<"/subscription-plans">) {
 	return children;
 }

--- a/apps/web/src/app/(dashboard)/updates/layout.tsx
+++ b/apps/web/src/app/(dashboard)/updates/layout.tsx
@@ -1,9 +1,8 @@
 "use client";
 
-import { ReactNode } from "react";
 import UpdateTabs from "@/components/updates/UpdateTabs";
 
-export default function UpdatesLayout({ children }: { children: ReactNode }) {
+export default function UpdatesLayout({ children }: LayoutProps<"/updates">) {
 	return (
 		<main className="flex min-h-screen flex-col">
 			<div className="container mx-auto flex-1 px-4 py-4">

--- a/apps/web/src/app/(dashboard)/works-with/layout.tsx
+++ b/apps/web/src/app/(dashboard)/works-with/layout.tsx
@@ -1,5 +1,3 @@
-import type { ReactNode } from "react";
-
-export default function WorksWithLayout({ children }: { children: ReactNode }) {
+export default function WorksWithLayout({ children }: LayoutProps<"/works-with">) {
 	return children;
 }

--- a/apps/web/src/app/my-statsig.tsx
+++ b/apps/web/src/app/my-statsig.tsx
@@ -233,7 +233,7 @@ export default function MyStatsig({
 	return (
 		<StatsigProvider client={client}>
 			<StatsigUserSync />
-			{children}
+			{children as React.ComponentProps<typeof StatsigProvider>["children"]}
 		</StatsigProvider>
 	);
 }

--- a/apps/web/src/app/og/[...slug]/route.tsx
+++ b/apps/web/src/app/og/[...slug]/route.tsx
@@ -136,12 +136,14 @@ export async function GET(
 	return new ImageResponse(
 		(
 			<div
-				tw="h-full w-full text-slate-900"
 				style={{
 					display: "flex",
+					height: "100%",
+					width: "100%",
 					padding: "56px 64px 48px",
 					position: "relative",
 					fontSize: 48,
+					color: "#0f172a",
 					background: "#ffffff",
 					fontFamily:
 						"system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif",
@@ -149,8 +151,13 @@ export async function GET(
 			>
 				{/* MAIN COLUMN */}
 				<div
-					tw="w-full h-full"
-					style={{ display: "flex", flexDirection: "column", zIndex: 1 }}
+					style={{
+						display: "flex",
+						width: "100%",
+						height: "100%",
+						flexDirection: "column",
+						zIndex: 1,
+					}}
 				>
 					<div
 						style={{
@@ -180,7 +187,6 @@ export async function GET(
 
 					{/* TITLE / SUBTITLE / STATS */}
 					<div
-						tw="mt-10 flex-1"
 						style={{
 							display: "flex",
 							flexDirection: "column",
@@ -189,11 +195,12 @@ export async function GET(
 						}}
 					>
 						<div
-							tw="leading-[1.05] tracking-tight max-w-[900px] mb-4"
 							style={{
 								display: "flex",
 								maxWidth: "900px",
 								marginBottom: 16,
+								lineHeight: 1.05,
+								letterSpacing: "-0.025em",
 								fontSize: titleFontSize,
 								color: "#020617",
 							}}
@@ -203,7 +210,6 @@ export async function GET(
 
 						{payload.subtitle ? (
 							<div
-								tw="text-2xl text-slate-500 max-w-[900px] mb-10"
 								style={{
 									display: "flex",
 									maxWidth: "900px",
@@ -217,13 +223,11 @@ export async function GET(
 
 						{stats.length > 0 ? (
 							<div
-								tw="flex flex-wrap"
 								style={{ display: "flex", flexWrap: "wrap" }}
 							>
 								{stats.map((stat, index) => (
 									<div
 										key={stat.label}
-										tw="flex flex-col min-w-[180px] mr-10"
 										style={{
 											display: "flex",
 											flexDirection: "column",
@@ -235,26 +239,31 @@ export async function GET(
 										}}
 									>
 										<div
-											tw="text-[11px] uppercase text-slate-400"
-											style={{ display: "flex" }}
+											style={{
+												display: "flex",
+												fontSize: 11,
+												textTransform: "uppercase",
+												color: "#94a3b8",
+											}}
 										>
 											{stat.label}
 										</div>
 										<div
-											tw="mt-2 text-2xl"
 											style={{
 												display: "flex",
 												marginTop: 8,
+												fontSize: 24,
 											}}
 										>
 											{stat.value}
 										</div>
 										{stat.helper ? (
 											<div
-												tw="mt-1 text-xs text-slate-500"
 												style={{
 													display: "flex",
 													marginTop: 4,
+													fontSize: 12,
+													color: "#64748b",
 												}}
 											>
 												{stat.helper}

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,3 @@
+{
+  "installCommand": "pnpm install --frozen-lockfile"
+}


### PR DESCRIPTION
## Summary
- replace legacy ReactNode layout props with route-aware Next LayoutProps across the affected public dashboard routes
- unblock the production build after the Cloudflare web migration

## Root cause
Next 16's generated route validation rejects the legacy ReactNode signature because it resolves through a different React type instance.

## Validation
- pnpm --filter @phaseo/web exec next typegen
- attempted pnpm --filter @phaseo/web exec tsc --noEmit --pretty false (blocked locally by an existing missing @streamdown/math module)
- Vercel production build confirmed the prior sequential layout failure

Created with Codex