### PR TITLE
Log gateway upstream provider requests

### DIFF
--- a/apps/api/src/core/types.ts
+++ b/apps/api/src/core/types.ts
@@ -76,6 +76,8 @@ export type RequestMeta = {
     generation_ms?: number;       // Post-first-token generation duration when available
     latency_ms?: number;          // Time to first token/byte when available; otherwise best-effort total latency
     end_to_end_ms?: number;       // Request start to completion when available
+    provider_generation_total_ms?: number; // Sum of provider generation across multi-round tool requests
+    provider_call_count?: number; // Main-model provider rounds used to produce the response
     preserve_stream_timing?: boolean; // Internal: stream is synthetic and already has authoritative timing
     before_ms?: number;           // Gateway preflight ("before" stage) latency
     beforeContextMs?: number;     // Context fetch + enrichment latency inside before

--- a/apps/api/src/executors/_shared/text-generate/openai-compat/__tests__/execute.test.ts
+++ b/apps/api/src/executors/_shared/text-generate/openai-compat/__tests__/execute.test.ts
@@ -44,6 +44,62 @@ function buildArgs(): ExecutorExecuteArgs {
 	} as ExecutorExecuteArgs;
 }
 
+function delayedSseResponse(frames: unknown[], delayMs = 8): Response {
+	const encoder = new TextEncoder();
+	let index = 0;
+	return new Response(new ReadableStream<Uint8Array>({
+		async pull(controller) {
+			if (index >= frames.length) {
+				controller.close();
+				return;
+			}
+			const frame = frames[index++];
+			await new Promise((resolve) => setTimeout(resolve, delayMs));
+			const data = frame === "[DONE]" ? frame : JSON.stringify(frame);
+			controller.enqueue(encoder.encode(`data: ${data}\n\n`));
+		},
+	}), {
+		status: 200,
+		headers: { "Content-Type": "text/event-stream" },
+	});
+}
+
+function delayedSingleChunkSseResponse(
+	frames: unknown[],
+	acceptedAtMs: number,
+	delayMs = 20,
+	splitBufferedDelivery = false,
+): Response {
+	const encoder = new TextEncoder();
+	let sent = false;
+	return new Response(new ReadableStream<Uint8Array>({
+		async pull(controller) {
+			if (sent) {
+				controller.close();
+				return;
+			}
+			sent = true;
+			await new Promise((resolve) => setTimeout(resolve, delayMs));
+			const body = frames
+				.map((frame) => `data: ${frame === "[DONE]" ? frame : JSON.stringify(frame)}\n\n`)
+				.join("");
+			if (splitBufferedDelivery) {
+				const midpoint = Math.floor(body.length / 2);
+				controller.enqueue(encoder.encode(body.slice(0, midpoint)));
+				controller.enqueue(encoder.encode(body.slice(midpoint)));
+			} else {
+				controller.enqueue(encoder.encode(body));
+			}
+		},
+	}), {
+		status: 200,
+		headers: {
+			"Content-Type": "text/event-stream",
+			"x-baseten-accepted-at": String(acceptedAtMs),
+		},
+	});
+}
+
 describe("executeOpenAICompat", () => {
 	const ALIBABA_CHAT_URL = "https://api.alibaba.example/compatible-mode/v1/chat/completions";
 
@@ -381,6 +437,7 @@ describe("executeOpenAICompat", () => {
 	it("retries transient baseten 429 responses once before failing over", async () => {
 		const args = buildArgs();
 		args.providerId = "baseten";
+		args.meta.returnUpstreamRequest = false;
 		args.ir = {
 			...args.ir,
 			model: "openai/gpt-oss-120b",
@@ -420,6 +477,101 @@ describe("executeOpenAICompat", () => {
 		expect(result.upstream.status).toBe(200);
 		expect(callCount).toBe(2);
 		expect(mock.calls[0]?.headers.Authorization).toBe("Api-Key test-baseten-key");
+		expect(result.mappedRequest).toContain('"model":"openai/gpt-oss-120b"');
+		expect(result.upstreamAttempts).toHaveLength(2);
+		expect(result.upstreamAttempts?.[0]).toEqual(expect.objectContaining({
+			sequence: 1,
+			route: "chat",
+			status: 429,
+			outcome: "upstream_non_2xx",
+			response: { error: { message: "rate limited" } },
+		}));
+		expect(result.upstreamAttempts?.[1]).toEqual(expect.objectContaining({
+			sequence: 2,
+			status: 200,
+			outcome: "success",
+		}));
+	});
+
+	it("measures Baseten streaming timing around the raw provider response", async () => {
+		const args = buildArgs();
+		args.providerId = "baseten";
+		args.providerModelSlug = "thinkingmachines/inkling";
+		args.ir = {
+			...args.ir,
+			model: "thinking-machines/inkling",
+			stream: true,
+		};
+
+		const mock = installFetchMock([{
+			match: (url) => url === "https://api.baseten.example/v1/chat/completions",
+			response: delayedSseResponse([
+				{
+					id: "chatcmpl_baseten_stream",
+					object: "chat.completion.chunk",
+					choices: [{ index: 0, delta: { content: "Hello" }, finish_reason: null }],
+				},
+				{
+					id: "chatcmpl_baseten_stream",
+					object: "chat.completion.chunk",
+					choices: [{ index: 0, delta: { content: " there" }, finish_reason: null }],
+				},
+				{
+					id: "chatcmpl_baseten_stream",
+					object: "chat.completion.chunk",
+					choices: [{ index: 0, delta: {}, finish_reason: "stop" }],
+					usage: { prompt_tokens: 4, completion_tokens: 2, total_tokens: 6 },
+				},
+				"[DONE]",
+			], 10),
+		}]);
+
+		const result = await executeOpenAICompat(args);
+		expect(result.kind).toBe("stream");
+		if (result.kind !== "stream") throw new Error("Expected a streaming result");
+		const timing = result.timing;
+		await new Response(result.stream).text();
+		mock.restore();
+
+		expect(timing?.latencyMs).toBeGreaterThan(0);
+		expect(timing?.generationMs).toBeGreaterThan(0);
+		expect(timing?.totalMs).toBeGreaterThanOrEqual(timing?.latencyMs ?? 0);
+		expect(timing?.totalMs).toBeGreaterThanOrEqual(timing?.generationMs ?? 0);
+	});
+
+	it("uses Baseten accepted-at timing when a buffered tool response arrives in same-tick chunks", async () => {
+		const args = buildArgs();
+		args.providerId = "baseten";
+		args.providerModelSlug = "thinkingmachines/inkling";
+		args.ir = {
+			...args.ir,
+			model: "thinking-machines/inkling",
+			stream: true,
+		};
+
+		const mock = installFetchMock([{
+			match: (url) => url === "https://api.baseten.example/v1/chat/completions",
+			response: () => delayedSingleChunkSseResponse([
+				{
+					id: "chatcmpl_baseten_buffered_tool",
+					object: "chat.completion.chunk",
+					choices: [{ index: 0, delta: { tool_calls: [] }, finish_reason: "tool_calls" }],
+					usage: { prompt_tokens: 10, completion_tokens: 30, total_tokens: 40 },
+				},
+				"[DONE]",
+			], Date.now() + 5, 20, true),
+		}]);
+
+		const result = await executeOpenAICompat(args);
+		expect(result.kind).toBe("stream");
+		if (result.kind !== "stream") throw new Error("Expected a streaming result");
+		const timing = result.timing;
+		await new Response(result.stream).text();
+		mock.restore();
+
+		expect(timing?.generationMs).toBeGreaterThan(0);
+		expect(timing?.latencyMs).toBeGreaterThanOrEqual(0);
+		expect(timing?.latencyMs).toBeLessThan(timing?.totalMs ?? 0);
 	});
 
 	it("retries transient groq 503 responses once before succeeding", async () => {

--- a/apps/api/src/executors/_shared/text-generate/openai-compat/index.ts
+++ b/apps/api/src/executors/_shared/text-generate/openai-compat/index.ts
@@ -6,7 +6,13 @@
 // Handles: OpenAI, Groq, DeepSeek, Together, Fireworks, and other OpenAI-compatible providers
 // Uses OpenAI Responses API format upstream for consistency
 
-import type { ExecutorExecuteArgs, ExecutorResult, Bill } from "@executors/types";
+import type {
+	ExecutorExecuteArgs,
+	ExecutorResult,
+	ExecutorTiming,
+	ExecutorUpstreamAttempt,
+	Bill,
+} from "@executors/types";
 import type { IRChatResponse } from "@core/ir";
 import { irToOpenAIResponses, openAIResponsesToIR } from "./transform";
 import { irToOpenAIChat, openAIChatToIR } from "./transform-chat";
@@ -78,10 +84,92 @@ async function sleep(ms: number): Promise<void> {
 	await new Promise((resolve) => setTimeout(resolve, ms));
 }
 
+function parseProviderAcceptedAtMs(res: Response, providerId: string): number | null {
+	if (providerId !== "baseten") return null;
+	const raw = res.headers.get("x-baseten-accepted-at");
+	if (!raw) return null;
+	const acceptedAtMs = Number(raw);
+	return Number.isFinite(acceptedAtMs) && acceptedAtMs > 0
+		? acceptedAtMs
+		: null;
+}
+
+function measureProviderStream(
+	stream: ReadableStream<Uint8Array>,
+	timing: ExecutorTiming,
+	providerStartedAtMs: number,
+	providerAcceptedAtMs: number | null,
+): ReadableStream<Uint8Array> {
+	const reader = stream.getReader();
+	let firstByteAtMs: number | null = null;
+	let settled = false;
+
+	const recordProgress = (nowMs: number) => {
+		if (firstByteAtMs === null) {
+			firstByteAtMs = nowMs;
+			timing.latencyMs = Math.max(0, nowMs - providerStartedAtMs);
+		}
+		timing.generationMs = Math.max(0, nowMs - firstByteAtMs);
+		timing.totalMs = Math.max(0, nowMs - providerStartedAtMs);
+	};
+
+	const recordCompletion = () => {
+		if (settled) return;
+		settled = true;
+		const nowMs = Date.now();
+		if (firstByteAtMs === null) {
+			timing.latencyMs = Math.max(0, nowMs - providerStartedAtMs);
+			timing.generationMs = 0;
+		} else {
+			timing.generationMs = Math.max(0, nowMs - firstByteAtMs);
+		}
+		if (
+			(timing.generationMs ?? 0) <= 2 &&
+			providerAcceptedAtMs !== null &&
+			providerAcceptedAtMs >= providerStartedAtMs &&
+			providerAcceptedAtMs <= nowMs
+		) {
+			// Some OpenAI-compatible providers buffer tool-call responses into one body
+			// delivery, which the runtime may expose as one or several same-tick chunks.
+			// Their accepted-at timestamp is the only observable latency/generation split.
+			timing.latencyMs = Math.max(0, providerAcceptedAtMs - providerStartedAtMs);
+			timing.generationMs = Math.max(0, nowMs - providerAcceptedAtMs);
+		} else if ((timing.generationMs ?? 0) <= 2 && nowMs > providerStartedAtMs) {
+			// If the provider exposes no processing boundary, consistently attribute
+			// an effectively buffered response to generation rather than zero-duration output.
+			timing.latencyMs = 0;
+			timing.generationMs = Math.max(0, nowMs - providerStartedAtMs);
+		}
+		timing.totalMs = Math.max(0, nowMs - providerStartedAtMs);
+	};
+
+	return new ReadableStream<Uint8Array>({
+		async pull(controller) {
+			try {
+				const { value, done } = await reader.read();
+				if (done) {
+					recordCompletion();
+					controller.close();
+					return;
+				}
+				if (value.byteLength > 0) {
+					recordProgress(Date.now());
+				}
+				controller.enqueue(value);
+			} catch (error) {
+				recordCompletion();
+				controller.error(error);
+			}
+		},
+		async cancel(reason) {
+			recordCompletion();
+			await reader.cancel(reason);
+		},
+	});
+}
+
 export async function executeOpenAICompat(args: ExecutorExecuteArgs): Promise<ExecutorResult> {
-	// Use upstream start time from pipeline (set before executor is called)
-	// Falls back to current time if not provided (backward compatibility)
-	const upstreamStartMs = args.meta.upstreamStartMs ?? Date.now();
+	const upstreamAttempts: ExecutorUpstreamAttempt[] = [];
 	// Resolve API key (gateway or BYOK)
 	const keyInfo = resolveOpenAICompatKey({
 		providerId: args.providerId,
@@ -140,16 +228,53 @@ export async function executeOpenAICompat(args: ExecutorExecuteArgs): Promise<Ex
 		}
 
 		const fetchStartMs = Date.now();
-		const response = await fetch(openAICompatUrl(args.providerId, endpointForRoute(targetRoute)), {
-			method: "POST",
-			headers: openAICompatHeaders(args.providerId, keyInfo.key, upstreamTestHeaders(args.meta)),
-			body: requestBody,
+		const url = openAICompatUrl(args.providerId, endpointForRoute(targetRoute));
+		let response: Response;
+		try {
+			response = await fetch(url, {
+				method: "POST",
+				headers: openAICompatHeaders(args.providerId, keyInfo.key, upstreamTestHeaders(args.meta)),
+				body: requestBody,
+			});
+		} catch (error) {
+			upstreamAttempts.push({
+				sequence: upstreamAttempts.length + 1,
+				route: targetRoute,
+				request: requestBody,
+				url,
+				durationMs: Math.max(0, Date.now() - fetchStartMs),
+				outcome: "network_error",
+				errorMessage: error instanceof Error ? error.message : String(error),
+			});
+			throw error;
+		}
+
+		let responsePayload: unknown;
+		if (!response.ok) {
+			try {
+				const text = await response.clone().text();
+				responsePayload = text ? JSON.parse(text) : null;
+			} catch {
+				responsePayload = null;
+			}
+		}
+		upstreamAttempts.push({
+			sequence: upstreamAttempts.length + 1,
+			route: targetRoute,
+			request: requestBody,
+			response: responsePayload,
+			status: response.status,
+			statusText: response.statusText || null,
+			url: response.url || url,
+			durationMs: Math.max(0, Date.now() - fetchStartMs),
+			outcome: response.ok ? "success" : "upstream_non_2xx",
 		});
 
 		return {
 			response,
 			requestBody,
 			request: sanitized.request,
+			fetchStartMs,
 			requestBuildMs: Math.max(0, fetchStartMs - requestBuildStartMs),
 			upstreamHeadersMs: Math.max(0, Date.now() - fetchStartMs),
 		};
@@ -202,7 +327,7 @@ export async function executeOpenAICompat(args: ExecutorExecuteArgs): Promise<Ex
 	let attempt = await sendPayloadWithRetry(route, buildPayloadForRoute(route));
 	let res = attempt.response;
 	let requestBody = attempt.requestBody;
-	let mappedRequest = (args.meta.echoUpstreamRequest || args.meta.returnUpstreamRequest) ? requestBody : undefined;
+	let mappedRequest = requestBody;
 	let requestBuildMs = attempt.requestBuildMs;
 	let upstreamHeadersMs = attempt.upstreamHeadersMs;
 	let transientRetryDelayMs = attempt.transientRetryDelayMs;
@@ -222,7 +347,7 @@ export async function executeOpenAICompat(args: ExecutorExecuteArgs): Promise<Ex
 			attempt = await sendPayloadWithRetry(route, buildPayloadForRoute(route));
 			res = attempt.response;
 			requestBody = attempt.requestBody;
-			mappedRequest = (args.meta.echoUpstreamRequest || args.meta.returnUpstreamRequest) ? requestBody : undefined;
+			mappedRequest = requestBody;
 			requestBuildMs = attempt.requestBuildMs;
 			upstreamHeadersMs = attempt.upstreamHeadersMs;
 			transientRetryDelayMs = attempt.transientRetryDelayMs;
@@ -253,7 +378,7 @@ export async function executeOpenAICompat(args: ExecutorExecuteArgs): Promise<Ex
 		attempt = await sendPayloadWithRetry(route, adapted.request);
 		res = attempt.response;
 		requestBody = attempt.requestBody;
-		mappedRequest = (args.meta.echoUpstreamRequest || args.meta.returnUpstreamRequest) ? requestBody : undefined;
+		mappedRequest = requestBody;
 		requestBuildMs = attempt.requestBuildMs;
 		upstreamHeadersMs = attempt.upstreamHeadersMs;
 		transientRetryDelayMs = attempt.transientRetryDelayMs;
@@ -267,6 +392,11 @@ export async function executeOpenAICompat(args: ExecutorExecuteArgs): Promise<Ex
 		upstream_id: res.headers.get("x-request-id") || undefined,
 		finish_reason: null,
 	};
+	const executorTiming: ExecutorTiming = {
+		requestBuildMs,
+		upstreamHeadersMs,
+		transientRetryDelayMs,
+	};
 	if (!res.ok) {
 		console.error(`Upstream error for provider ${args.providerId}: ${res.status} ${res.statusText}`);
 		return {
@@ -277,17 +407,24 @@ export async function executeOpenAICompat(args: ExecutorExecuteArgs): Promise<Ex
 			keySource: keyInfo.source,
 			byokKeyId: keyInfo.byokId,
 			mappedRequest,
-			timing: {
-				requestBuildMs,
-				upstreamHeadersMs,
-				transientRetryDelayMs,
-			},
+			timing: executorTiming,
+			upstreamAttempts,
 		};
 	}
 
 	// Handle streaming vs non-streaming
 	if (args.ir.stream) {
-		const stream = resolveStreamForProtocol(res, args, route);
+		if (!res.body) {
+			throw new Error("openai_stream_missing_body");
+		}
+		executorTiming.streamTimingSource = "provider";
+		const measuredProviderStream = measureProviderStream(
+			res.body,
+			executorTiming,
+			attempt.fetchStartMs,
+			parseProviderAcceptedAtMs(res, args.providerId),
+		);
+		const stream = resolveStreamForProtocol(res, args, route, measuredProviderStream);
 		return {
 			kind: "stream",
 			stream,
@@ -297,17 +434,17 @@ export async function executeOpenAICompat(args: ExecutorExecuteArgs): Promise<Ex
 			keySource: keyInfo.source,
 			byokKeyId: keyInfo.byokId,
 			mappedRequest,
-			timing: {
-				latencyMs: undefined,
-				generationMs: undefined,
-				requestBuildMs,
-				upstreamHeadersMs,
-				transientRetryDelayMs,
-			},
+			timing: executorTiming,
+			upstreamAttempts,
 		};
 	} else {
 		// Buffer the stream and return complete response
-		const { ir, usage, rawResponse, firstByteMs, totalMs } = await bufferStreamToIR(res, args, route, upstreamStartMs);
+		const { ir, usage, rawResponse, firstByteMs, totalMs } = await bufferStreamToIR(
+			res,
+			args,
+			route,
+			attempt.fetchStartMs,
+		);
 		if (ir) {
 			(ir as any).rawResponse = rawResponse;
 		}
@@ -327,12 +464,12 @@ export async function executeOpenAICompat(args: ExecutorExecuteArgs): Promise<Ex
 			byokKeyId: keyInfo.byokId,
 			mappedRequest,
 			rawResponse,
+			upstreamAttempts,
 			timing: {
+				...executorTiming,
 				latencyMs: firstByteMs ?? totalMs,
 				generationMs: firstByteMs === null ? 0 : Math.max(0, totalMs - firstByteMs),
-				requestBuildMs,
-				upstreamHeadersMs,
-				transientRetryDelayMs,
+				totalMs,
 			},
 		};
 	}
@@ -399,8 +536,9 @@ export function resolveStreamForProtocol(
 	res: Response,
 	args: ExecutorExecuteArgs,
 	route: "responses" | "chat",
+	providerStream: ReadableStream<Uint8Array> | null = res.body,
 ): ReadableStream<Uint8Array> {
-	if (!res.body) {
+	if (!providerStream) {
 		throw new Error("openai_stream_missing_body");
 	}
 
@@ -409,25 +547,25 @@ export function resolveStreamForProtocol(
 
 	if (protocol === "openai.chat.completions") {
 		if (route === "responses") {
-			return transformResponsesStreamToChat(res.body, args, state);
+			return transformResponsesStreamToChat(providerStream, args, state);
 		}
-		return transformChatStream(res.body, args, state);
+		return transformChatStream(providerStream, args, state);
 	}
 
 	if (protocol === "openai.responses") {
-		return transformChatStreamToResponses(res.body, args, state);
+		return transformChatStreamToResponses(providerStream, args, state);
 	}
 
 	if (protocol === "anthropic.messages") {
 		// Always normalize through chat->responses adapter first.
 		// This keeps /messages streaming compatible whether upstream emits responses events
 		// or chat-completion chunks on a responses route.
-		const responsesStream = transformChatStreamToResponses(res.body, args, state);
+		const responsesStream = transformChatStreamToResponses(providerStream, args, state);
 		return transformResponsesStreamToAnthropic(responsesStream, args);
 	}
 
 	// Default: passthrough (responses protocol or unknown)
-	return res.body;
+	return providerStream;
 }
 
 function resolvePreferredRoute(

--- a/apps/api/src/executors/amazon-bedrock/text-generate/__tests__/index.test.ts
+++ b/apps/api/src/executors/amazon-bedrock/text-generate/__tests__/index.test.ts
@@ -312,6 +312,15 @@ describe("amazon-bedrock text executor", () => {
 		expect(mock.calls[1]?.url.endsWith("/openai/v1/chat/completions")).toBe(true);
 		expect(result.kind).toBe("completed");
 		expect(result.ir?.choices?.[0]?.message?.content?.[0]?.type).toBe("text");
+		expect(result.upstreamAttempts).toHaveLength(2);
+		expect(result.upstreamAttempts?.map((attempt) => ({
+			route: attempt.route,
+			status: attempt.status,
+			outcome: attempt.outcome,
+		}))).toEqual([
+			{ route: "responses", status: 404, outcome: "upstream_non_2xx" },
+			{ route: "chat", status: 200, outcome: "success" },
+		]);
 	});
 
 });

--- a/apps/api/src/executors/amazon-bedrock/text-generate/index.ts
+++ b/apps/api/src/executors/amazon-bedrock/text-generate/index.ts
@@ -3,7 +3,12 @@
 // How: IR -> OpenAI Chat/Responses payload, then protocol shaping is handled by the pipeline.
 
 import type { IRChatRequest } from "@core/ir";
-import type { ExecutorExecuteArgs, ExecutorResult, Bill } from "@executors/types";
+import type {
+	ExecutorExecuteArgs,
+	ExecutorResult,
+	ExecutorUpstreamAttempt,
+	Bill,
+} from "@executors/types";
 import { buildTextExecutor, cherryPickIRParams } from "@executors/_shared/text-generate/shared";
 import { resolveStreamForProtocol, bufferStreamToIR } from "@executors/_shared/text-generate/openai-compat";
 import { irToOpenAIChat, openAIChatToIR } from "@executors/_shared/text-generate/openai-compat/transform-chat";
@@ -57,6 +62,7 @@ async function executeBedrockOpenAI(
 ): Promise<ExecutorResult> {
 	const irRequest = args.ir as IRChatRequest;
 	const upstreamStartMs = args.meta.upstreamStartMs ?? Date.now();
+	const upstreamAttempts: ExecutorUpstreamAttempt[] = [];
 
 	const buildPayload = (route: "chat" | "responses"): Record<string, any> => {
 		const providerId = args.providerId || "amazon-bedrock";
@@ -79,15 +85,37 @@ async function executeBedrockOpenAI(
 	let requestPayload = buildPayload(route);
 	let requestBody = JSON.stringify(requestPayload);
 	let mappedRequest = (args.meta.echoUpstreamRequest || args.meta.returnUpstreamRequest) ? requestBody : undefined;
-	let res = await sendBedrockRequest(auth, {
-		url: buildBedrockOpenAIUrl(auth.baseUrl, route),
-		body: requestBody,
-		headers: {
-			"Content-Type": "application/json",
-			Accept: requestPayload.stream ? "text/event-stream" : "application/json",
-			...upstreamTestHeaders(args.meta),
-		},
-	});
+	const performRequest = async (targetRoute: "chat" | "responses") => {
+		const url = buildBedrockOpenAIUrl(auth.baseUrl, targetRoute);
+		const startedAt = Date.now();
+		const response = await sendBedrockRequest(auth, {
+			url,
+			body: requestBody,
+			headers: {
+				"Content-Type": "application/json",
+				Accept: requestPayload.stream ? "text/event-stream" : "application/json",
+				...upstreamTestHeaders(args.meta),
+			},
+		});
+		let responsePayload: unknown;
+		if (!response.ok) {
+			const failure = await readErrorPayload(response);
+			responsePayload = failure.errorPayload ?? failure.errorText ?? null;
+		}
+		upstreamAttempts.push({
+			sequence: upstreamAttempts.length + 1,
+			route: targetRoute,
+			request: requestBody,
+			response: responsePayload,
+			status: response.status,
+			statusText: response.statusText || null,
+			url: response.url || url,
+			durationMs: Math.max(0, Date.now() - startedAt),
+			outcome: response.ok ? "success" : "upstream_non_2xx",
+		});
+		return response;
+	};
+	let res = await performRequest(route);
 
 	if (!res.ok && route === "responses") {
 		const { errorText } = await readErrorPayload(res);
@@ -96,15 +124,7 @@ async function executeBedrockOpenAI(
 			requestPayload = buildPayload(route);
 			requestBody = JSON.stringify(requestPayload);
 			mappedRequest = (args.meta.echoUpstreamRequest || args.meta.returnUpstreamRequest) ? requestBody : undefined;
-			res = await sendBedrockRequest(auth, {
-				url: buildBedrockOpenAIUrl(auth.baseUrl, route),
-				body: requestBody,
-				headers: {
-					"Content-Type": "application/json",
-					Accept: requestPayload.stream ? "text/event-stream" : "application/json",
-					...upstreamTestHeaders(args.meta),
-				},
-			});
+			res = await performRequest(route);
 		}
 	}
 
@@ -128,6 +148,7 @@ async function executeBedrockOpenAI(
 			keySource: keyInfo.source,
 			byokKeyId: keyInfo.byokId,
 			mappedRequest,
+			upstreamAttempts,
 		};
 	}
 
@@ -142,6 +163,7 @@ async function executeBedrockOpenAI(
 			keySource: keyInfo.source,
 			byokKeyId: keyInfo.byokId,
 			mappedRequest,
+			upstreamAttempts,
 			timing: {
 				latencyMs: undefined,
 				generationMs: undefined,
@@ -171,6 +193,7 @@ async function executeBedrockOpenAI(
 			byokKeyId: keyInfo.byokId,
 			mappedRequest,
 			rawResponse,
+			upstreamAttempts,
 			timing: {
 				latencyMs: firstByteMs ?? undefined,
 				generationMs:
@@ -201,6 +224,7 @@ async function executeBedrockOpenAI(
 		byokKeyId: keyInfo.byokId,
 		mappedRequest,
 		rawResponse: json,
+		upstreamAttempts,
 		timing: {
 			latencyMs: Date.now() - upstreamStartMs,
 			generationMs: 0,

--- a/apps/api/src/executors/google-ai-studio/text-generate/__tests__/upstream-attempts.test.ts
+++ b/apps/api/src/executors/google-ai-studio/text-generate/__tests__/upstream-attempts.test.ts
@@ -1,0 +1,67 @@
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import type { ExecutorExecuteArgs } from "@executors/types";
+import { execute } from "../index";
+import { installFetchMock, jsonResponse } from "../../../../../tests/helpers/mock-fetch";
+import { setupTestRuntime, teardownTestRuntime } from "../../../../../tests/helpers/runtime";
+
+beforeAll(() => setupTestRuntime());
+afterAll(() => teardownTestRuntime());
+
+describe("google-ai-studio upstream attempts", () => {
+	it("records every native retry before the successful response", async () => {
+		let calls = 0;
+		const mock = installFetchMock([{
+			match: (url) => url.includes("models/lyria-3-pro-preview:generateContent"),
+			response: () => {
+				calls += 1;
+				if (calls === 1) {
+					return jsonResponse({ error: { message: "temporary failure" } }, { status: 500 });
+				}
+				return jsonResponse({
+					responseId: "gemini_retry_ok",
+					modelVersion: "lyria-3-pro-preview",
+					candidates: [{
+						index: 0,
+						content: { parts: [{ text: "Recovered" }] },
+						finishReason: "STOP",
+					}],
+					usageMetadata: {
+						promptTokenCount: 4,
+						candidatesTokenCount: 2,
+						totalTokenCount: 6,
+					},
+				});
+			},
+		}]);
+
+		const result = await execute({
+			ir: {
+				model: "google/lyria-3-pro-preview",
+				stream: false,
+				messages: [{ role: "user", content: [{ type: "text", text: "hello" }] }],
+			},
+			requestId: "req_gemini_upstream_attempts",
+			workspaceId: "team_test",
+			providerId: "google-ai-studio",
+			endpoint: "responses",
+			protocol: "openai.responses",
+			capability: "text.generate",
+			providerModelSlug: "lyria-3-pro-preview",
+			capabilityParams: null,
+			byokMeta: [],
+			pricingCard: null as any,
+			meta: { returnUpstreamRequest: true },
+		} as ExecutorExecuteArgs);
+		mock.restore();
+
+		expect(result.kind).toBe("completed");
+		expect(result.upstreamAttempts).toHaveLength(2);
+		expect(result.upstreamAttempts?.map((attempt) => ({
+			status: attempt.status,
+			outcome: attempt.outcome,
+		}))).toEqual([
+			{ status: 500, outcome: "upstream_non_2xx" },
+			{ status: 200, outcome: "success" },
+		]);
+	});
+});

--- a/apps/api/src/executors/google-ai-studio/text-generate/index.ts
+++ b/apps/api/src/executors/google-ai-studio/text-generate/index.ts
@@ -7,7 +7,11 @@
 // Uses Google's native Gemini API format (NOT OpenAI-compatible)
 
 import type { IRChatRequest, IRChatResponse, IRContentPart, IRChoice, IRStreamChunk, IRStreamDelta } from "@core/ir";
-import type { ExecutorExecuteArgs, ExecutorResult } from "@executors/types";
+import type {
+	ExecutorExecuteArgs,
+	ExecutorResult,
+	ExecutorUpstreamAttempt,
+} from "@executors/types";
 import type { ProviderExecutor } from "../../types";
 import { buildTextExecutor, cherryPickIRParams } from "@executors/_shared/text-generate/shared";
 import { getBindings } from "@/runtime/env";
@@ -485,6 +489,7 @@ export async function execute(args: ExecutorExecuteArgs): Promise<ExecutorResult
 	const baseUrl = /\/v1(beta)?$/i.test(baseRoot) ? baseRoot : `${baseRoot}/v1beta`;
 
 	const upstreamStartMs = meta.upstreamStartMs ?? Date.now();
+	const upstreamAttempts: ExecutorUpstreamAttempt[] = [];
 
 	const makeEndpoint = (candidateModel: string, stream: boolean) =>
 		stream
@@ -508,6 +513,8 @@ export async function execute(args: ExecutorExecuteArgs): Promise<ExecutorResult
 				candidateModel,
 				Boolean(ir.stream) && !forceSyntheticImageStream,
 			);
+			const startedAt = Date.now();
+			const serializedRequest = JSON.stringify(requestBody);
 			const response = await fetch(endpoint, {
 				method: "POST",
 				headers: {
@@ -515,7 +522,27 @@ export async function execute(args: ExecutorExecuteArgs): Promise<ExecutorResult
 					"x-goog-api-key": keyInfo.key,
 					...upstreamTestHeaders(meta),
 				},
-				body: JSON.stringify(requestBody),
+				body: serializedRequest,
+			});
+			let responsePayload: unknown;
+			if (!response.ok) {
+				try {
+					const text = await response.clone().text();
+					responsePayload = text ? JSON.parse(text) : null;
+				} catch {
+					responsePayload = null;
+				}
+			}
+			upstreamAttempts.push({
+				sequence: upstreamAttempts.length + 1,
+				route: ir.stream && !forceSyntheticImageStream ? "streamGenerateContent" : "generateContent",
+				request: serializedRequest,
+				response: responsePayload,
+				status: response.status,
+				statusText: response.statusText || null,
+				url: response.url || endpoint,
+				durationMs: Math.max(0, Date.now() - startedAt),
+				outcome: response.ok ? "success" : "upstream_non_2xx",
 			});
 			return { candidateModel, requestBody, response };
 		};
@@ -564,6 +591,7 @@ export async function execute(args: ExecutorExecuteArgs): Promise<ExecutorResult
 				keySource: keyInfo.source,
 				byokKeyId: keyInfo.byokId,
 				mappedRequest,
+				upstreamAttempts,
 			};
 		}
 
@@ -608,6 +636,7 @@ export async function execute(args: ExecutorExecuteArgs): Promise<ExecutorResult
 				keySource: keyInfo.source,
 				byokKeyId: keyInfo.byokId,
 				mappedRequest,
+				upstreamAttempts,
 				usageFinalizer: async () => bill.usage ?? null,
 				timing: {
 					latencyMs: totalMs,
@@ -634,6 +663,7 @@ export async function execute(args: ExecutorExecuteArgs): Promise<ExecutorResult
 					keySource: keyInfo.source,
 					byokKeyId: keyInfo.byokId,
 					mappedRequest,
+					upstreamAttempts,
 					usageFinalizer: async () => null,
 				};
 			}
@@ -688,6 +718,7 @@ export async function execute(args: ExecutorExecuteArgs): Promise<ExecutorResult
 				byokKeyId: keyInfo.byokId,
 				mappedRequest,
 				rawResponse,
+				upstreamAttempts,
 				timing: {
 					latencyMs: firstByteMs ?? totalMs,
 					generationMs: firstByteMs === null ? 0 : Math.max(0, totalMs - firstByteMs),
@@ -722,6 +753,7 @@ export async function execute(args: ExecutorExecuteArgs): Promise<ExecutorResult
 			byokKeyId: keyInfo.byokId,
 			mappedRequest,
 			rawResponse: rawData,
+			upstreamAttempts,
 			timing: {
 				latencyMs: totalMs,
 				generationMs: 0,
@@ -745,6 +777,7 @@ export async function execute(args: ExecutorExecuteArgs): Promise<ExecutorResult
 			keySource: keyInfo.source,
 			byokKeyId: keyInfo.byokId,
 			mappedRequest,
+			upstreamAttempts,
 		};
 	}
 }

--- a/apps/api/src/executors/types.ts
+++ b/apps/api/src/executors/types.ts
@@ -79,6 +79,29 @@ export type Bill = {
 	finish_reason?: string | null;
 };
 
+export type ExecutorTiming = {
+	latencyMs?: number;
+	generationMs?: number;
+	totalMs?: number;
+	streamTimingSource?: "provider" | "executor";
+	requestBuildMs?: number;
+	upstreamHeadersMs?: number;
+	transientRetryDelayMs?: number;
+};
+
+export type ExecutorUpstreamAttempt = {
+	sequence: number;
+	route?: string | null;
+	request?: string | null;
+	response?: unknown;
+	status?: number | null;
+	statusText?: string | null;
+	url?: string | null;
+	durationMs: number;
+	outcome: "success" | "upstream_non_2xx" | "network_error";
+	errorMessage?: string | null;
+};
+
 export type ExecutorCompletedResult = {
 	kind: "completed";
 	ir?:
@@ -99,13 +122,8 @@ export type ExecutorCompletedResult = {
 	byokKeyId?: string | null;
 	mappedRequest?: string;
 	rawResponse?: any;
-	timing?: {
-		latencyMs?: number;
-		generationMs?: number;
-		requestBuildMs?: number;
-		upstreamHeadersMs?: number;
-		transientRetryDelayMs?: number;
-	};
+	timing?: ExecutorTiming;
+	upstreamAttempts?: ExecutorUpstreamAttempt[];
 };
 
 export type ExecutorStreamingResult = {
@@ -118,13 +136,8 @@ export type ExecutorStreamingResult = {
 	byokKeyId?: string | null;
 	mappedRequest?: string;
 	rawResponse?: any;
-	timing?: {
-		latencyMs?: number;
-		generationMs?: number;
-		requestBuildMs?: number;
-		upstreamHeadersMs?: number;
-		transientRetryDelayMs?: number;
-	};
+	timing?: ExecutorTiming;
+	upstreamAttempts?: ExecutorUpstreamAttempt[];
 };
 
 export type ExecutorResult = ExecutorCompletedResult | ExecutorStreamingResult;

--- a/apps/api/src/executors/x-ai/text-generate/index.ts
+++ b/apps/api/src/executors/x-ai/text-generate/index.ts
@@ -3,7 +3,13 @@
 // How: Transforms IR to SpaceXAI Responses API and normalizes usage.
 
 import type { IRChatRequest } from "@core/ir";
-import type { ExecutorExecuteArgs, ExecutorResult, Bill, ProviderExecutor } from "@executors/types";
+import type {
+	ExecutorExecuteArgs,
+	ExecutorResult,
+	ExecutorUpstreamAttempt,
+	Bill,
+	ProviderExecutor,
+} from "@executors/types";
 import { normalizeTextUsageForPricing } from "@executors/_shared/usage/text";
 import { irToOpenAIResponses } from "@executors/_shared/text-generate/openai-compat/transform";
 import { resolveStreamForProtocol, bufferStreamToIR } from "@executors/_shared/text-generate/openai-compat";
@@ -24,6 +30,7 @@ const XAI_MAX_ADAPTIVE_RETRIES = 0;
 
 async function executeXAi(args: ExecutorExecuteArgs): Promise<ExecutorResult> {
 	const upstreamStartMs = args.meta.upstreamStartMs ?? Date.now();
+	const upstreamAttempts: ExecutorUpstreamAttempt[] = [];
 	const irRequest = args.ir as IRChatRequest;
 	const quirks = getProviderQuirks(args.providerId);
 	const keyInfo = resolveProviderKey(
@@ -86,7 +93,9 @@ async function executeXAi(args: ExecutorExecuteArgs): Promise<ExecutorResult> {
 			// ignore if readonly
 		}
 		const requestBody = JSON.stringify(sanitized.request);
-			const response = await fetch(openAICompatUrl(args.providerId, "/responses"), {
+		const url = openAICompatUrl(args.providerId, "/responses");
+		const startedAt = Date.now();
+		const response = await fetch(url, {
 				method: "POST",
 				headers: openAICompatHeaders(args.providerId, keyInfo.key, {
 					"x-grok-conv-id": irRequest.xaiConversationId,
@@ -94,7 +103,23 @@ async function executeXAi(args: ExecutorExecuteArgs): Promise<ExecutorResult> {
 					...upstreamTestHeaders(args.meta),
 				}),
 				body: requestBody,
-			});
+		});
+		let responsePayload: unknown;
+		if (!response.ok) {
+			const failure = await readErrorPayload(response);
+			responsePayload = failure.errorPayload ?? failure.errorText ?? null;
+		}
+		upstreamAttempts.push({
+			sequence: upstreamAttempts.length + 1,
+			route: "responses",
+			request: requestBody,
+			response: responsePayload,
+			status: response.status,
+			statusText: response.statusText || null,
+			url: response.url || url,
+			durationMs: Math.max(0, Date.now() - startedAt),
+			outcome: response.ok ? "success" : "upstream_non_2xx",
+		});
 		return {
 			response,
 			request: sanitized.request,
@@ -162,6 +187,7 @@ async function executeXAi(args: ExecutorExecuteArgs): Promise<ExecutorResult> {
 			keySource: keyInfo.source,
 			byokKeyId: keyInfo.byokId,
 			mappedRequest,
+			upstreamAttempts,
 		};
 	}
 
@@ -176,6 +202,7 @@ async function executeXAi(args: ExecutorExecuteArgs): Promise<ExecutorResult> {
 			keySource: keyInfo.source,
 			byokKeyId: keyInfo.byokId,
 			mappedRequest,
+			upstreamAttempts,
 			timing: {
 				latencyMs: undefined,
 				generationMs: undefined,
@@ -223,6 +250,7 @@ async function executeXAi(args: ExecutorExecuteArgs): Promise<ExecutorResult> {
 		byokKeyId: keyInfo.byokId,
 		mappedRequest,
 		rawResponse: rawResponse ?? null,
+		upstreamAttempts,
 		timing: {
 			latencyMs: firstByteMs ?? totalMs,
 			generationMs: firstByteMs === null ? 0 : Math.max(0, totalMs - firstByteMs),

--- a/apps/api/src/pipeline/after/audit.ts
+++ b/apps/api/src/pipeline/after/audit.ts
@@ -16,9 +16,197 @@ import {
 	resolveExecuteTotalLatencyMs,
 	resolveNonStreamLatencyMs,
 } from "./timing";
+import {
+    extractProviderFinishReason,
+    normalizeFinishReason,
+} from "../audit/normalize-finish-reason";
 
 function getProviderAttempts(ctx: PipelineContext): Array<Record<string, unknown>> {
     return Array.isArray(ctx.providerAttempts) ? ctx.providerAttempts : [];
+}
+
+function buildUpstreamExchanges(args: {
+    ctx: PipelineContext;
+    result: RequestResult;
+    finalFinishReason?: string | null;
+    gatewayResponse?: unknown;
+}) {
+    const attempts = Array.isArray(args.ctx.providerAttempts)
+        ? args.ctx.providerAttempts
+        : [];
+    const rounds = Array.isArray(args.ctx.providerRounds)
+        ? args.ctx.providerRounds
+        : [];
+    const finalSuccessfulAttempt = [...attempts]
+        .reverse()
+        .find((attempt) => attempt.outcome === "success") ?? null;
+
+    const buildExchange = (
+        attempt: (typeof attempts)[number],
+        index: number,
+    ): Record<string, any> => {
+        const round = rounds.find((candidate) =>
+            candidate.round_number === (attempt.round_number ?? 1) &&
+            candidate.provider === attempt.provider &&
+            attempt.outcome === "success"
+        ) ?? null;
+        const isFinalSuccess = attempt === finalSuccessfulAttempt;
+        const providerResponse =
+            round?.raw_response ??
+            attempt.upstream_response ??
+            (isFinalSuccess ? args.result.rawResponse ?? args.gatewayResponse ?? null : null);
+        const providerFinishReason =
+            round?.provider_finish_reason ??
+            attempt.provider_finish_reason ??
+            extractProviderFinishReason(providerResponse);
+        const normalizedFinishReason =
+            round?.finish_reason ??
+            attempt.finish_reason ??
+            normalizeFinishReason(
+                providerFinishReason ?? (isFinalSuccess ? args.finalFinishReason : null),
+                attempt.provider,
+            );
+        const mappedRequest =
+            round?.mapped_request ??
+            attempt.upstream_request ??
+            (isFinalSuccess ? args.result.mappedRequest ?? null : null);
+
+        return {
+            sequence: index + 1,
+            stage: ["blocked", "no_pricing", "unsupported_executor"].includes(attempt.outcome)
+                ? "routing"
+                : "upstream",
+            round_number: attempt.round_number ?? 1,
+            attempt_number: attempt.attempt_number,
+            provider: attempt.provider,
+            model: attempt.model,
+            api_model_id: attempt.api_model_id ?? null,
+            provider_model_slug: attempt.provider_model_slug ?? null,
+            outcome: attempt.outcome,
+            status: attempt.status ?? null,
+            status_text: attempt.status_text ?? null,
+            duration_ms: attempt.duration_ms,
+            latency_ms: round?.latency_ms ?? null,
+            generation_ms: round?.generation_ms ?? null,
+            total_ms: round?.total_ms ?? attempt.duration_ms,
+            native_response_id:
+                round?.native_response_id ??
+                attempt.native_response_id ??
+                (isFinalSuccess ? args.result.bill?.upstream_id ?? null : null),
+            provider_finish_reason: providerFinishReason,
+            finish_reason: normalizedFinishReason,
+            usage: round?.usage ?? (isFinalSuccess ? args.result.bill?.usage ?? null : null),
+            key_source: attempt.key_source ?? null,
+            byok_key_id: attempt.byok_key_id ?? null,
+            upstream_url: attempt.upstream_url ?? null,
+            response_kind: attempt.response_kind ?? null,
+            retryable: attempt.retryable ?? null,
+            fallback_attempted: attempt.fallback_attempted ?? false,
+            was_probe: attempt.was_probe ?? false,
+            request_build_ms: attempt.request_build_ms ?? null,
+            upstream_headers_ms: attempt.upstream_headers_ms ?? null,
+            retry_delay_ms: attempt.retry_delay_ms ?? null,
+            error: attempt.outcome === "success"
+                ? null
+                : {
+                    code: attempt.upstream_error_code ?? null,
+                    type: attempt.upstream_error_type ?? null,
+                    message: attempt.upstream_error_message ?? null,
+                    description: attempt.upstream_error_description ?? null,
+                    param: attempt.upstream_error_param ?? null,
+                },
+            upstream_request: attempt.upstream_request ?? sanitizeJsonStringForAxiom(
+                typeof mappedRequest === "string" ? mappedRequest : null,
+            ) ?? sanitizeForAxiom(mappedRequest),
+            upstream_response: attempt.upstream_response ?? sanitizeForAxiom(providerResponse),
+            response_source:
+                round?.raw_response != null || attempt.upstream_response != null || args.result.rawResponse != null
+                    ? "provider"
+                    : isFinalSuccess && args.gatewayResponse != null
+                        ? "gateway_reconstructed"
+                        : null,
+        };
+    };
+
+    if (attempts.length > 0) {
+        return attempts.flatMap((attempt, attemptIndex) => {
+            const base = buildExchange(attempt, attemptIndex);
+            const upstreamAttempts = Array.isArray(attempt.upstream_attempts)
+                ? attempt.upstream_attempts
+                : [];
+            if (upstreamAttempts.length === 0) return [base];
+
+            return upstreamAttempts.map((upstreamAttempt, upstreamIndex) => {
+                const isLastUpstreamAttempt = upstreamIndex === upstreamAttempts.length - 1;
+                return {
+                    ...base,
+                    sequence: 0,
+                    stage: "upstream",
+                    internal_attempt_number: upstreamAttempt.sequence,
+                    upstream_route: upstreamAttempt.route ?? null,
+                    outcome: upstreamAttempt.outcome,
+                    status: upstreamAttempt.status ?? null,
+                    status_text: upstreamAttempt.status_text ?? null,
+                    duration_ms: upstreamAttempt.duration_ms,
+                    total_ms: upstreamAttempt.duration_ms,
+                    upstream_url: upstreamAttempt.url ?? base.upstream_url,
+                    provider_finish_reason: isLastUpstreamAttempt
+                        ? base.provider_finish_reason
+                        : null,
+                    finish_reason: isLastUpstreamAttempt ? base.finish_reason : null,
+                    usage: isLastUpstreamAttempt && upstreamAttempt.outcome === "success"
+                        ? base.usage
+                        : null,
+                    error: upstreamAttempt.outcome === "success"
+                        ? null
+                        : {
+                            code: null,
+                            type: upstreamAttempt.outcome,
+                            message: upstreamAttempt.error_message ?? null,
+                            description: null,
+                            param: null,
+                        },
+                    upstream_request: upstreamAttempt.request ?? base.upstream_request,
+                    upstream_response: isLastUpstreamAttempt
+                        ? upstreamAttempt.response ?? base.upstream_response
+                        : upstreamAttempt.response ?? null,
+                    response_source: upstreamAttempt.response != null || isLastUpstreamAttempt
+                        ? base.response_source
+                        : null,
+                };
+            });
+        }).map((exchange, index) => ({ ...exchange, sequence: index + 1 }));
+    }
+
+    const providerResponse = args.result.rawResponse ?? args.gatewayResponse ?? null;
+    const providerFinishReason = extractProviderFinishReason(providerResponse);
+    return [{
+        sequence: 1,
+        stage: "upstream",
+        round_number: 1,
+        attempt_number: 1,
+        provider: args.result.provider,
+        model: args.ctx.model,
+        api_model_id: args.result.apiModelId ?? null,
+        provider_model_slug: args.result.providerModelSlug ?? null,
+        outcome: args.result.upstream.ok ? "success" : "upstream_non_2xx",
+        status: args.result.upstream.status,
+        status_text: args.result.upstream.statusText || null,
+        duration_ms: args.result.timing?.totalMs ?? args.result.generationTimeMs ?? null,
+        latency_ms: args.result.timing?.latencyMs ?? null,
+        generation_ms: args.result.timing?.generationMs ?? args.result.generationTimeMs ?? null,
+        total_ms: args.result.timing?.totalMs ?? null,
+        native_response_id: args.result.bill?.upstream_id ?? null,
+        provider_finish_reason: providerFinishReason,
+        finish_reason: normalizeFinishReason(
+            providerFinishReason ?? args.finalFinishReason ?? null,
+            args.result.provider,
+        ),
+        usage: args.result.bill?.usage ?? null,
+        upstream_request: sanitizeJsonStringForAxiom(args.result.mappedRequest),
+        upstream_response: sanitizeForAxiom(providerResponse),
+        response_source: args.result.rawResponse != null ? "provider" : "gateway_reconstructed",
+    }];
 }
 
 // ============================================================================
@@ -366,6 +554,12 @@ export async function handleFailureAudit(
             providerResponse: errorDetails ?? result.rawResponse ?? null,
             detailMetadata: {
                 stage: "execute",
+                upstream_exchanges: buildUpstreamExchanges({
+                    ctx,
+                    result,
+                    finalFinishReason: null,
+                    gatewayResponse: gatewayErrorPayload ?? gatewayFailurePayload,
+                }),
                 routing_diagnostics: sanitizeForAxiom((ctx as any).routingDiagnostics ?? null),
                 provider_enablement_diagnostics: sanitizeForAxiom(
                     ctx.providerEnablementDiagnostics ?? null,
@@ -488,8 +682,6 @@ export async function handleSuccessAudit(
     })();
 
     // Extract enrichment data for wide event logging
-    const requestEnrichment = extractRequestEnrichment(ctx);
-    const routingContext = extractRoutingContext(ctx, result);
     const guardrailEnforcementPayload = ctx.guardrailEnforcement
         ? sanitizeForAxiom({
             guardrail_enforcement: ctx.guardrailEnforcement,
@@ -507,6 +699,14 @@ export async function handleSuccessAudit(
         mergeWebFetchObservability(ctx.webFetchObservability ?? null),
     );
 
+    const upstreamExchanges = buildUpstreamExchanges({
+        ctx,
+        result,
+        finalFinishReason: finishReason,
+        gatewayResponse: gatewayResponse ?? null,
+    });
+    const requestEnrichment = extractRequestEnrichment(ctx);
+    const routingContext = extractRoutingContext(ctx, result);
     try {
         await auditSuccess({
             requestId: ctx.requestId,
@@ -560,6 +760,7 @@ export async function handleSuccessAudit(
             detailMetadata: {
                 stage: "execute",
                 finish_reason: finishReason ?? null,
+                upstream_exchanges: upstreamExchanges,
                 plugin_executions: sanitizeForAxiom(ctx.pluginExecutions ?? null),
                 routing_diagnostics: sanitizeForAxiom((ctx as any).routingDiagnostics ?? null),
                 response_cache: sanitizeForAxiom(ctx.responseCache ?? null),
@@ -574,7 +775,6 @@ export async function handleSuccessAudit(
                 replay_supported: true,
                 guardrail_enforcement_present: Boolean(ctx.guardrailEnforcement),
             },
-            // Wide event enrichment
             teamEnrichment: ctx.teamEnrichment ?? null,
             keyEnrichment: ctx.keyEnrichment ?? null,
             requestEnrichment,

--- a/apps/api/src/pipeline/after/audit.upstream-exchanges.test.ts
+++ b/apps/api/src/pipeline/after/audit.upstream-exchanges.test.ts
@@ -1,0 +1,316 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const auditSuccessMock = vi.fn();
+const auditFailureMock = vi.fn();
+const emitGatewayRequestEventMock = vi.fn();
+
+vi.mock("../audit", () => ({
+	auditSuccess: (...args: any[]) => auditSuccessMock(...args),
+	auditFailure: (...args: any[]) => auditFailureMock(...args),
+}));
+
+vi.mock("@observability/events", () => ({
+	emitGatewayRequestEvent: (...args: any[]) => emitGatewayRequestEventMock(...args),
+}));
+
+import { handleFailureAudit, handleSuccessAudit } from "./audit";
+
+function createResult(provider = "wafer") {
+	return {
+		kind: "completed",
+		provider,
+		apiModelId: "glm-5.2",
+		providerModelSlug: "glm-5.2",
+		upstream: new Response(null, { status: 200 }),
+		generationTimeMs: 80,
+		bill: {
+			usage: { input_tokens: 10, output_tokens: 5, total_tokens: 15 },
+			currency: "USD",
+			cost_cents: 0,
+			upstream_id: "resp_wafer",
+			finish_reason: "stop",
+		},
+		mappedRequest: JSON.stringify({ model: "glm-5.2", messages: [{ role: "user", content: "hello" }] }),
+		rawResponse: {
+			id: "resp_wafer",
+			choices: [{ finish_reason: "stop", message: { content: "Hello" } }],
+		},
+		keySource: "gateway",
+		timing: { latencyMs: 120, generationMs: 80, totalMs: 200 },
+	} as any;
+}
+
+function createContext() {
+	return {
+		requestId: "req_glm",
+		workspaceId: "ws_1",
+		endpoint: "chat.completions",
+		capability: "text.generate",
+		requestedModel: "z-ai/glm-5.2",
+		model: "z-ai/glm-5.2",
+		stream: false,
+		body: { model: "z-ai/glm-5.2", messages: [{ role: "user", content: "hello" }] },
+		rawBody: { model: "z-ai/glm-5.2", messages: [{ role: "user", content: "hello" }] },
+		meta: { apiKeyId: "key_1", authMethod: "api_key" },
+		providers: [],
+		pricing: {},
+		gating: {
+			key: { ok: true, reason: null, resetAt: null },
+			keyLimit: { ok: true, reason: null, resetAt: null },
+			credit: { ok: true, reason: null, resetAt: null },
+		},
+	} as any;
+}
+
+describe("handleSuccessAudit upstream exchanges", () => {
+	beforeEach(() => {
+		auditSuccessMock.mockReset();
+		auditFailureMock.mockReset();
+		emitGatewayRequestEventMock.mockReset();
+		auditSuccessMock.mockResolvedValue(undefined);
+		auditFailureMock.mockResolvedValue(undefined);
+		emitGatewayRequestEventMock.mockResolvedValue(undefined);
+	});
+
+	it("keeps one API row and records the complete provider failover timeline", async () => {
+		const ctx = createContext();
+		ctx.providerAttempts = [
+			{
+				attempt_number: 1,
+				round_number: 1,
+				provider: "moonshot-ai",
+				endpoint: "chat.completions",
+				model: "z-ai/glm-5.2",
+				api_model_id: "glm-5.2",
+				outcome: "upstream_non_2xx",
+				duration_ms: 45,
+				status: 429,
+				upstream_error_code: "rate_limit_exceeded",
+				upstream_request: { model: "glm-5.2" },
+				upstream_response: { error: { code: "rate_limit_exceeded" } },
+			},
+			{
+				attempt_number: 2,
+				round_number: 1,
+				provider: "wafer",
+				endpoint: "chat.completions",
+				model: "z-ai/glm-5.2",
+				api_model_id: "glm-5.2",
+				outcome: "success",
+				duration_ms: 200,
+				status: 200,
+				native_response_id: "resp_wafer",
+				provider_finish_reason: "stop",
+				finish_reason: "stop",
+				upstream_request: { model: "glm-5.2" },
+				upstream_response: { id: "resp_wafer", choices: [{ finish_reason: "stop" }] },
+			},
+		];
+
+		await handleSuccessAudit(
+			ctx,
+			createResult(),
+			false,
+			{ input_tokens: 10, output_tokens: 5, total_tokens: 15 },
+			0,
+			0,
+			"USD",
+			"stop",
+			200,
+			"resp_wafer",
+			{ choices: [{ finish_reason: "stop" }] },
+		);
+
+		expect(auditSuccessMock).toHaveBeenCalledTimes(1);
+		const exchanges = auditSuccessMock.mock.calls[0][0].detailMetadata.upstream_exchanges;
+		expect(exchanges).toHaveLength(2);
+		expect(exchanges[0]).toEqual(expect.objectContaining({
+			provider: "moonshot-ai",
+			outcome: "upstream_non_2xx",
+			status: 429,
+		}));
+		expect(exchanges[1]).toEqual(expect.objectContaining({
+			provider: "wafer",
+			outcome: "success",
+			provider_finish_reason: "stop",
+			finish_reason: "stop",
+		}));
+	});
+
+	it("records managed tool rounds as upstream children of one complete gateway request", async () => {
+		const ctx = createContext();
+		ctx.providerAttempts = [
+			{ attempt_number: 1, round_number: 1, provider: "wafer", endpoint: "chat.completions", model: "z-ai/glm-5.2", outcome: "success", duration_ms: 100, status: 200 },
+			{ attempt_number: 1, round_number: 2, provider: "wafer", endpoint: "chat.completions", model: "z-ai/glm-5.2", outcome: "success", duration_ms: 200, status: 200 },
+		];
+		ctx.providerRounds = [
+			{
+				round_number: 1,
+				provider: "wafer",
+				api_model_id: "glm-5.2",
+				pricing_key: null,
+				provider_finish_reason: "tool_calls",
+				finish_reason: "tool_calls",
+				usage: { input_tokens: 10, output_tokens: 2, total_tokens: 12 },
+				native_response_id: "resp_tool",
+				generation_ms: 40,
+				latency_ms: 60,
+				total_ms: 100,
+				mapped_request: "{\"model\":\"glm-5.2\"}",
+				raw_response: { id: "resp_tool", choices: [{ finish_reason: "tool_calls" }] },
+				status_code: 200,
+				key_source: "gateway",
+				byok_key_id: null,
+				provider_attempts: [ctx.providerAttempts[0]],
+			},
+			{
+				round_number: 2,
+				provider: "wafer",
+				api_model_id: "glm-5.2",
+				pricing_key: null,
+				provider_finish_reason: "stop",
+				finish_reason: "stop",
+				usage: { input_tokens: 20, output_tokens: 5, total_tokens: 25 },
+				native_response_id: "resp_stop",
+				generation_ms: 80,
+				latency_ms: 120,
+				total_ms: 200,
+				mapped_request: "{\"model\":\"glm-5.2\"}",
+				raw_response: { id: "resp_stop", choices: [{ finish_reason: "stop" }] },
+				status_code: 200,
+				key_source: "gateway",
+				byok_key_id: null,
+				provider_attempts: [ctx.providerAttempts[1]],
+			},
+		];
+
+		await handleSuccessAudit(ctx, createResult(), false, {}, 3.7, 37_000_000, "USD", "stop", 200);
+
+		expect(auditSuccessMock).toHaveBeenCalledTimes(1);
+		const parent = auditSuccessMock.mock.calls[0][0];
+		expect(parent.requestId).toBe("req_glm");
+		expect(parent.keyId).toBe("key_1");
+		expect(parent.finishReason).toBe("stop");
+		expect(parent.totalNanos).toBe(37_000_000);
+		expect(parent.detailMetadata.upstream_exchanges).toHaveLength(2);
+		expect(parent.detailMetadata.upstream_exchanges.map((exchange: any) => ({
+			round: exchange.round_number,
+			finishReason: exchange.finish_reason,
+		}))).toEqual([
+			{ round: 1, finishReason: "tool_calls" },
+			{ round: 2, finishReason: "stop" },
+		]);
+		expect(emitGatewayRequestEventMock).toHaveBeenCalledTimes(1);
+	});
+
+	it("expands executor-level HTTP retries into ordered upstream exchanges", async () => {
+		const ctx = createContext();
+		ctx.providerAttempts = [{
+			attempt_number: 1,
+			round_number: 1,
+			provider: "baseten",
+			endpoint: "chat.completions",
+			model: "thinking-machines/inkling",
+			outcome: "success",
+			duration_ms: 210,
+			status: 200,
+			provider_finish_reason: "stop",
+			finish_reason: "stop",
+			upstream_attempts: [
+				{
+					sequence: 1,
+					route: "responses",
+					request: { model: "thinkingmachines/inkling" },
+					response: { error: { message: "unsupported endpoint" } },
+					status: 404,
+					duration_ms: 40,
+					outcome: "upstream_non_2xx",
+				},
+				{
+					sequence: 2,
+					route: "chat",
+					request: { model: "thinkingmachines/inkling" },
+					status: 200,
+					duration_ms: 170,
+					outcome: "success",
+				},
+			],
+		}];
+
+		await handleSuccessAudit(ctx, createResult("baseten"), false, {}, 0, 0, "USD", "stop", 210);
+
+		const exchanges = auditSuccessMock.mock.calls[0][0].detailMetadata.upstream_exchanges;
+		expect(exchanges).toHaveLength(2);
+		expect(exchanges[0]).toEqual(expect.objectContaining({
+			sequence: 1,
+			internal_attempt_number: 1,
+			upstream_route: "responses",
+			status: 404,
+			finish_reason: null,
+		}));
+		expect(exchanges[1]).toEqual(expect.objectContaining({
+			sequence: 2,
+			internal_attempt_number: 2,
+			upstream_route: "chat",
+			status: 200,
+			finish_reason: "stop",
+		}));
+	});
+
+	it("keeps every failed provider attempt on an ultimately failed gateway request", async () => {
+		const ctx = createContext();
+		ctx.providerAttempts = [
+			{
+				attempt_number: 1,
+				provider: "moonshot-ai",
+				endpoint: "chat.completions",
+				model: "z-ai/glm-5.2",
+				outcome: "upstream_non_2xx",
+				duration_ms: 30,
+				status: 429,
+				upstream_request: { model: "glm-5.2" },
+				upstream_response: { error: { message: "rate limited" } },
+			},
+			{
+				attempt_number: 2,
+				provider: "wafer",
+				endpoint: "chat.completions",
+				model: "z-ai/glm-5.2",
+				outcome: "upstream_non_2xx",
+				duration_ms: 70,
+				status: 503,
+				upstream_request: { model: "glm-5.2" },
+				upstream_response: { error: { message: "temporarily unavailable" } },
+			},
+		];
+		const result = {
+			...createResult("wafer"),
+			upstream: new Response(null, { status: 503 }),
+			rawResponse: { error: { message: "temporarily unavailable" } },
+		};
+
+		await handleFailureAudit(
+			ctx,
+			result,
+			503,
+			"provider",
+			"upstream_error",
+			"All providers failed",
+			result.rawResponse,
+		);
+
+		expect(auditFailureMock).toHaveBeenCalledTimes(1);
+		const logged = auditFailureMock.mock.calls[0][0];
+		expect(logged.requestId).toBe("req_glm");
+		expect(logged.keyId).toBe("key_1");
+		expect(logged.detailMetadata.upstream_exchanges).toHaveLength(2);
+		expect(logged.detailMetadata.upstream_exchanges.map((exchange: any) => ({
+			provider: exchange.provider,
+			status: exchange.status,
+			outcome: exchange.outcome,
+		}))).toEqual([
+			{ provider: "moonshot-ai", status: 429, outcome: "upstream_non_2xx" },
+			{ provider: "wafer", status: 503, outcome: "upstream_non_2xx" },
+		]);
+	});
+});

--- a/apps/api/src/pipeline/after/stream.ts
+++ b/apps/api/src/pipeline/after/stream.ts
@@ -95,6 +95,12 @@ function attachStreamTimingMeta(args: {
         generation_ms: generationMs,
         latency_ms: ctx.meta.latency_ms ?? 0,
         end_to_end_ms: ctx.meta.end_to_end_ms ?? null,
+        ...(typeof ctx.meta.provider_generation_total_ms === "number"
+            ? { provider_generation_total_ms: ctx.meta.provider_generation_total_ms }
+            : {}),
+        ...(typeof ctx.meta.provider_call_count === "number"
+            ? { provider_call_count: ctx.meta.provider_call_count }
+            : {}),
     };
     const responsePayload =
         frame.response &&
@@ -113,6 +119,12 @@ function attachStreamTimingMeta(args: {
             generation_ms: generationMs,
             end_to_end_ms: ctx.meta.end_to_end_ms ?? null,
             throughput_tps: throughputTps,
+            ...(typeof ctx.meta.provider_generation_total_ms === "number"
+                ? { provider_generation_total_ms: ctx.meta.provider_generation_total_ms }
+                : {}),
+            ...(typeof ctx.meta.provider_call_count === "number"
+                ? { provider_call_count: ctx.meta.provider_call_count }
+                : {}),
         };
     }
     if (frame.meta && typeof frame.meta === "object" && "finish_reason" in frame.meta) {
@@ -208,6 +220,7 @@ export async function handleStreamResponse(
         ctx,
         provider: result.provider,
         priceCard: card,
+        providerTiming: result.timing,
         rewriteFrame: (frame: any) => {
             if (!frame || typeof frame !== "object") return frame;
             const includeMeta = ctx.meta.returnMeta ?? false;

--- a/apps/api/src/pipeline/after/streaming.test.ts
+++ b/apps/api/src/pipeline/after/streaming.test.ts
@@ -534,4 +534,46 @@ describe("passthroughWithPricing", () => {
 		expect((ctx.meta.generation_ms as number)!).toBeLessThan((ctx.meta.latency_ms as number)!);
 	});
 
+	it("uses authoritative timing measured around the provider stream", async () => {
+		const ctx = baseCtx({
+			endpoint: "chat.completions",
+			protocol: "openai.chat.completions",
+			meta: {
+				upstreamStartMs: Date.now() - 500,
+			},
+		});
+		const upstream = makeDelayedSseResponse([
+			{
+				data: {
+					object: "chat.completion.chunk",
+					choices: [{ index: 0, delta: { content: "hello" }, finish_reason: null }],
+				},
+			},
+			{
+				data: {
+					object: "chat.completion",
+					choices: [{ index: 0, message: { role: "assistant", content: "hello" }, finish_reason: "stop" }],
+				},
+			},
+		], 20);
+
+		const response = await passthroughWithPricing({
+			upstream: upstream.response,
+			ctx,
+			provider: "baseten",
+			priceCard: null,
+			providerTiming: {
+				latencyMs: 31,
+				generationMs: 87,
+				totalMs: 118,
+			},
+		});
+
+		await drain(response);
+
+		expect(ctx.meta.latency_ms).toBe(31);
+		expect(ctx.meta.generation_ms).toBe(87);
+		expect(ctx.meta.end_to_end_ms).toBe(118);
+	});
+
 });

--- a/apps/api/src/pipeline/after/streaming.ts
+++ b/apps/api/src/pipeline/after/streaming.ts
@@ -16,6 +16,7 @@ import {
 } from "@protocols/stream/encode";
 import { dispatchBackground } from "@/runtime/env";
 import { supportsProviderStreamCancellation } from "./stream-cancellation";
+import type { ExecutorTiming } from "@executors/types";
 
 /** Pure passthrough for non-stream fallbacks (keeps upstream headers where safe). */
 export function passthrough(upstream: Response): Response {
@@ -53,6 +54,7 @@ type PassthroughWithPricingOpts = {
      * Optional Server-Timing value; if present we'll include it.
      */
     timingHeader?: string;
+    providerTiming?: ExecutorTiming;
 };
 
 /** Re-stream SSE while:
@@ -61,7 +63,17 @@ type PassthroughWithPricingOpts = {
  *  - detecting the final snapshot frame with `usage` to trigger onFinalUsage
  */
 export async function passthroughWithPricing(opts: PassthroughWithPricingOpts): Promise<Response> {
-    const { upstream, rewriteFrame, onFinalUsage, onFinalSnapshot, onStreamEvent, timingHeader, ctx, provider } = opts;
+    const {
+        upstream,
+        rewriteFrame,
+        onFinalUsage,
+        onFinalSnapshot,
+        onStreamEvent,
+        timingHeader,
+        providerTiming,
+        ctx,
+        provider,
+    } = opts;
     const canCancelUpstream = supportsProviderStreamCancellation(provider);
 
     const reader = upstream.body?.getReader();
@@ -84,6 +96,21 @@ export async function passthroughWithPricing(opts: PassthroughWithPricingOpts): 
         return null;
     };
 
+    const readTimingValue = (value: number | null | undefined): number | null =>
+        typeof value === "number" && Number.isFinite(value)
+            ? Math.max(0, Math.round(value))
+            : null;
+
+    const applyProviderTiming = () => {
+        const latencyMs = readTimingValue(providerTiming?.latencyMs);
+        const generationMs = readTimingValue(providerTiming?.generationMs);
+        const totalMs = readTimingValue(providerTiming?.totalMs);
+        if (latencyMs !== null) ctx.meta.latency_ms = latencyMs;
+        if (generationMs !== null) ctx.meta.generation_ms = generationMs;
+        if (totalMs !== null) ctx.meta.end_to_end_ms = totalMs;
+        return latencyMs !== null && generationMs !== null && totalMs !== null;
+    };
+
     const recordCompletionTiming = () => {
         if (
             ctx.meta.preserve_stream_timing &&
@@ -93,6 +120,7 @@ export async function passthroughWithPricing(opts: PassthroughWithPricingOpts): 
         ) {
             return;
         }
+        if (applyProviderTiming()) return;
         const nowMs = Date.now();
         const nowPerf = performance.now();
         const requestStartMs = resolveRequestStartMs();
@@ -210,10 +238,9 @@ export async function passthroughWithPricing(opts: PassthroughWithPricingOpts): 
                     if (firstFrameAt === null) {
                         firstFrameAt = performance.now();
                         firstFrameAtMs = Date.now();
-                        // For streamed responses, latency means upstream request start -> first frame
-                        // emitted back to the client. Provider adapters may record earlier upstream
-                        // timings, so overwrite here with the actual downstream first-frame timing.
-                        if (!ctx.meta.preserve_stream_timing) {
+                        // Prefer timing measured around the provider's raw stream. Executors without
+                        // that measurement fall back to request start -> first downstream frame.
+                        if (!ctx.meta.preserve_stream_timing && !applyProviderTiming()) {
                             const requestStartMs = resolveRequestStartMs();
                             if (requestStartMs !== null) {
                                 ctx.meta.latency_ms = Math.max(

--- a/apps/api/src/pipeline/audit/index.test.ts
+++ b/apps/api/src/pipeline/audit/index.test.ts
@@ -21,6 +21,10 @@ vi.mock("@core/workspace-usage-rollups", () => ({
 		syncWorkspaceUsageRollupForRequestMock(...args),
 }));
 
+vi.mock("./io-logging", () => ({
+	persistGatewayIoLog: vi.fn(async () => ({ io_log_status: "not_enabled" })),
+}));
+
 import { auditFailure, auditSuccess } from "./index";
 
 describe("audit request detail persistence", () => {
@@ -39,6 +43,7 @@ describe("audit request detail persistence", () => {
 	it("stores replay-ready details for successful requests", async () => {
 		const gatewayRequestRows: any[] = [];
 		const detailRows: any[] = [];
+		const upstreamRows: any[] = [];
 
 		getSupabaseAdminMock.mockReturnValue({
 			from: vi.fn((table: string) => {
@@ -71,6 +76,15 @@ describe("audit request detail persistence", () => {
 					};
 				}
 
+				if (table === "gateway_upstream_requests") {
+					return {
+						insert: vi.fn(async (rows: any[]) => {
+							upstreamRows.push(...rows);
+							return { error: null };
+						}),
+					};
+				}
+
 				throw new Error(`unexpected table ${table}`);
 			}),
 		});
@@ -85,8 +99,8 @@ describe("audit request detail persistence", () => {
 			stream: false,
 			byok: false,
 			usagePriced: { prompt_tokens: 2, completion_tokens: 1, pricing: { lines: [] } },
-			totalCents: 0.001,
-			totalNanos: 1000000,
+			totalCents: 3.7,
+			totalNanos: 37_000_000,
 			currency: "USD",
 			statusCode: 200,
 			requestPayload: {
@@ -96,7 +110,46 @@ describe("audit request detail persistence", () => {
 			gatewayResponse: { id: "resp_1", output_text: "hi" },
 			providerRequest: { model: "openai/gpt-5-nano", messages: [{ role: "user", content: "hello" }] },
 			providerResponse: { id: "chatcmpl_1" },
-			detailMetadata: { replay_supported: true },
+			detailMetadata: {
+				replay_supported: true,
+				upstream_exchanges: [
+					{
+						sequence: 1,
+						round_number: 1,
+						attempt_number: 1,
+						stage: "upstream",
+						provider: "moonshot-ai",
+						model: "phaseo/free",
+						status: 429,
+						outcome: "upstream_non_2xx",
+						error: { type: "rate_limit", message: "rate limited" },
+					},
+					{
+						sequence: 2,
+						round_number: 1,
+						attempt_number: 2,
+						stage: "upstream",
+						provider: "wafer",
+						model: "phaseo/free",
+						status: 200,
+						outcome: "success",
+						finish_reason: "tool_calls",
+						usage: { input_tokens: 10, output_tokens: 2, total_tokens: 12 },
+					},
+					{
+						sequence: 3,
+						round_number: 2,
+						attempt_number: 1,
+						stage: "upstream",
+						provider: "wafer",
+						model: "phaseo/free",
+						status: 200,
+						outcome: "success",
+						finish_reason: "stop",
+						usage: { input_tokens: 20, output_tokens: 5, total_tokens: 25 },
+					},
+				],
+			},
 			providerAttempts: [
 				{
 					attempt_number: 1,
@@ -104,6 +157,8 @@ describe("audit request detail persistence", () => {
 					api_model_id: "openai/gpt-5-nano",
 					outcome: "success",
 					status: 200,
+					upstream_request: { model: "openai/gpt-5-nano" },
+					upstream_response: { id: "chatcmpl_1" },
 				},
 			],
 		});
@@ -113,19 +168,19 @@ describe("audit request detail persistence", () => {
 			expect.objectContaining({
 				model_id: "phaseo/free",
 				provider: "openai",
-				provider_attempts: [
-					expect.objectContaining({
-						api_model_id: "openai/gpt-5-nano",
-					}),
-				],
+				provider_attempts: [],
 				usage_input_tokens: 2,
 				usage_output_tokens: 1,
 				usage_total_tokens: 3,
 				usage_input_quad_tokens: expect.any(Number),
 				usage_output_quad_tokens: expect.any(Number),
 				usage_total_quad_tokens: expect.any(Number),
+				detail_metadata: expect.objectContaining({
+					upstream_exchange_count: 3,
+				}),
 			}),
 		);
+		expect(gatewayRequestRows[0].detail_metadata).not.toHaveProperty("upstream_exchanges");
 		expect(gatewayRequestRows[0].usage_input_quad_tokens).toBeGreaterThan(0);
 		expect(gatewayRequestRows[0].usage_output_quad_tokens).toBeGreaterThan(0);
 		expect(detailRows).toHaveLength(1);
@@ -138,14 +193,39 @@ describe("audit request detail persistence", () => {
 					messages: [{ role: "user", content: "hello" }],
 				},
 				request_content: [{ role: "user", content: "hello" }],
-				metadata: expect.objectContaining({ replay_supported: true }),
+				metadata: expect.objectContaining({
+					replay_supported: true,
+					upstream_exchange_count: 3,
+				}),
 			}),
 		);
+		expect(upstreamRows).toHaveLength(3);
+		expect(upstreamRows[0]).toEqual(expect.objectContaining({
+			gateway_request_id: "row_1",
+			gateway_request_created_at: "2026-05-05T12:00:00.000Z",
+			created_at: "2026-05-05T12:00:00.000Z",
+			request_id: "req_success_1",
+			workspace_id: "ws_1",
+			sequence: 1,
+			provider: "moonshot-ai",
+			status_code: 429,
+			success: false,
+			cost_nanos: 0,
+		}));
+		expect(upstreamRows.slice(1).map((row) => ({
+			provider: row.provider,
+			finishReason: row.finish_reason,
+			costNanos: row.cost_nanos,
+		}))).toEqual([
+			{ provider: "wafer", finishReason: "tool_calls", costNanos: 12_000_000 },
+			{ provider: "wafer", finishReason: "stop", costNanos: 25_000_000 },
+		]);
 	});
 
 	it("stores replay-ready details for execute-stage failures", async () => {
 		const gatewayRequestRows: any[] = [];
 		const detailRows: any[] = [];
+		const upstreamRows: any[] = [];
 
 		getSupabaseAdminMock.mockReturnValue({
 			from: vi.fn((table: string) => {
@@ -178,6 +258,15 @@ describe("audit request detail persistence", () => {
 					};
 				}
 
+				if (table === "gateway_upstream_requests") {
+					return {
+						insert: vi.fn(async (rows: any[]) => {
+							upstreamRows.push(...rows);
+							return { error: null };
+						}),
+					};
+				}
+
 				throw new Error(`unexpected table ${table}`);
 			}),
 		});
@@ -201,7 +290,14 @@ describe("audit request detail persistence", () => {
 			gatewayResponse: { error: "upstream_error" },
 			providerRequest: { model: "openai/gpt-5.4-nano" },
 			providerResponse: { error: { message: "bad gateway" } },
-			detailMetadata: { replay_supported: true, stage: "execute" },
+			detailMetadata: {
+				replay_supported: true,
+				stage: "execute",
+				upstream_exchanges: [
+					{ sequence: 1, provider: "moonshot-ai", model: "phaseo/free", status: 429, outcome: "upstream_non_2xx" },
+					{ sequence: 2, provider: "openai", model: "phaseo/free", status: 500, outcome: "upstream_non_2xx" },
+				],
+			},
 			providerAttempts: [
 				{
 					attempt_number: 1,
@@ -218,11 +314,7 @@ describe("audit request detail persistence", () => {
 			expect.objectContaining({
 				model_id: "phaseo/free",
 				provider: "openai",
-				provider_attempts: [
-					expect.objectContaining({
-						api_model_id: "openai/gpt-5.4-nano",
-					}),
-				],
+				provider_attempts: [],
 			}),
 		);
 		expect(detailRows).toHaveLength(1);
@@ -242,6 +334,16 @@ describe("audit request detail persistence", () => {
 				}),
 			}),
 		);
+		expect(upstreamRows).toHaveLength(2);
+		expect(upstreamRows.map((row) => ({
+			provider: row.provider,
+			status: row.status_code,
+			success: row.success,
+			cost: row.cost_nanos,
+		}))).toEqual([
+			{ provider: "moonshot-ai", status: 429, success: false, cost: 0 },
+			{ provider: "openai", status: 500, success: false, cost: 0 },
+		]);
 	});
 
 	it("keeps rollup sync independent from detail persistence failures", async () => {

--- a/apps/api/src/pipeline/audit/index.ts
+++ b/apps/api/src/pipeline/audit/index.ts
@@ -12,6 +12,7 @@ import {
 	stripGatewayRequestUsageColumns,
 } from "../usage-columns";
 import { persistGatewayIoLog } from "./io-logging";
+import { persistGatewayUpstreamRequests } from "./upstream-requests";
 
 function supaAdmin() {
     return getSupabaseAdmin();
@@ -250,6 +251,19 @@ async function insertGatewayRequestDetailsNonBlocking(
     }
 }
 
+function summarizeDetailMetadata(
+    metadata: Record<string, unknown> | null | undefined,
+): Record<string, unknown> | null {
+    if (!metadata) return null;
+    const { upstream_exchanges: upstreamExchanges, ...summary } = metadata;
+    return {
+        ...summary,
+        upstream_exchange_count: Array.isArray(upstreamExchanges)
+            ? upstreamExchanges.length
+            : 0,
+    };
+}
+
 function buildSupaRow(args: {
     requestId: string; workspaceId?: string | null;
     endpoint: Endpoint; model?: string | null; canonicalModel?: string | null; provider?: string | null;
@@ -270,6 +284,7 @@ function buildSupaRow(args: {
     usage?: any | null; costNanos?: number | null; currency?: string | null;
     pricingLines?: any[] | null; throughput?: number | null;
     finishReason?: string | null;
+    detailMetadata?: Record<string, unknown> | null;
     requestPayload?: unknown;
     gatewayResponse?: unknown;
     edgeColo?: string | null;
@@ -300,7 +315,29 @@ function buildSupaRow(args: {
         end_user_id: args.requestUserId ?? null,
         session_id: args.sessionId ?? null,
         trace_data: args.traceData ?? null,
-        provider_attempts: Array.isArray(args.providerAttempts) ? args.providerAttempts : [],
+        provider_attempts: Array.isArray(args.providerAttempts)
+            ? args.providerAttempts.map((attempt) => {
+                const {
+                    upstream_request: _upstreamRequest,
+                    upstream_response: _upstreamResponse,
+                    upstream_attempts: upstreamAttempts,
+                    ...summary
+                } = attempt;
+                return {
+                    ...summary,
+                    upstream_attempts: Array.isArray(upstreamAttempts)
+                        ? upstreamAttempts.map((upstreamAttempt) => {
+                            const {
+                                request: _request,
+                                response: _response,
+                                ...upstreamSummary
+                            } = upstreamAttempt;
+                            return upstreamSummary;
+                        })
+                        : undefined,
+                };
+            })
+            : [],
         stream: !!args.stream,
         byok: !!args.byok,
         status_code: args.statusCode ?? null,
@@ -321,6 +358,7 @@ function buildSupaRow(args: {
         key_id: args.keyId ?? null,
         throughput: args.throughput ?? null,
         finish_reason: args.finishReason ?? null,
+        detail_metadata: args.detailMetadata ?? null,
         location: args.edgeColo ?? null,
     };
 }
@@ -378,6 +416,7 @@ export async function auditSuccess(args: {
 }) {
     const releaseRuntime = ensureRuntimeForBackground();
     try {
+        const persistedDetailMetadata = summarizeDetailMetadata(args.detailMetadata);
         const pricingLines = args.usagePriced?.pricing?.lines ?? [];
         const strippedUsage = stripPricingFromUsage(args.usagePriced);
         const appId = await ensureAppId({
@@ -413,7 +452,7 @@ export async function auditSuccess(args: {
             requestUserId: args.requestUserId ?? null,
             sessionId: args.sessionId ?? null,
             traceData: args.traceData ?? null,
-            providerAttempts: args.providerAttempts ?? null,
+            providerAttempts: null,
             statusCode: args.statusCode,
             success: true,
             errorCode: null,
@@ -436,6 +475,7 @@ export async function auditSuccess(args: {
             edgeContinent: args.edgeContinent ?? null,
             edgeAsn: args.edgeAsn ?? null,
             finishReason: args.finishReason ?? null,
+            detailMetadata: persistedDetailMetadata,
         });
 
         let supabaseError: Error | null = null;
@@ -445,6 +485,19 @@ export async function auditSuccess(args: {
                 "supabase_audit_success_insert",
             );
             await syncInsertedRequestRollup(insertedRow, "audit_success");
+            await persistGatewayUpstreamRequests({
+                insertedRow,
+                requestId: args.requestId,
+                workspaceId: args.workspaceId,
+                appId,
+                keyId: args.keyId ?? null,
+                endpoint: args.endpoint,
+                modelId: args.model,
+                currency: args.currency,
+                totalNanos: args.totalNanos ?? Math.round(args.totalCents * 1e7),
+                detailMetadata: args.detailMetadata ?? null,
+                context: "audit_success",
+            });
             await persistGatewayIoLog({
                 requestId: args.requestId,
                 workspaceId: args.workspaceId,
@@ -459,7 +512,7 @@ export async function auditSuccess(args: {
                 gatewayResponse: args.gatewayResponse,
                 providerRequest: args.providerRequest,
                 providerResponse: args.providerResponse,
-                metadata: args.detailMetadata ?? {},
+                metadata: persistedDetailMetadata ?? {},
             });
             await insertGatewayRequestDetailsNonBlocking(
                 {
@@ -480,7 +533,7 @@ export async function auditSuccess(args: {
                     response_content: normalizeJsonValue(extractReplayContent(args.gatewayResponse)),
                     provider_request: normalizeJsonValue(args.providerRequest),
                     provider_response: normalizeJsonValue(args.providerResponse),
-                    metadata: normalizeJsonValue(args.detailMetadata) ?? {},
+                    metadata: normalizeJsonValue(persistedDetailMetadata) ?? {},
                 },
                 "supabase_audit_success_details_insert",
             );
@@ -588,6 +641,7 @@ type AuditFailureExecute = {
 export async function auditFailure(args: AuditFailureBefore | AuditFailureExecute) {
     const releaseRuntime = ensureRuntimeForBackground();
     try {
+        const persistedDetailMetadata = summarizeDetailMetadata(args.detailMetadata);
         if (args.stage === "before") {
             const resolvedAppId = args.workspaceId
                 ? await ensureAppId({
@@ -614,7 +668,7 @@ export async function auditFailure(args: AuditFailureBefore | AuditFailureExecut
                 requestUserId: args.requestUserId ?? null,
                 sessionId: args.sessionId ?? null,
                 traceData: args.traceData ?? null,
-                providerAttempts: args.providerAttempts ?? null,
+                providerAttempts: null,
                 statusCode: args.statusCode,
                 success: false,
                 errorCode: args.errorCode,
@@ -634,6 +688,7 @@ export async function auditFailure(args: AuditFailureBefore | AuditFailureExecut
                 edgeCountry: args.edgeCountry ?? null,
                 edgeContinent: args.edgeContinent ?? null,
                 edgeAsn: args.edgeAsn ?? null,
+                detailMetadata: persistedDetailMetadata,
             });
 
             let supabaseError: Error | null = null;
@@ -644,6 +699,17 @@ export async function auditFailure(args: AuditFailureBefore | AuditFailureExecut
                         "supabase_audit_failure_before_insert",
                     );
                     await syncInsertedRequestRollup(insertedRow, "audit_failure_before");
+                    await persistGatewayUpstreamRequests({
+                        insertedRow,
+                        requestId: args.requestId,
+                        workspaceId: args.workspaceId,
+                        appId: resolvedAppId ?? null,
+                        keyId: args.keyId ?? null,
+                        endpoint: args.endpoint,
+                        modelId: args.requestedModel ?? args.model ?? "unknown",
+                        detailMetadata: args.detailMetadata ?? null,
+                        context: "audit_failure_before",
+                    });
                     await persistGatewayIoLog({
                         requestId: args.requestId,
                         workspaceId: args.workspaceId,
@@ -658,7 +724,7 @@ export async function auditFailure(args: AuditFailureBefore | AuditFailureExecut
                         gatewayResponse: args.gatewayResponse,
                         providerRequest: null,
                         providerResponse: args.providerResponse,
-                        metadata: args.detailMetadata ?? {},
+                        metadata: persistedDetailMetadata ?? {},
                     });
                     await insertGatewayRequestDetailsNonBlocking(
                         {
@@ -679,7 +745,7 @@ export async function auditFailure(args: AuditFailureBefore | AuditFailureExecut
                             response_content: normalizeJsonValue(extractReplayContent(args.gatewayResponse)),
                             provider_request: null,
                             provider_response: normalizeJsonValue(args.providerResponse),
-                            metadata: normalizeJsonValue(args.detailMetadata) ?? {},
+                            metadata: normalizeJsonValue(persistedDetailMetadata) ?? {},
                         },
                         "supabase_audit_failure_before_details_insert",
                     );
@@ -716,7 +782,7 @@ export async function auditFailure(args: AuditFailureBefore | AuditFailureExecut
             requestUserId: args.requestUserId ?? null,
             sessionId: args.sessionId ?? null,
             traceData: args.traceData ?? null,
-            providerAttempts: args.providerAttempts ?? null,
+            providerAttempts: null,
             statusCode: args.statusCode,
             success: false,
             errorCode: args.errorCode,
@@ -736,6 +802,7 @@ export async function auditFailure(args: AuditFailureBefore | AuditFailureExecut
             edgeCountry: args.edgeCountry ?? null,
             edgeContinent: args.edgeContinent ?? null,
             edgeAsn: args.edgeAsn ?? null,
+            detailMetadata: persistedDetailMetadata,
         });
 
         let supabaseError: Error | null = null;
@@ -746,6 +813,17 @@ export async function auditFailure(args: AuditFailureBefore | AuditFailureExecut
                     "supabase_audit_failure_execute_insert",
                 );
                 await syncInsertedRequestRollup(insertedRow, "audit_failure_execute");
+                await persistGatewayUpstreamRequests({
+                    insertedRow,
+                    requestId: args.requestId,
+                    workspaceId: args.workspaceId,
+                    appId: resolvedAppId ?? null,
+                    keyId: args.keyId ?? null,
+                    endpoint: args.endpoint,
+                    modelId: args.model,
+                    detailMetadata: args.detailMetadata ?? null,
+                    context: "audit_failure_execute",
+                });
                 await persistGatewayIoLog({
                     requestId: args.requestId,
                     workspaceId: args.workspaceId,
@@ -760,7 +838,7 @@ export async function auditFailure(args: AuditFailureBefore | AuditFailureExecut
                     gatewayResponse: args.gatewayResponse,
                     providerRequest: args.providerRequest,
                     providerResponse: args.providerResponse,
-                    metadata: args.detailMetadata ?? {},
+                    metadata: persistedDetailMetadata ?? {},
                 });
                 await insertGatewayRequestDetailsNonBlocking(
                     {
@@ -781,7 +859,7 @@ export async function auditFailure(args: AuditFailureBefore | AuditFailureExecut
                         response_content: normalizeJsonValue(extractReplayContent(args.gatewayResponse)),
                         provider_request: normalizeJsonValue(args.providerRequest),
                         provider_response: normalizeJsonValue(args.providerResponse),
-                        metadata: normalizeJsonValue(args.detailMetadata) ?? {},
+                        metadata: normalizeJsonValue(persistedDetailMetadata) ?? {},
                     },
                     "supabase_audit_failure_execute_details_insert",
                 );

--- a/apps/api/src/pipeline/audit/normalize-finish-reason.test.ts
+++ b/apps/api/src/pipeline/audit/normalize-finish-reason.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import {
+	extractProviderFinishReason,
+	normalizeFinishReason,
+} from "./normalize-finish-reason";
+
+describe("provider finish reasons", () => {
+	it("extracts native reasons from OpenAI, Anthropic, and Gemini payloads", () => {
+		expect(extractProviderFinishReason({
+			choices: [{ finish_reason: "tool_calls" }],
+		})).toBe("tool_calls");
+		expect(extractProviderFinishReason({ stop_reason: "pause_turn" })).toBe("pause_turn");
+		expect(extractProviderFinishReason({
+			candidates: [{ finishReason: "PROHIBITED_CONTENT" }],
+		})).toBe("PROHIBITED_CONTENT");
+	});
+
+	it("normalizes expanded Gemini safety and malformed response reasons", () => {
+		expect(normalizeFinishReason("SPII", "google-ai-studio")).toBe("content_filter");
+		expect(normalizeFinishReason("PROHIBITED_CONTENT", "google-vertex")).toBe("content_filter");
+		expect(normalizeFinishReason("MALFORMED_FUNCTION_CALL", "google-ai-studio")).toBe("error");
+		expect(normalizeFinishReason("MALFORMED_FUNCTION_CALL", "google-vertex-eu")).toBe("error");
+		expect(normalizeFinishReason("RECITATION", "google")).toBe("recitation");
+		expect(normalizeFinishReason("UNEXPECTED_TOOL_CALL", "google-ai-studio")).toBe("tool_calls");
+	});
+
+	it("normalizes shared OpenAI-compatible and native provider tool reasons", () => {
+		expect(normalizeFinishReason("tool_calls", "baseten")).toBe("tool_calls");
+		expect(normalizeFinishReason("function_call", "together")).toBe("tool_calls");
+		expect(normalizeFinishReason("tool_use", "anthropic")).toBe("tool_calls");
+		expect(normalizeFinishReason("end_turn", "amazon-bedrock")).toBe("stop");
+		expect(normalizeFinishReason("sensitive", "z-ai")).toBe("content_filter");
+	});
+});

--- a/apps/api/src/pipeline/audit/normalize-finish-reason.ts
+++ b/apps/api/src/pipeline/audit/normalize-finish-reason.ts
@@ -15,6 +15,36 @@ export type NormalizedFinishReason =
 	| "other" // Unknown/other
 	| null; // No finish reason provided
 
+export function extractProviderFinishReason(payload: unknown): string | null {
+	if (!payload || typeof payload !== "object" || Array.isArray(payload)) return null;
+	const record = payload as Record<string, any>;
+	const nestedResponse = record.response && typeof record.response === "object"
+		? extractProviderFinishReason(record.response)
+		: null;
+	if (nestedResponse) return nestedResponse;
+	for (const value of [record.finish_reason, record.finishReason, record.stop_reason]) {
+		if (typeof value === "string" && value.trim()) return value.trim();
+	}
+	if (Array.isArray(record.choices)) {
+		const choice = record.choices.find((entry: any) =>
+			typeof entry?.finish_reason === "string" || typeof entry?.finishReason === "string"
+		);
+		const value = choice?.finish_reason ?? choice?.finishReason;
+		if (typeof value === "string" && value.trim()) return value.trim();
+	}
+	if (Array.isArray(record.candidates)) {
+		const candidate = record.candidates.find((entry: any) =>
+			typeof entry?.finishReason === "string" || typeof entry?.finish_reason === "string"
+		);
+		const value = candidate?.finishReason ?? candidate?.finish_reason;
+		if (typeof value === "string" && value.trim()) return value.trim();
+	}
+	const incompleteReason = record.incomplete_details?.reason;
+	return typeof incompleteReason === "string" && incompleteReason.trim()
+		? incompleteReason.trim()
+		: null;
+}
+
 /**
  * Normalize finish_reason from provider-specific value to canonical value
  */
@@ -25,6 +55,11 @@ export function normalizeFinishReason(
 	if (!finishReason) return null;
 
 	const lower = finishReason.toLowerCase();
+	const normalizedProvider = provider.toLowerCase();
+	const isGoogleProvider =
+		normalizedProvider === "google" ||
+		normalizedProvider === "google-ai-studio" ||
+		normalizedProvider.startsWith("google-vertex");
 
 	// OpenAI & OpenAI-compatible providers
 	if (
@@ -57,11 +92,25 @@ export function normalizeFinishReason(
 	}
 
 	// Google (Gemini/Vertex)
-	if (provider === "google-ai-studio" || provider === "google-vertex") {
+	if (isGoogleProvider) {
 		if (lower === "stop") return "stop";
 		if (lower === "max_tokens") return "length";
 		if (lower === "safety") return "safety";
 		if (lower === "recitation") return "recitation";
+		if (
+			lower === "blocklist" ||
+			lower === "prohibited_content" ||
+			lower === "spii" ||
+			lower === "language" ||
+			lower === "image_safety" ||
+			lower === "image_prohibited_content"
+		) return "content_filter";
+		if (
+			lower === "malformed_function_call" ||
+			lower === "malformed_response" ||
+			lower === "missing_thought_signature"
+		) return "error";
+		if (lower === "unexpected_tool_call" || lower === "too_many_tool_calls") return "tool_calls";
 		if (lower === "other") return "other";
 		if (lower === "finish_reason_unspecified") return null;
 	}

--- a/apps/api/src/pipeline/audit/upstream-requests.ts
+++ b/apps/api/src/pipeline/audit/upstream-requests.ts
@@ -1,0 +1,186 @@
+// Purpose: Persist normalized provider interactions beneath one gateway request.
+// Why: Keeps high-cardinality upstream attempts queryable without bloating the parent JSONB row.
+
+import type { Endpoint } from "@core/types";
+import { getSupabaseAdmin } from "@/runtime/env";
+
+let tableAvailable: boolean | null = null;
+let warnedMissingTable = false;
+
+function normalizeJsonValue(value: unknown): unknown {
+    if (value == null) return null;
+    if (["string", "number", "boolean"].includes(typeof value)) return value;
+    try {
+        return JSON.parse(JSON.stringify(value));
+    } catch {
+        return null;
+    }
+}
+
+function isMissingTableError(error: unknown): boolean {
+    const candidate = error && typeof error === "object" ? error as Record<string, unknown> : null;
+    const cause = candidate?.cause && typeof candidate.cause === "object"
+        ? candidate.cause as Record<string, unknown>
+        : null;
+    const code = String(cause?.code ?? candidate?.code ?? "");
+    const message = String(cause?.message ?? candidate?.message ?? "").toLowerCase();
+    return (code === "PGRST205" || code === "42P01") && message.includes("gateway_upstream_requests");
+}
+
+function readUsageWeight(usage: unknown): number {
+    if (!usage || typeof usage !== "object" || Array.isArray(usage)) return 0;
+    const record = usage as Record<string, unknown>;
+    for (const key of ["total_tokens", "totalTokens"]) {
+        const value = Number(record[key]);
+        if (Number.isFinite(value) && value > 0) return value;
+    }
+    const input = Number(record.input_tokens ?? record.inputTokens ?? record.prompt_tokens ?? 0);
+    const output = Number(record.output_tokens ?? record.outputTokens ?? record.completion_tokens ?? 0);
+    const total = (Number.isFinite(input) ? input : 0) + (Number.isFinite(output) ? output : 0);
+    return total > 0 ? total : 0;
+}
+
+function allocateCosts(exchanges: Array<Record<string, any>>, totalNanos: number): number[] {
+    const safeTotal = Number.isFinite(totalNanos) ? Math.max(0, Math.round(totalNanos)) : 0;
+    const weights = exchanges.map((exchange) =>
+        exchange.outcome === "success" ? readUsageWeight(exchange.usage) : 0
+    );
+    const totalWeight = weights.reduce((sum, value) => sum + value, 0);
+    let finalSuccessIndex = -1;
+    for (let index = exchanges.length - 1; index >= 0; index -= 1) {
+        if (exchanges[index]?.outcome === "success") {
+            finalSuccessIndex = index;
+            break;
+        }
+    }
+    if (safeTotal === 0 || finalSuccessIndex < 0) return exchanges.map(() => 0);
+    if (totalWeight <= 0) {
+        return exchanges.map((_, index) => index === finalSuccessIndex ? safeTotal : 0);
+    }
+    let allocated = 0;
+    return exchanges.map((_, index) => {
+        if (index === finalSuccessIndex) return Math.max(0, safeTotal - allocated);
+        const value = Math.max(0, Math.floor((safeTotal * weights[index]!) / totalWeight));
+        allocated += value;
+        return value;
+    });
+}
+
+function buildRows(args: PersistGatewayUpstreamRequestsArgs, exchanges: Array<Record<string, any>>) {
+    const costs = allocateCosts(exchanges, args.totalNanos ?? 0);
+    return exchanges.map((exchange, index) => {
+        const error = exchange.error && typeof exchange.error === "object"
+            ? exchange.error as Record<string, unknown>
+            : {};
+        const statusCode = Number(exchange.status);
+        const success = exchange.outcome === "success" ||
+            (Number.isFinite(statusCode) && statusCode >= 200 && statusCode < 300);
+        const finiteMs = (value: unknown) =>
+            Number.isFinite(Number(value)) ? Math.round(Number(value)) : null;
+        return {
+            created_at: args.insertedRow.created_at,
+            gateway_request_id: args.insertedRow.id,
+            gateway_request_created_at: args.insertedRow.created_at,
+            request_id: args.requestId,
+            workspace_id: args.workspaceId,
+            app_id: args.appId ?? null,
+            key_id: args.keyId ?? null,
+            sequence: Number(exchange.sequence) || index + 1,
+            round_number: Number(exchange.round_number) || 1,
+            attempt_number: Number(exchange.attempt_number) || null,
+            internal_attempt_number: Number(exchange.internal_attempt_number) || null,
+            stage: exchange.stage === "routing" ? "routing" : "upstream",
+            endpoint: args.endpoint,
+            model_id: typeof exchange.model === "string" && exchange.model ? exchange.model : args.modelId,
+            provider: typeof exchange.provider === "string" ? exchange.provider : null,
+            api_model_id: typeof exchange.api_model_id === "string" ? exchange.api_model_id : null,
+            provider_model_slug: typeof exchange.provider_model_slug === "string" ? exchange.provider_model_slug : null,
+            upstream_route: typeof exchange.upstream_route === "string" ? exchange.upstream_route : null,
+            upstream_url: typeof exchange.upstream_url === "string" ? exchange.upstream_url : null,
+            status_code: Number.isFinite(statusCode) ? statusCode : null,
+            status_text: typeof exchange.status_text === "string" ? exchange.status_text : null,
+            success,
+            outcome: typeof exchange.outcome === "string" ? exchange.outcome : success ? "success" : "error",
+            retryable: typeof exchange.retryable === "boolean" ? exchange.retryable : null,
+            fallback_attempted: exchange.fallback_attempted === true,
+            was_probe: exchange.was_probe === true,
+            key_source: exchange.key_source === "gateway" || exchange.key_source === "byok" ? exchange.key_source : null,
+            native_response_id: typeof exchange.native_response_id === "string" ? exchange.native_response_id : null,
+            provider_finish_reason: typeof exchange.provider_finish_reason === "string" ? exchange.provider_finish_reason : null,
+            finish_reason: typeof exchange.finish_reason === "string" ? exchange.finish_reason : null,
+            duration_ms: finiteMs(exchange.duration_ms),
+            latency_ms: finiteMs(exchange.latency_ms),
+            generation_ms: finiteMs(exchange.generation_ms),
+            total_ms: finiteMs(exchange.total_ms),
+            request_build_ms: finiteMs(exchange.request_build_ms),
+            upstream_headers_ms: finiteMs(exchange.upstream_headers_ms),
+            retry_delay_ms: finiteMs(exchange.retry_delay_ms),
+            usage: normalizeJsonValue(exchange.usage) ?? {},
+            cost_nanos: costs[index] ?? 0,
+            currency: args.currency ?? null,
+            error_code: typeof error.code === "string" ? error.code : null,
+            error_type: typeof error.type === "string" ? error.type : null,
+            error_message: typeof error.message === "string" ? error.message : null,
+            error_description: typeof error.description === "string" ? error.description : null,
+            error_param: typeof error.param === "string" ? error.param : null,
+            request_payload: normalizeJsonValue(exchange.upstream_request),
+            response_payload: normalizeJsonValue(exchange.upstream_response),
+            metadata: normalizeJsonValue({
+                response_source: exchange.response_source ?? null,
+                response_kind: exchange.response_kind ?? null,
+                byok_key_id: exchange.byok_key_id ?? null,
+            }) ?? {},
+        };
+    });
+}
+
+export type PersistGatewayUpstreamRequestsArgs = {
+    insertedRow: { id: string; created_at: string; workspace_id: string };
+    requestId: string;
+    workspaceId: string;
+    appId?: string | null;
+    keyId?: string | null;
+    endpoint: Endpoint;
+    modelId: string;
+    currency?: string | null;
+    totalNanos?: number | null;
+    detailMetadata?: Record<string, unknown> | null;
+    context: string;
+};
+
+export async function persistGatewayUpstreamRequests(
+    args: PersistGatewayUpstreamRequestsArgs,
+): Promise<void> {
+    if (tableAvailable === false) return;
+    const exchanges = Array.isArray(args.detailMetadata?.upstream_exchanges)
+        ? args.detailMetadata.upstream_exchanges as Array<Record<string, any>>
+        : [];
+    if (exchanges.length === 0) return;
+    try {
+        const { error } = await getSupabaseAdmin()
+            .from("gateway_upstream_requests")
+            .insert(buildRows(args, exchanges));
+        if (error) {
+            const wrapped = new Error(
+                `[audit] insert gateway_upstream_requests error: ${error.message ?? "unknown"}`
+            );
+            (wrapped as any).cause = error;
+            throw wrapped;
+        }
+        tableAvailable = true;
+    } catch (error) {
+        if (isMissingTableError(error)) {
+            tableAvailable = false;
+            if (!warnedMissingTable) {
+                warnedMissingTable = true;
+                console.warn("[audit] gateway_upstream_requests is unavailable; skipping normalized child rows.");
+            }
+            return;
+        }
+        console.error("[audit] failed to persist upstream requests", {
+            context: args.context,
+            requestId: args.requestId,
+            error: error instanceof Error ? error.message : String(error),
+        });
+    }
+}

--- a/apps/api/src/pipeline/before/types.ts
+++ b/apps/api/src/pipeline/before/types.ts
@@ -403,6 +403,7 @@ export type ProviderEnablementDiagnostics = {
 
 export type ProviderAttemptLog = {
     attempt_number: number;
+    round_number?: number | null;
     provider: string;
     endpoint: Endpoint;
     model: string;
@@ -436,6 +437,44 @@ export type ProviderAttemptLog = {
     request_build_ms?: number | null;
     upstream_headers_ms?: number | null;
     retry_delay_ms?: number | null;
+    native_response_id?: string | null;
+    provider_finish_reason?: string | null;
+    finish_reason?: string | null;
+    upstream_request?: unknown;
+    upstream_response?: unknown;
+    upstream_attempts?: Array<{
+        sequence: number;
+        route?: string | null;
+        request?: unknown;
+        response?: unknown;
+        status?: number | null;
+        status_text?: string | null;
+        url?: string | null;
+        duration_ms: number;
+        outcome: "success" | "upstream_non_2xx" | "network_error";
+        error_message?: string | null;
+    }>;
+};
+
+export type ProviderRoundLog = {
+    round_number: number;
+    request_payload?: unknown;
+    provider: string;
+    api_model_id: string | null;
+    pricing_key: string | null;
+    provider_finish_reason: string | null;
+    finish_reason: string | null;
+    usage: Record<string, unknown> | null;
+    native_response_id: string | null;
+    generation_ms: number | null;
+    latency_ms: number | null;
+    total_ms: number | null;
+    mapped_request: unknown;
+    raw_response: unknown;
+    status_code: number;
+    key_source: "gateway" | "byok" | null;
+    byok_key_id: string | null;
+    provider_attempts: ProviderAttemptLog[];
 };
 
 export type WorkspacePolicy = {
@@ -628,6 +667,7 @@ export type PipelineContext = {
     responseCache?: ResponseCacheDiagnostics | null;
     attemptErrors?: Array<Record<string, unknown>>;
     providerAttempts?: ProviderAttemptLog[];
+    providerRounds?: ProviderRoundLog[];
     // Enrichment data for observability (wide events)
     teamEnrichment?: TeamEnrichment | null;
     keyEnrichment?: KeyEnrichment | null;

--- a/apps/api/src/pipeline/execute/executor-timing.test.ts
+++ b/apps/api/src/pipeline/execute/executor-timing.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from "vitest";
+import type { ExecutorResult } from "@executors/types";
+import { instrumentTextExecutorTiming } from "./executor-timing";
+
+function streamingResult(stream: ReadableStream<Uint8Array>): ExecutorResult {
+	return {
+		kind: "stream",
+		stream,
+		upstream: new Response(null, { status: 200 }),
+		provider: "openai",
+		bill: { cost_cents: 0, currency: "USD" },
+	} as ExecutorResult;
+}
+
+describe("instrumentTextExecutorTiming", () => {
+	it("measures latency and generation for every uninstrumented executor stream", async () => {
+		const encoder = new TextEncoder();
+		let index = 0;
+		const stream = new ReadableStream<Uint8Array>({
+			async pull(controller) {
+				if (index >= 2) {
+					controller.close();
+					return;
+				}
+				await new Promise((resolve) => setTimeout(resolve, 8));
+				controller.enqueue(encoder.encode(index++ === 0 ? "first" : "second"));
+			},
+		});
+		const result = instrumentTextExecutorTiming(streamingResult(stream), Date.now());
+		expect(result.kind).toBe("stream");
+		if (result.kind !== "stream") throw new Error("Expected stream result");
+		await new Response(result.stream).text();
+
+		expect(result.timing?.streamTimingSource).toBe("executor");
+		expect(result.timing?.latencyMs).toBeGreaterThan(0);
+		expect(result.timing?.generationMs).toBeGreaterThan(0);
+		expect(result.timing?.totalMs).toBeGreaterThanOrEqual(result.timing?.latencyMs ?? 0);
+	});
+
+	it("attributes effectively buffered streams to generation consistently", async () => {
+		const encoder = new TextEncoder();
+		const stream = new ReadableStream<Uint8Array>({
+			start(controller) {
+				controller.enqueue(encoder.encode("first"));
+				controller.enqueue(encoder.encode("second"));
+				controller.close();
+			},
+		});
+		const result = instrumentTextExecutorTiming(streamingResult(stream), Date.now() - 20);
+		expect(result.kind).toBe("stream");
+		if (result.kind !== "stream") throw new Error("Expected stream result");
+		await new Response(result.stream).text();
+
+		expect(result.timing?.latencyMs).toBe(0);
+		expect(result.timing?.generationMs).toBeGreaterThanOrEqual(20);
+		expect(result.timing?.totalMs).toBe(result.timing?.generationMs);
+	});
+
+	it("does not wrap streams already measured by a provider executor", () => {
+		const stream = new ReadableStream<Uint8Array>();
+		const result = streamingResult(stream);
+		result.timing = { streamTimingSource: "provider" };
+		const instrumented = instrumentTextExecutorTiming(result, Date.now());
+
+		expect(instrumented.kind).toBe("stream");
+		if (instrumented.kind !== "stream") throw new Error("Expected stream result");
+		expect(instrumented.stream).toBe(stream);
+	});
+
+	it("normalizes buffered completed responses with output tokens", () => {
+		const result = {
+			kind: "completed",
+			ir: { usage: { outputTokens: 12 } },
+			upstream: new Response(null, { status: 200 }),
+			provider: "google-ai-studio",
+			bill: { cost_cents: 0, currency: "USD" },
+			timing: { latencyMs: 40, generationMs: 0, totalMs: 40 },
+		} as ExecutorResult;
+
+		instrumentTextExecutorTiming(result, Date.now() - 40);
+
+		expect(result.timing).toMatchObject({
+			latencyMs: 0,
+			generationMs: 40,
+			totalMs: 40,
+		});
+	});
+});

--- a/apps/api/src/pipeline/execute/executor-timing.ts
+++ b/apps/api/src/pipeline/execute/executor-timing.ts
@@ -1,0 +1,130 @@
+import type { ExecutorResult, ExecutorTiming } from "@executors/types";
+
+function finiteDuration(value: unknown): number | null {
+	return typeof value === "number" && Number.isFinite(value)
+		? Math.max(0, value)
+		: null;
+}
+
+function completedOutputTokens(result: ExecutorResult): number {
+	if (result.kind !== "completed") return 0;
+	const usage = (result.ir as any)?.usage;
+	const value = usage?.outputTokens ?? usage?.output_tokens ?? usage?.completion_tokens;
+	const tokens = Number(value);
+	return Number.isFinite(tokens) && tokens > 0 ? tokens : 0;
+}
+
+function normalizeBufferedTiming(
+	timing: ExecutorTiming,
+	providerStartedAtMs: number,
+	hasOutput: boolean,
+): void {
+	const totalMs = finiteDuration(timing.totalMs) ?? Math.max(0, Date.now() - providerStartedAtMs);
+	let latencyMs = finiteDuration(timing.latencyMs);
+	let generationMs = finiteDuration(timing.generationMs);
+
+	if (generationMs === null && latencyMs !== null) {
+		generationMs = Math.max(0, totalMs - latencyMs);
+	}
+	if (latencyMs === null && generationMs !== null) {
+		latencyMs = Math.max(0, totalMs - generationMs);
+	}
+	if (latencyMs === null && generationMs === null) {
+		latencyMs = hasOutput ? 0 : totalMs;
+		generationMs = hasOutput ? totalMs : 0;
+	}
+
+	// A buffered response can expose all output in the same clock tick. In that
+	// case TTFT and generation cannot be separated, so attribute the provider
+	// duration to generation instead of reporting a misleading zero throughput.
+	if (hasOutput && generationMs <= 2 && totalMs > 2) {
+		latencyMs = 0;
+		generationMs = totalMs;
+	}
+
+	timing.latencyMs = latencyMs;
+	timing.generationMs = generationMs;
+	timing.totalMs = totalMs;
+}
+
+function measureExecutorStream(
+	stream: ReadableStream<Uint8Array>,
+	timing: ExecutorTiming,
+	providerStartedAtMs: number,
+): ReadableStream<Uint8Array> {
+	const reader = stream.getReader();
+	let firstByteAtMs: number | null = null;
+	let settled = false;
+
+	const recordProgress = (nowMs: number) => {
+		if (firstByteAtMs === null) {
+			firstByteAtMs = nowMs;
+			timing.latencyMs = Math.max(0, nowMs - providerStartedAtMs);
+		}
+		timing.generationMs = Math.max(0, nowMs - firstByteAtMs);
+		timing.totalMs = Math.max(0, nowMs - providerStartedAtMs);
+	};
+
+	const recordCompletion = () => {
+		if (settled) return;
+		settled = true;
+		const nowMs = Date.now();
+		const totalMs = Math.max(0, nowMs - providerStartedAtMs);
+		if (firstByteAtMs === null) {
+			timing.latencyMs = totalMs;
+			timing.generationMs = 0;
+		} else {
+			const generationMs = Math.max(0, nowMs - firstByteAtMs);
+			if (generationMs <= 2 && totalMs > 2) {
+				timing.latencyMs = 0;
+				timing.generationMs = totalMs;
+			} else {
+				timing.generationMs = generationMs;
+			}
+		}
+		timing.totalMs = totalMs;
+	};
+
+	return new ReadableStream<Uint8Array>({
+		async pull(controller) {
+			try {
+				const { value, done } = await reader.read();
+				if (done) {
+					recordCompletion();
+					controller.close();
+					return;
+				}
+				if (value.byteLength > 0) recordProgress(Date.now());
+				controller.enqueue(value);
+			} catch (error) {
+				recordCompletion();
+				controller.error(error);
+			}
+		},
+		async cancel(reason) {
+			recordCompletion();
+			await reader.cancel(reason);
+		},
+	});
+}
+
+export function instrumentTextExecutorTiming(
+	result: ExecutorResult,
+	providerStartedAtMs: number,
+): ExecutorResult {
+	const timing = result.timing ?? {};
+	result.timing = timing;
+
+	if (result.kind === "stream" && result.stream) {
+		if (timing.streamTimingSource) return result;
+		timing.streamTimingSource = "executor";
+		result.stream = measureExecutorStream(result.stream, timing, providerStartedAtMs);
+		return result;
+	}
+
+	if (result.kind === "completed") {
+		normalizeBufferedTiming(timing, providerStartedAtMs, completedOutputTokens(result) > 0);
+	}
+
+	return result;
+}

--- a/apps/api/src/pipeline/execute/index.ts
+++ b/apps/api/src/pipeline/execute/index.ts
@@ -67,13 +67,16 @@ import type {
 	IRVideoGenerationRequest,
 	IRVideoGenerationResponse,
 } from "@core/ir";
-import type { ExecutorExecuteArgs } from "@executors/types";
+import type { ExecutorExecuteArgs, ExecutorTiming } from "@executors/types";
 import { normalizeIRForProvider } from "./normalize";
 import { normalizeCapability } from "@/executors";
 import { filterCandidatesByModalities, filterEmbeddingCandidatesByModalities } from "./modalities";
 import { loadPriceCard } from "../pricing";
 import { stripUsagePricing } from "../usage";
 import { getEffectiveRoutingHints } from "../requestRouting";
+import { instrumentTextExecutorTiming } from "./executor-timing";
+import { sanitizeForAxiom, sanitizeJsonStringForAxiom } from "@observability/privacy";
+import { extractProviderFinishReason, normalizeFinishReason } from "../audit/normalize-finish-reason";
 
 function shouldFallbackFromByok(status: number | null | undefined): boolean {
 	const code = Number(status ?? 0);
@@ -308,6 +311,7 @@ export type IRRequestResult = {
 	byokKeyId?: string | null;
 	mappedRequest?: string;
 	rawResponse?: any;
+	timing?: ExecutorTiming;
 };
 
 export type RequestResult = IRRequestResult;
@@ -648,6 +652,12 @@ async function attemptProviderWithIR(
 				},
 			}) as ExecutorExecuteArgs;
 
+		let executorInvocationStartedAtMs = ctx.meta.upstreamStartMs ?? Date.now();
+		const invokeExecutor = (forceGatewayKey: boolean, byokMeta: any[]) => {
+			executorInvocationStartedAtMs = Date.now();
+			ctx.meta.upstreamStartMs = executorInvocationStartedAtMs;
+			return executor(buildExecutorArgs(forceGatewayKey, byokMeta));
+		};
 		const executeWithRetry = async () => {
 			let lastErr: unknown = null;
 			const maxRetries = allowSingleProviderRetry
@@ -655,7 +665,7 @@ async function attemptProviderWithIR(
 				: MAX_RETRYABLE_EXECUTOR_RETRIES;
 			for (let retryAttempt = 0; retryAttempt <= maxRetries; retryAttempt += 1) {
 				try {
-					let nextResult = await executor(buildExecutorArgs(false, candidate.byokMeta || []));
+					let nextResult = await invokeExecutor(false, candidate.byokMeta || []);
 					if (
 						allowByokFallback &&
 						nextResult.keySource === "byok" &&
@@ -663,7 +673,7 @@ async function attemptProviderWithIR(
 						shouldFallbackFromByok(nextResult.upstream.status)
 					) {
 						(nextResult as any).fallbackAttempted = true;
-						nextResult = await executor(buildExecutorArgs(true, []));
+						nextResult = await invokeExecutor(true, []);
 					}
 					const shouldRetryStatus =
 						allowSingleProviderRetry &&
@@ -689,9 +699,15 @@ async function attemptProviderWithIR(
 			throw (lastErr instanceof Error ? lastErr : new Error("executor_retry_exhausted"));
 		};
 
-		const executorResult = await timing.timer.span(`${attemptPrefix}_executor_total`, () =>
+		let executorResult = await timing.timer.span(`${attemptPrefix}_executor_total`, () =>
 			executeWithRetry(),
 		);
+		if (isTextGenerate) {
+			executorResult = instrumentTextExecutorTiming(
+				executorResult,
+				executorInvocationStartedAtMs,
+			);
+		}
 
 		if (executorResult.timing) {
 			if (typeof executorResult.timing.latencyMs === "number") {
@@ -810,6 +826,20 @@ async function attemptProviderWithIR(
 				request_build_ms: executorResult.timing?.requestBuildMs ?? null,
 				upstream_headers_ms: executorResult.timing?.upstreamHeadersMs ?? null,
 				retry_delay_ms: executorResult.timing?.transientRetryDelayMs ?? null,
+				upstream_request: sanitizeJsonStringForAxiom(executorResult.mappedRequest),
+				upstream_response: sanitizeForAxiom(upstreamFailure.payload),
+				upstream_attempts: executorResult.upstreamAttempts?.map((attempt) => ({
+					sequence: attempt.sequence,
+					route: attempt.route ?? null,
+					request: sanitizeJsonStringForAxiom(attempt.request ?? null),
+					response: sanitizeForAxiom(attempt.response),
+					status: attempt.status ?? null,
+					status_text: attempt.statusText ?? null,
+					url: attempt.url ?? null,
+					duration_ms: attempt.durationMs,
+					outcome: attempt.outcome,
+					error_message: attempt.errorMessage ?? null,
+				})),
 			});
 			return { ok: false };
 		}
@@ -838,6 +868,7 @@ async function attemptProviderWithIR(
 			byokKeyId: executorResult.byokKeyId,
 			mappedRequest: executorResult.mappedRequest,
 			rawResponse: executorResult.rawResponse,
+			timing: executorResult.timing,
 		};
 		(result as any).healthContext = {
 			provider: candidate.providerId,
@@ -861,6 +892,7 @@ async function attemptProviderWithIR(
 			});
 		}
 
+		const providerFinishReason = extractProviderFinishReason(executorResult.rawResponse);
 		recordProviderAttempt(ctx, {
 			attempt_number: attemptNumber,
 			provider: candidate.providerId,
@@ -882,6 +914,26 @@ async function attemptProviderWithIR(
 			request_build_ms: executorResult.timing?.requestBuildMs ?? null,
 			upstream_headers_ms: executorResult.timing?.upstreamHeadersMs ?? null,
 			retry_delay_ms: executorResult.timing?.transientRetryDelayMs ?? null,
+			native_response_id: executorResult.bill?.upstream_id ?? null,
+			provider_finish_reason: providerFinishReason,
+			finish_reason: normalizeFinishReason(
+				providerFinishReason ?? executorResult.bill?.finish_reason ?? null,
+				candidate.providerId,
+			),
+			upstream_request: sanitizeJsonStringForAxiom(executorResult.mappedRequest),
+			upstream_response: sanitizeForAxiom(executorResult.rawResponse),
+			upstream_attempts: executorResult.upstreamAttempts?.map((attempt) => ({
+				sequence: attempt.sequence,
+				route: attempt.route ?? null,
+				request: sanitizeJsonStringForAxiom(attempt.request ?? null),
+				response: sanitizeForAxiom(attempt.response),
+				status: attempt.status ?? null,
+				status_text: attempt.statusText ?? null,
+				url: attempt.url ?? null,
+				duration_ms: attempt.durationMs,
+				outcome: attempt.outcome,
+				error_message: attempt.errorMessage ?? null,
+			})),
 		});
 
 		return { ok: true, result };

--- a/apps/api/src/pipeline/surfaces/text-generate.server-tools.test.ts
+++ b/apps/api/src/pipeline/surfaces/text-generate.server-tools.test.ts
@@ -400,6 +400,28 @@ describe("runTextGeneratePipeline server tools", () => {
 		});
 
 		const finalizeArgs = finalizeRequestMock.mock.calls[0]?.[0];
+		expect(finalizeArgs.pre.ctx.providerRounds).toEqual([
+			expect.objectContaining({
+				round_number: 1,
+				provider: "openai",
+				finish_reason: "tool_calls",
+				usage: {
+					prompt_tokens: 10,
+					completion_tokens: 2,
+					total_tokens: 12,
+				},
+			}),
+			expect.objectContaining({
+				round_number: 2,
+				provider: "openai",
+				finish_reason: "stop",
+				usage: {
+					prompt_tokens: 6,
+					completion_tokens: 5,
+					total_tokens: 11,
+				},
+			}),
+		]);
 		expect(finalizeArgs.exec.result.ir.usage).toEqual(usageWithServerTool);
 		expect(finalizeArgs.exec.result.bill.usage).toEqual(billUsageWithServerTool);
 		expect(finalizeArgs.exec.result.rawResponse.usage).toEqual(
@@ -488,6 +510,7 @@ describe("runTextGeneratePipeline server tools", () => {
 					upstream: new Response(null, { status: 200 }),
 					provider: "openai",
 					generationTimeMs: 1,
+					timing: { generationMs: 11 },
 					bill: { cost_cents: 0, currency: "USD", usage: {} },
 					rawResponse: null,
 				},
@@ -512,6 +535,7 @@ describe("runTextGeneratePipeline server tools", () => {
 					upstream: new Response(JSON.stringify({ ok: true }), { status: 200 }),
 					provider: "openai",
 					generationTimeMs: 3,
+					timing: { generationMs: 17 },
 					bill: { cost_cents: 0, currency: "USD", usage: {} },
 					rawResponse: {
 						id: "chatcmpl_final_stream",
@@ -533,6 +557,8 @@ describe("runTextGeneratePipeline server tools", () => {
 		);
 
 		const args = createArgs({ stream: true });
+		args.pre.ctx.meta.upstreamStartMs = Date.now() - 100;
+		args.pre.ctx.meta.startedAtMs = Date.now() - 1_000;
 		const response = await runTextGeneratePipeline(args);
 
 		expect(response.status).toBe(200);
@@ -562,6 +588,13 @@ describe("runTextGeneratePipeline server tools", () => {
 		expect(finalizeArgs.exec.result.upstream.headers.get("Content-Type")).toBe(
 			"text/event-stream",
 		);
+		expect(finalizeArgs.pre.ctx.meta.generation_ms).toBe(17);
+		expect(finalizeArgs.pre.ctx.meta.provider_generation_total_ms).toBe(28);
+		expect(finalizeArgs.pre.ctx.meta.provider_call_count).toBe(2);
+		expect(finalizeArgs.pre.ctx.meta.throughput_tps).toBeCloseTo(5 / 0.017);
+		expect(finalizeArgs.pre.ctx.meta.end_to_end_ms).toBeGreaterThanOrEqual(900);
+		expect(finalizeArgs.pre.ctx.meta.latency_ms).toBeGreaterThanOrEqual(883);
+		expect(finalizeArgs.pre.ctx.meta.preserve_stream_timing).toBe(true);
 	});
 
 	it("executes the managed web search follow-up loop and records search result usage on non-stream requests", async () => {
@@ -1035,7 +1068,7 @@ describe("runTextGeneratePipeline server tools", () => {
 			created: 1778073808,
 			serverToolTrace: [{
 				id: "call_web_fetch",
-				name: "ai_stats_web_fetch",
+					name: "phaseo_web_fetch",
 				arguments: "{\"url\":\"https://example.com/spec\",\"max_chars\":4000}",
 				output: "{\"provider\":\"fetch\",\"url\":\"https://example.com/spec\",\"final_url\":\"https://example.com/spec\",\"status\":200,\"content_type\":\"text/html\",\"title\":\"Gateway Spec\",\"text\":\"Grounded specification text\",\"truncated\":false,\"returned_chars\":27}",
 			}],

--- a/apps/api/src/pipeline/surfaces/text-generate.ts
+++ b/apps/api/src/pipeline/surfaces/text-generate.ts
@@ -54,6 +54,10 @@ import {
 import { fetchGatewayContext } from "../before/context";
 import { buildProviderCandidatesWithDiagnostics } from "../before/utils";
 import type { PipelineContext } from "../before/types";
+import {
+	extractProviderFinishReason,
+	normalizeFinishReason,
+} from "../audit/normalize-finish-reason";
 
 function createJsonErrorResponse(
 	status: number,
@@ -577,6 +581,88 @@ async function materializeStreamResultToCompleted(args: {
 	};
 }
 
+function readProviderGenerationMs(result: any): number {
+	const measured = result?.timing?.generationMs;
+	if (typeof measured === "number" && Number.isFinite(measured)) {
+		return Math.max(0, measured);
+	}
+	const fallback = result?.generationTimeMs;
+	return typeof fallback === "number" && Number.isFinite(fallback)
+		? Math.max(0, fallback)
+		: 0;
+}
+
+function readProviderOutputTokens(result: any): number {
+	const usage = result?.ir?.usage;
+	const value = usage?.outputTokens ?? usage?.output_tokens ?? usage?.completion_tokens;
+	const outputTokens = Number(value);
+	return Number.isFinite(outputTokens) && outputTokens > 0 ? outputTokens : 0;
+}
+
+function captureProviderRound(
+	result: any,
+	roundNumber: number,
+	providerAttempts: PipelineContext["providerAttempts"],
+	requestPayload: unknown,
+): NonNullable<PipelineContext["providerRounds"]>[number] {
+	const generationMs = readProviderGenerationMs(result);
+	const totalMs = Number(result?.timing?.totalMs);
+	const measuredLatencyMs = Number(result?.timing?.latencyMs);
+	const latencyMs = Number.isFinite(measuredLatencyMs)
+		? Math.max(0, measuredLatencyMs)
+		: Number.isFinite(totalMs)
+			? Math.max(0, totalMs - generationMs)
+			: null;
+	const rawFinishReason =
+		result?.ir?.choices?.[0]?.finishReason ?? result?.bill?.finish_reason ?? null;
+	const providerFinishReason = extractProviderFinishReason(result?.rawResponse);
+	return {
+		round_number: roundNumber,
+		request_payload: requestPayload,
+		provider: result.provider,
+		api_model_id: result?.apiModelId ?? null,
+		pricing_key: result?.pricingKey ?? null,
+		provider_finish_reason: providerFinishReason,
+		finish_reason: normalizeFinishReason(
+			rawFinishReason ?? providerFinishReason,
+			result.provider,
+		),
+		usage:
+			result?.bill?.usage && typeof result.bill.usage === "object"
+				? { ...result.bill.usage }
+				: result?.ir?.usage && typeof result.ir.usage === "object"
+					? { ...result.ir.usage }
+				: null,
+		native_response_id:
+			result?.bill?.upstream_id ?? result?.ir?.nativeId ?? null,
+		generation_ms: Number.isFinite(generationMs) ? Math.max(0, generationMs) : null,
+		latency_ms: latencyMs,
+		total_ms: Number.isFinite(totalMs) ? Math.max(0, totalMs) : null,
+		mapped_request: result?.mappedRequest ?? null,
+		raw_response: result?.rawResponse ?? null,
+		status_code: result?.upstream?.status ?? 200,
+		key_source: result?.keySource ?? null,
+		byok_key_id: result?.byokKeyId ?? null,
+		provider_attempts: Array.isArray(providerAttempts)
+			? providerAttempts.map((attempt) => ({ ...attempt }))
+			: [],
+	};
+}
+
+function assignProviderAttemptRound(
+	ctx: PipelineContext,
+	start: number,
+	end: number,
+	roundNumber: number,
+): void {
+	if (!Array.isArray(ctx.providerAttempts)) return;
+	for (let index = start; index < end; index += 1) {
+		if (ctx.providerAttempts[index]) {
+			ctx.providerAttempts[index].round_number = roundNumber;
+		}
+	}
+}
+
 export async function runTextGeneratePipeline(args: PipelineRunnerArgs): Promise<Response> {
 	const { pre, req, endpoint, timing } = args;
 
@@ -785,6 +871,18 @@ export async function runTextGeneratePipeline(args: PipelineRunnerArgs): Promise
 				});
 			}
 		}
+		let accumulatedProviderGenerationMs = readProviderGenerationMs(exec.result);
+		let providerCallCount = 1;
+		let finalProviderOutputTokens = readProviderOutputTokens(exec.result);
+		const providerRounds: NonNullable<PipelineContext["providerRounds"]> = [];
+		let providerAttemptCursor = pre.ctx.providerAttempts?.length ?? 0;
+		assignProviderAttemptRound(pre.ctx, 0, providerAttemptCursor, 1);
+		providerRounds.push(captureProviderRound(
+			exec.result,
+			1,
+			pre.ctx.providerAttempts?.slice(0, providerAttemptCursor),
+			irForExecution,
+		));
 
 		const serverToolTrace: Array<{
 			id: string;
@@ -923,6 +1021,14 @@ export async function runTextGeneratePipeline(args: PipelineRunnerArgs): Promise
 				};
 
 				const followUpExec = await doRequestWithIR(pre.ctx, nextIrRequest, timing);
+				const nextProviderAttemptCursor =
+					pre.ctx.providerAttempts?.length ?? providerAttemptCursor;
+				assignProviderAttemptRound(
+					pre.ctx,
+					providerAttemptCursor,
+					nextProviderAttemptCursor,
+					providerCallCount + 1,
+				);
 				if (followUpExec instanceof Response) {
 					const header = timing.timer.header();
 					pre.ctx.timing = timing.timer.snapshot();
@@ -981,6 +1087,16 @@ export async function runTextGeneratePipeline(args: PipelineRunnerArgs): Promise
 					});
 				}
 
+				accumulatedProviderGenerationMs += readProviderGenerationMs(followUpResult);
+				providerCallCount += 1;
+				providerRounds.push(captureProviderRound(
+					followUpResult,
+					providerCallCount,
+					pre.ctx.providerAttempts?.slice(providerAttemptCursor, nextProviderAttemptCursor),
+					nextIrRequest,
+				));
+				providerAttemptCursor = nextProviderAttemptCursor;
+				finalProviderOutputTokens = readProviderOutputTokens(followUpResult);
 				exec.result = followUpResult;
 				latestIrResponse = followUpResult.ir as IRChatResponse;
 				aggregateUsage = mergeIRUsageTotals(aggregateUsage, latestIrResponse.usage);
@@ -993,6 +1109,9 @@ export async function runTextGeneratePipeline(args: PipelineRunnerArgs): Promise
 
 			pre.ctx.searchObservability = searchObservability;
 			pre.ctx.webFetchObservability = webFetchObservability;
+			if (providerRounds.length > 1) {
+				pre.ctx.providerRounds = providerRounds;
+			}
 
 			if (
 				serverToolUsage.datetimeRequests > 0 ||
@@ -1048,29 +1167,30 @@ export async function runTextGeneratePipeline(args: PipelineRunnerArgs): Promise
 			protocolResponse
 		) {
 			const requestStartMs =
-				typeof pre.ctx.meta.upstreamStartMs === "number"
-					? pre.ctx.meta.upstreamStartMs
-					: typeof pre.ctx.meta.startedAtMs === "number"
-						? pre.ctx.meta.startedAtMs
+				typeof pre.ctx.meta.startedAtMs === "number"
+					? pre.ctx.meta.startedAtMs
+					: typeof pre.ctx.meta.upstreamStartMs === "number"
+						? pre.ctx.meta.upstreamStartMs
 						: null;
 			const endToEndMs =
 				requestStartMs !== null
 					? Math.max(0, Math.round(Date.now() - requestStartMs))
 					: Math.max(0, Math.round(timing.timer.elapsed("execute_start")));
-			const resultTiming = (exec.result as { timing?: { generationMs?: number } }).timing;
 			const generationMs = Math.max(
 				0,
-				Math.round(
-					typeof resultTiming?.generationMs === "number"
-						? resultTiming.generationMs
-						: typeof exec.result.generationTimeMs === "number"
-							? exec.result.generationTimeMs
-							: 0,
-				),
+				Math.round(readProviderGenerationMs(exec.result)),
 			);
 			pre.ctx.meta.end_to_end_ms = endToEndMs;
 			pre.ctx.meta.generation_ms = generationMs;
 			pre.ctx.meta.latency_ms = Math.max(0, endToEndMs - generationMs);
+			pre.ctx.meta.throughput_tps = generationMs > 0 && finalProviderOutputTokens > 0
+				? finalProviderOutputTokens / (generationMs / 1000)
+				: undefined;
+			pre.ctx.meta.provider_generation_total_ms = Math.max(
+				0,
+				Math.round(accumulatedProviderGenerationMs),
+			);
+			pre.ctx.meta.provider_call_count = providerCallCount;
 			pre.ctx.meta.preserve_stream_timing = true;
 
 			const stream = buildSyntheticServerToolStream({

--- a/apps/web/src/app/(dashboard)/gateway/usage/server-actions.ts
+++ b/apps/web/src/app/(dashboard)/gateway/usage/server-actions.ts
@@ -76,7 +76,154 @@ export interface RequestDetailMetadata {
 	provider_candidate_diagnostics?: unknown;
 	provider_enablement_diagnostics?: unknown;
 	routing_diagnostics?: unknown;
+	upstream_exchanges?: UpstreamExchangeRow[];
 	[key: string]: unknown;
+}
+
+export interface UpstreamExchangeRow {
+	id?: string;
+	sequence: number;
+	stage: "routing" | "upstream" | string;
+	round_number: number;
+	attempt_number: number;
+	internal_attempt_number?: number | null;
+	upstream_route?: string | null;
+	provider: string | null;
+	model: string | null;
+	api_model_id: string | null;
+	provider_model_slug: string | null;
+	outcome: string | null;
+	status: number | null;
+	status_text: string | null;
+	duration_ms: number | null;
+	latency_ms: number | null;
+	generation_ms: number | null;
+	total_ms: number | null;
+	native_response_id: string | null;
+	provider_finish_reason: string | null;
+	finish_reason: string | null;
+	usage?: Record<string, unknown> | null;
+	cost_nanos?: number | string | null;
+	currency?: string | null;
+	response_source: string | null;
+	upstream_request: unknown;
+	upstream_response: unknown;
+	error: Record<string, unknown> | null;
+}
+
+export async function fetchGatewayUpstreamRequests(
+	requestId: string,
+	requestCreatedAt?: string | null,
+): Promise<{ success: boolean; data: UpstreamExchangeRow[]; error?: string }> {
+	const supabase = await createClient();
+	const { workspaceId } = await requireAuthedTeamContext(supabase);
+	if (!workspaceId) return { success: false, data: [], error: "Not authenticated" };
+	const trimmedRequestId = requestId.trim();
+	if (!trimmedRequestId) return { success: false, data: [], error: "Request ID required" };
+
+	const admin = createAdminClient();
+	let query = admin
+		.from("gateway_upstream_requests")
+		.select(`
+			id,
+			sequence,
+			round_number,
+			attempt_number,
+			internal_attempt_number,
+			stage,
+			model_id,
+			provider,
+			api_model_id,
+			provider_model_slug,
+			upstream_route,
+			status_code,
+			status_text,
+			outcome,
+			duration_ms,
+			latency_ms,
+			generation_ms,
+			total_ms,
+			native_response_id,
+			provider_finish_reason,
+			finish_reason,
+			usage,
+			cost_nanos,
+			currency,
+			error_code,
+			error_type,
+			error_message,
+			error_description,
+			error_param,
+			request_payload,
+			response_payload,
+			metadata
+		`)
+		.eq("workspace_id", workspaceId)
+		.eq("request_id", trimmedRequestId)
+		.order("sequence", { ascending: true });
+	if (requestCreatedAt) {
+		query = query.eq("gateway_request_created_at", requestCreatedAt);
+	}
+	const { data, error } = await query;
+	if (error) {
+		if (error.code === "PGRST205" || error.code === "42P01") {
+			return { success: true, data: [] };
+		}
+		return { success: false, data: [], error: error.message };
+	}
+
+	const rows = (data ?? []) as Array<Record<string, any>>;
+	return {
+		success: true,
+		data: rows.map((row) => {
+			const metadata = row.metadata && typeof row.metadata === "object"
+				? row.metadata as Record<string, unknown>
+				: {};
+			const hasError = [
+				row.error_code,
+				row.error_type,
+				row.error_message,
+				row.error_description,
+				row.error_param,
+			].some((value) => value != null);
+			return {
+				id: typeof row.id === "string" ? row.id : undefined,
+				sequence: Number(row.sequence) || 0,
+				stage: typeof row.stage === "string" ? row.stage : "upstream",
+				round_number: Number(row.round_number) || 1,
+				attempt_number: Number(row.attempt_number) || 1,
+				internal_attempt_number: Number(row.internal_attempt_number) || null,
+				upstream_route: typeof row.upstream_route === "string" ? row.upstream_route : null,
+				provider: typeof row.provider === "string" ? row.provider : null,
+				model: typeof row.model_id === "string" ? row.model_id : null,
+				api_model_id: typeof row.api_model_id === "string" ? row.api_model_id : null,
+				provider_model_slug: typeof row.provider_model_slug === "string" ? row.provider_model_slug : null,
+				outcome: typeof row.outcome === "string" ? row.outcome : null,
+				status: Number.isFinite(Number(row.status_code)) ? Number(row.status_code) : null,
+				status_text: typeof row.status_text === "string" ? row.status_text : null,
+				duration_ms: Number.isFinite(Number(row.duration_ms)) ? Number(row.duration_ms) : null,
+				latency_ms: Number.isFinite(Number(row.latency_ms)) ? Number(row.latency_ms) : null,
+				generation_ms: Number.isFinite(Number(row.generation_ms)) ? Number(row.generation_ms) : null,
+				total_ms: Number.isFinite(Number(row.total_ms)) ? Number(row.total_ms) : null,
+				native_response_id: typeof row.native_response_id === "string" ? row.native_response_id : null,
+				provider_finish_reason: typeof row.provider_finish_reason === "string" ? row.provider_finish_reason : null,
+				finish_reason: typeof row.finish_reason === "string" ? row.finish_reason : null,
+				usage: row.usage && typeof row.usage === "object" ? row.usage : null,
+				cost_nanos: row.cost_nanos ?? null,
+				currency: typeof row.currency === "string" ? row.currency : null,
+				response_source: typeof metadata.response_source === "string" ? metadata.response_source : null,
+				upstream_request: row.request_payload ?? null,
+				upstream_response: row.response_payload ?? null,
+				error: hasError ? {
+					code: row.error_code ?? null,
+					type: row.error_type ?? null,
+					message: row.error_message ?? null,
+					description: row.error_description ?? null,
+					param: row.error_param ?? null,
+				} : null,
+			};
+		}),
+	};
 }
 
 export interface NormalizedRequestUsageColumns {
@@ -159,6 +306,7 @@ export interface RequestRow extends NormalizedRequestUsageColumns {
 	pricing_lines: AsyncJobRequestPricingLine[];
 	provider_attempts: Array<{
 		attempt_number: number | null;
+		round_number?: number | null;
 		provider: string | null;
 		api_model_id: string | null;
 		provider_model_slug: string | null;
@@ -169,6 +317,8 @@ export interface RequestRow extends NormalizedRequestUsageColumns {
 		upstream_error_code: string | null;
 		upstream_error_message: string | null;
 		upstream_error_description: string | null;
+		provider_finish_reason?: string | null;
+		finish_reason?: string | null;
 	}>;
 }
 
@@ -291,6 +441,12 @@ function normalizeProviderAttempts(
 				: typeof attempt?.attempt_number === "string"
 					? Number(attempt.attempt_number)
 					: null,
+		round_number:
+			typeof attempt?.round_number === "number"
+				? attempt.round_number
+				: typeof attempt?.round_number === "string"
+					? Number(attempt.round_number)
+					: null,
 		provider:
 			typeof attempt?.provider === "string" ? attempt.provider : null,
 		api_model_id:
@@ -328,6 +484,14 @@ function normalizeProviderAttempts(
 		upstream_error_description:
 			typeof attempt?.upstream_error_description === "string"
 				? attempt.upstream_error_description
+				: null,
+		provider_finish_reason:
+			typeof attempt?.provider_finish_reason === "string"
+				? attempt.provider_finish_reason
+				: null,
+		finish_reason:
+			typeof attempt?.finish_reason === "string"
+				? attempt.finish_reason
 				: null,
 	}));
 }

--- a/apps/web/src/components/(gateway)/usage/RequestDetailDialog.tsx
+++ b/apps/web/src/components/(gateway)/usage/RequestDetailDialog.tsx
@@ -37,9 +37,11 @@ import {
 } from "@/components/ui/table";
 import { Logo } from "@/components/Logo";
 import {
+	fetchGatewayUpstreamRequests,
 	RequestRow,
 	type GatewayIoLog,
 	type ProviderMetadataEntry,
+	type UpstreamExchangeRow,
 } from "@/app/(dashboard)/gateway/usage/server-actions";
 import { cn } from "@/lib/utils";
 import {
@@ -77,6 +79,18 @@ interface RequestDetailDialogProps {
 }
 
 type ProviderAttemptRow = RequestRow["provider_attempts"][number];
+
+function extractUpstreamExchanges(
+	metadata: RequestRow["detail_metadata"],
+): UpstreamExchangeRow[] {
+	const exchanges = metadata?.upstream_exchanges;
+	if (!Array.isArray(exchanges)) return [];
+	return exchanges
+		.filter((entry): entry is UpstreamExchangeRow =>
+			Boolean(entry) && typeof entry === "object" && !Array.isArray(entry),
+		)
+		.sort((left, right) => Number(left.sequence ?? 0) - Number(right.sequence ?? 0));
+}
 
 function formatRequestPricingLine(line: RequestRow["pricing_lines"][number]): string {
 	if (line == null) return "null";
@@ -832,6 +846,32 @@ export default function RequestDetailDialog({
 	ioLog,
 }: RequestDetailDialogProps) {
 	const searchParams = useSearchParams();
+	const requestId = request?.request_id ?? null;
+	const requestCreatedAt = request?.created_at ?? null;
+	const legacyUpstreamExchanges = React.useMemo(
+		() => extractUpstreamExchanges(request?.detail_metadata ?? null),
+		[request?.detail_metadata],
+	);
+	const [persistedUpstreamState, setPersistedUpstreamState] = React.useState<{
+		requestId: string;
+		data: UpstreamExchangeRow[];
+	} | null>(null);
+	React.useEffect(() => {
+		if (!open || !requestId) return;
+		let cancelled = false;
+		void fetchGatewayUpstreamRequests(requestId, requestCreatedAt)
+			.then((response) => {
+				if (!cancelled && response.success) {
+					setPersistedUpstreamState({ requestId, data: response.data });
+				}
+			});
+		return () => {
+			cancelled = true;
+		};
+	}, [open, requestCreatedAt, requestId]);
+	const persistedUpstreamExchanges = persistedUpstreamState?.requestId === requestId
+		? persistedUpstreamState.data
+		: null;
 
 	if (!request) return null;
 
@@ -853,9 +893,29 @@ export default function RequestDetailDialog({
 				normalizeProviderPromptTrainingPolicy(providerMeta.promptTrainingPolicy)
 			]
 		: null;
-	const attempts = Array.isArray(request.provider_attempts)
-		? request.provider_attempts
-		: [];
+	const upstreamExchanges = persistedUpstreamExchanges?.length
+		? persistedUpstreamExchanges
+		: legacyUpstreamExchanges;
+	const attempts = upstreamExchanges.length > 0
+		? upstreamExchanges.map((exchange) => ({
+			attempt_number: exchange.attempt_number ?? null,
+			round_number: exchange.round_number ?? null,
+			provider: exchange.provider,
+			api_model_id: exchange.api_model_id,
+			provider_model_slug: exchange.provider_model_slug,
+			outcome: exchange.outcome,
+			status: exchange.status,
+			status_text: exchange.status_text,
+			duration_ms: exchange.total_ms ?? exchange.duration_ms,
+			provider_finish_reason: exchange.provider_finish_reason,
+			finish_reason: exchange.finish_reason,
+			upstream_error_code: typeof exchange.error?.code === "string" ? exchange.error.code : null,
+			upstream_error_message: typeof exchange.error?.message === "string" ? exchange.error.message : null,
+			upstream_error_description: typeof exchange.error?.description === "string" ? exchange.error.description : null,
+		}))
+		: Array.isArray(request.provider_attempts)
+			? request.provider_attempts
+			: [];
 	const finalSuccessAttempt = [...attempts]
 		.reverse()
 		.find(
@@ -885,7 +945,7 @@ export default function RequestDetailDialog({
 						providerModelSlug: attempt.provider_model_slug,
 					});
 					const providerRow = {
-						key: `provider-${attempt.attempt_number ?? index}`,
+						key: `provider-${attempt.round_number ?? 1}-${attempt.attempt_number ?? index}`,
 						label: (
 							<div className="grid min-w-0 grid-cols-[auto_minmax(0,1fr)_auto] items-center gap-2">
 								{attemptProviderId ? (
@@ -897,12 +957,17 @@ export default function RequestDetailDialog({
 									/>
 								) : null}
 								<div className="min-w-0">
-									<div className="min-w-0 break-words">{attemptProviderName}</div>
+								<div className="min-w-0 break-words">
+									{attemptProviderName}
+									{attempt.round_number && attempt.round_number > 1
+										? ` · Round ${attempt.round_number}`
+										: ""}
+								</div>
 									{attemptModelParts.length > 0 ? (
 										<div className="mt-0.5 flex flex-wrap gap-1">
 											{attemptModelParts.map((value) => (
 												<code
-													key={`${attempt.attempt_number ?? index}-${value}`}
+											key={`${attempt.round_number ?? 1}-${attempt.attempt_number ?? index}-${value}`}
 													className="rounded bg-rose-100 px-1 py-0.5 text-[10px]"
 												>
 													{value}
@@ -954,7 +1019,7 @@ export default function RequestDetailDialog({
 								duration: timingLatency,
 							},
 							{
-								key: `generation-${attempt.attempt_number ?? index}`,
+								key: `generation-${attempt.round_number ?? 1}-${attempt.attempt_number ?? index}`,
 								label: (
 									<div className="flex min-w-0 items-center gap-2 pl-5">
 										<span className="truncate">Generation</span>
@@ -2653,9 +2718,100 @@ export default function RequestDetailDialog({
 							</DetailSection>
 						) : null}
 
-						<DetailSection title="Provider response">
+						<DetailSection title="Upstream exchanges">
 							<div className="space-y-4">
 								<DetailTimingBar items={responseTimelineItems} />
+								{upstreamExchanges.length > 0 ? (
+									<div className="space-y-3">
+										{upstreamExchanges.map((exchange, index) => {
+											const providerId = exchange.provider ?? "unknown";
+											const succeeded =
+												exchange.outcome === "success" ||
+												(typeof exchange.status === "number" &&
+													exchange.status >= 200 && exchange.status < 300);
+											const exchangeUsage = exchange.usage ?? {};
+											const exchangeTokens = Number(
+												exchangeUsage.total_tokens ??
+												exchangeUsage.totalTokens ??
+												(Number(exchangeUsage.input_tokens ?? exchangeUsage.inputTokens ?? exchangeUsage.prompt_tokens ?? 0) +
+													Number(exchangeUsage.output_tokens ?? exchangeUsage.outputTokens ?? exchangeUsage.completion_tokens ?? 0)),
+											);
+											const exchangeCostNanos = Number(exchange.cost_nanos ?? 0);
+											return (
+												<div
+													key={`${exchange.sequence ?? index}-${providerId}-${exchange.round_number ?? 1}-${exchange.attempt_number ?? index + 1}`}
+													className="rounded-xl border border-border/70 bg-muted/20 p-3"
+												>
+													<div className="flex flex-wrap items-center justify-between gap-2">
+														<div className="flex min-w-0 items-center gap-2">
+															{exchange.provider ? <Logo id={exchange.provider} width={16} height={16} /> : null}
+															<span className="font-medium">
+																{providerNames?.get(providerId) ?? providerId}
+															</span>
+													<span className="text-xs text-muted-foreground">
+														Round {exchange.round_number ?? 1}, attempt {exchange.attempt_number ?? index + 1}
+														{exchange.internal_attempt_number
+															? `, HTTP ${exchange.internal_attempt_number}`
+															: ""}
+													</span>
+													<code className="rounded bg-muted px-1.5 py-0.5 text-[10px]">{exchange.stage}</code>
+													{exchange.upstream_route ? (
+														<code className="rounded bg-muted px-1.5 py-0.5 text-[10px]">/{exchange.upstream_route}</code>
+													) : null}
+														</div>
+														<div className="flex flex-wrap items-center gap-2 text-xs">
+															{exchange.status != null ? <code>{exchange.status}</code> : null}
+															<span className={cn(
+																"rounded-full px-2 py-0.5 font-medium",
+																succeeded
+																	? "bg-emerald-100 text-emerald-800"
+																	: "bg-rose-100 text-rose-800",
+															)}>
+																{exchange.outcome ?? (succeeded ? "success" : "failed")}
+															</span>
+																	<span>{formatDuration(exchange.total_ms ?? exchange.duration_ms)}</span>
+																	{Number.isFinite(exchangeTokens) && exchangeTokens > 0 ? (
+																		<span>{exchangeTokens.toLocaleString()} tokens</span>
+																	) : null}
+																	{Number.isFinite(exchangeCostNanos) && exchangeCostNanos > 0 ? (
+																		<span className="font-mono">{formatCost(exchangeCostNanos)}</span>
+																	) : null}
+														</div>
+													</div>
+													<div className="mt-2 flex flex-wrap gap-2 text-xs">
+														{exchange.api_model_id ? <code className="rounded bg-muted px-1.5 py-0.5">{exchange.api_model_id}</code> : null}
+														{exchange.provider_finish_reason ? (
+															<code className="rounded bg-amber-100 px-1.5 py-0.5 text-amber-900">
+																Provider: {exchange.provider_finish_reason}
+															</code>
+														) : null}
+														{exchange.finish_reason ? (
+															<code className="rounded bg-sky-100 px-1.5 py-0.5 text-sky-900">
+																Normalized: {exchange.finish_reason}
+															</code>
+														) : null}
+														{exchange.native_response_id ? <code className="rounded bg-muted px-1.5 py-0.5">{exchange.native_response_id}</code> : null}
+													</div>
+													{exchange.error ? (
+														<pre className="mt-3 max-h-48 overflow-auto rounded-md border border-rose-200 bg-rose-50 p-2 text-xs whitespace-pre-wrap break-words">{JSON.stringify(exchange.error, null, 2)}</pre>
+													) : null}
+													<div className="mt-3 grid gap-3 xl:grid-cols-2">
+														<div className="min-w-0">
+															<p className="mb-1 text-xs font-medium text-muted-foreground">Upstream request</p>
+															<pre className="max-h-64 overflow-auto rounded-md border bg-background p-2 text-xs whitespace-pre-wrap break-words">{JSON.stringify(exchange.upstream_request ?? null, null, 2)}</pre>
+														</div>
+														<div className="min-w-0">
+															<p className="mb-1 text-xs font-medium text-muted-foreground">Upstream response</p>
+															<pre className="max-h-64 overflow-auto rounded-md border bg-background p-2 text-xs whitespace-pre-wrap break-words">{JSON.stringify(exchange.upstream_response ?? null, null, 2)}</pre>
+														</div>
+													</div>
+												</div>
+											);
+										})}
+									</div>
+								) : (
+									<p className="text-sm text-muted-foreground">No upstream exchange details were captured for this request.</p>
+								)}
 							</div>
 						</DetailSection>
 					</div>

--- a/supabase/migrations/20260716110000_gateway_upstream_requests.sql
+++ b/supabase/migrations/20260716110000_gateway_upstream_requests.sql
@@ -1,0 +1,169 @@
+-- Normalize every provider interaction beneath its complete gateway request.
+
+create table if not exists public.gateway_upstream_requests (
+  id uuid not null default gen_random_uuid(),
+  created_at timestamp with time zone not null,
+  gateway_request_id uuid not null,
+  gateway_request_created_at timestamp with time zone not null,
+  request_id text not null,
+  workspace_id uuid not null references public.workspaces (id) on delete cascade,
+  app_id uuid null references public.api_apps (id) on delete set null,
+  key_id uuid null references public.keys (id) on delete set null,
+  sequence integer not null,
+  round_number integer not null default 1,
+  attempt_number integer null,
+  internal_attempt_number integer null,
+  stage text not null default 'upstream',
+  endpoint text not null,
+  model_id text not null,
+  provider text null,
+  api_model_id text null,
+  provider_model_slug text null,
+  upstream_route text null,
+  upstream_url text null,
+  status_code integer null,
+  status_text text null,
+  success boolean not null default false,
+  outcome text not null,
+  retryable boolean null,
+  fallback_attempted boolean not null default false,
+  was_probe boolean not null default false,
+  key_source text null,
+  native_response_id text null,
+  provider_finish_reason text null,
+  finish_reason text null,
+  duration_ms integer null,
+  latency_ms integer null,
+  generation_ms integer null,
+  total_ms integer null,
+  request_build_ms integer null,
+  upstream_headers_ms integer null,
+  retry_delay_ms integer null,
+  usage jsonb not null default '{}'::jsonb,
+  cost_nanos bigint not null default 0,
+  currency text null,
+  error_code text null,
+  error_type text null,
+  error_message text null,
+  error_description text null,
+  error_param text null,
+  request_payload jsonb null,
+  response_payload jsonb null,
+  metadata jsonb not null default '{}'::jsonb,
+  constraint gateway_upstream_requests_pkey primary key (id, created_at),
+  constraint gateway_upstream_requests_gateway_request_fkey
+    foreign key (gateway_request_id, gateway_request_created_at)
+    references public.gateway_requests (id, created_at)
+    on delete cascade,
+  constraint gateway_upstream_requests_sequence_ck check (sequence > 0),
+  constraint gateway_upstream_requests_round_ck check (round_number > 0),
+  constraint gateway_upstream_requests_attempt_ck
+    check (attempt_number is null or attempt_number > 0),
+  constraint gateway_upstream_requests_internal_attempt_ck
+    check (internal_attempt_number is null or internal_attempt_number > 0),
+  constraint gateway_upstream_requests_status_ck
+    check (status_code is null or status_code between 100 and 599),
+  constraint gateway_upstream_requests_key_source_ck
+    check (key_source is null or key_source in ('gateway', 'byok')),
+  constraint gateway_upstream_requests_stage_ck
+    check (stage in ('routing', 'upstream')),
+  constraint gateway_upstream_requests_parent_sequence_key
+    unique (gateway_request_id, gateway_request_created_at, sequence, created_at)
+) partition by range (created_at);
+
+create table if not exists public.gateway_upstream_requests_default
+  partition of public.gateway_upstream_requests default;
+
+create index if not exists gateway_upstream_requests_parent_sequence_idx
+  on public.gateway_upstream_requests
+  (gateway_request_id, gateway_request_created_at, sequence);
+
+create index if not exists gateway_upstream_requests_workspace_created_idx
+  on public.gateway_upstream_requests (workspace_id, created_at desc);
+
+create index if not exists gateway_upstream_requests_workspace_request_created_sequence_idx
+  on public.gateway_upstream_requests
+  (workspace_id, request_id, gateway_request_created_at, sequence);
+
+create index if not exists gateway_upstream_requests_workspace_provider_created_idx
+  on public.gateway_upstream_requests (workspace_id, provider, created_at desc)
+  where provider is not null;
+
+create index if not exists gateway_upstream_requests_key_created_idx
+  on public.gateway_upstream_requests (key_id, created_at desc)
+  where key_id is not null;
+
+alter table public.gateway_upstream_requests enable row level security;
+
+drop policy if exists gateway_upstream_requests_select_service
+  on public.gateway_upstream_requests;
+create policy gateway_upstream_requests_select_service
+  on public.gateway_upstream_requests
+  for select
+  to service_role
+  using (true);
+
+drop policy if exists gateway_upstream_requests_insert_service
+  on public.gateway_upstream_requests;
+create policy gateway_upstream_requests_insert_service
+  on public.gateway_upstream_requests
+  for insert
+  to service_role
+  with check (true);
+
+revoke all on public.gateway_upstream_requests from public, anon, authenticated;
+grant select, insert on public.gateway_upstream_requests to service_role;
+
+comment on table public.gateway_upstream_requests is
+  'Ordered provider interactions, retries, fallbacks, and model rounds linked to one complete gateway request.';
+comment on column public.gateway_upstream_requests.request_payload is
+  'Sanitized upstream request snapshot. Full raw payloads remain in opt-in R2 I/O logs.';
+comment on column public.gateway_upstream_requests.response_payload is
+  'Sanitized upstream response snapshot. Full raw payloads remain in opt-in R2 I/O logs.';
+
+create or replace function public.ensure_gateway_requests_partitions(months_ahead integer default 1)
+returns void
+language plpgsql
+as $$
+declare
+  v_cur_month timestamptz;
+  v_last_month timestamptz;
+  v_gateway_partition_name text;
+  v_upstream_partition_name text;
+begin
+  if months_ahead is null or months_ahead < 0 then
+    raise exception 'months_ahead must be >= 0';
+  end if;
+
+  v_cur_month := date_trunc('month', now());
+  v_last_month := v_cur_month + make_interval(months => months_ahead);
+
+  while v_cur_month <= v_last_month loop
+    v_gateway_partition_name := format('gateway_requests_%s', to_char(v_cur_month, 'YYYY_MM'));
+    execute format(
+      'create table if not exists public.%I partition of public.gateway_requests for values from (%L) to (%L)',
+      v_gateway_partition_name,
+      v_cur_month,
+      v_cur_month + interval '1 month'
+    );
+
+    v_upstream_partition_name := format(
+      'gateway_upstream_requests_%s',
+      to_char(v_cur_month, 'YYYY_MM')
+    );
+    execute format(
+      'create table if not exists public.%I partition of public.gateway_upstream_requests for values from (%L) to (%L)',
+      v_upstream_partition_name,
+      v_cur_month,
+      v_cur_month + interval '1 month'
+    );
+
+    v_cur_month := v_cur_month + interval '1 month';
+  end loop;
+end;
+$$;
+
+comment on function public.ensure_gateway_requests_partitions(integer) is
+  'Creates current and future monthly partitions for gateway_requests and gateway_upstream_requests.';
+
+select public.ensure_gateway_requests_partitions(1);


### PR DESCRIPTION
## Summary

Gateway observability previously flattened provider routing, retries, fallbacks, and managed tool rounds into one request record. That made the customer-facing request visible, but it could not faithfully show every upstream interaction or preserve provider-native finish reasons and per-attempt timings.

This change introduces a two-table logging model:

- `gateway_requests` remains the parent row for each request made through the gateway, with aggregate status, timing, usage, cost, and final finish reason.
- `gateway_upstream_requests` stores ordered child rows for every provider interaction, including failures, failover, retries, adaptive endpoint fallback, and managed tool rounds such as `tool_calls` followed by `stop`.

The API now captures upstream attempts consistently across the shared OpenAI-compatible executor and native Bedrock, Google AI Studio, and xAI paths. It persists child rows in one batch, retains native and normalized finish reasons, allocates successful child costs back to the exact parent total, and keeps parent writes independent if child persistence fails.

The gateway usage UI lazily loads the child rows only when request details are opened. It displays provider order, route, status, timing, usage, allocated cost, finish reasons, and sanitized request/response snapshots, while retaining legacy fallback behavior for older rows. Full raw payloads remain in opt-in R2 logs.

## Database

- Adds the monthly partitioned `gateway_upstream_requests` table.
- Adds the composite parent foreign key and indexes for parent lookup, workspace/time listing, provider filtering, and lazy request-detail loading.
- Restricts the table to service-role reads and writes with RLS enabled.
- Extends the existing partition maintenance function to create parent and child partitions together.

Migration `20260716110000_gateway_upstream_requests.sql` was applied to production before the API and web deployments.

## Validation

- `pnpm --filter @phaseo/gateway-api typecheck`
- `pnpm --filter @phaseo/web typecheck`
- 52 affected API tests across audit persistence, finish normalization, managed tools, streaming, executor timing, OpenAI-compatible routing, Bedrock, and Google AI Studio upstream attempts
- `git diff --check`
- Cloudflare Worker dry-run and production deployment
- Vercel production build and deployment (`READY`)
- Public API root smoke check returned HTTP 200

## Deployment

- Supabase migration: `20260716110000`
- Cloudflare Worker version: `530a2bde-00ee-4e99-996a-2a37bd28503a` (100%)
- Vercel deployment: `dpl_CuzoQdGTxNiFZC2rhP7p5SgzF7gr` (`READY`, aliased to `phaseo.app`)

Created with Codex
