### PR TITLE
Make passkeys generally available

### DIFF
--- a/apps/docs/v1/changelog.mdx
+++ b/apps/docs/v1/changelog.mdx
@@ -4,6 +4,14 @@ description: "Recent product updates, SDK changes, and model releases across Pha
 rss: true
 ---
 
+<Update label="July 16, 2026" tags={["Features"]}>
+
+### Features
+
+- Passkeys are now available to all users for passwordless sign-in and account management with device biometrics, PINs, or security keys.
+
+</Update>
+
 <Update label="July 15, 2026" tags={["Model Releases"]}>
 
 ![Inkling model release artwork](../images/model-releases/2026-07-15--thinking-machines--inkling.png)

--- a/apps/web/src/app/(auth)/sign-in/actions.ts
+++ b/apps/web/src/app/(auth)/sign-in/actions.ts
@@ -13,7 +13,6 @@ import {
 } from "@/lib/auth/authOrigin";
 import { sanitizeReturnUrl } from "@/lib/auth/return-url";
 import { finalizePostLogin } from "@/lib/auth/post-login";
-import { passkeysAdminBetaFlag } from "@/lib/flags";
 import {
 	buildStartSsoRequest,
 	mapSsoAuthErrorMessage,
@@ -137,11 +136,6 @@ export async function completePasskeySignIn(returnUrl?: string) {
 	} = await supabase.auth.getUser();
 	if (!user) {
 		throw new Error("Passkey sign-in did not create a session");
-	}
-
-	if (!(await passkeysAdminBetaFlag())) {
-		await supabase.auth.signOut();
-		throw new Error("passkey_disabled");
 	}
 
 	const {

--- a/apps/web/src/app/(auth)/sign-in/page.tsx
+++ b/apps/web/src/app/(auth)/sign-in/page.tsx
@@ -3,7 +3,6 @@ import { Suspense } from "react";
 import { Login } from "@/components/(gateway)/auth/Login";
 import { AuthWordmark } from "@/components/(gateway)/auth/AuthWordmark";
 import { sanitizeReturnUrl } from "@/lib/auth/return-url";
-import { passkeysAdminBetaFlag } from "@/lib/flags";
 import { AuthSuspenseFallback } from "../AuthSuspenseFallback";
 
 type SignInPageProps = {
@@ -41,7 +40,6 @@ async function SignInPageContent({ searchParams }: SignInPageProps) {
 		"/",
 	);
 	const returnUrl = sanitizedReturnUrl === "/" ? undefined : sanitizedReturnUrl;
-	const showPasskeySignIn = await passkeysAdminBetaFlag();
 
 	return (
 		<div className="min-h-svh">
@@ -54,7 +52,6 @@ async function SignInPageContent({ searchParams }: SignInPageProps) {
 						signupNotice={signupNotice}
 						authError={authError}
 						returnUrl={returnUrl}
-						showPasskeySignIn={showPasskeySignIn}
 					/>
 				</div>
 			</div>

--- a/apps/web/src/app/(dashboard)/settings/account/mfa/page.tsx
+++ b/apps/web/src/app/(dashboard)/settings/account/mfa/page.tsx
@@ -3,7 +3,6 @@ import SettingsSectionFallback from "@/components/(gateway)/settings/SettingsSec
 import AccountMFAClient from "@/components/(gateway)/settings/account/AccountMFAClient";
 import SettingsPageHeader from "@/components/(gateway)/settings/SettingsPageHeader";
 import { fetchSettingsAccountMfaInitialData } from "@/lib/fetchers/internal/fetchSettingsAccountMfaInitialData";
-import { passkeysAdminBetaFlag } from "@/lib/flags";
 
 export const metadata = {
 	title: "MFA - Settings",
@@ -34,13 +33,10 @@ async function AccountMFAContent() {
 		);
 	}
 
-	const passkeysEnabled = await passkeysAdminBetaFlag();
-
 	return (
 		<AccountMFAClient
 			mfaEnabled={initialData.mfaEnabled}
 			mfaFactorId={initialData.mfaFactorId}
-			showPasskeyManagement={passkeysEnabled}
 		/>
 	);
 }

--- a/apps/web/src/components/(gateway)/auth/Login.tsx
+++ b/apps/web/src/components/(gateway)/auth/Login.tsx
@@ -8,12 +8,10 @@ export function Login({
 	signupNotice = null,
 	authError = null,
 	returnUrl,
-	showPasskeySignIn = false,
 }: {
 	signupNotice?: SignupNotice;
 	authError?: "auth-failed" | null;
 	returnUrl?: string;
-	showPasskeySignIn?: boolean;
 }) {
 	const signupNoticeText =
 		signupNotice === "check-email"
@@ -44,7 +42,7 @@ export function Login({
 
 			<div className="flex flex-col gap-2">
 				<OAuthButtons returnUrl={returnUrl} />
-				{showPasskeySignIn ? <PasskeySignInButton returnUrl={returnUrl} /> : null}
+				<PasskeySignInButton returnUrl={returnUrl} />
 			</div>
 			<EmailPassword returnUrl={returnUrl} />
 		</div>

--- a/apps/web/src/components/(gateway)/settings/account/AccountMFAClient.tsx
+++ b/apps/web/src/components/(gateway)/settings/account/AccountMFAClient.tsx
@@ -37,11 +37,9 @@ import { Loader2, Shield, ShieldCheck } from "lucide-react";
 export default function AccountMFAClient({
 	mfaEnabled,
 	mfaFactorId,
-	showPasskeyManagement,
 }: {
 	mfaEnabled: boolean;
 	mfaFactorId: string | null;
-	showPasskeyManagement: boolean;
 }) {
 	const router = useRouter();
 
@@ -170,7 +168,7 @@ export default function AccountMFAClient({
 				onOpenChange={handleMFADialogClose}
 				onSuccess={handleMFASuccess}
 			/>
-			{showPasskeyManagement ? <PasskeyManager /> : null}
+			<PasskeyManager />
 		</div>
 	);
 }

--- a/apps/web/src/lib/flags/index.ts
+++ b/apps/web/src/lib/flags/index.ts
@@ -65,19 +65,3 @@ export const gatewayIoLoggingFlag = statsigAdapter
 			key: GATEWAY_IO_LOGGING_GATE,
 			decide: () => false,
 		});
-
-/**
- * Temporary production rollout gate for passkey enrollment and management.
- * The gate itself targets approved admin user IDs in Statsig; callers must
- * still verify the Phaseo admin role before exposing account controls.
- */
-export const passkeysAdminBetaFlag = statsigAdapter
-	? flag<boolean, StatsigUser>({
-			key: "passkeys_admin_beta",
-			identify,
-			adapter: statsigAdapter.featureGate((gate) => gate.value),
-		})
-	: flag<boolean>({
-			key: "passkeys_admin_beta",
-			decide: () => false,
-		});


### PR DESCRIPTION
## Summary

Passkeys were introduced behind the temporary `passkeys_admin_beta` Statsig gate. That gate controlled both enrollment management and the sign-in entry point, which made a general release unnecessarily dependent on a rollout configuration.

This change makes passkeys generally available to every signed-in user in account settings and keeps the passkey sign-in option available to anonymous visitors who have already enrolled a credential. It removes the now-unused feature flag and its server-side rejection path, and records the release in the July 16 changelog.

The Statsig gate has been converted to a 100% production compatibility rule so the current deployment is already enabled for everyone. It can be deleted after this PR is deployed because this branch no longer reads it.

## Validation

- `git diff --check`
- Verified no `passkeys_admin_beta`, `passkeysAdminBetaFlag`, or conditional passkey visibility references remain in the web and docs source.
- `pnpm --filter @phaseo/web typecheck` could not run in the fresh worktree because its `node_modules` links are incomplete and `tsc` is unavailable. `pnpm install --frozen-lockfile` did not finish linking the local dependency tree.

Created with Codex


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Passkeys are now available to all users for passwordless sign-in and account management using biometrics, PINs, or security keys.
  * Passkey sign-in is always available on the login screen.
  * Passkey management is now available in account security settings.
* **Documentation**
  * Added a July 16, 2026 changelog entry announcing general passkey availability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->