### PR TITLE
Fix health endpoint usage

### DIFF
--- a/.changeset/tidy-health-endpoint-usage.md
+++ b/.changeset/tidy-health-endpoint-usage.md
@@ -1,0 +1,5 @@
+---
+"@phaseo/web": patch
+---
+
+Normalize the configured Gateway API URL to the versioned `/v1` base before publishing discovery and health endpoint metadata.

--- a/apps/api/src/routes/root.ts
+++ b/apps/api/src/routes/root.ts
@@ -1,5 +1,5 @@
 // src/routes/root.ts
-// Purpose: Root routes (health, basic info, and top-level wiring).
+// Purpose: Root routes (basic info, OAuth discovery, and top-level wiring).
 // Why: Keeps non-versioned routes explicit and minimal.
 // How: Wires HTTP routes to pipeline entrypoints and response helpers.
 

--- a/apps/api/tests/sdk/README.md
+++ b/apps/api/tests/sdk/README.md
@@ -34,7 +34,7 @@ Create a `.env.test` file in `apps/api/`:
 
 ```bash
 # Gateway configuration
-GATEWAY_BASE_URL=http://localhost:8787
+GATEWAY_BASE_URL=http://localhost:8787/v1
 GATEWAY_API_KEY=your_gateway_api_key
 
 # Optional: Provider keys if testing passthrough
@@ -45,7 +45,7 @@ ANTHROPIC_API_KEY=sk-ant-...
 Or export them:
 
 ```bash
-export GATEWAY_BASE_URL=http://localhost:8787
+export GATEWAY_BASE_URL=http://localhost:8787/v1
 export GATEWAY_API_KEY=gw_test123
 ```
 
@@ -72,7 +72,7 @@ pnpm test tests/sdk/anthropic-sdk-compat
 ### Run with Environment Variables Inline
 
 ```bash
-GATEWAY_BASE_URL=http://localhost:8787 GATEWAY_API_KEY=gw_test pnpm test tests/sdk
+GATEWAY_BASE_URL=http://localhost:8787/v1 GATEWAY_API_KEY=gw_test pnpm test tests/sdk
 ```
 
 ## Test Coverage
@@ -222,7 +222,7 @@ Test Files  2 passed (2)
 ⚠️  Skipping OpenAI SDK compatibility tests
 
 To run these tests, set:
-  GATEWAY_BASE_URL=http://localhost:8787
+  GATEWAY_BASE_URL=http://localhost:8787/v1
   GATEWAY_API_KEY=your_gateway_key
 ```
 
@@ -234,7 +234,7 @@ To run these tests, set:
 
 **Solution**:
 ```bash
-export GATEWAY_BASE_URL=http://localhost:8787
+export GATEWAY_BASE_URL=http://localhost:8787/v1
 export GATEWAY_API_KEY=your_key
 pnpm test tests/sdk
 ```
@@ -308,7 +308,7 @@ jobs:
 
       - name: Run SDK Tests
         env:
-          GATEWAY_BASE_URL: http://localhost:8787
+          GATEWAY_BASE_URL: http://localhost:8787/v1
           GATEWAY_API_KEY: ${{ secrets.GATEWAY_TEST_KEY }}
         run: pnpm test tests/sdk
 ```

--- a/apps/api/tests/sdk/anthropic-sdk-compat.test.ts
+++ b/apps/api/tests/sdk/anthropic-sdk-compat.test.ts
@@ -3,20 +3,23 @@
 
 import { describe, it, expect, beforeAll } from "vitest";
 import Anthropic from "@anthropic-ai/sdk";
+import { normalizeGatewayBaseUrl } from "./test-config";
 
 /**
  * These tests verify that our gateway is fully compatible with the official Anthropic SDK.
  *
  * To run these tests:
  * 1. Set GATEWAY_API_KEY environment variable (your gateway API key)
- * 2. Set GATEWAY_BASE_URL environment variable (e.g., http://localhost:8787)
+ * 2. Set GATEWAY_BASE_URL environment variable (e.g., http://localhost:8787/v1)
  * 3. Ensure gateway is running
  *
  * Example:
- * GATEWAY_API_KEY=gw_test123 GATEWAY_BASE_URL=http://localhost:8787 pnpm test tests/sdk/anthropic-sdk-compat
+ * GATEWAY_API_KEY=gw_test123 GATEWAY_BASE_URL=http://localhost:8787/v1 pnpm test tests/sdk/anthropic-sdk-compat
  */
 
-const GATEWAY_BASE_URL = process.env.GATEWAY_BASE_URL;
+const GATEWAY_BASE_URL = normalizeGatewayBaseUrl(
+	process.env.GATEWAY_BASE_URL,
+);
 const GATEWAY_API_KEY = process.env.GATEWAY_API_KEY;
 
 // Skip tests if environment variables not set
@@ -377,7 +380,7 @@ if (shouldSkip) {
 ⚠️  Skipping Anthropic SDK compatibility tests
 
 To run these tests, set:
-  GATEWAY_BASE_URL=http://localhost:8787
+  GATEWAY_BASE_URL=http://localhost:8787/v1
   GATEWAY_API_KEY=your_gateway_key
 	`);
 }

