### PR TITLE
Fix settings sidebar icon collapse

### DIFF
--- a/.changeset/calm-settings-sidebar-icons.md
+++ b/.changeset/calm-settings-sidebar-icons.md
@@ -1,0 +1,5 @@
+---
+"@phaseo/web": patch
+---
+
+Collapse the desktop settings sidebar to an accessible icon rail with navigation tooltips and an explicit expand control.

--- a/apps/web/src/app/(dashboard)/settings/layout.tsx
+++ b/apps/web/src/app/(dashboard)/settings/layout.tsx
@@ -71,6 +71,7 @@ export default async function SettingsLayout({
 
 			<SidebarProvider defaultOpen className="flex flex-1 min-h-0">
 				<Sidebar
+					collapsible="icon"
 					desktopClassName="hidden lg:block"
 					// Keep desktop sidebar fixed under sticky chrome (notice + header).
 					className="top-[calc(var(--site-header-height,4rem)+var(--site-notice-height,0px))] bottom-0 h-auto bg-white dark:bg-zinc-950"

--- a/apps/web/src/components/(gateway)/settings/Sidebar.tsx
+++ b/apps/web/src/components/(gateway)/settings/Sidebar.tsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link";
 import { usePathname } from "next/navigation";
-import { ExternalLink, PanelLeftClose } from "lucide-react";
+import { ExternalLink, PanelLeftClose, PanelLeftOpen } from "lucide-react";
 import type { ReactNode } from "react";
 
 import { Badge } from "@/components/ui/badge";
@@ -36,7 +36,8 @@ export default function SettingsSidebar({
 	showWebhooks?: boolean;
 }) {
 	const pathname = usePathname();
-	const { isMobile, setOpenMobile, toggleSidebar } = useSidebar();
+	const { isMobile, setOpenMobile, state, toggleSidebar } = useSidebar();
+	const isCollapsed = state === "collapsed" && !isMobile;
 	const navGroups = getSettingsSidebar({ showBroadcast, showWebhooks });
 
 	function matchScore(item: NavItem) {
@@ -106,20 +107,22 @@ export default function SettingsSidebar({
 						className="h-4 w-4 shrink-0 text-muted-foreground"
 					/>
 				) : null}
-				<span className="min-w-0 flex-1 truncate">{item.label}</span>
+				<span className="min-w-0 flex-1 truncate group-data-[collapsible=icon]:hidden">
+					{item.label}
+				</span>
 				{item.badge && (
 					<Badge
 						variant="outline"
-						className="ml-auto h-5 px-1.5 text-[10px] uppercase tracking-wide"
+						className="ml-auto h-5 px-1.5 text-[10px] uppercase tracking-wide group-data-[collapsible=icon]:hidden"
 					>
 						{item.badge}
 					</Badge>
 				)}
-				{item.href === "/settings/usage" ? children : null}
+				{item.href === "/settings/usage" && !isCollapsed ? children : null}
 				{item.external && (
 					<ExternalLink
 						aria-hidden="true"
-						className="ml-2 h-4 w-4 shrink-0 text-muted-foreground"
+						className="ml-2 h-4 w-4 shrink-0 text-muted-foreground group-data-[collapsible=icon]:hidden"
 					/>
 				)}
 			</>
@@ -131,6 +134,7 @@ export default function SettingsSidebar({
 					disabled
 					aria-disabled="true"
 					className="cursor-not-allowed"
+					tooltip={item.label}
 				>
 					{content}
 				</SidebarMenuButton>
@@ -139,7 +143,7 @@ export default function SettingsSidebar({
 
 		if (item.external) {
 			return (
-				<SidebarMenuButton asChild>
+				<SidebarMenuButton asChild tooltip={item.label}>
 					<a
 						href={item.href}
 						target="_blank"
@@ -154,7 +158,7 @@ export default function SettingsSidebar({
 		}
 
 		return (
-			<SidebarMenuButton asChild isActive={active}>
+			<SidebarMenuButton asChild isActive={active} tooltip={item.label}>
 				<Link
 					href={item.href}
 					prefetch={false}
@@ -169,19 +173,24 @@ export default function SettingsSidebar({
 
 	return (
 		<>
-			<SidebarHeader className="gap-0 px-2 pt-6 flex-shrink-0">
-				<div className="flex items-center gap-2 px-2 pb-3">
-					<div className="text-sm font-semibold text-foreground">
+			<SidebarHeader className="gap-0 px-2 pt-6 flex-shrink-0 group-data-[collapsible=icon]:px-2">
+				<div className="flex items-center gap-2 px-2 pb-3 group-data-[collapsible=icon]:justify-center group-data-[collapsible=icon]:px-0">
+					<div className="text-sm font-semibold text-foreground group-data-[collapsible=icon]:hidden">
 						Settings
 					</div>
 					<Button
 						variant="ghost"
 						size="icon"
-						className="ml-auto lg:hidden"
+						className="ml-auto group-data-[collapsible=icon]:ml-0"
 						onClick={toggleSidebar}
-						aria-label="Close sidebar"
+						aria-label={isCollapsed ? "Expand settings sidebar" : "Collapse settings sidebar"}
+						title={isCollapsed ? "Expand settings sidebar" : "Collapse settings sidebar"}
 					>
-						<PanelLeftClose className="h-4 w-4" />
+						{isCollapsed ? (
+							<PanelLeftOpen className="h-4 w-4" />
+						) : (
+							<PanelLeftClose className="h-4 w-4" />
+						)}
 					</Button>
 				</div>
 				<div className="h-px w-full bg-border" />


### PR DESCRIPTION
## Summary

- collapse the desktop settings sidebar into a 47px icon rail instead of hiding it entirely
- keep an explicit expand/collapse control available and update its accessible label and icon with the current state
- hide labels, badges, and usage details in icon mode while providing navigation tooltips
- add a patch changeset for the web app

## Why

The settings layout used the shared sidebar's default `offcanvas` behavior. Its custom navigation content was also not prepared for icon mode, so collapsing removed the sidebar rather than leaving a usable icon rail.

This focused fix is isolated from the larger uncommitted settings/API overhaul worktree so it can ship independently.

## Validation

- `pnpm exec next typegen`
- `pnpm run typecheck`
- `pnpm exec eslint 'src/app/(dashboard)/settings/layout.tsx' 'src/components/(gateway)/settings/Sidebar.tsx'`
- authenticated browser check at `/settings/account/details`: expanded width 255px, collapsed width 47px, labels hidden, explicit expand control available, and Ctrl+B restores the expanded sidebar

Created with Codex


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Settings navigation now supports a compact icon-only sidebar on desktop.
  * Added tooltips to clarify navigation icons, including disabled and external links.
  * Added a clear control to expand the sidebar when needed.
  * Updated navigation styling and accessibility labels for collapsed and expanded states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->