### PR TITLE
Show provider list pricing before usage exists

### DIFF
--- a/apps/web/src/components/(data)/model/pricing/PricingInsights.tsx
+++ b/apps/web/src/components/(data)/model/pricing/PricingInsights.tsx
@@ -31,7 +31,11 @@ import {
 	TooltipTrigger,
 } from "@/components/ui/tooltip";
 import { Logo } from "@/components/Logo";
-import { fmtUSD } from "@/components/(data)/model/pricing/pricingHelpers";
+import {
+	buildProviderSections,
+	buildProviderTablePriceSummary,
+	fmtUSD,
+} from "@/components/(data)/model/pricing/pricingHelpers";
 import { assignSeriesColours, keyForSeries } from "@/components/(rankings)/chart-colors";
 import type { ProviderPricing } from "@/lib/fetchers/models/getModelPricing";
 import type { ModelPricingHistoryRule } from "@/lib/fetchers/models/getModelPricingHistoryRules";
@@ -720,6 +724,11 @@ export default function PricingInsights({
 			const effectivePrices = usage
 				? calculateEffectivePriceSummaryForUsage(usage, matchingRules)
 				: null;
+			const listSections = buildProviderSections(provider, plan);
+			const listInputPricePer1M =
+				buildProviderTablePriceSummary(listSections, "input").primary?.price ?? null;
+			const listOutputPricePer1M =
+				buildProviderTablePriceSummary(listSections, "output").primary?.price ?? null;
 
 			return {
 				providerId,
@@ -727,8 +736,10 @@ export default function PricingInsights({
 				logoProviderId,
 				seriesKey: keyForSeries(providerId),
 				color: providerColours[providerId]?.stroke ?? "hsl(210 70% 55%)",
-				inputPricePer1M: effectivePrices?.weightedInputPricePer1M ?? null,
-				outputPricePer1M: effectivePrices?.weightedOutputPricePer1M ?? null,
+				inputPricePer1M:
+					effectivePrices?.weightedInputPricePer1M ?? listInputPricePer1M,
+				outputPricePer1M:
+					effectivePrices?.weightedOutputPricePer1M ?? listOutputPricePer1M,
 				cacheHitRatePct:
 					usage && usage.inputWeightTokens30d > 0
 						? (usage.cachedReadInputTokens30d / usage.inputWeightTokens30d) * 100
@@ -742,7 +753,7 @@ export default function PricingInsights({
 				outputWeightTokens30d: usage?.outputWeightTokens30d ?? 0,
 			} satisfies EffectiveRow;
 		});
-	}, [filteredHistoryRules, providerColours, providers, usageByProvider]);
+	}, [filteredHistoryRules, plan, providerColours, providers, usageByProvider]);
 
 	const effectiveSummary = useMemo(() => {
 		let inputCostUsd = 0;
@@ -870,7 +881,8 @@ export default function PricingInsights({
 				<div className="space-y-1">
 					<h3 className="text-sm font-medium text-foreground">Effective pricing</h3>
 					<p className="text-xs text-muted-foreground">
-						Weighted by routed usage over the last 30 days.
+						Weighted by routed usage over the last 30 days; provider list prices are shown
+						until usage is available.
 					</p>
 				</div>
 				{!showPlanInEffectiveHeader && availablePlans.length > 1 && onPlanChange ? (

--- a/apps/web/src/components/(data)/model/pricing/PricingInsights.tsx
+++ b/apps/web/src/components/(data)/model/pricing/PricingInsights.tsx
@@ -725,10 +725,22 @@ export default function PricingInsights({
 				? calculateEffectivePriceSummaryForUsage(usage, matchingRules)
 				: null;
 			const listSections = buildProviderSections(provider, plan);
+			const listInputPrice = buildProviderTablePriceSummary(
+				listSections,
+				"input",
+			).primary;
+			const listOutputPrice = buildProviderTablePriceSummary(
+				listSections,
+				"output",
+			).primary;
 			const listInputPricePer1M =
-				buildProviderTablePriceSummary(listSections, "input").primary?.price ?? null;
+				listInputPrice?.unitLabel === "Per 1M tokens"
+					? listInputPrice.price
+					: null;
 			const listOutputPricePer1M =
-				buildProviderTablePriceSummary(listSections, "output").primary?.price ?? null;
+				listOutputPrice?.unitLabel === "Per 1M tokens"
+					? listOutputPrice.price
+					: null;
 
 			return {
 				providerId,


### PR DESCRIPTION
## Summary

- show imported provider list prices in the model pricing table when no routed usage exists yet
- keep usage-weighted prices when observed traffic is available
- clarify the fallback in the pricing copy

## Validation

- `pnpm --filter @phaseo/web exec eslint 'src/components/(data)/model/pricing/PricingInsights.tsx'`
- `pnpm --filter @phaseo/web exec tsc --noEmit --pretty false` (fails on three pre-existing `LayoutProps` errors in provider/apps/benchmarks layouts)
- browser verification confirmed Baseten and Tinker provider model lists already show Inkling rates

Created with Codex


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Pricing insights now display list prices when 30-day usage-based pricing data is unavailable.
  * Pricing charts and tables no longer show blank values for providers without sufficient usage data.

* **Documentation**
  * Updated the effective pricing explanation to clarify when list prices are displayed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->