### PR TITLE
Fix first Chat model selection

### DIFF
--- a/apps/web/src/components/(chat)/ChatPlayground.tsx
+++ b/apps/web/src/components/(chat)/ChatPlayground.tsx
@@ -3225,7 +3225,25 @@ function ChatPlaygroundContent({
 
 	const updateActiveModel = useCallback(
 		(modelId: string) => {
-			if (!activeThread) return;
+			if (!activeThread) {
+				const defaults: ChatSettings = {
+					...DEFAULT_SETTINGS,
+					systemPrompt: buildDefaultSystemPrompt(modelId),
+				};
+				void createThreadWithSettings(modelId, defaults)
+					.then(() => {
+						if (typeof window !== "undefined") {
+							window.localStorage.setItem(
+								STORAGE_KEYS.lastModelId,
+								modelId,
+							);
+						}
+					})
+					.catch(() => {
+						setError("Unable to create a chat for the selected model.");
+					});
+				return;
+			}
 			const requiredCapability = getPrimaryCapabilityForModel(modelId);
 			const currentModelDisplayName =
 				activeThread.settings.modelOverridesById?.[
@@ -3301,6 +3319,7 @@ function ChatPlaygroundContent({
 		},
 		[
 			activeThread,
+			createThreadWithSettings,
 			getPrimaryCapabilityForModel,
 			isProviderSupportedForModel,
 			isModelSelectableForContext,

--- a/apps/web/src/components/(chat)/ChatPlayground.tsx
+++ b/apps/web/src/components/(chat)/ChatPlayground.tsx
@@ -727,14 +727,20 @@ function ChatPlaygroundContent({
 			]);
 			const normalized = await ensureInitialThread(chats);
 			if (!mounted) return;
-			setThreads(normalized);
+			setThreads((current) => {
+				const currentIds = new Set(current.map((thread) => thread.id));
+				return [
+					...current,
+					...normalized.filter((thread) => !currentIds.has(thread.id)),
+				];
+			});
 			setChatTags(storedTags.sort(compareChatTags));
 
 			const initialId =
 				storedActive && normalized.some((t) => t.id === storedActive)
 					? storedActive
 					: (normalized[0]?.id ?? null);
-			setActiveId(initialId);
+			setActiveId((current) => current ?? initialId);
 		})();
 		return () => {
 			mounted = false;


### PR DESCRIPTION
## Summary

Selecting a model on a fresh Chat page silently failed whenever no active thread existed. The picker invoked `updateActiveModel`, but that callback returned immediately for a missing `activeThread`, leaving the picker open and the composer disabled.

This hotfix creates a new local chat seeded with the selected model and default settings when the user makes their first model selection. Existing threads continue through the unchanged update path. Persistence failures now surface a visible error instead of becoming another silent no-op.

## Validation

- `pnpm --filter @phaseo/web typecheck`
- `pnpm --filter @phaseo/web exec eslint 'src/components/(chat)/ChatPlayground.tsx'`
- `git diff --check`
- Reproduced the production failure before the fix: selecting Hy3 left the dialog open and no model selected

Created with Codex


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Selecting a model when no chat is active now automatically creates a new chat with the appropriate default settings.
  * The selected model is remembered for future sessions.

* **Bug Fixes**
  * Added an error message when creating the new chat fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->