### PR TITLE
data: prepare Moonshot Kimi K3

### DIFF
--- a/.changeset/prepare-kimi-k3-moonshot.md
+++ b/.changeset/prepare-kimi-k3-moonshot.md
@@ -1,0 +1,5 @@
+---
+"@phaseo/data-catalog": patch
+---
+
+Prepare a coming-soon Moonshot AI catalog entry for Kimi K3 with text/image input, text output, and a 1M-token context window. Pricing remains unset until Moonshot publishes the final rate card, and the provider capability is inactive pending release confirmation.

--- a/packages/data/catalog/src/data/api_providers/moonshotai/models.json
+++ b/packages/data/catalog/src/data/api_providers/moonshotai/models.json
@@ -271,5 +271,26 @@
         "params": []
       }
     ]
+  },
+  {
+    "api_model_id": "moonshotai/kimi-k3",
+    "provider_api_model_id": "moonshotai:moonshotai/kimi-k3",
+    "provider_model_slug": "kimi-k3",
+    "internal_model_id": "moonshotai/kimi-k3",
+    "is_active_gateway": false,
+    "quantization_scheme": null,
+    "input_modalities": "text,image",
+    "output_modalities": "text",
+    "context_length": 1000000,
+    "max_output_tokens": null,
+    "effective_from": null,
+    "effective_to": null,
+    "capabilities": [
+      {
+        "capability_id": "text.generate",
+        "status": "inactive",
+        "params": []
+      }
+    ]
   }
 ]

--- a/packages/data/catalog/src/data/models/moonshotai/kimi-k3/model.json
+++ b/packages/data/catalog/src/data/models/moonshotai/kimi-k3/model.json
@@ -1,0 +1,29 @@
+{
+  "model_id": "moonshotai/kimi-k3",
+  "organisation_id": "moonshotai",
+  "name": "Kimi K3",
+  "status": "Limited Access",
+  "previous_model_id": "moonshotai/kimi-k2.6",
+  "description": "Kimi K3 is Moonshot AI's forthcoming multimodal model with text and image input, text output, and a rumored 1M-token context window. Pricing and final release metadata are not yet confirmed.",
+  "announced_date": null,
+  "release_date": null,
+  "deprecation_date": null,
+  "retirement_date": null,
+  "license": "Modified MIT",
+  "input_types": "text,image,video",
+  "output_types": "text",
+  "api_model_id": "moonshotai/kimi-k3",
+  "family_id": "moonshotai/kimi-k2",
+  "links": [],
+  "details": [
+    {
+      "name": "input_context_length",
+      "value": 1000000
+    },
+    {
+      "name": "availability_note",
+      "value": "Coming-soon catalog entry; provider availability is staged for Moonshot AI only and pricing is intentionally unknown."
+    }
+  ],
+  "benchmarks": []
+}

--- a/packages/data/catalog/src/data/models/moonshotai/kimi-k3/model.json
+++ b/packages/data/catalog/src/data/models/moonshotai/kimi-k3/model.json
@@ -2,7 +2,7 @@
   "model_id": "moonshotai/kimi-k3",
   "organisation_id": "moonshotai",
   "name": "Kimi K3",
-  "status": "Limited Access",
+  "status": "Rumoured",
   "previous_model_id": "moonshotai/kimi-k2.6",
   "description": "Kimi K3 is Moonshot AI's forthcoming multimodal model with text and image input, text output, and a rumored 1M-token context window. Pricing and final release metadata are not yet confirmed.",
   "announced_date": null,


### PR DESCRIPTION
## What changed

- Add a coming-soon catalog record for `moonshotai/kimi-k3`.
- Record the rumored text/image input, text output, and 1M-token context window.
- Add an inactive Moonshot provider mapping using the provisional `kimi-k3` slug.
- Leave pricing, aliases, and gateway activation unset until Moonshot publishes final release details.

## Validation

- `pnpm --filter @phaseo/web run validate`
- `git diff --check`

## Notes

This PR intentionally excludes OpenRouter and all other providers. The Moonshot mapping is staged as inactive so the model can be activated quickly once the official API ID and pricing are confirmed.
