### PR TITLE
Require reauthentication for passkey changes

### DIFF
--- a/apps/web/src/app/(dashboard)/settings/account/actions.passkeys.test.ts
+++ b/apps/web/src/app/(dashboard)/settings/account/actions.passkeys.test.ts
@@ -1,0 +1,156 @@
+jest.mock("@/utils/supabase/server", () => ({
+	createClient: jest.fn(),
+}));
+jest.mock("@supabase/supabase-js", () => ({
+	createClient: jest.fn(),
+}));
+jest.mock("@/utils/supabase/admin", () => ({
+	createAdminClient: jest.fn(),
+}));
+jest.mock("next/cache", () => ({ revalidatePath: jest.fn() }));
+jest.mock("next/navigation", () => ({ redirect: jest.fn() }));
+jest.mock("next/headers", () => ({ cookies: jest.fn() }));
+jest.mock("@/lib/auth/accountLifecycleDiscord", () => ({
+	sendAccountLifecycleDiscordWebhook: jest.fn(),
+}));
+
+import {
+	deletePasskeyAction,
+	startPasskeyRegistrationAction,
+	verifyPasskeyRegistrationAction,
+} from "./actions";
+import { createClient } from "@/utils/supabase/server";
+import { createClient as createSupabaseAuthClient } from "@supabase/supabase-js";
+
+const mockCreateClient = createClient as jest.MockedFunction<typeof createClient>;
+const mockCreateSupabaseAuthClient =
+	createSupabaseAuthClient as jest.MockedFunction<
+		typeof createSupabaseAuthClient
+	>;
+
+function createSupabaseMock(options: {
+	lastSignInAt?: string;
+	provider?: string;
+}) {
+	const passkey = {
+		delete: jest.fn().mockResolvedValue({ error: null }),
+		startRegistration: jest.fn().mockResolvedValue({
+			data: {
+				challenge_id: "challenge_123",
+				options: { challenge: "AQID", user: { id: "BAUG" } },
+			},
+			error: null,
+		}),
+		verifyRegistration: jest.fn().mockResolvedValue({ error: null }),
+	};
+	const user = {
+		app_metadata: { provider: options.provider ?? "email" },
+		email: "user@example.com",
+		id: "11111111-1111-4111-8111-111111111111",
+		last_sign_in_at: options.lastSignInAt ?? "2026-07-16T12:00:00.000Z",
+	};
+	return {
+		auth: {
+			getClaims: jest.fn().mockResolvedValue({
+				data: { claims: { amr: [] } },
+				error: null,
+			}),
+			getUser: jest.fn().mockResolvedValue({
+				data: { user },
+				error: null,
+			}),
+			mfa: {
+				getAuthenticatorAssuranceLevel: jest.fn().mockResolvedValue({
+					data: { currentLevel: "aal1", nextLevel: "aal1" },
+					error: null,
+				}),
+			},
+			passkey,
+		},
+	};
+}
+
+describe("passkey server actions", () => {
+	beforeEach(() => {
+		jest.clearAllMocks();
+		jest.useRealTimers();
+		process.env.NEXT_PUBLIC_SUPABASE_URL = "https://example.supabase.co";
+		process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY = "public-anon-key";
+	});
+
+	it("verifies the current password before starting registration", async () => {
+		const supabase = createSupabaseMock({ provider: "email" });
+		mockCreateClient.mockResolvedValue(supabase as never);
+		const passwordVerifier = {
+			auth: {
+				signInWithPassword: jest.fn().mockResolvedValue({
+					data: {
+						user: { id: "11111111-1111-4111-8111-111111111111" },
+					},
+					error: null,
+				}),
+			},
+		};
+		mockCreateSupabaseAuthClient.mockReturnValue(passwordVerifier as never);
+
+		const result = await startPasskeyRegistrationAction("current-password");
+
+		expect(result.ok).toBe(true);
+		expect(passwordVerifier.auth.signInWithPassword).toHaveBeenCalledWith({
+			email: "user@example.com",
+			password: "current-password",
+		});
+		expect(supabase.auth.passkey.startRegistration).toHaveBeenCalledTimes(1);
+	});
+
+	it("rejects stale passwordless sessions before starting registration", async () => {
+		jest.useFakeTimers().setSystemTime(new Date("2026-07-16T12:10:00.000Z"));
+		const supabase = createSupabaseMock({
+			lastSignInAt: "2026-07-16T12:00:00.000Z",
+			provider: "google",
+		});
+		mockCreateClient.mockResolvedValue(supabase as never);
+
+		const result = await startPasskeyRegistrationAction();
+
+		expect(result).toMatchObject({
+			code: "fresh_sign_in_required",
+			ok: false,
+		});
+		expect(supabase.auth.passkey.startRegistration).not.toHaveBeenCalled();
+	});
+
+	it("deletes a passkey only after server-side password verification", async () => {
+		const supabase = createSupabaseMock({ provider: "email" });
+		mockCreateClient.mockResolvedValue(supabase as never);
+		const passwordVerifier = {
+			auth: {
+				signInWithPassword: jest.fn().mockResolvedValue({
+					data: {
+						user: { id: "11111111-1111-4111-8111-111111111111" },
+					},
+					error: null,
+				}),
+			},
+		};
+		mockCreateSupabaseAuthClient.mockReturnValue(passwordVerifier as never);
+
+		const result = await deletePasskeyAction(
+			"22222222-2222-4222-8222-222222222222",
+			"current-password",
+		);
+
+		expect(result.ok).toBe(true);
+		expect(passwordVerifier.auth.signInWithPassword).toHaveBeenCalledTimes(1);
+		expect(supabase.auth.passkey.delete).toHaveBeenCalledWith({
+			passkeyId: "22222222-2222-4222-8222-222222222222",
+		});
+	});
+
+	it("rejects malformed registration responses before opening Supabase", async () => {
+		const result = await verifyPasskeyRegistrationAction("bad id!", {});
+
+		expect(result).toMatchObject({ code: "invalid_request", ok: false });
+		expect(mockCreateClient).not.toHaveBeenCalled();
+	});
+});

--- a/apps/web/src/app/(dashboard)/settings/account/actions.ts
+++ b/apps/web/src/app/(dashboard)/settings/account/actions.ts
@@ -7,6 +7,288 @@ import { redirect } from 'next/navigation'
 import { cookies } from 'next/headers'
 import { OBFUSCATE_INFO_COOKIE, serializeObfuscateInfo } from '@/lib/obfuscation'
 import { sendAccountLifecycleDiscordWebhook } from '@/lib/auth/accountLifecycleDiscord'
