### PR TITLE
Fix stale changeset package names

### DIFF
--- a/.changeset/batch-api-webhooks.md
+++ b/.changeset/batch-api-webhooks.md
@@ -1,6 +1,6 @@
 ---
-"@ai-stats/sdk": minor
-"@ai-stats/gateway-api": patch
+"@phaseo/sdk": minor
+"@phaseo/gateway-api": patch
 ---
 
 Enable the public Batch API and Files routes, add managed batch webhook processing, and expose TypeScript SDK helpers for polling batches, listing request rows, and verifying signed webhook deliveries.


### PR DESCRIPTION
## Summary

- replace stale pre-rebrand package names in the batch API changeset
- restore the Changesets release plan on `main`

## Validation

- `pnpm install --frozen-lockfile`
- `pnpm exec changeset status`
- `rg -n '"@ai-stats/' .changeset` (no matches)
- `git diff --check`

Fixes the `Handle Versions` failure from CI run 29398101597.

Created with Codex


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added public Batch API and Files routes.
  - Added managed processing for batch webhooks.
  - Expanded the TypeScript SDK with helpers for polling batch status, listing request rows, and verifying signed webhook deliveries.
- **Release Updates**
  - Updated package release entries to reflect the latest SDK and gateway API versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->