### PR TITLE
data: add GPT-Red as withheld

### DIFF
--- a/.changeset/add-gpt-red-withheld.md
+++ b/.changeset/add-gpt-red-withheld.md
@@ -1,0 +1,5 @@
+---
+"@phaseo/data-catalog": patch
+---
+
+Add GPT-Red as a withheld OpenAI safety research model. The entry documents its internal red-teaming purpose and official announcement without adding provider mappings, pricing, aliases, or callable gateway access.

--- a/packages/data/catalog/src/data/models/openai/gpt-red/model.json
+++ b/packages/data/catalog/src/data/models/openai/gpt-red/model.json
@@ -1,0 +1,38 @@
+{
+  "model_id": "openai/gpt-red",
+  "organisation_id": "openai",
+  "name": "GPT-Red",
+  "status": "Withheld",
+  "previous_model_id": null,
+  "description": "GPT-Red is OpenAI's internal automated red-teaming model for discovering prompt-injection vulnerabilities and improving the robustness of deployed models.",
+  "announced_date": "2026-07-15T00:00:00",
+  "release_date": null,
+  "deprecation_date": null,
+  "retirement_date": null,
+  "license": "Proprietary",
+  "input_types": "text",
+  "output_types": "text",
+  "api_model_id": "openai/gpt-red",
+  "links": [
+    {
+      "title": "GPT-Red: Unlocking Self-Improvement for Robustness",
+      "kind": "announcement",
+      "url": "https://openai.com/index/unlocking-self-improvement-gpt-red/"
+    }
+  ],
+  "details": [
+    {
+      "name": "availability",
+      "value": "Internal-only OpenAI safety research model; not available through public APIs or hosted providers."
+    },
+    {
+      "name": "purpose",
+      "value": "Automated red-teaming and adversarial training for prompt-injection robustness."
+    },
+    {
+      "name": "withheld_reason",
+      "value": "OpenAI keeps GPT-Red separate from deployed models because it is trained to generate malicious prompt-injection attacks."
+    }
+  ],
+  "benchmarks": []
+}


### PR DESCRIPTION
## What changed

- Add `openai/gpt-red` to the catalog with status `Withheld`.
- Document its internal automated red-teaming purpose and official OpenAI announcement.
- Leave provider mappings, pricing, aliases, and gateway access absent.

## Validation

- `pnpm --filter @phaseo/web run validate`
- `git diff --check`

## Notes

GPT-Red is explicitly documented by OpenAI as an internal-only safety research model. This entry records it for completeness without representing it as publicly callable.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added GPT-Red to the model catalog as a withheld OpenAI research model.
  * Added metadata describing its status, capabilities, licensing, and official announcement.
  * Documented its red-teaming and adversarial training focus, including its separation from deployed models.

* **Release**
  * Prepared a patch release for the data catalog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->