### PR TITLE
fix(data): retire deprecated Baseten model APIs

### DIFF
--- a/packages/data/catalog/src/data/api_providers/baseten/models.json
+++ b/packages/data/catalog/src/data/api_providers/baseten/models.json
@@ -179,7 +179,7 @@
     "context_length": 262000,
     "max_output_tokens": 262000,
     "effective_from": "2026-03-25T00:00:00",
-    "effective_to": null,
+    "effective_to": "2026-07-25T00:00:00Z",
     "capabilities": [
       {
         "capability_id": "text.generate",
@@ -242,7 +242,7 @@
     "context_length": 202800,
     "max_output_tokens": 202800,
     "effective_from": "2026-03-11T00:00:00",
-    "effective_to": null,
+    "effective_to": "2026-07-25T00:00:00Z",
     "capabilities": [
       {
         "capability_id": "text.generate",
@@ -404,7 +404,7 @@
     "context_length": 202800,
     "max_output_tokens": 202800,
     "effective_from": "2026-03-25T00:00:00",
-    "effective_to": null,
+    "effective_to": "2026-07-25T00:00:00Z",
     "capabilities": [
       {
         "capability_id": "text.generate",
@@ -425,7 +425,7 @@
     "context_length": 202000,
     "max_output_tokens": 202000,
     "effective_from": "2026-05-27T00:00:00",
-    "effective_to": null,
+    "effective_to": "2026-07-25T00:00:00Z",
     "capabilities": [
       {
         "capability_id": "text.generate",


### PR DESCRIPTION
## Summary

Baseten announced that the GLM 5.1, GLM 5, Kimi K2.5, and Nemotron Super 120B model APIs will be deprecated at 5pm PT on July 24, 2026. After that time, the model IDs will be inactive and requests will return errors.

This updates the Baseten provider catalog records with an `effective_to` boundary of `2026-07-25T00:00:00Z`, matching the announced retirement time. The change keeps historical pricing intact while ensuring the models are no longer represented as active after the provider's deadline.

## Source

- https://www.baseten.co/resources/changelog/model-deprecation-glm5-glm51-kimik25-nemosuper120b/

## Validation

- `git diff --check`
- `pnpm validate:data`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Added availability end dates of July 25, 2026, to four gateway models in the catalog.
  * Updated model availability information for Kimi K2.5, Nemotron 3 Super 120B, GLM-5, and GLM-5.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->