### PR TITLE
Fix web React type resolution

### DIFF
--- a/apps/web/src/components/ai-elements/message.tsx
+++ b/apps/web/src/components/ai-elements/message.tsx
@@ -211,7 +211,7 @@ export const MessageBranchContent = ({
   ));
 };
 
-export type MessageBranchSelectorProps = HTMLAttributes<HTMLDivElement> & {
+export type MessageBranchSelectorProps = ComponentProps<typeof ButtonGroup> & {
   from: UIMessage["role"];
 };
 

--- a/packages/devtools/raycast-extension/package.json
+++ b/packages/devtools/raycast-extension/package.json
@@ -49,7 +49,7 @@
   },
   "devDependencies": {
     "@types/node": "22.19.17",
-    "@types/react": "19.0.10",
+    "@types/react": "19.2.17",
     "eslint": "^10.0.3",
     "prettier": "^3.8.3",
     "typescript": "^6.0.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -635,10 +635,10 @@ importers:
     dependencies:
       '@raycast/api':
         specifier: ^1.104.21
-        version: 1.104.21(@types/node@22.19.17)(@types/react@19.0.10)
+        version: 1.104.21(@types/node@22.19.17)(@types/react@19.2.17)
       '@raycast/utils':
         specifier: ^2.2.7
-        version: 2.2.7(@raycast/api@1.104.21(@types/node@22.19.17)(@types/react@19.0.10))(react@19.2.7)
+        version: 2.2.7(@raycast/api@1.104.21(@types/node@22.19.17)(@types/react@19.2.17))(react@19.2.7)
     devDependencies:
       '@raycast/eslint-config':
         specifier: ^2.1.1
@@ -647,8 +647,8 @@ importers:
         specifier: 22.19.17
         version: 22.19.17
       '@types/react':
-        specifier: 19.0.10
-        version: 19.0.10
+        specifier: 19.2.17
+        version: 19.2.17
       eslint:
         specifier: ^10.0.3
         version: 10.1.0(jiti@2.7.0)
@@ -15758,7 +15758,7 @@ snapshots:
 
   '@radix-ui/rect@1.1.1': {}
 
-  '@raycast/api@1.104.21(@types/node@22.19.17)(@types/react@19.0.10)':
+  '@raycast/api@1.104.21(@types/node@22.19.17)(@types/react@19.2.17)':
     dependencies:
       '@oclif/core': 4.10.0
       '@oclif/plugin-autocomplete': 3.2.41
@@ -15768,7 +15768,7 @@ snapshots:
       react: 19.0.0
     optionalDependencies:
       '@types/node': 22.19.17
-      '@types/react': 19.0.10
+      '@types/react': 19.2.17
     transitivePeerDependencies:
       - supports-color
 
@@ -15793,9 +15793,9 @@ snapshots:
       - supports-color
       - typescript
 
-  '@raycast/utils@2.2.7(@raycast/api@1.104.21(@types/node@22.19.17)(@types/react@19.0.10))(react@19.2.7)':
+  '@raycast/utils@2.2.7(@raycast/api@1.104.21(@types/node@22.19.17)(@types/react@19.2.17))(react@19.2.7)':
     dependencies:
-      '@raycast/api': 1.104.21(@types/node@22.19.17)(@types/react@19.0.10)
+      '@raycast/api': 1.104.21(@types/node@22.19.17)(@types/react@19.2.17)
       dequal: 2.0.3
     optionalDependencies:
       react: 19.2.7


### PR DESCRIPTION
## Summary

Restores reliable Vercel production builds after the Cloudflare web-route rollout exposed a hidden monorepo React type conflict. The web app used `@types/react` 19.2.17 while the Raycast extension retained 19.0.10. During a full Vercel install, Next could resolve the older copy for generated types and the newer copy for application types, making otherwise valid React props incompatible.

This aligns the Raycast extension to 19.2.17 and makes the branch selector derive its props from the button group it renders. The lockfile change is deliberately limited to the affected peer snapshots.

## Validation

- `pnpm install --frozen-lockfile --offline`
- `pnpm --filter @phaseo/web typecheck`
- `pnpm --filter @phaseo/web build` compiled and completed TypeScript locally; the Windows build worker then exited with code `3221225794` during static generation, so the Vercel production deployment is the final platform validation.

Created with Codex