--- a/apps/api/tests/sdk/openai-sdk-compat.test.ts
+++ b/apps/api/tests/sdk/openai-sdk-compat.test.ts
@@ -3,20 +3,23 @@
 
 import { describe, it, expect, beforeAll } from "vitest";
 import OpenAI from "openai";
+import { normalizeGatewayBaseUrl } from "./test-config";
 
 /**
  * These tests verify that our gateway is fully compatible with the official OpenAI SDK.
  *
  * To run these tests:
  * 1. Set GATEWAY_API_KEY environment variable (your gateway API key)
- * 2. Set GATEWAY_BASE_URL environment variable (e.g., http://localhost:8787)
+ * 2. Set GATEWAY_BASE_URL environment variable (e.g., http://localhost:8787/v1)
  * 3. Ensure gateway is running
  *
  * Example:
- * GATEWAY_API_KEY=gw_test123 GATEWAY_BASE_URL=http://localhost:8787 pnpm test tests/sdk/openai-sdk-compat
+ * GATEWAY_API_KEY=gw_test123 GATEWAY_BASE_URL=http://localhost:8787/v1 pnpm test tests/sdk/openai-sdk-compat
  */
 
-const GATEWAY_BASE_URL = process.env.GATEWAY_BASE_URL;
+const GATEWAY_BASE_URL = normalizeGatewayBaseUrl(
+	process.env.GATEWAY_BASE_URL,
+);
 const GATEWAY_API_KEY = process.env.GATEWAY_API_KEY;
 
 // Skip tests if environment variables not set
