### PR TITLE
Preserve refreshable CLI PKCE sessions

### DIFF
--- a/apps/api/src/lib/oauth/service.ts
+++ b/apps/api/src/lib/oauth/service.ts
@@ -19,6 +19,10 @@ export const CLI_CLIENT_ID = "phaseo_cli";
 export const LEGACY_CLI_CLIENT_ID = "aistats_cli";
 const CLI_CLIENT_IDS = new Set([CLI_CLIENT_ID, LEGACY_CLI_CLIENT_ID]);
 
+export function isFirstPartyCliClient(clientId: string): boolean {
+	return CLI_CLIENT_IDS.has(clientId.trim());
+}
+
 export const CLI_DEFAULT_SCOPES = DEFAULT_CLI_OAUTH_CAPABILITIES;
 
 type OAuthClient = {
@@ -101,7 +105,7 @@ export function isThirdPartyOAuthEnabled(): boolean {
 }
 
 export function isOAuthClientUsable(clientId: string): boolean {
-	return CLI_CLIENT_IDS.has(clientId.trim()) || isThirdPartyOAuthEnabled();
+	return isFirstPartyCliClient(clientId) || isThirdPartyOAuthEnabled();
 }
 
 export function normalizeScopes(raw: unknown, fallback: readonly string[] = []): string[] {

--- a/apps/api/src/routes/oauth.security.test.ts
+++ b/apps/api/src/routes/oauth.security.test.ts
@@ -3,10 +3,13 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 const state = vi.hoisted(() => ({
 	deviceRow: null as Record<string, unknown> | null,
 	authorizationRow: null as Record<string, unknown> | null,
+	authorizationCodeRow: null as Record<string, unknown> | null,
+	client: { id: "phaseo_cli", name: "Phaseo CLI", client_type: "public" } as Record<string, unknown>,
 	updateResult: null as Record<string, unknown> | null,
 	updatePayloads: [] as Array<Record<string, unknown>>,
 	updateFilters: [] as Array<Array<{ column: string; value: unknown }>>,
 	issuedTokenPairs: [] as Array<Record<string, unknown>>,
+	issuedManagedKeys: [] as Array<Record<string, unknown>>,
 	pollStatus: "ok" as string,
 }));
 
@@ -27,6 +30,17 @@ vi.mock("@/runtime/env", () => ({
 	getSupabaseAdmin: () => ({
 		rpc: async () => ({ data: state.pollStatus, error: null }),
 		from(table: string) {
+			if (table === "oauth_authorization_codes") {
+				return {
+					select: () => ({
+						in: () => ({
+							eq: () => ({
+								maybeSingle: async () => ({ data: state.authorizationCodeRow, error: null }),
+							}),
+						}),
+					}),
+				};
+			}
 			if (table === "oauth_authorizations") {
 				return {
 					select: () => ({
@@ -111,10 +125,11 @@ vi.mock("@/lib/oauth/service", () => ({
 		return { access_token: "token" };
 	}),
 	issueOAuthManagedKeyForAuthorizationCode: vi.fn(async (_grantId: string, input: Record<string, unknown>) => {
-		state.issuedTokenPairs.push(input);
+		state.issuedManagedKeys.push(input);
 		return { access_token: "phaseo_v1_sk_test", token_type: "Bearer" };
 	}),
-	loadOAuthClient: vi.fn(async () => ({ id: "phaseo_cli", name: "Phaseo CLI", client_type: "public" })),
+	isFirstPartyCliClient: vi.fn((clientId: string) => clientId === "phaseo_cli" || clientId === "aistats_cli"),
+	loadOAuthClient: vi.fn(async () => state.client),
 	makeAuthCodeExpiry: vi.fn(() => "2026-06-10T16:00:00.000Z"),
 	makeDeviceCodeExpiry: vi.fn(() => "2026-06-10T16:00:00.000Z"),
 	normalizeScopes: vi.fn((raw, fallback) => fallback ?? []),
@@ -134,10 +149,13 @@ describe("OAuth route security", () => {
 	beforeEach(() => {
 		state.deviceRow = null;
 		state.authorizationRow = null;
+		state.authorizationCodeRow = null;
+		state.client = { id: "phaseo_cli", name: "Phaseo CLI", client_type: "public" };
 		state.updateResult = null;
 		state.updatePayloads.length = 0;
 		state.updateFilters.length = 0;
 		state.issuedTokenPairs.length = 0;
+		state.issuedManagedKeys.length = 0;
 		state.pollStatus = "ok";
 		vi.resetModules();
 	});
@@ -258,5 +276,84 @@ describe("OAuth route security", () => {
 				scopes: ["openid"],
 			},
 		]);
+	});
+
+	it("keeps browser-based CLI login on a refreshable token pair", async () => {
+		state.authorizationCodeRow = {
+			id: "authorization_code_1",
+			client_id: "phaseo_cli",
+			user_id: "user_1",
+			workspace_id: "ws_1",
+			redirect_uri: "http://127.0.0.1:8976/callback",
+			scopes: ["openid"],
+			code_challenge: "challenge",
+			code_challenge_method: "S256",
+			expires_at: FUTURE_EXPIRES_AT,
+			used_at: null,
+		};
+		state.authorizationRow = { id: "auth_1", revoked_at: null };
+
+		const { oauthRouter } = await import("./oauth");
+		const response = await oauthRouter.request("https://example.com/token", {
+			method: "POST",
+			headers: { "content-type": "application/json" },
+			body: JSON.stringify({
+				grant_type: "authorization_code",
+				client_id: "phaseo_cli",
+				code: "authorization-code",
+				redirect_uri: "http://127.0.0.1:8976/callback",
+				code_verifier: "verifier",
+			}),
+		});
+
+		expect(response.status).toBe(200);
+		expect(await response.json()).toMatchObject({ access_token: "token" });
+		expect(state.issuedTokenPairs).toContainEqual({
+			userId: "user_1",
+			workspaceId: "ws_1",
+			clientId: "phaseo_cli",
+			scopes: ["openid"],
+		});
+		expect(state.issuedManagedKeys).toEqual([]);
+	});
+
+	it("issues a managed key only for a third-party PKCE client", async () => {
+		state.client = { id: "third_party", name: "Third Party", client_type: "confidential" };
+		state.authorizationCodeRow = {
+			id: "authorization_code_2",
+			client_id: "third_party",
+			user_id: "user_1",
+			workspace_id: "ws_1",
+			redirect_uri: "https://example.com/callback",
+			scopes: ["models:read"],
+			code_challenge: "challenge",
+			code_challenge_method: "S256",
+			expires_at: FUTURE_EXPIRES_AT,
+			used_at: null,
+		};
+		state.authorizationRow = { id: "auth_1", revoked_at: null };
+
+		const { oauthRouter } = await import("./oauth");
+		const response = await oauthRouter.request("https://example.com/token", {
+			method: "POST",
+			headers: { "content-type": "application/json" },
+			body: JSON.stringify({
+				grant_type: "authorization_code",
+				client_id: "third_party",
+				code: "authorization-code",
+				redirect_uri: "https://example.com/callback",
+				code_verifier: "verifier",
+			}),
+		});
+
+		expect(response.status).toBe(200);
+		expect(await response.json()).toMatchObject({ access_token: "phaseo_v1_sk_test" });
+		expect(state.issuedTokenPairs).toEqual([]);
+		expect(state.issuedManagedKeys).toContainEqual({
+			userId: "user_1",
+			workspaceId: "ws_1",
+			clientId: "third_party",
+			scopes: ["models:read"],
+		});
 	});
 });

--- a/apps/api/src/routes/oauth.ts
+++ b/apps/api/src/routes/oauth.ts
@@ -25,6 +25,7 @@ import {
 	hasActiveOAuthWorkspaceAccess,
 	issueTokenPairForGrant,
 	issueOAuthManagedKeyForAuthorizationCode,
+	isFirstPartyCliClient,
 	loadOAuthClient,
 	makeAuthCodeExpiry,
 	makeDeviceCodeExpiry,
@@ -483,15 +484,20 @@ oauthRouter.post(
 			}))) {
 				return oauthError("invalid_grant", "OAuth workspace access is no longer active");
 			}
-			const tokens = await issueOAuthManagedKeyForAuthorizationCode(
-				String(data.id),
-				{
-					userId: String(data.user_id),
-					workspaceId: String(data.workspace_id),
-					clientId: String(data.client_id),
-					scopes: Array.isArray(data.scopes) ? data.scopes.map(String) : [],
-				},
-			);
+			const tokenInput = {
+				userId: String(data.user_id),
+				workspaceId: String(data.workspace_id),
+				clientId: String(data.client_id),
+				scopes: Array.isArray(data.scopes) ? data.scopes.map(String) : [],
+			};
+			// The CLI retains refreshable sessions for `login`, logout, and token
+			// renewal. Third-party PKCE clients receive durable user-funded keys.
+			const tokens = isFirstPartyCliClient(client.id)
+				? await issueTokenPairForGrant(
+					{ type: "authorization_code", id: String(data.id) },
+					tokenInput,
+				)
+				: await issueOAuthManagedKeyForAuthorizationCode(String(data.id), tokenInput);
 			if (!tokens) return oauthError("invalid_grant", "Authorization code is invalid or expired");
 			return json(tokens, 200, { "Cache-Control": "no-store" });
 		}


### PR DESCRIPTION
## Summary

- keep first-party CLI authorization-code exchanges on the existing refreshable token-pair flow
- retain OAuth-managed key issuance for third-party PKCE clients
- add route coverage for both credential outcomes

## Validation

- pnpm --filter @phaseo/gateway-api typecheck
- targeted OAuth and authentication tests (31 passed)
- pnpm --filter @phaseo/cli test (23 passed)

Created with Codex

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved OAuth token handling for CLI sign-ins and third-party integrations.
  - CLI clients now retain or refresh token pairs without receiving managed keys.
  - Third-party PKCE authorization-code exchanges now issue managed keys when eligible.

- **Bug Fixes**
  - Ensured token issuance follows the correct client type while preserving existing security checks, including redirect URI, PKCE, and workspace access validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->