### PR TITLE
Fix web provider link build type

### DIFF
--- a/apps/web/src/components/(data)/model/pricing/ProviderCard.tsx
+++ b/apps/web/src/components/(data)/model/pricing/ProviderCard.tsx
@@ -124,7 +124,7 @@ function ProviderSheetSectionLink({
 	className,
 }: {
 	href: string;
-	children: React.ReactNode;
+	children: React.ComponentProps<typeof Link>["children"];
 	className?: string;
 }) {
 	return (


### PR DESCRIPTION
## Summary

Fixes the production-only type-check failure in the provider pricing card. `next/link` expects its own React children type, while the component was declaring the broader local `React.ReactNode` type; the mismatch prevented Vercel from completing the production build after the Cloudflare route rollout.

The link helper now derives `children` directly from `next/link`, preserving the UI and runtime behaviour while matching the component contract.

## Validation

- `pnpm --filter @phaseo/web typecheck`

Created with Codex