@@ -323,7 +326,7 @@ if (shouldSkip) {
 ⚠️  Skipping OpenAI SDK compatibility tests
 
 To run these tests, set:
-  GATEWAY_BASE_URL=http://localhost:8787
+  GATEWAY_BASE_URL=http://localhost:8787/v1
   GATEWAY_API_KEY=your_gateway_key
 	`);
 }

--- a/apps/api/tests/sdk/run-sdk-tests.sh
+++ b/apps/api/tests/sdk/run-sdk-tests.sh
@@ -16,7 +16,7 @@ echo ""
 # Check if environment variables are set
 if [ -z "$GATEWAY_BASE_URL" ]; then
     echo -e "${YELLOW}[WARN]  GATEWAY_BASE_URL not set${NC}"
-    echo "   Please set: export GATEWAY_BASE_URL=http://localhost:8787"
+    echo "   Please set: export GATEWAY_BASE_URL=http://localhost:8787/v1"
     echo ""
 fi
 
@@ -30,12 +30,23 @@ if [ -z "$GATEWAY_BASE_URL" ] || [ -z "$GATEWAY_API_KEY" ]; then
     echo -e "${RED}[FAIL] Missing required environment variables${NC}"
     echo ""
     echo "Quick setup:"
-    echo "  export GATEWAY_BASE_URL=http://localhost:8787"
+    echo "  export GATEWAY_BASE_URL=http://localhost:8787/v1"
     echo "  export GATEWAY_API_KEY=gw_test123"
     echo "  ./tests/sdk/run-sdk-tests.sh"
     echo ""
     exit 1
 fi
+
+# SDKs expect the versioned API base. Accept the server origin for convenience,
+# but normalize it before both the health probe and the compatibility tests.
+while [ "${GATEWAY_BASE_URL%/}" != "$GATEWAY_BASE_URL" ]; do
+    GATEWAY_BASE_URL="${GATEWAY_BASE_URL%/}"
+done
+case "$GATEWAY_BASE_URL" in
+    */v1) ;;
+    *) GATEWAY_BASE_URL="$GATEWAY_BASE_URL/v1" ;;
+esac
+export GATEWAY_BASE_URL
 
 echo -e "${GREEN}[OK] Environment variables configured${NC}"
 echo "  GATEWAY_BASE_URL: $GATEWAY_BASE_URL"

--- a/apps/api/tests/sdk/test-config.test.ts
+++ b/apps/api/tests/sdk/test-config.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from "vitest";
+import { normalizeGatewayBaseUrl } from "./test-config";
+
+describe("normalizeGatewayBaseUrl", () => {
+	it.each([
+		[undefined, undefined],
+		["http://localhost:8787", "http://localhost:8787/v1"],
+		["http://localhost:8787/", "http://localhost:8787/v1"],
+		["http://localhost:8787/v1", "http://localhost:8787/v1"],
+		["http://localhost:8787/v1/", "http://localhost:8787/v1"],
+	])("normalizes %s to the versioned API base", (input, expected) => {
+		expect(normalizeGatewayBaseUrl(input)).toBe(expected);
+	});
+});

--- a/apps/api/tests/sdk/test-config.ts
+++ b/apps/api/tests/sdk/test-config.ts
@@ -1,0 +1,6 @@
+export function normalizeGatewayBaseUrl(value: string | undefined) {
+	if (!value) return undefined;
+
+	const normalized = value.replace(/\/+$/, "");
+	return normalized.endsWith("/v1") ? normalized : `${normalized}/v1`;
+}

--- a/apps/web/src/lib/agent-discovery.test.ts
+++ b/apps/web/src/lib/agent-discovery.test.ts
@@ -1,0 +1,12 @@
+import { normalizeGatewayApiBaseUrl } from "./agent-discovery";
+
+describe("normalizeGatewayApiBaseUrl", () => {
+	it.each([
+		["https://api.phaseo.app", "https://api.phaseo.app/v1"],
+		["https://api.phaseo.app/", "https://api.phaseo.app/v1"],
+		["https://api.phaseo.app/v1", "https://api.phaseo.app/v1"],
+		["https://api.phaseo.app/v1/", "https://api.phaseo.app/v1"],
+	])("normalizes %s to the versioned API base", (input, expected) => {
+		expect(normalizeGatewayApiBaseUrl(input)).toBe(expected);
+	});
+});

--- a/apps/web/src/lib/agent-discovery.ts
+++ b/apps/web/src/lib/agent-discovery.ts
@@ -9,6 +9,11 @@ function normalizeUrl(value: string): string {
 	return value.replace(/\/+$/, "");
 }
 
+export function normalizeGatewayApiBaseUrl(value: string): string {
+	const normalized = normalizeUrl(value);
+	return normalized.endsWith("/v1") ? normalized : `${normalized}/v1`;
+}
+
 function normalizeSupabaseBaseUrl(value: string): string {
 	const trimmed = normalizeUrl(value);
 	if (trimmed.endsWith("/auth/v1")) {
@@ -20,7 +25,7 @@ function normalizeSupabaseBaseUrl(value: string): string {
 export const DOCS_BASE_URL = normalizeUrl(
 	process.env.NEXT_PUBLIC_DOCS_URL ?? DEFAULT_DOCS_BASE_URL,
 );
-export const API_BASE_URL = normalizeUrl(
+export const API_BASE_URL = normalizeGatewayApiBaseUrl(
 	process.env.NEXT_PUBLIC_GATEWAY_API_URL ?? DEFAULT_GATEWAY_API_BASE_URL,
 );
 export const API_ORIGIN = new URL(API_BASE_URL).origin;

--- a/scripts/run-poolside-performance.ts
+++ b/scripts/run-poolside-performance.ts
@@ -63,7 +63,7 @@ async function main() {
 	);
 
 	const health = await client.getHealth();
-	console.log(`Gateway health: ${health.status} (${health.timestamp})`);
+	console.log(`Gateway health: ${health.status}`);
 	console.log("");
 
 	const results: Array<{


### PR DESCRIPTION
## Summary

- normalize configured Gateway URLs to the canonical `/v1` API base before publishing health and discovery metadata
- correct and harden the legacy OpenAI/Anthropic SDK compatibility harness so origin-only values cannot probe the nonexistent root `/health` route
- align the Poolside performance script with the actual health response contract
- clarify that non-versioned root routes do not include health
- add focused normalization regression tests and a web patch changeset

## Validation

- `pnpm --filter @phaseo/web test -- agent-discovery.test.ts`
- `pnpm --filter @phaseo/web typecheck` (after `next typegen` in the clean worktree)
- targeted web ESLint for the changed discovery files
- `pnpm --filter @phaseo/gateway-api typecheck`
- targeted API ESLint for the changed route and SDK compatibility files
- targeted Vitest coverage for URL normalization, SDK compatibility test loading, and the OpenAPI runtime health contract
- Git Bash syntax check for `apps/api/tests/sdk/run-sdk-tests.sh`
- `pnpm exec changeset status`
- `git diff --check`

Created with Codex
