### PR TITLE
Issue OAuth-managed keys for PKCE grants

### DIFF
--- a/apps/api/src/lib/oauth/service.security.test.ts
+++ b/apps/api/src/lib/oauth/service.security.test.ts
@@ -257,7 +257,8 @@ describe("OAuth refresh rotation security", () => {
 		);
 
 		expect(result?.access_token).toMatch(/^phaseo_v1_sk_/);
-		expect(state.rpcCalls.at(-1)).toMatchObject({
+		const rpcCall = state.rpcCalls.at(-1);
+		expect(rpcCall).toMatchObject({
 			name: "consume_oauth_code_and_issue_managed_key",
 			args: {
 				p_code_id: "00000000-0000-0000-0000-000000000002",
@@ -267,6 +268,13 @@ describe("OAuth refresh rotation security", () => {
 				p_scopes: ["models:read"],
 			},
 		});
+		expect(rpcCall?.args).toMatchObject({
+			p_key_kid: expect.any(String),
+			p_key_prefix: expect.stringMatching(/^[A-Za-z0-9]{6}$/),
+			p_key_name: "OAuth: phaseo_cli",
+			p_key_hash: expect.stringMatching(/^[a-f0-9]{64}$/),
+		});
+		expect(rpcCall?.args.p_key_hash).not.toBe(result?.access_token);
 	});
 
 	it("fails authorization approval when the grant cannot be persisted", async () => {

--- a/apps/api/src/lib/oauth/service.security.test.ts
+++ b/apps/api/src/lib/oauth/service.security.test.ts
@@ -247,6 +247,28 @@ describe("OAuth refresh rotation security", () => {
 		});
 	});
 
+	it("only returns an OAuth-managed key after the database atomically consumes its code", async () => {
+		state.rotationStatus = "issued";
+		const { issueOAuthManagedKeyForAuthorizationCode } = await import("./service");
+
+		const result = await issueOAuthManagedKeyForAuthorizationCode(
+			"00000000-0000-0000-0000-000000000002",
+			{ userId: "user_1", workspaceId: "ws_1", clientId: "phaseo_cli", scopes: ["models:read"] },
+		);
+
+		expect(result?.access_token).toMatch(/^phaseo_v1_sk_/);
+		expect(state.rpcCalls.at(-1)).toMatchObject({
+			name: "consume_oauth_code_and_issue_managed_key",
+			args: {
+				p_code_id: "00000000-0000-0000-0000-000000000002",
+				p_user_id: "user_1",
+				p_workspace_id: "ws_1",
+				p_client_id: "phaseo_cli",
+				p_scopes: ["models:read"],
+			},
+		});
+	});
+
 	it("fails authorization approval when the grant cannot be persisted", async () => {
 		state.authorizationUpdateError = { message: "grant update failed" };
 		const { ensureGrant } = await import("./service");

--- a/apps/api/src/lib/oauth/service.ts
+++ b/apps/api/src/lib/oauth/service.ts
@@ -474,16 +474,16 @@ export async function ensureGrant(args: {
 	if (error) throw new Error(error.message || "Failed to create OAuth authorization");
 }
 
-export async function hasActiveOAuthWorkspaceAccess(args: {
+export async function getActiveOAuthWorkspaceScopes(args: {
 	userId: string;
 	workspaceId: string;
 	clientId: string;
-}): Promise<boolean> {
+}): Promise<string[] | null> {
 	const supabase = getSupabaseAdmin();
 	const [authorization, membership] = await Promise.all([
 		supabase
 			.from("oauth_authorizations")
-			.select("id, revoked_at")
+			.select("scopes, revoked_at")
 			.eq("user_id", args.userId)
 			.eq("workspace_id", args.workspaceId)
 			.eq("client_id", args.clientId)
@@ -495,9 +495,21 @@ export async function hasActiveOAuthWorkspaceAccess(args: {
 			.eq("workspace_id", args.workspaceId)
 			.maybeSingle(),
 	]);
-	return !authorization.error && !membership.error && Boolean(
-		authorization.data && authorization.data.revoked_at === null && membership.data,
-	);
+	if (authorization.error || membership.error || !authorization.data || authorization.data.revoked_at !== null || !membership.data) {
+		return null;
+	}
+
+	return Array.isArray(authorization.data.scopes)
+		? authorization.data.scopes.map(String).filter(Boolean)
+		: [];
+}
+
+export async function hasActiveOAuthWorkspaceAccess(args: {
+	userId: string;
+	workspaceId: string;
+	clientId: string;
+}): Promise<boolean> {
+	return (await getActiveOAuthWorkspaceScopes(args)) !== null;
 }
 
 async function createTokenPairMaterial(input: TokenIssueInput) {

--- a/apps/api/src/lib/oauth/service.ts
+++ b/apps/api/src/lib/oauth/service.ts
@@ -1,6 +1,7 @@
 import { getBindings, getSupabaseAdmin } from "@/runtime/env";
 import { DEFAULT_CLI_OAUTH_CAPABILITIES, parseStoredScopeList } from "@/lib/authz/capabilities";
-import { timingSafeEqual } from "@/routes/auth.helpers";
+import { resolveActiveKeyPepper } from "@/lib/security/keyPepper";
+import { generateGatewayKey, hmacSecret, timingSafeEqual } from "@/routes/auth.helpers";
 import { validateOAuthToken, type JWTClaims } from "./jwt";
 
 const encoder = new TextEncoder();
@@ -574,6 +575,34 @@ export async function issueTokenPairForGrant(
 	if (error) throw new Error(error.message || "Failed to consume OAuth grant and persist refresh token");
 	if (data !== "issued") return null;
 	return material.response;
+}
+
+export async function issueOAuthManagedKeyForAuthorizationCode(
+	grantId: string,
+	input: TokenIssueInput,
+) {
+	const pepper = resolveActiveKeyPepper(getBindings());
+	if (!pepper) throw new Error("KEY_PEPPER_ACTIVE is not configured");
+
+	const generated = generateGatewayKey();
+	const { data, error } = await getSupabaseAdmin().rpc("consume_oauth_code_and_issue_managed_key", {
+		p_code_id: grantId,
+		p_key_hash: await hmacSecret(generated.secret, pepper),
+		p_key_kid: generated.kid,
+		p_key_prefix: generated.prefix,
+		p_key_name: `OAuth: ${input.clientId}`,
+		p_user_id: input.userId,
+		p_workspace_id: input.workspaceId,
+		p_client_id: input.clientId,
+		p_scopes: input.scopes,
+	});
+	if (error) throw new Error(error.message || "Failed to consume OAuth code and issue key");
+	if (data !== "issued") return null;
+	return {
+		access_token: generated.plaintext,
+		token_type: "Bearer",
+		scope: input.scopes.join(" "),
+	};
 }
 
 export async function rotateRefreshToken(

--- a/apps/api/src/pipeline/before/auth.cache.test.ts
+++ b/apps/api/src/pipeline/before/auth.cache.test.ts
@@ -7,6 +7,10 @@ type KeyRow = {
     status: string;
     hash: string;
     expires_at?: string | null;
+	key_kind?: string | null;
+	oauth_client_id?: string | null;
+	oauth_user_id?: string | null;
+	oauth_scopes?: string[] | null;
 };
 
 const runtime = vi.hoisted(() => {
@@ -19,6 +23,14 @@ const runtime = vi.hoisted(() => {
         data: dbRow.value,
         error: null,
     }));
+	const authorizationMaybeSingle = vi.fn(async () => ({
+		data: { scopes: ["models:read"], revoked_at: null },
+		error: null,
+	}));
+	const membershipMaybeSingle = vi.fn(async () => ({
+		data: { workspace_id: "team_oauth" },
+		error: null,
+	}));
     const updateEq = vi.fn(async () => ({ error: null }));
 
     const cache = {
@@ -38,9 +50,18 @@ const runtime = vi.hoisted(() => {
 
     const supabase = {
         from: vi.fn((table: string) => {
-            if (table !== "keys") {
-                throw new Error(`Unexpected table: ${table}`);
-            }
+			if (table === "oauth_authorizations") {
+				return {
+					select: () => ({ eq: () => ({ eq: () => ({ eq: () => ({ maybeSingle: authorizationMaybeSingle }) }) }) }),
+					update: () => ({ eq: () => ({ eq: () => ({ eq: updateEq }) }) }),
+				};
+			}
+			if (table === "workspace_members") {
+				return {
+					select: () => ({ eq: () => ({ eq: () => ({ maybeSingle: membershipMaybeSingle }) }) }),
+				};
+			}
+			if (table !== "keys") throw new Error(`Unexpected table: ${table}`);
             return {
                 select: () => ({
                     eq: () => ({
@@ -62,6 +83,8 @@ const runtime = vi.hoisted(() => {
         backgroundTasks,
         dbRow,
         maybeSingle,
+		authorizationMaybeSingle,
+		membershipMaybeSingle,
         updateEq,
         cache,
         supabase,
@@ -120,6 +143,8 @@ describe("authenticate hot-path caching", () => {
         runtime.cache.delete.mockClear();
         runtime.supabase.from.mockClear();
         runtime.maybeSingle.mockClear();
+		runtime.authorizationMaybeSingle.mockClear();
+		runtime.membershipMaybeSingle.mockClear();
         runtime.updateEq.mockClear();
         vi.resetModules();
     });
@@ -204,6 +229,57 @@ describe("authenticate hot-path caching", () => {
             expect.objectContaining({ hash: migratedHash }),
         );
     });
+
+	it("does not accept a cached OAuth-managed key after it is revoked", async () => {
+		const kid = "KIDOAUTHREVOKE";
+		const secret = "secret_oauth_revoked";
+		const token = `phaseo_v1_sk_${kid}_${secret}`;
+		const cachedRow: KeyRow = {
+			id: "key_oauth",
+			workspace_id: "team_oauth",
+			status: "active",
+			hash: hashSecret(secret),
+			key_kind: "oauth_delegated",
+			oauth_user_id: "user_oauth",
+			oauth_client_id: "client_oauth",
+			oauth_scopes: ["models:read"],
+		};
+		runtime.dbRow.value = { ...cachedRow, status: "revoked" };
+		await runtime.cache.put(`gateway:keyver:kid:${kid}`, "1");
+		await runtime.cache.put(`gateway:key:${kid}:v1`, JSON.stringify(cachedRow));
+
+		const { authenticate } = await import("./auth");
+		const result = await authenticate(buildRequest(token), { useKvCache: true });
+
+		expect(result).toEqual({ ok: false, reason: "key_not_found_or_revoked" });
+		expect(runtime.maybeSingle).toHaveBeenCalledTimes(1);
+	});
+
+	it("enforces the current consent scope for an OAuth-managed key", async () => {
+		const kid = "KIDOAUTHSCOPE";
+		const secret = "secret_oauth_scope";
+		runtime.dbRow.value = {
+			id: "key_oauth_scope",
+			workspace_id: "team_oauth",
+			status: "active",
+			hash: hashSecret(secret),
+			key_kind: "oauth_delegated",
+			oauth_user_id: "user_oauth",
+			oauth_client_id: "client_oauth",
+			oauth_scopes: ["models:read", "logs:read"],
+		};
+
+		const { authenticateManagement } = await import("./auth");
+		const result = await authenticateManagement(buildRequest(`phaseo_v1_sk_${kid}_${secret}`), { useKvCache: false });
+		await flushBackground();
+
+		expect(result).toMatchObject({
+			ok: true,
+			authMethod: "oauth",
+			oauthScopes: ["models:read"],
+			scopes: ["models:read"],
+		});
+	});
 
     it("rejects expired keys when expires_at has passed", async () => {
         const kid = "KIDEXPIRED001";

--- a/apps/api/src/pipeline/before/auth.management.test.ts
+++ b/apps/api/src/pipeline/before/auth.management.test.ts
@@ -36,6 +36,19 @@ const runtime = vi.hoisted(() => {
 
 	const supabase = {
 		from: vi.fn((table: string) => {
+			if (table === "keys") {
+				return {
+					select: () => ({
+						eq: () => ({
+							maybeSingle,
+						}),
+					}),
+					update: (payload: Record<string, unknown>) => {
+						updatePayloads.push(payload);
+						return { eq: updateEq };
+					},
+				};
+			}
 			if (table === "oauth_authorizations") {
 				return {
 					select: () => ({
@@ -106,6 +119,7 @@ vi.mock("@/runtime/env", () => ({
 
 vi.mock("@/lib/oauth/service", () => ({
 	hasActiveOAuthWorkspaceAccess: vi.fn(async () => true),
+	getActiveOAuthWorkspaceScopes: vi.fn(async () => ["keys:read", "keys:write"]),
 	validateLocalAccessToken: vi.fn(async () => ({
 		valid: true,
 		claims: {
@@ -218,13 +232,21 @@ describe("authenticateManagement", () => {
 		expect(runtime.supabase.from).not.toHaveBeenCalled();
 	});
 
-	it("rejects inference and legacy management key formats before querying the database", async () => {
+	it("rejects user-created inference and legacy management key formats", async () => {
 		const kid = "MGMTLEGACY1";
 		const secret = "secret_legacy_management_key";
+		runtime.dbRow.value = {
+			id: "standard_key",
+			workspace_id: "team_standard",
+			status: "active",
+			hash: hashSecret(secret),
+		};
 		const { authenticateManagement } = await import("./auth");
 
+		const standardResult = await authenticateManagement(buildRequest(`phaseo_v1_sk_${kid}_${secret}`));
+		expect(standardResult).toEqual({ ok: false, reason: "management_key_required" });
+
 		for (const token of [
-			`phaseo_v1_sk_${kid}_${secret}`,
 			`aistats_v1_sk_${kid}_${secret}`,
 			`aistats_v1_mk_${kid}_${secret}`,
 		]) {
@@ -232,7 +254,8 @@ describe("authenticateManagement", () => {
 			expect(result).toEqual({ ok: false, reason: "management_key_required" });
 		}
 
-		expect(runtime.supabase.from).not.toHaveBeenCalled();
+		expect(runtime.supabase.from).toHaveBeenCalledTimes(2);
+		expect(runtime.supabase.from).toHaveBeenNthCalledWith(1, "keys");
 	});
 
 	it("rejects soft-blocked management keys", async () => {

--- a/apps/api/src/pipeline/before/auth.ts
+++ b/apps/api/src/pipeline/before/auth.ts
@@ -485,6 +485,29 @@ export async function authenticate(req: Request, options: AuthenticateOptions = 
         return { ok: false, reason: "invalid_secret" };
     }
 
+    // OAuth-managed keys must observe revocation and consent changes immediately.
+    // They deliberately bypass the KV cache after the initial lookup so a removed
+    // workspace member or a revoked/rotated delegated key cannot remain usable
+    // for the cache TTL.
+    if (String(keyRow.key_kind ?? "standard") === "oauth_delegated") {
+        const freshKeyRow = await fetchFreshKeyRow();
+        if (freshKeyRow === "db_error") return { ok: false, reason: "db_error" };
+        if (!freshKeyRow || freshKeyRow.status !== "active") {
+            return { ok: false, reason: "key_not_found_or_revoked" };
+        }
+        if (isExpiredKey(freshKeyRow.expires_at)) return { ok: false, reason: "key_expired" };
+
+        keyRow = freshKeyRow;
+        keyRowSource = "db";
+        stored = String(keyRow.hash).toLowerCase().trim();
+        matchedPepper = await findMatchingPepperCandidate({
+            secret: parsed.secret,
+            storedHash: stored,
+            pepperCandidates,
+        });
+        if (!matchedPepper) return { ok: false, reason: "invalid_secret" };
+    }
+
     const success = async (nextHash?: string): Promise<AuthSuccess | AuthFailure> => {
         let workspaceId = keyRow.workspace_id;
         const internal = isInternalRequestAuthorized(req, bindings);
@@ -500,10 +523,13 @@ export async function authenticate(req: Request, options: AuthenticateOptions = 
 			if (!userId || !clientId || oauthScopes.length === 0) {
 				return { ok: false, reason: "oauth_managed_key_invalid" };
 			}
-			const { hasActiveOAuthWorkspaceAccess } = await import("@/lib/oauth/service");
-			if (!(await hasActiveOAuthWorkspaceAccess({ userId, workspaceId, clientId }))) {
+			const { getActiveOAuthWorkspaceScopes } = await import("@/lib/oauth/service");
+			const activeAuthorizationScopes = await getActiveOAuthWorkspaceScopes({ userId, workspaceId, clientId });
+			if (activeAuthorizationScopes === null) {
 				return { ok: false, reason: "oauth_authorization_revoked" };
 			}
+			const effectiveScopes = oauthScopes.filter((scope) => activeAuthorizationScopes.includes(scope));
+			if (effectiveScopes.length === 0) return { ok: false, reason: "oauth_managed_key_invalid" };
 
 			dispatchBackground((async () => {
 				configureRuntime(bindings);
@@ -532,8 +558,8 @@ export async function authenticate(req: Request, options: AuthenticateOptions = 
 				internal,
 				authMethod: "oauth",
 				oauthClientId: clientId,
-				oauthScopes,
-				scopes: oauthScopes,
+				oauthScopes: effectiveScopes,
+				scopes: effectiveScopes,
 			};
 		}
 
@@ -599,10 +625,25 @@ export async function authenticateManagement(
 
     const parsed = parseV2(token);
     if (!parsed) return { ok: false, reason: "invalid_key_format" };
+
+    // OAuth-managed credentials deliberately use the normal `sk` syntax so
+    // clients can use them as standard Bearer tokens. Allow only the delegated
+    // variant onto control routes; a user-created inference key remains unable
+    // to reach management APIs. Capability checks on each route then enforce
+    // the current OAuth consent scopes.
+    if (parsed.namespace === "phaseo" && parsed.keyType === "inference") {
+        const delegatedAuth = await authenticate(req, options);
+        if (!delegatedAuth.ok) return delegatedAuth;
+        if (delegatedAuth.authMethod !== "oauth") {
+            return { ok: false, reason: "management_key_required" };
+        }
+        return delegatedAuth;
+    }
+
     // Management routes are intentionally strict: `sk` credentials are
-    // inference-only, and management credentials must use the current,
-    // unambiguous Phaseo `mk` format. Do this before any database lookup so an
-    // inference key can never be mistaken for a management key.
+    // user-created inference credentials are not management credentials, and
+    // elevated management credentials use the current, unambiguous Phaseo `mk`
+    // format. Do this before any management-key database lookup.
     if (parsed.namespace !== "phaseo" || parsed.keyType !== "management") {
         return { ok: false, reason: "management_key_required" };
     }
@@ -703,18 +744,21 @@ async function authenticateOAuth(req: Request, token: string, options: Authentic
     const useKvCache = options.useKvCache ?? true;
 
     try {
-        const { hasActiveOAuthWorkspaceAccess, validateLocalAccessToken } = await import("@/lib/oauth/service");
+        const { getActiveOAuthWorkspaceScopes, validateLocalAccessToken } = await import("@/lib/oauth/service");
         const localValidation = await validateLocalAccessToken(token);
         if (localValidation.valid && localValidation.claims) {
             const claims = localValidation.claims;
             const supabase = getSupabaseAdmin();
-            if (!(await hasActiveOAuthWorkspaceAccess({
+            const activeAuthorizationScopes = await getActiveOAuthWorkspaceScopes({
                 userId: claims.user_id,
                 clientId: claims.client_id,
                 workspaceId: claims.workspace_id,
-            }))) {
+            });
+            if (activeAuthorizationScopes === null) {
                 return { ok: false, reason: "oauth_authorization_revoked" };
             }
+			const tokenScopes = typeof claims.scope === "string" ? claims.scope.split(/\s+/).filter(Boolean) : [];
+			const effectiveScopes = tokenScopes.filter((scope) => activeAuthorizationScopes.includes(scope));
 
             dispatchBackground((async () => {
                 configureRuntime(bindings);
@@ -740,8 +784,8 @@ async function authenticateOAuth(req: Request, token: string, options: Authentic
                 internal: isInternalRequestAuthorized(req, bindings),
                 authMethod: "oauth",
                 oauthClientId: claims.client_id,
-                oauthScopes: typeof claims.scope === "string" ? claims.scope.split(/\s+/).filter(Boolean) : [],
-                scopes: typeof claims.scope === "string" ? claims.scope.split(/\s+/).filter(Boolean) : [],
+				oauthScopes: effectiveScopes,
+				scopes: effectiveScopes,
             } as AuthSuccess;
         }
     } catch {
@@ -807,14 +851,17 @@ async function authenticateOAuth(req: Request, token: string, options: Authentic
 
         // Check that both the authorization and workspace membership remain active.
         const supabase = getSupabaseAdmin();
-        const { hasActiveOAuthWorkspaceAccess } = await import("@/lib/oauth/service");
-        if (!(await hasActiveOAuthWorkspaceAccess({
+        const { getActiveOAuthWorkspaceScopes } = await import("@/lib/oauth/service");
+        const activeAuthorizationScopes = await getActiveOAuthWorkspaceScopes({
             userId: claims.user_id,
             clientId: claims.client_id,
             workspaceId: claims.workspace_id,
-        }))) {
+        });
+        if (activeAuthorizationScopes === null) {
             return { ok: false, reason: "oauth_authorization_revoked" };
         }
+		const tokenScopes = typeof claims.scope === "string" ? claims.scope.split(/\s+/).filter(Boolean) : [];
+		const effectiveScopes = tokenScopes.filter((scope) => activeAuthorizationScopes.includes(scope));
 
         // Update last_used_at (fire and forget)
         dispatchBackground((async () => {
@@ -844,8 +891,8 @@ async function authenticateOAuth(req: Request, token: string, options: Authentic
             internal: isInternalRequestAuthorized(req, bindings),
             authMethod: "oauth",
             oauthClientId: claims.client_id,
-            oauthScopes: typeof claims.scope === "string" ? claims.scope.split(/\s+/).filter(Boolean) : [],
-            scopes: typeof claims.scope === "string" ? claims.scope.split(/\s+/).filter(Boolean) : [],
+			oauthScopes: effectiveScopes,
+			scopes: effectiveScopes,
         } as AuthSuccess;
     } catch (error: any) {
         const message = String(error?.message ?? "");

--- a/apps/api/src/pipeline/before/auth.ts
+++ b/apps/api/src/pipeline/before/auth.ts
@@ -208,6 +208,10 @@ type KeyRow = {
     expires_at?: string | null;
     soft_blocked?: boolean | null;
     scopes?: unknown;
+	key_kind?: string | null;
+	oauth_client_id?: string | null;
+	oauth_user_id?: string | null;
+	oauth_scopes?: unknown;
 };
 
 type CachedKeyLookup = KeyRow | "missing" | null;
@@ -485,6 +489,53 @@ export async function authenticate(req: Request, options: AuthenticateOptions = 
         let workspaceId = keyRow.workspace_id;
         const internal = isInternalRequestAuthorized(req, bindings);
         const hasHashMigration = Boolean(nextHash) && nextHash !== stored;
+		const keyKind = String(keyRow.key_kind ?? "standard");
+
+		if (keyKind === "oauth_delegated") {
+			const userId = String(keyRow.oauth_user_id ?? "").trim();
+			const clientId = String(keyRow.oauth_client_id ?? "").trim();
+			const oauthScopes = Array.isArray(keyRow.oauth_scopes)
+				? keyRow.oauth_scopes.map(String).filter(Boolean)
+				: [];
+			if (!userId || !clientId || oauthScopes.length === 0) {
+				return { ok: false, reason: "oauth_managed_key_invalid" };
+			}
+			const { hasActiveOAuthWorkspaceAccess } = await import("@/lib/oauth/service");
+			if (!(await hasActiveOAuthWorkspaceAccess({ userId, workspaceId, clientId }))) {
+				return { ok: false, reason: "oauth_authorization_revoked" };
+			}
+
+			dispatchBackground((async () => {
+				configureRuntime(bindings);
+				try {
+					const updatePayload: Record<string, unknown> = { last_used_at: new Date().toISOString() };
+					if (hasHashMigration) updatePayload.hash = nextHash;
+					await supabase.from("keys").update(updatePayload).eq("id", keyRow.id);
+					await supabase
+						.from("oauth_authorizations")
+						.update({ last_used_at: new Date().toISOString() })
+						.eq("user_id", userId)
+						.eq("client_id", clientId)
+						.eq("workspace_id", workspaceId);
+				} finally {
+					clearRuntime();
+				}
+			})());
+
+			return {
+				ok: true,
+				apiKeyId: keyRow.id,
+				apiKeyRef: `kid_${parsed.kid}`,
+				apiKeyKid: parsed.kid,
+				workspaceId,
+				userId,
+				internal,
+				authMethod: "oauth",
+				oauthClientId: clientId,
+				oauthScopes,
+				scopes: oauthScopes,
+			};
+		}
 
         // Fire-and-forget update of last_used_at timestamp (+ hash migration when needed).
         dispatchBackground((async () => {

--- a/apps/api/src/routes/oauth.security.test.ts
+++ b/apps/api/src/routes/oauth.security.test.ts
@@ -110,6 +110,10 @@ vi.mock("@/lib/oauth/service", () => ({
 		state.issuedTokenPairs.push(input);
 		return { access_token: "token" };
 	}),
+	issueOAuthManagedKeyForAuthorizationCode: vi.fn(async (_grantId: string, input: Record<string, unknown>) => {
+		state.issuedTokenPairs.push(input);
+		return { access_token: "phaseo_v1_sk_test", token_type: "Bearer" };
+	}),
 	loadOAuthClient: vi.fn(async () => ({ id: "phaseo_cli", name: "Phaseo CLI", client_type: "public" })),
 	makeAuthCodeExpiry: vi.fn(() => "2026-06-10T16:00:00.000Z"),
 	makeDeviceCodeExpiry: vi.fn(() => "2026-06-10T16:00:00.000Z"),

--- a/apps/api/src/routes/oauth.ts
+++ b/apps/api/src/routes/oauth.ts
@@ -24,6 +24,7 @@ import {
 	hashOAuthSecretCandidates,
 	hasActiveOAuthWorkspaceAccess,
 	issueTokenPairForGrant,
+	issueOAuthManagedKeyForAuthorizationCode,
 	loadOAuthClient,
 	makeAuthCodeExpiry,
 	makeDeviceCodeExpiry,
@@ -482,8 +483,8 @@ oauthRouter.post(
 			}))) {
 				return oauthError("invalid_grant", "OAuth workspace access is no longer active");
 			}
-			const tokens = await issueTokenPairForGrant(
-				{ type: "authorization_code", id: String(data.id) },
+			const tokens = await issueOAuthManagedKeyForAuthorizationCode(
+				String(data.id),
 				{
 					userId: String(data.user_id),
 					workspaceId: String(data.workspace_id),

--- a/supabase/migrations/20260715090000_add_oauth_managed_keys.sql
+++ b/supabase/migrations/20260715090000_add_oauth_managed_keys.sql
@@ -1,0 +1,82 @@
+-- OAuth-managed credentials are ordinary gateway keys with additional
+-- ownership metadata. Management keys remain in their separate table.
+
+alter table public.keys
+  add column if not exists key_kind text not null default 'standard'
+    check (key_kind in ('standard', 'oauth_delegated')),
+  add column if not exists oauth_client_id text,
+  add column if not exists oauth_user_id uuid references auth.users(id) on delete set null,
+  add column if not exists oauth_scopes text[],
+  add column if not exists issued_via text not null default 'dashboard'
+    check (issued_via in ('dashboard', 'oauth_pkce', 'cli'));
+
+create index if not exists keys_oauth_delegated_active_idx
+  on public.keys (oauth_user_id, workspace_id, oauth_client_id)
+  where key_kind = 'oauth_delegated' and status = 'active';
+
+-- The Worker verifies PKCE before calling this RPC. This transaction then
+-- consumes the code and creates the one durable OAuth-managed key together.
+create or replace function public.consume_oauth_code_and_issue_managed_key(
+  p_code_id uuid,
+  p_key_hash text,
+  p_key_kid text,
+  p_key_prefix text,
+  p_key_name text,
+  p_user_id uuid,
+  p_workspace_id uuid,
+  p_client_id text,
+  p_scopes text[]
+)
+returns text
+language plpgsql
+security definer
+set search_path = ''
+as $$
+begin
+  update public.oauth_authorization_codes code
+  set used_at = now()
+  where code.id = p_code_id
+    and code.used_at is null
+    and code.expires_at > now()
+    and code.user_id = p_user_id
+    and code.workspace_id = p_workspace_id
+    and code.client_id = p_client_id
+    and exists (
+      select 1 from public.oauth_authorizations grant
+      where grant.user_id = p_user_id
+        and grant.workspace_id = p_workspace_id
+        and grant.client_id = p_client_id
+        and grant.revoked_at is null
+    )
+    and exists (
+      select 1 from public.workspace_members member
+      where member.user_id = p_user_id
+        and member.workspace_id = p_workspace_id
+    );
+
+  if not found then
+    return 'invalid';
+  end if;
+
+  update public.keys
+  set status = 'revoked'
+  where key_kind = 'oauth_delegated'
+    and oauth_user_id = p_user_id
+    and workspace_id = p_workspace_id
+    and oauth_client_id = p_client_id
+    and status = 'active';
+
+  insert into public.keys (
+    workspace_id, name, hash, prefix, status, scopes, created_by, kid,
+    key_kind, oauth_client_id, oauth_user_id, oauth_scopes, issued_via
+  ) values (
+    p_workspace_id, p_key_name, p_key_hash, p_key_prefix, 'active', '[]', p_user_id, p_key_kid,
+    'oauth_delegated', p_client_id, p_user_id, p_scopes, 'oauth_pkce'
+  );
+
+  return 'issued';
+end;
+$$;
+
+revoke all on function public.consume_oauth_code_and_issue_managed_key(uuid, text, text, text, text, uuid, uuid, text, text[]) from public, anon, authenticated;
+grant execute on function public.consume_oauth_code_and_issue_managed_key(uuid, text, text, text, text, uuid, uuid, text, text[]) to service_role;

--- a/supabase/migrations/20260715090000_add_oauth_managed_keys.sql
+++ b/supabase/migrations/20260715090000_add_oauth_managed_keys.sql
@@ -5,12 +5,23 @@ alter table public.keys
   add column if not exists key_kind text not null default 'standard'
     check (key_kind in ('standard', 'oauth_delegated')),
   add column if not exists oauth_client_id text,
-  add column if not exists oauth_user_id uuid references auth.users(id) on delete set null,
+  add column if not exists oauth_user_id uuid,
   add column if not exists oauth_scopes text[],
   add column if not exists issued_via text not null default 'dashboard'
     check (issued_via in ('dashboard', 'oauth_pkce', 'cli'));
 
-create index if not exists keys_oauth_delegated_active_idx
+-- The column is new and starts NULL, but keep the FK addition non-blocking for
+-- production writes. Validation uses a lighter lock than adding a validated FK.
+alter table public.keys
+  add constraint keys_oauth_user_id_fkey
+  foreign key (oauth_user_id) references auth.users(id) on delete set null not valid;
+
+alter table public.keys validate constraint keys_oauth_user_id_fkey;
+
+-- A unique partial index is a final invariant guard in addition to the grant
+-- row lock in the issuance RPC. There are no delegated rows before this
+-- migration, so building it is bounded to an empty partial index at rollout.
+create unique index if not exists keys_oauth_delegated_active_idx
   on public.keys (oauth_user_id, workspace_id, oauth_client_id)
   where key_kind = 'oauth_delegated' and status = 'active';
 
@@ -33,6 +44,21 @@ security definer
 set search_path = ''
 as $$
 begin
+  -- Serialise exchanges for this consent grant. Without this lock, two valid
+  -- codes exchanged concurrently could each revoke the prior key then create
+  -- a new active one.
+  perform 1
+  from public.oauth_authorizations grant
+  where grant.user_id = p_user_id
+    and grant.workspace_id = p_workspace_id
+    and grant.client_id = p_client_id
+    and grant.revoked_at is null
+  for update;
+
+  if not found then
+    return 'invalid';
+  end if;
+
   update public.oauth_authorization_codes code
   set used_at = now()
   where code.id = p_code_id
@@ -41,13 +67,6 @@ begin
     and code.user_id = p_user_id
     and code.workspace_id = p_workspace_id
     and code.client_id = p_client_id
-    and exists (
-      select 1 from public.oauth_authorizations grant
-      where grant.user_id = p_user_id
-        and grant.workspace_id = p_workspace_id
-        and grant.client_id = p_client_id
-        and grant.revoked_at is null
-    )
     and exists (
       select 1 from public.workspace_members member
       where member.user_id = p_user_id


### PR DESCRIPTION
## Summary
- issue a scoped OAuth-managed Phaseo gateway key for PKCE authorization-code exchanges
- store OAuth ownership, app identity, scopes, and issuance source directly on the existing `keys` table
- keep management keys unchanged and preserve the existing CLI device-token flow
- validate an OAuth-managed key against active consent and current workspace membership on every request
- atomically consume a code, rotate any prior app connection, and create the replacement key in a single database RPC

## Validation
- `pnpm --filter @phaseo/gateway-api typecheck`
- `pnpm --filter @phaseo/gateway-api test -- --run src/routes/oauth.security.test.ts src/lib/oauth/service.security.test.ts src/pipeline/before/auth.cache.test.ts`
- `git diff --check`

## Deployment note
Apply `20260715090000_add_oauth_managed_keys.sql` before enabling third-party OAuth. The existing CLI device flow is intentionally unchanged.

Created with Codex

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * OAuth authorization-code exchanges now issue managed access keys securely.
  * Existing managed keys are replaced when a new authorization is completed.
  * OAuth-managed keys now validate authorization and workspace access during use.
  * OAuth key activity is tracked for improved authorization and usage management.

* **Bug Fixes**
  * Authorization codes are consumed atomically before tokens are issued, preventing reuse.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->