+import {
+    hasRecentInteractiveAuthentication,
+    hasRecentSignIn,
+} from '@/lib/auth/method'
+import { createClient as createSupabaseAuthClient } from '@supabase/supabase-js'
+import { z } from 'zod'
+
+export type PasskeyMutationFailure = {
+    code:
+        | 'fresh_sign_in_required'
+        | 'incorrect_password'
+        | 'invalid_request'
+        | 'not_authenticated'
+        | 'passkey_error'
+    message: string
+    ok: false
+}
+
+export type PasskeyMutationResult<T = undefined> =
+    | { data: T; ok: true }
+    | PasskeyMutationFailure
+
+const passkeyChallengeIdSchema = z
+    .string()
+    .min(1)
+    .max(256)
+    .regex(/^[A-Za-z0-9_-]+$/)
+
+const passkeyIdSchema = z.string().uuid()
+
+const base64UrlSchema = z
+    .string()
+    .min(1)
+    .max(131_072)
+    .regex(/^[A-Za-z0-9_-]+$/)
+
+const passkeyRegistrationCredentialSchema = z
+    .object({
+        authenticatorAttachment: z.string().max(64).optional(),
+        clientExtensionResults: z.object({}).passthrough(),
+        id: z.string().min(1).max(4096),
+        rawId: z.string().min(1).max(4096),
+        response: z
+            .object({
+                attestationObject: base64UrlSchema,
+                clientDataJSON: base64UrlSchema,
+            })
+            .passthrough(),
+        type: z.literal('public-key'),
+    })
+    .passthrough()
+
+function userHasPassword(user: {
+    app_metadata?: { provider?: unknown }
+}) {
+    const provider = String(user.app_metadata?.provider ?? '').toLowerCase()
+    return !provider || provider === 'email'
+}
+
+async function hasRecentServerAuthentication(
+    supabase: Awaited<ReturnType<typeof createClient>>,
+    lastSignInAt: string | null | undefined
+) {
+    const { data, error } = await supabase.auth.getClaims()
+    return (
+        !error &&
+        (hasRecentInteractiveAuthentication(
+            data?.claims as Record<string, unknown> | undefined
+        ) || hasRecentSignIn(lastSignInAt))
+    )
+}
+
+async function requirePasskeyStepUp(
+    supabase: Awaited<ReturnType<typeof createClient>>,
+    currentPassword?: string
+): Promise<
+    | { ok: true; user: NonNullable<Awaited<ReturnType<typeof supabase.auth.getUser>>['data']['user']> }
+    | { ok: false; result: PasskeyMutationFailure }
+> {
+    const { data: userData, error: userError } = await supabase.auth.getUser()
+    const user = userData.user
+    if (userError || !user) {
+        return {
+            ok: false,
+            result: {
+                code: 'not_authenticated',
+                message: 'Your session has expired. Sign in again to continue.',
+                ok: false,
+            },
+        }
+    }
+
+    const { data: aalData, error: aalError } =
+        await supabase.auth.mfa.getAuthenticatorAssuranceLevel()
+    if (aalError) {
+        return {
+            ok: false,
+            result: {
+                code: 'passkey_error',
+                message: 'Could not verify your authentication level.',
+                ok: false,
+            },
+        }
+    }
+    if (aalData?.nextLevel === 'aal2' && aalData.currentLevel !== 'aal2') {
+        return {
+            ok: false,
+            result: {
+                code: 'fresh_sign_in_required',
+                message: 'Complete MFA verification before changing passkeys.',
+                ok: false,
+            },
+        }
+    }
+
+    if (userHasPassword(user)) {
+        if (!user.email || !currentPassword) {
+            return {
+                ok: false,
+                result: {
+                    code: 'incorrect_password',
+                    message: 'Enter your current password.',
+                    ok: false,
+                },
+            }
+        }
+
+        const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL
+        const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
+        if (!supabaseUrl || !supabaseAnonKey) {
+            return {
+                ok: false,
+                result: {
+                    code: 'passkey_error',
+                    message: 'Passkey verification is unavailable.',
+                    ok: false,
+                },
+            }
+        }
+
+        // Verify the password without replacing or downgrading the user's
+        // existing session (which may already be elevated to AAL2).
+        const passwordVerifier = createSupabaseAuthClient(
+            supabaseUrl,
+            supabaseAnonKey,
+            {
+                auth: {
+                    autoRefreshToken: false,
+                    persistSession: false,
+                },
+            }
+        )
+        const { data, error } = await passwordVerifier.auth.signInWithPassword({
+            email: user.email,
+            password: currentPassword,
+        })
+        if (error || data.user?.id !== user.id) {
+            return {
+                ok: false,
+                result: {
+                    code: 'incorrect_password',
+                    message: 'Current password is incorrect.',
+                    ok: false,
+                },
+            }
+        }
+        return { ok: true, user }
+    }
+
+    if (!(await hasRecentServerAuthentication(supabase, user.last_sign_in_at))) {
+        return {
+            ok: false,
+            result: {
+                code: 'fresh_sign_in_required',
+                message: 'Sign in again before changing passkeys.',
+                ok: false,
+            },
+        }
+    }
+
+    return { ok: true, user }
+}
+
+export async function startPasskeyRegistrationAction(
+    currentPassword?: string
+): Promise<
+    PasskeyMutationResult<{
+        challengeId: string
+        options: unknown
+    }>
+> {
+    const supabase = await createClient()
+    const stepUp = await requirePasskeyStepUp(supabase, currentPassword)
+    if (!stepUp.ok) return stepUp.result
+
+    const { data, error } = await supabase.auth.passkey.startRegistration()
+    if (error || !data) {
+        return {
+            code: 'passkey_error',
+            message: 'Could not start passkey registration.',
+            ok: false,
+        }
+    }
+
+    return {
+        data: {
+            challengeId: data.challenge_id,
+            options: data.options,
+        },
+        ok: true,
+    }
+}
+
+export async function verifyPasskeyRegistrationAction(
+    challengeId: unknown,
+    credential: unknown,
+    currentPassword?: string
+): Promise<PasskeyMutationResult> {
+    const parsedChallengeId = passkeyChallengeIdSchema.safeParse(challengeId)
+    const parsedCredential =
+        passkeyRegistrationCredentialSchema.safeParse(credential)
+    if (!parsedChallengeId.success || !parsedCredential.success) {
+        return {
+            code: 'invalid_request',
+            message: 'The passkey response was invalid.',
+            ok: false,
+        }
+    }
+
+    const supabase = await createClient()
+    const stepUp = await requirePasskeyStepUp(supabase, currentPassword)
+    if (!stepUp.ok) return stepUp.result
+
+    type VerifyRegistrationParams = Parameters<
+        typeof supabase.auth.passkey.verifyRegistration
+    >[0]
+    const { error } = await supabase.auth.passkey.verifyRegistration({
+        challengeId: parsedChallengeId.data,
+        credential:
+            parsedCredential.data as VerifyRegistrationParams['credential'],
+    })
+    if (error) {
+        return {
+            code: 'passkey_error',
+            message: 'Could not verify the new passkey.',
+            ok: false,
+        }
+    }
+
+    return { data: undefined, ok: true }
+}
+
+export async function deletePasskeyAction(
+    passkeyId: unknown,
+    currentPassword?: string
+): Promise<PasskeyMutationResult> {
+    const parsedPasskeyId = passkeyIdSchema.safeParse(passkeyId)
+    if (!parsedPasskeyId.success) {
+        return {
+            code: 'invalid_request',
+            message: 'The passkey identifier was invalid.',
+            ok: false,
+        }
+    }
+
+    const supabase = await createClient()
+    const stepUp = await requirePasskeyStepUp(supabase, currentPassword)
+    if (!stepUp.ok) return stepUp.result
+
+    const { error } = await supabase.auth.passkey.delete({
+        passkeyId: parsedPasskeyId.data,
+    })
+    if (error) {
+        return {
+            code: 'passkey_error',
+            message: 'Could not remove passkey.',
+            ok: false,
+        }
+    }
+
+    return { data: undefined, ok: true }
+}
 
 export async function updateAccount(payload: {
     display_name?: string | null

--- a/apps/web/src/app/(dashboard)/settings/account/mfa/page.tsx
+++ b/apps/web/src/app/(dashboard)/settings/account/mfa/page.tsx
@@ -35,6 +35,7 @@ async function AccountMFAContent() {
 
 	return (
 		<AccountMFAClient
+			hasPassword={initialData.hasPassword}
 			mfaEnabled={initialData.mfaEnabled}
 			mfaFactorId={initialData.mfaFactorId}
 		/>

--- a/apps/web/src/app/api/internal/settings/account/mfa/initial/route.ts
+++ b/apps/web/src/app/api/internal/settings/account/mfa/initial/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from "next/server";
 import { createClient } from "@/utils/supabase/server";
 
 export type SettingsAccountMfaInitialData = {
+	hasPassword: boolean;
 	mfaEnabled: boolean;
 	mfaFactorId: string | null;
 	signedIn: boolean;
@@ -14,6 +15,7 @@ export async function GET() {
 
 	if (!authUser) {
 		return NextResponse.json({
+			hasPassword: false,
 			mfaEnabled: false,
 			mfaFactorId: null,
 			signedIn: false,
@@ -22,7 +24,10 @@ export async function GET() {
 
 	const { data: mfaData } = await supabase.auth.mfa.listFactors();
 	const mfaFactor = mfaData?.totp?.find((factor) => factor.status === "verified");
+	const provider = authUser.app_metadata?.provider;
+	const hasPassword = !provider || provider === "email";
 	return NextResponse.json({
+		hasPassword,
 		mfaEnabled: Boolean(mfaFactor),
 		mfaFactorId: mfaFactor?.id ?? null,
 		signedIn: true,

--- a/apps/web/src/components/(gateway)/settings/account/AccountMFAClient.tsx
+++ b/apps/web/src/components/(gateway)/settings/account/AccountMFAClient.tsx
@@ -35,9 +35,11 @@ import {
 import { Loader2, Shield, ShieldCheck } from "lucide-react";
 
 export default function AccountMFAClient({
+	hasPassword,
 	mfaEnabled,
 	mfaFactorId,
 }: {
+	hasPassword: boolean;
 	mfaEnabled: boolean;
 	mfaFactorId: string | null;
 }) {
@@ -168,7 +170,7 @@ export default function AccountMFAClient({
 				onOpenChange={handleMFADialogClose}
 				onSuccess={handleMFASuccess}
 			/>
-			<PasskeyManager />
+			<PasskeyManager hasPassword={hasPassword} />
 		</div>
 	);
 }

--- a/apps/web/src/components/(gateway)/settings/account/PasskeyManager.tsx
+++ b/apps/web/src/components/(gateway)/settings/account/PasskeyManager.tsx
@@ -1,9 +1,23 @@
 "use client";
 
 import * as React from "react";
-import { KeyRound, Loader2, Trash2 } from "lucide-react";
+import { KeyRound, Loader2, LogIn, Trash2 } from "lucide-react";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
+import {
+	Dialog,
+	DialogContent,
+	DialogDescription,
+	DialogFooter,
+	DialogHeader,
+	DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+	hasRecentInteractiveAuthentication,
+	hasRecentSignIn,
+} from "@/lib/auth/method";
 import { createClient } from "@/utils/supabase/client";
 
 type Passkey = {
@@ -13,10 +27,19 @@ type Passkey = {
 	last_used_at?: string;
 };
 
-export function PasskeyManager() {
+type PendingPasskeyAction =
+	| { type: "register" }
+	| { passkeyId: string; type: "remove" };
+
+export function PasskeyManager({ hasPassword }: { hasPassword: boolean }) {
 	const [passkeys, setPasskeys] = React.useState<Passkey[]>([]);
 	const [loading, setLoading] = React.useState(true);
 	const [pending, setPending] = React.useState(false);
+	const [reauthOpen, setReauthOpen] = React.useState(false);
+	const [currentPassword, setCurrentPassword] = React.useState("");
+	const [freshSignInRequired, setFreshSignInRequired] = React.useState(false);
+	const [requestedAction, setRequestedAction] =
+		React.useState<PendingPasskeyAction | null>(null);
 
 	const load = React.useCallback(async () => {
 		setLoading(true);
@@ -33,35 +56,109 @@ export function PasskeyManager() {
 	}, []);
 
 	React.useEffect(() => {
-		void load();
+		let cancelled = false;
+		queueMicrotask(() => {
+			if (!cancelled) void load();
+		});
+		return () => {
+			cancelled = true;
+		};
 	}, [load]);
 
-	async function register() {
-		setPending(true);
-		try {
-			const { error } = await createClient().auth.registerPasskey();
+	async function executeAction(action: PendingPasskeyAction) {
+		const supabase = createClient();
+		if (action.type === "register") {
+			const { error } = await supabase.auth.registerPasskey();
 			if (error) throw error;
 			toast.success("Passkey added");
 			await load();
+			return;
+		}
+
+		const { error } = await supabase.auth.passkey.delete({
+			passkeyId: action.passkeyId,
+		});
+		if (error) throw error;
+		setPasskeys((items) =>
+			items.filter((item) => item.id !== action.passkeyId),
+		);
+		toast.success("Passkey removed");
+	}
+
+	function requestAction(action: PendingPasskeyAction) {
+		setRequestedAction(action);
+		setCurrentPassword("");
+		setFreshSignInRequired(false);
+		setReauthOpen(true);
+	}
+
+	async function confirmAndExecute(event: React.FormEvent) {
+		event.preventDefault();
+		if (!requestedAction) return;
+		if (hasPassword && !currentPassword) {
+			toast.error("Enter your current password");
+			return;
+		}
+
+		setPending(true);
+		try {
+			const supabase = createClient();
+			const { data: userData, error: userError } =
+				await supabase.auth.getUser();
+			const user = userData.user;
+			if (userError || !user) throw new Error("Your session has expired");
+
+			if (hasPassword) {
+				if (!user.email) throw new Error("No sign-in email is available");
+				const { data, error } = await supabase.auth.signInWithPassword({
+					email: user.email,
+					password: currentPassword,
+				});
+				if (error || data.user?.id !== user.id) {
+					throw new Error("Current password is incorrect");
+				}
+			} else {
+				const { data: claimsData, error: claimsError } =
+					await supabase.auth.getClaims();
+				const recentAuthentication =
+					!claimsError &&
+					(hasRecentInteractiveAuthentication(
+						claimsData?.claims as Record<string, unknown> | undefined,
+					) || hasRecentSignIn(user.last_sign_in_at));
+				if (!recentAuthentication) {
+					setFreshSignInRequired(true);
+					return;
+				}
+			}
+
+			await executeAction(requestedAction);
+			setReauthOpen(false);
+			setRequestedAction(null);
+			setCurrentPassword("");
 		} catch (error) {
-			const message = error instanceof Error ? error.message : "Could not add passkey";
-			toast.error(message.includes("passkey_disabled") ? "Passkeys are not enabled for this environment yet." : message);
+			const fallback =
+				requestedAction.type === "register"
+					? "Could not add passkey"
+					: "Could not remove passkey";
+			const message = error instanceof Error ? error.message : fallback;
+			toast.error(
+				message.includes("passkey_disabled")
+					? "Passkeys are not enabled for this environment yet."
+					: message,
+			);
 		} finally {
 			setPending(false);
 		}
 	}
 
-	async function remove(passkeyId: string) {
+	async function restartSignIn() {
 		setPending(true);
 		try {
-			const { error } = await createClient().auth.passkey.delete({ passkeyId });
-			if (error) throw error;
-			setPasskeys((items) => items.filter((item) => item.id !== passkeyId));
-			toast.success("Passkey removed");
-		} catch (error) {
-			toast.error(error instanceof Error ? error.message : "Could not remove passkey");
+			await createClient().auth.signOut();
 		} finally {
-			setPending(false);
+			window.location.assign(
+				`/sign-in?returnUrl=${encodeURIComponent("/settings/account/mfa")}`,
+			);
 		}
 	}
 
@@ -72,7 +169,7 @@ export function PasskeyManager() {
 					<h3 className="flex items-center gap-2 text-sm font-medium"><KeyRound className="h-4 w-4" />Passkeys</h3>
 					<p className="mt-1 text-sm text-muted-foreground">Sign in with your device biometrics, PIN, or security key.</p>
 				</div>
-				<Button onClick={register} disabled={pending}>
+				<Button onClick={() => requestAction({ type: "register" })} disabled={pending}>
 					{pending ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : null}Add passkey
 				</Button>
 			</div>
@@ -81,9 +178,90 @@ export function PasskeyManager() {
 			{passkeys.map((passkey) => (
 				<div key={passkey.id} className="flex items-center justify-between gap-3 border-t pt-3">
 					<div className="min-w-0 text-sm"><p className="truncate font-medium">{passkey.friendly_name || "Passkey"}</p><p className="text-muted-foreground">Added {new Date(passkey.created_at).toLocaleDateString()}</p></div>
-					<Button variant="ghost" size="icon" aria-label="Remove passkey" onClick={() => remove(passkey.id)} disabled={pending}><Trash2 className="h-4 w-4" /></Button>
+					<Button variant="ghost" size="icon" aria-label="Remove passkey" onClick={() => requestAction({ type: "remove", passkeyId: passkey.id })} disabled={pending}><Trash2 className="h-4 w-4" /></Button>
 				</div>
 			))}
+
+			<Dialog
+				open={reauthOpen}
+				onOpenChange={(open) => {
+					if (pending) return;
+					setReauthOpen(open);
+					if (!open) {
+						setRequestedAction(null);
+						setCurrentPassword("");
+						setFreshSignInRequired(false);
+					}
+				}}
+			>
+				<DialogContent className="sm:max-w-md">
+					<DialogHeader>
+						<DialogTitle>Verify it&apos;s you</DialogTitle>
+						<DialogDescription>
+							Adding or removing a passkey changes how your account can be
+							accessed, so recent authentication is required.
+						</DialogDescription>
+					</DialogHeader>
+
+					{freshSignInRequired ? (
+						<div className="space-y-4">
+							<p className="text-sm text-muted-foreground">
+								Your last sign-in is too old for this security change. Sign in
+								again, then return here to continue.
+							</p>
+							<DialogFooter>
+								<Button type="button" onClick={restartSignIn} disabled={pending}>
+									{pending ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : <LogIn className="mr-2 h-4 w-4" />}
+									Sign in again
+								</Button>
+							</DialogFooter>
+						</div>
+					) : (
+						<form onSubmit={confirmAndExecute} className="space-y-4">
+							{hasPassword ? (
+								<div className="grid gap-2">
+									<Label htmlFor="passkey-current-password">
+										Current password
+									</Label>
+									<Input
+										id="passkey-current-password"
+										type="password"
+										autoComplete="current-password"
+										value={currentPassword}
+										onChange={(event) => setCurrentPassword(event.target.value)}
+										disabled={pending}
+										autoFocus
+									/>
+								</div>
+							) : (
+								<p className="text-sm text-muted-foreground">
+									Continue using your recent social, SSO, or passkey sign-in.
+								</p>
+							)}
+
+							<DialogFooter>
+								<Button
+									type="button"
+									variant="outline"
+									onClick={() => setReauthOpen(false)}
+									disabled={pending}
+								>
+									Cancel
+								</Button>
+								<Button
+									type="submit"
+									disabled={pending || (hasPassword && !currentPassword)}
+								>
+									{pending ? (
+										<Loader2 className="mr-2 h-4 w-4 animate-spin" />
+									) : null}
+									Continue
+								</Button>
+							</DialogFooter>
+						</form>
+					)}
+				</DialogContent>
+			</Dialog>
 		</div>
 	);
 }

--- a/apps/web/src/components/(gateway)/settings/account/PasskeyManager.tsx
+++ b/apps/web/src/components/(gateway)/settings/account/PasskeyManager.tsx
@@ -3,6 +3,11 @@
 import * as React from "react";
 import { KeyRound, Loader2, LogIn, Trash2 } from "lucide-react";
 import { toast } from "sonner";
+import {
+	deletePasskeyAction,
+	startPasskeyRegistrationAction,
+	verifyPasskeyRegistrationAction,
+} from "@/app/(dashboard)/settings/account/actions";
 import { Button } from "@/components/ui/button";
 import {
 	Dialog,
@@ -15,9 +20,9 @@ import {
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import {
-	hasRecentInteractiveAuthentication,
-	hasRecentSignIn,
-} from "@/lib/auth/method";
+	parsePasskeyCreationOptions,
+	serializePasskeyRegistrationCredential,
+} from "@/lib/auth/passkeyWebAuthn";
 import { createClient } from "@/utils/supabase/client";
 
 type Passkey = {
@@ -65,24 +70,42 @@ export function PasskeyManager({ hasPassword }: { hasPassword: boolean }) {
 		};
 	}, [load]);
 
-	async function executeAction(action: PendingPasskeyAction) {
-		const supabase = createClient();
+	async function executeAction(
+		action: PendingPasskeyAction,
+		password?: string,
+	) {
 		if (action.type === "register") {
-			const { error } = await supabase.auth.registerPasskey();
-			if (error) throw error;
+			const startResult = await startPasskeyRegistrationAction(password);
+			if (!startResult.ok) return startResult;
+
+			const publicKey = parsePasskeyCreationOptions(startResult.data.options);
+			const credential = await navigator.credentials.create({ publicKey });
+			if (!(credential instanceof PublicKeyCredential)) {
+				throw new Error("Passkey registration was cancelled");
+			}
+
+			const verifyResult = await verifyPasskeyRegistrationAction(
+				startResult.data.challengeId,
+				serializePasskeyRegistrationCredential(credential),
+				password,
+			);
+			if (!verifyResult.ok) return verifyResult;
+
 			toast.success("Passkey added");
 			await load();
-			return;
+			return verifyResult;
 		}
 
-		const { error } = await supabase.auth.passkey.delete({
-			passkeyId: action.passkeyId,
-		});
-		if (error) throw error;
+		const deleteResult = await deletePasskeyAction(
+			action.passkeyId,
+			password,
+		);
+		if (!deleteResult.ok) return deleteResult;
 		setPasskeys((items) =>
 			items.filter((item) => item.id !== action.passkeyId),
 		);
 		toast.success("Passkey removed");
+		return deleteResult;
 	}
 
 	function requestAction(action: PendingPasskeyAction) {
@@ -102,36 +125,21 @@ export function PasskeyManager({ hasPassword }: { hasPassword: boolean }) {
 
 		setPending(true);
 		try {
-			const supabase = createClient();
-			const { data: userData, error: userError } =
-				await supabase.auth.getUser();
-			const user = userData.user;
-			if (userError || !user) throw new Error("Your session has expired");
-
-			if (hasPassword) {
-				if (!user.email) throw new Error("No sign-in email is available");
-				const { data, error } = await supabase.auth.signInWithPassword({
-					email: user.email,
-					password: currentPassword,
-				});
-				if (error || data.user?.id !== user.id) {
-					throw new Error("Current password is incorrect");
-				}
-			} else {
-				const { data: claimsData, error: claimsError } =
-					await supabase.auth.getClaims();
-				const recentAuthentication =
-					!claimsError &&
-					(hasRecentInteractiveAuthentication(
-						claimsData?.claims as Record<string, unknown> | undefined,
-					) || hasRecentSignIn(user.last_sign_in_at));
-				if (!recentAuthentication) {
+			const result = await executeAction(
+				requestedAction,
+				hasPassword ? currentPassword : undefined,
+			);
+			if (!result.ok) {
+				if (
+					result.code === "fresh_sign_in_required" ||
+					result.code === "not_authenticated"
+				) {
 					setFreshSignInRequired(true);
 					return;
 				}
+				throw new Error(result.message);
 			}
 
-			await executeAction(requestedAction);
 			setReauthOpen(false);
 			setRequestedAction(null);
 			setCurrentPassword("");

--- a/apps/web/src/lib/auth/method.test.ts
+++ b/apps/web/src/lib/auth/method.test.ts
@@ -1,0 +1,63 @@
+import {
+	hasRecentInteractiveAuthentication,
+	hasRecentSignIn,
+	latestInteractiveAuthenticationTimestamp,
+} from "./method";
+
+describe("recent authentication helpers", () => {
+	it("uses the latest interactive AMR timestamp", () => {
+		expect(
+			latestInteractiveAuthenticationTimestamp({
+				amr: [
+					{ method: "password", timestamp: 1_000 },
+					{ method: "mfa/totp", timestamp: 1_200 },
+				],
+			}),
+		).toBe(1_200);
+	});
+
+	it("ignores refresh-only AMR entries", () => {
+		expect(
+			latestInteractiveAuthenticationTimestamp({
+				amr: [{ method: "token_refresh", timestamp: 1_200 }],
+			}),
+		).toBeNull();
+	});
+
+	it("accepts only authentication inside the sensitive-action window", () => {
+		const claims = { amr: [{ method: "oauth", timestamp: 1_000 }] };
+		expect(
+			hasRecentInteractiveAuthentication(claims, {
+				nowSeconds: 1_299,
+			}),
+		).toBe(true);
+		expect(
+			hasRecentInteractiveAuthentication(claims, {
+				nowSeconds: 1_301,
+			}),
+		).toBe(false);
+	});
+
+	it("rejects future AMR timestamps", () => {
+		expect(
+			hasRecentInteractiveAuthentication(
+				{ amr: [{ method: "password", timestamp: 1_001 }] },
+				{ nowSeconds: 1_000 },
+			),
+		).toBe(false);
+	});
+
+	it("uses the server-reported last sign-in time as a fallback", () => {
+		const now = Date.parse("2026-07-16T12:00:00.000Z");
+		expect(
+			hasRecentSignIn("2026-07-16T11:56:00.000Z", {
+				nowMilliseconds: now,
+			}),
+		).toBe(true);
+		expect(
+			hasRecentSignIn("2026-07-16T11:54:00.000Z", {
+				nowMilliseconds: now,
+			}),
+		).toBe(false);
+	});
+});

--- a/apps/web/src/lib/auth/method.ts
+++ b/apps/web/src/lib/auth/method.ts
@@ -1,5 +1,82 @@
 export type AuthMethod = "password" | "social" | "sso" | "unknown";
 
+export const SENSITIVE_AUTH_MAX_AGE_SECONDS = 5 * 60;
+
+const NON_INTERACTIVE_AUTH_METHODS = new Set([
+	"refresh_token",
+	"token_refresh",
+]);
+
+function normalizeTimestampSeconds(value: unknown): number | null {
+	if (typeof value !== "number" || !Number.isFinite(value) || value <= 0) {
+		return null;
+	}
+
+	return Math.floor(value);
+}
+
+export function latestInteractiveAuthenticationTimestamp(
+	claims: Record<string, unknown> | null | undefined,
+): number | null {
+	const rawAmr = claims?.amr;
+	if (!Array.isArray(rawAmr)) return null;
+
+	let latest: number | null = null;
+	for (const entry of rawAmr) {
+		if (typeof entry !== "object" || entry === null) continue;
+
+		const method = String(
+			(entry as { method?: unknown }).method ?? "",
+		).toLowerCase();
+		if (!method || NON_INTERACTIVE_AUTH_METHODS.has(method)) continue;
+
+		const timestamp = normalizeTimestampSeconds(
+			(entry as { timestamp?: unknown }).timestamp,
+		);
+		if (timestamp !== null && (latest === null || timestamp > latest)) {
+			latest = timestamp;
+		}
+	}
+
+	return latest;
+}
+
+export function hasRecentInteractiveAuthentication(
+	claims: Record<string, unknown> | null | undefined,
+	options: {
+		maxAgeSeconds?: number;
+		nowSeconds?: number;
+	} = {},
+): boolean {
+	const latest = latestInteractiveAuthenticationTimestamp(claims);
+	if (latest === null) return false;
+
+	const now = Math.floor(options.nowSeconds ?? Date.now() / 1000);
+	const maxAge = options.maxAgeSeconds ?? SENSITIVE_AUTH_MAX_AGE_SECONDS;
+	const age = now - latest;
+
+	return age >= 0 && age <= maxAge;
+}
+
+export function hasRecentSignIn(
+	lastSignInAt: string | null | undefined,
+	options: {
+		maxAgeSeconds?: number;
+		nowMilliseconds?: number;
+	} = {},
+): boolean {
+	if (!lastSignInAt) return false;
+	const timestamp = Date.parse(lastSignInAt);
+	if (!Number.isFinite(timestamp)) return false;
+
+	const now = options.nowMilliseconds ?? Date.now();
+	const maxAgeMilliseconds =
+		(options.maxAgeSeconds ?? SENSITIVE_AUTH_MAX_AGE_SECONDS) * 1000;
+	const age = now - timestamp;
+
+	return age >= 0 && age <= maxAgeMilliseconds;
+}
+
 function decodeJwtPayload(token: string): Record<string, unknown> | null {
 	const parts = token.split(".");
 	if (parts.length < 2 || !parts[1]) return null;
@@ -27,8 +104,8 @@ export function classifyAuthMethodFromJwtClaims(
 				typeof entry === "string"
 					? entry
 					: typeof entry === "object" &&
-						  entry !== null &&
-						  typeof (entry as { method?: unknown }).method === "string"
+							entry !== null &&
+							typeof (entry as { method?: unknown }).method === "string"
 						? String((entry as { method: string }).method)
 						: "";
 			const normalized = method.toLowerCase();
@@ -51,7 +128,7 @@ export function classifyAuthMethodFromSession(
 	session:
 		| {
 				access_token?: string | null;
-		  }
+			}
 		| null
 		| undefined,
 ): AuthMethod {

--- a/apps/web/src/lib/auth/passkeyWebAuthn.test.ts
+++ b/apps/web/src/lib/auth/passkeyWebAuthn.test.ts
@@ -1,0 +1,47 @@
+import { parsePasskeyCreationOptions } from "./passkeyWebAuthn";
+
+describe("parsePasskeyCreationOptions", () => {
+	it("decodes the challenge, user id, and excluded credential ids", () => {
+		const originalPublicKeyCredential = globalThis.PublicKeyCredential;
+		Object.defineProperty(globalThis, "PublicKeyCredential", {
+			configurable: true,
+			value: class {},
+		});
+
+		try {
+			const parsed = parsePasskeyCreationOptions({
+				challenge: "AQID",
+				excludeCredentials: [{ id: "BAUG", type: "public-key" }],
+				pubKeyCredParams: [{ alg: -7, type: "public-key" }],
+				rp: { name: "Phaseo" },
+				user: { displayName: "User", id: "BwgJ", name: "user" },
+			});
+
+			expect(
+				Array.from(new Uint8Array(parsed.challenge as ArrayBuffer)),
+			).toEqual([1, 2, 3]);
+			expect(
+				Array.from(new Uint8Array(parsed.user.id as ArrayBuffer)),
+			).toEqual([7, 8, 9]);
+			expect(
+				Array.from(
+					new Uint8Array(
+						(parsed.excludeCredentials?.[0]?.id ??
+							new ArrayBuffer(0)) as ArrayBuffer,
+					),
+				),
+			).toEqual([4, 5, 6]);
+		} finally {
+			Object.defineProperty(globalThis, "PublicKeyCredential", {
+				configurable: true,
+				value: originalPublicKeyCredential,
+			});
+		}
+	});
+
+	it("rejects malformed server options", () => {
+		expect(() => parsePasskeyCreationOptions({ challenge: "AQID" })).toThrow(
+			"Passkey user options are invalid",
+		);
+	});
+});

--- a/apps/web/src/lib/auth/passkeyWebAuthn.ts
+++ b/apps/web/src/lib/auth/passkeyWebAuthn.ts
@@ -1,0 +1,130 @@
+type RegistrationOptionsJson = {
+	challenge: string;
+	excludeCredentials?: Array<{
+		id: string;
+		transports?: AuthenticatorTransport[];
+		type?: PublicKeyCredentialType;
+	}>;
+	user: {
+		id: string;
+	};
+	[key: string]: unknown;
+};
+
+export type SerializedRegistrationCredential = {
+	authenticatorAttachment?: string;
+	clientExtensionResults: AuthenticationExtensionsClientOutputs;
+	id: string;
+	rawId: string;
+	response: {
+		attestationObject: string;
+		clientDataJSON: string;
+	};
+	type: "public-key";
+};
+
+function base64UrlToArrayBuffer(value: string): ArrayBuffer {
+	const normalized = value.replace(/-/g, "+").replace(/_/g, "/");
+	const padded = normalized.padEnd(
+		normalized.length + ((4 - (normalized.length % 4 || 4)) % 4),
+		"=",
+	);
+	const binary = atob(padded);
+	const bytes = new Uint8Array(binary.length);
+	for (let index = 0; index < binary.length; index += 1) {
+		bytes[index] = binary.charCodeAt(index);
+	}
+	return bytes.buffer;
+}
+
+function arrayBufferToBase64Url(value: ArrayBuffer): string {
+	const bytes = new Uint8Array(value);
+	let binary = "";
+	for (const byte of bytes) binary += String.fromCharCode(byte);
+	return btoa(binary)
+		.replace(/\+/g, "-")
+		.replace(/\//g, "_")
+		.replace(/=+$/g, "");
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null;
+}
+
+export function parsePasskeyCreationOptions(
+	input: unknown,
+): PublicKeyCredentialCreationOptions {
+	if (!isRecord(input) || typeof input.challenge !== "string") {
+		throw new Error("Passkey creation options are invalid");
+	}
+	if (!isRecord(input.user) || typeof input.user.id !== "string") {
+		throw new Error("Passkey user options are invalid");
+	}
+
+	const options = input as RegistrationOptionsJson;
+	const nativeParser = (
+		PublicKeyCredential as typeof PublicKeyCredential & {
+			parseCreationOptionsFromJSON?: (
+				options: RegistrationOptionsJson,
+			) => PublicKeyCredentialCreationOptions;
+		}
+	).parseCreationOptionsFromJSON;
+	if (typeof nativeParser === "function") {
+		return (
+			PublicKeyCredential as typeof PublicKeyCredential & {
+				parseCreationOptionsFromJSON: (
+					options: RegistrationOptionsJson,
+				) => PublicKeyCredentialCreationOptions;
+			}
+		).parseCreationOptionsFromJSON(options);
+	}
+
+	return {
+		...(options as unknown as PublicKeyCredentialCreationOptions),
+		challenge: base64UrlToArrayBuffer(options.challenge),
+		excludeCredentials: options.excludeCredentials?.map((credential) => ({
+			...credential,
+			id: base64UrlToArrayBuffer(credential.id),
+			type: credential.type ?? "public-key",
+		})),
+		user: {
+			...(options.user as unknown as PublicKeyCredentialUserEntity),
+			id: base64UrlToArrayBuffer(options.user.id),
+		},
+	};
+}
+
+export function serializePasskeyRegistrationCredential(
+	credential: PublicKeyCredential,
+): SerializedRegistrationCredential {
+	const credentialWithJson = credential as PublicKeyCredential & {
+		authenticatorAttachment?: AuthenticatorAttachment | null;
+		toJSON?: () => SerializedRegistrationCredential;
+	};
+	if (typeof credentialWithJson.toJSON === "function") {
+		return credentialWithJson.toJSON() as SerializedRegistrationCredential;
+	}
+
+	const response = credential.response;
+	if (
+		!("attestationObject" in response) ||
+		!(response.attestationObject instanceof ArrayBuffer)
+	) {
+		throw new Error("Passkey attestation response is invalid");
+	}
+
+	return {
+		authenticatorAttachment:
+			credentialWithJson.authenticatorAttachment ?? undefined,
+		clientExtensionResults: credential.getClientExtensionResults(),
+		id: credential.id,
+		rawId: credential.id,
+		response: {
+			attestationObject: arrayBufferToBase64Url(
+				response.attestationObject,
+			),
+			clientDataJSON: arrayBufferToBase64Url(response.clientDataJSON),
+		},
+		type: "public-key",
+	};
+}

--- a/security_best_practices_report.md
+++ b/security_best_practices_report.md
@@ -23,7 +23,7 @@ No open GitHub secret-scanning alerts were present. This review does not prove t
 | Medium | Meta `web_search_options` injects arbitrary tools | Fixed here with an allowlist and server-owned tool/location types. |
 | Medium | SpaceXAI BYOK migration can delete the active legacy key | Fixed for existing and fresh environments. The original applied migration remains immutable; a new locked, idempotent corrective migration ranks active/always-use keys before provider spelling and then normalizes the keeper. A read-only production check found no SpaceXAI/xAI BYOK rows requiring recovery. |
 | Medium | API-model route exposes hidden model metadata | Fixed here by applying hidden-model visibility checks after provider/API-model resolution. |
-| Medium | Passkey enrollment exposed without reauthentication | Fixed in the follow-up branch. Password-backed accounts must re-enter their current password before adding or deleting a passkey. Passwordless, social, SSO, and existing-passkey accounts require an interactive sign-in no more than five minutes old; token refreshes do not satisfy the check. |
+| Medium | Passkey enrollment exposed without reauthentication | Fixed in the follow-up branch. Passkey registration start/verify and deletion now run through server actions that enforce step-up authentication. Password-backed accounts must re-enter their current password; passwordless, social, SSO, and existing-passkey accounts require an interactive sign-in no more than five minutes old. Token refreshes do not satisfy the check. |
 | Low | Passkey management no longer checks the administrator role | Superseded by the intentional general-availability release on `main`. Passkeys are personal account credentials, not workspace administration; the temporary admin-only rollout gate has been removed consistently from enrollment, management, and sign-in. Supabase Auth scopes passkey operations to the authenticated user. |
 | Informational | Tinker and Baseten pricing mismatches, OpenAI Pro-mode metadata, pricing expiry placement, and provider discovery errors | Reviewed; these are catalog/availability correctness findings and do not create a security boundary bypass. |
 
@@ -39,7 +39,7 @@ No open GitHub secret-scanning alerts were present. This review does not prove t
 - Removed OAuth E2E result details from stdout; detailed results remain in the sanitized report.
 - Removed exception messages and stack fields from gateway and route responses, including debug mode and pricing cron results.
 - Reconciled the temporary passkey admin-beta gate with the subsequent general-availability release so enrollment, management, and sign-in use one consistent account-level policy.
-- Added step-up authentication before passkey enrollment or deletion: current-password verification for password accounts and a five-minute interactive-authentication window for passwordless accounts.
+- Moved passkey registration start/verify and deletion behind server actions with step-up authentication: current-password verification for password accounts and a five-minute interactive-authentication window for passwordless accounts.
 - Rejected prototype-pollution path segments in both pricing simulator implementations.
 - Replaced backtracking OpenAPI path-template parsing with a linear scanner and escaped generated literals/parameter keys across C++, C#, Go, Java, PHP, Python, Ruby, Rust, and TypeScript backends.
 
@@ -75,14 +75,15 @@ Both migrations were executed against the linked production schema inside explic
 4. **Webhook DNS rebinding remains a bounded defense-in-depth concern.** Delivery requires HTTPS, rejects private/local literals and private DNS answers immediately before use, disallows redirects, and runs in a Worker with no VPC/private-network binding. Cloudflare's `global_fetch_strictly_public` flag only controls same-zone routing and `resolveOverride` cannot pin arbitrary third-party origins. Fully eliminating the remaining DNS time-of-check/time-of-use window would require a managed egress policy or an outbound proxy that pins the validated destination; adding a VPC binding without such a deny policy would increase rather than reduce exposure.
 5. The dashboard now shows six open findings. The passkey reauthentication finding has a verified fix in this follow-up branch and remains open until merge; the other five are informational catalog/availability observations rather than security boundary bypasses.
 6. **Linked Supabase migration history needs reconciliation before deployment.** A linked dry run reports 17 older local migration files missing from the remote history table and refuses the normal push. Do not use `--include-all` blindly; reconcile which migrations are already represented in production, repair history deliberately, then apply the three new security migrations.
+7. **Supabase's experimental passkey API still accepts a valid project session at its public Auth endpoint.** Phaseo's management UI now routes registration verification and deletion through server actions with step-up authentication, but a holder of a raw Supabase session can address the hosted Auth endpoint directly. Full provider-level enforcement requires native Supabase support for recent-authentication/AAL requirements on passkey mutations or placing the entire Auth surface behind an enforcing proxy. Keep the upstream experimental API under review.
 
 ## Validation performed
 
 - API security regression suite: 49 tests passed.
 - Targeted webhook URL and delivery regression suite: 12 tests passed.
 - Web security regression suite: 5 tests passed.
-- Passkey recent-authentication regression suite: 5 tests passed.
-- Full web regression suite after the general-availability merge: 79 suites and 342 tests passed.
+- Passkey server-action and recent-authentication regression suites: 11 tests passed.
+- Full web regression suite after the passkey step-up remediation: 82 suites and 353 tests passed.
 - CI secret-boundary regression suite: 2 tests passed, and the live workflow validation passed.
 - Python devtools tests: 9 passed.
 - API and web TypeScript checks passed (web after Next route type generation).

--- a/security_best_practices_report.md
+++ b/security_best_practices_report.md
@@ -4,7 +4,7 @@
 
 The audit reviewed the 17 open Codex Security dashboard findings, the current application and SDK code, GitHub code-scanning and Dependabot alerts, CI permissions and action pinning, tracked build artifacts, and the linked production Supabase security advisor.
 
-Five OAuth/CLI findings were already remediated on `main` and have now been closed in the dashboard as already fixed. This branch remediates the other five previously open actionable medium findings, the newly reported merge-queue secret-exposure and passkey-authorization findings, the actionable high/medium GitHub code-scanning findings, all currently fixable dependency alerts identified during the audit, and two additional live database authorization issues. The five Codex informational findings are availability or catalog-data observations rather than security vulnerabilities.
+The primary hardening branch is merged on `main`, and its resolved dashboard findings are closed. This follow-up branch addresses the newly reported passkey reauthentication issue. The audit also remediated the actionable GitHub code-scanning findings, all currently fixable dependency alerts identified during the review, and two additional live database authorization issues. The five remaining Codex informational findings are availability or catalog-data observations rather than security vulnerabilities.
 
 No open GitHub secret-scanning alerts were present. This review does not prove the absence of vulnerabilities; it records the tested controls and the residual risks below.
 
@@ -15,7 +15,7 @@ No open GitHub secret-scanning alerts were present. This review does not prove t
 | High | Merge-queue preview deploy exposes Vercel secrets to PR code | Fixed here. Merge-queue commits still run ordinary validation, but the Vercel-token job is limited to manual dispatches and trusted same-repository pull requests. A CI regression validator rejects reintroduction. |
 | High | Third-party OAuth keys bypass gateway scope | Already fixed on `main`: delegated spend keys require `gateway:access`, and third-party device flow is disabled. |
 | High | Identity-only OAuth grants mint spend keys | Already fixed by the same authorization and token-exchange enforcement. |
-| Medium | Generation lookup exposes raw R2 I/O logs | Fixed here. Raw input/output and replay data now require an internal caller or explicit `generations:read`/`activity:read`. |
+| Medium | Generation lookup exposes raw R2 I/O logs | Fixed on `main`. Raw input/output and replay data now require an internal caller or explicit `generations:read`; `activity:read` alone is rejected. |
 | Medium | OAuth refresh rotation can deadlock during member removal | Already fixed on `main` by consistent refresh/revocation lock ordering. |
 | Medium | Raycast extension legacy URL rewrite | Already fixed on `main`; the legacy host is rewritten before the authorization header is attached. |
 | Medium | Webhook validation misses IPv4-mapped IPv6 | Fixed here for mapped, compatible, canonical hexadecimal, and NAT64 representations, including DNS answers. |
@@ -23,6 +23,7 @@ No open GitHub secret-scanning alerts were present. This review does not prove t
 | Medium | Meta `web_search_options` injects arbitrary tools | Fixed here with an allowlist and server-owned tool/location types. |
 | Medium | SpaceXAI BYOK migration can delete the active legacy key | Fixed for existing and fresh environments. The original applied migration remains immutable; a new locked, idempotent corrective migration ranks active/always-use keys before provider spelling and then normalizes the keeper. A read-only production check found no SpaceXAI/xAI BYOK rows requiring recovery. |
 | Medium | API-model route exposes hidden model metadata | Fixed here by applying hidden-model visibility checks after provider/API-model resolution. |
+| Medium | Passkey enrollment exposed without reauthentication | Fixed in the follow-up branch. Password-backed accounts must re-enter their current password before adding or deleting a passkey. Passwordless, social, SSO, and existing-passkey accounts require an interactive sign-in no more than five minutes old; token refreshes do not satisfy the check. |
 | Low | Passkey management no longer checks the administrator role | Superseded by the intentional general-availability release on `main`. Passkeys are personal account credentials, not workspace administration; the temporary admin-only rollout gate has been removed consistently from enrollment, management, and sign-in. Supabase Auth scopes passkey operations to the authenticated user. |
 | Informational | Tinker and Baseten pricing mismatches, OpenAI Pro-mode metadata, pricing expiry placement, and provider discovery errors | Reviewed; these are catalog/availability correctness findings and do not create a security boundary bypass. |
 
@@ -38,6 +39,7 @@ No open GitHub secret-scanning alerts were present. This review does not prove t
 - Removed OAuth E2E result details from stdout; detailed results remain in the sanitized report.
 - Removed exception messages and stack fields from gateway and route responses, including debug mode and pricing cron results.
 - Reconciled the temporary passkey admin-beta gate with the subsequent general-availability release so enrollment, management, and sign-in use one consistent account-level policy.
+- Added step-up authentication before passkey enrollment or deletion: current-password verification for password accounts and a five-minute interactive-authentication window for passwordless accounts.
 - Rejected prototype-pollution path segments in both pricing simulator implementations.
 - Replaced backtracking OpenAPI path-template parsing with a linear scanner and escaped generated literals/parameter keys across C++, C#, Go, Java, PHP, Python, Ruby, Rust, and TypeScript backends.
 
@@ -71,7 +73,7 @@ Both migrations were executed against the linked production schema inside explic
 2. **Authenticated `SECURITY DEFINER` advisories will remain for the explicit allowlist.** Those functions are intentionally callable and perform `auth.uid()`/workspace checks. They should continue receiving targeted authorization tests.
 3. **The repository has an accepted single-maintainer review exception.** Main still requires PRs and status checks through an active ruleset. A mandatory non-author approval is not feasible while there is only one maintainer, so that governance setting was intentionally left unchanged.
 4. **Webhook DNS rebinding remains a bounded defense-in-depth concern.** Delivery requires HTTPS, rejects private/local literals and private DNS answers immediately before use, disallows redirects, and runs in a Worker with no VPC/private-network binding. Cloudflare's `global_fetch_strictly_public` flag only controls same-zone routing and `resolveOverride` cannot pin arbitrary third-party origins. Fully eliminating the remaining DNS time-of-check/time-of-use window would require a managed egress policy or an outbound proxy that pins the validated destination; adding a VPC binding without such a deny policy would increase rather than reduce exposure.
-5. The dashboard now shows 12 open findings. Seven have verified fixes only in this branch and remain open until merge and scanner confirmation; the other five are informational catalog/availability observations. Five findings whose fixes are already on `main` were closed as already fixed during this review.
+5. The dashboard now shows six open findings. The passkey reauthentication finding has a verified fix in this follow-up branch and remains open until merge; the other five are informational catalog/availability observations rather than security boundary bypasses.
 6. **Linked Supabase migration history needs reconciliation before deployment.** A linked dry run reports 17 older local migration files missing from the remote history table and refuses the normal push. Do not use `--include-all` blindly; reconcile which migrations are already represented in production, repair history deliberately, then apply the three new security migrations.
 
 ## Validation performed
@@ -79,11 +81,12 @@ Both migrations were executed against the linked production schema inside explic
 - API security regression suite: 49 tests passed.
 - Targeted webhook URL and delivery regression suite: 12 tests passed.
 - Web security regression suite: 5 tests passed.
+- Passkey recent-authentication regression suite: 5 tests passed.
 - Full web regression suite after the general-availability merge: 79 suites and 342 tests passed.
 - CI secret-boundary regression suite: 2 tests passed, and the live workflow validation passed.
 - Python devtools tests: 9 passed.
 - API and web TypeScript checks passed (web after Next route type generation).
-- The production web build passed with the restored passkey gate.
+- The production web build passed with the general-availability passkey UI and account-level policy.
 - API Worker dry-run build passed and confirmed both OAuth rate-limit bindings.
 - OpenAPI core and all nine backend packages built; the new adversarial path parser tests passed.
 - Java Maven tests passed with Jackson 2.22.1.


### PR DESCRIPTION
## Summary

Require server-enforced step-up authentication before a signed-in user can add or delete a passkey.

## Problem

Passkeys are persistent account credentials, but the generally available management UI called the Supabase registration and deletion APIs with any active session. A stolen but otherwise valid session could therefore be used to register an attacker-controlled passkey and preserve access after that session expired. A browser-only confirmation would not be a security boundary because code holding the session could bypass the component.

## Changes

- move passkey registration start/verify and deletion into authenticated server actions;
- validate challenge IDs, passkey IDs, and serialized WebAuthn attestation responses at runtime before calling Supabase;
- require password-backed accounts to verify their current password immediately before both registration stages or deletion;
- verify passwords through a transient non-persisting client so an existing AAL2 session is not replaced or downgraded;
- require passwordless, social, SSO, and existing-passkey accounts to have an interactive authentication no more than five minutes old;
- require AAL2 when the account has an enrolled MFA factor;
- ignore refresh-only authentication records so ordinary token rotation cannot satisfy the step-up check;
- send stale sessions through the normal sign-out/sign-in flow and return them to passkey settings;
- leave only the WebAuthn hardware ceremony in the browser and add compatible option/attestation serialization; and
- document the residual limitation of Supabase's experimental hosted Auth endpoint, which does not yet expose a native recent-auth policy for passkey mutations.

## Validation

- `pnpm --filter @phaseo/web test` — 82 suites and 353 tests passed
- focused server-action and WebAuthn/recent-auth suites — 3 suites and 11 tests passed
- `pnpm --filter @phaseo/web typecheck` — passed
- targeted ESLint in error-only mode on all changed TypeScript/TSX files — passed
- `git diff --check` — passed
- Vercel preview deployment and repository CI passed on the first revision; the updated revision reruns the same protected checks

Created with Codex
