### PR TITLE
Speed up Chat model selection

### DIFF
--- a/apps/web/src/components/(chat)/ChatHeader.tsx
+++ b/apps/web/src/components/(chat)/ChatHeader.tsx
@@ -6,6 +6,7 @@ import {
 	useMemo,
 	useRef,
 	useState,
+	startTransition,
 	type KeyboardEvent,
 } from "react";
 import {
@@ -78,6 +79,7 @@ import { cn } from "@/lib/utils";
 import type {
 	ChatApiTarget,
 	ChatResponseLayout,
+	NewChatModelPreference,
 } from "@/components/(chat)/playground/chat-playground-core";
 import {
 	LOCAL_CHAT_API_BASE_URL,
@@ -265,6 +267,8 @@ type ChatHeaderProps = {
 	onSaveSettings: () => void;
 	personalization: PersonalizationSettings;
 	onPersonalizationChange: (next: PersonalizationSettings) => void;
+	newChatModelPreference: NewChatModelPreference;
+	onNewChatModelPreferenceChange: (value: NewChatModelPreference) => void;
 	onExportChats: () => void;
 	isAdmin: boolean;
 	debugEnabled: boolean;
@@ -313,6 +317,8 @@ export function ChatHeader({
 	onSaveSettings,
 	personalization,
 	onPersonalizationChange,
+	newChatModelPreference,
+	onNewChatModelPreferenceChange,
 	onExportChats,
 	isAdmin,
 	debugEnabled,
@@ -705,30 +711,32 @@ export function ChatHeader({
 		setActiveBrowseModelId(null);
 		onModelPickerOpenChange(false);
 	};
+	const commitModelPickerSelection = (commit: () => void) => {
+		closeModelPicker();
+		startTransition(commit);
+	};
 	const handleModelSelect = (modelId: string) => {
 		if (!isModelCapabilityCompatible(modelId)) {
 			return;
 		}
 		if (!allowModelCompare) {
-			onUpdateModel(modelId);
-			closeModelPicker();
+			commitModelPickerSelection(() => onUpdateModel(modelId));
 			return;
 		}
 		if (!activeThread?.modelId) {
-			onUpdateModel(modelId);
-			closeModelPicker();
+			commitModelPickerSelection(() => onUpdateModel(modelId));
 			return;
 		}
 		if (activeThread.modelId === modelId) {
 			if (selectedModelIds.length > 0) {
-				onRemoveModel?.(modelId);
+				commitModelPickerSelection(() => onRemoveModel?.(modelId));
+				return;
 			}
 			closeModelPicker();
 			return;
 		}
 		if (!onCompareModelIdsChange) {
-			onUpdateModel(modelId);
-			closeModelPicker();
+			commitModelPickerSelection(() => onUpdateModel(modelId));
 			return;
 		}
 		const nextSet = new Set(compareModelIdSet);
@@ -737,8 +745,10 @@ export function ChatHeader({
 		} else {
 			nextSet.add(modelId);
 		}
-		onCompareModelIdsChange(Array.from(nextSet));
-		closeModelPicker();
+		const nextModelIds = Array.from(nextSet);
+		commitModelPickerSelection(() =>
+			onCompareModelIdsChange(nextModelIds),
+		);
 	};
 	const handleModelPickerDialogOpenChange = (open: boolean) => {
 		if (!open) {
@@ -1873,7 +1883,7 @@ export function ChatHeader({
 															</div>
 														) : null}
 													</div>
-													<SelectContent>
+												<SelectContent>
 														{ACCENT_COLORS.map(
 															(color) => (
 																<SelectItem
@@ -1915,10 +1925,42 @@ export function ChatHeader({
 																Custom
 															</span>
 														</SelectItem>
-													</SelectContent>
-												</Select>
-											</div>
+												</SelectContent>
+											</Select>
 										</div>
+										<div className="grid gap-2">
+											<Label htmlFor="new-chat-model-preference">
+												New chats
+											</Label>
+											<Select
+												value={newChatModelPreference}
+												onValueChange={(value) =>
+													onNewChatModelPreferenceChange(
+														value as NewChatModelPreference,
+													)
+												}
+											>
+												<SelectTrigger
+													id="new-chat-model-preference"
+													className="w-full sm:w-64"
+												>
+													<SelectValue />
+												</SelectTrigger>
+												<SelectContent>
+													<SelectItem value="blank">
+														Start without models
+													</SelectItem>
+													<SelectItem value="selected">
+														Keep selected model(s)
+													</SelectItem>
+												</SelectContent>
+											</Select>
+											<p className="text-xs text-muted-foreground">
+												Choose whether a new chat starts empty or reuses
+												the current model selection.
+											</p>
+										</div>
+									</div>
 									)}
 									{settingsTab === "data-controls" && (
 										<div className="grid gap-3">

--- a/apps/web/src/components/(chat)/ChatHeader.tsx
+++ b/apps/web/src/components/(chat)/ChatHeader.tsx
@@ -1,6 +1,13 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+	useCallback,
+	useEffect,
+	useMemo,
+	useRef,
+	useState,
+	type KeyboardEvent,
+} from "react";
 import {
 	ModelSelector,
 	ModelSelectorContent,
@@ -9,7 +16,6 @@ import {
 	ModelSelectorInput,
 	ModelSelectorItem,
 	ModelSelectorList,
-	ModelSelectorSeparator,
 	ModelSelectorTrigger,
 } from "@/components/ai-elements/model-selector";
 import {
@@ -56,6 +62,11 @@ import { Textarea } from "@/components/ui/textarea";
 import { useSidebar } from "@/components/ui/sidebar";
 import { Logo } from "@/components/Logo";
 import { ChatShortcutReference } from "@/components/(chat)/ChatShortcutReference";
+import {
+	getVirtualizedModelCatalogItemId,
+	VirtualizedModelCatalog,
+	type VirtualizedModelCatalogSection,
+} from "@/components/(chat)/VirtualizedModelCatalog";
 import {
 	compareByReleaseDateDesc,
 	groupModelsByReleaseMonth,
@@ -125,6 +136,8 @@ type ModelOptions = {
 	active: ModelOption[];
 	comingSoon: ModelOption[];
 };
+
+const getModelOptionKey = (option: ModelOption) => option.modelId;
 
 type PersonalizationSettings = {
 	name: string;
@@ -326,6 +339,9 @@ export function ChatHeader({
 		"personalization" | "data-controls" | "shortcuts" | "admin"
 	>("personalization");
 	const [modelSearchValue, setModelSearchValue] = useState("");
+	const [activeBrowseModelId, setActiveBrowseModelId] = useState<string | null>(
+		null,
+	);
 	const modelSearchInputRef = useRef<HTMLInputElement | null>(null);
 	const [quickFilters, setQuickFilters] = useState({
 		free: false,
@@ -487,10 +503,51 @@ export function ChatHeader({
 		() => groupModelsByReleaseMonth(filteredComingSoonEntries),
 		[filteredComingSoonEntries],
 	);
-	const comingSoonCount = useMemo(
-		() => filteredComingSoonEntries.length,
-		[filteredComingSoonEntries]
+	const virtualizedModelSections = useMemo<
+		VirtualizedModelCatalogSection<ModelOption>[]
+	>(() => {
+		const activeSections: VirtualizedModelCatalogSection<ModelOption>[] = [
+			...(favoriteActiveOptions.length > 0
+				? [
+						{
+							key: "favorites",
+							heading: "Favourites",
+							items: favoriteActiveOptions,
+						},
+					]
+				: []),
+			...groupedActiveOptions.map((group, index) => ({
+				key: `active-${group.heading}-${index}`,
+				heading: group.heading,
+				items: group.items,
+			})),
+		];
+		const comingSoonSections = groupedComingSoonOptions.map((group, index) => ({
+			key: `coming-soon-${group.heading}-${index}`,
+			heading: `Coming soon · ${group.heading}`,
+			items: group.items,
+			separatorBefore: index === 0,
+		}));
+		return [...activeSections, ...comingSoonSections];
+	}, [favoriteActiveOptions, groupedActiveOptions, groupedComingSoonOptions]);
+	const selectableBrowseModelOptions = useMemo(
+		() => [
+			...favoriteActiveOptions,
+			...groupedActiveOptions.flatMap((group) => group.items),
+		],
+		[favoriteActiveOptions, groupedActiveOptions],
 	);
+	const resolvedActiveBrowseModelId = useMemo(() => {
+		if (
+			activeBrowseModelId &&
+			selectableBrowseModelOptions.some(
+				(option) => option.modelId === activeBrowseModelId,
+			)
+		) {
+			return activeBrowseModelId;
+		}
+		return selectableBrowseModelOptions[0]?.modelId ?? null;
+	}, [activeBrowseModelId, selectableBrowseModelOptions]);
 	const allModelOptions = useMemo(
 		() => [
 			...filteredActive,
@@ -643,30 +700,35 @@ export function ChatHeader({
 		if (labels.length === 1) return labels[0];
 		return labels.slice(0, 2).join("/");
 	};
+	const closeModelPicker = () => {
+		setModelSearchValue("");
+		setActiveBrowseModelId(null);
+		onModelPickerOpenChange(false);
+	};
 	const handleModelSelect = (modelId: string) => {
 		if (!isModelCapabilityCompatible(modelId)) {
 			return;
 		}
 		if (!allowModelCompare) {
 			onUpdateModel(modelId);
-			onModelPickerOpenChange(false);
+			closeModelPicker();
 			return;
 		}
 		if (!activeThread?.modelId) {
 			onUpdateModel(modelId);
-			onModelPickerOpenChange(false);
+			closeModelPicker();
 			return;
 		}
 		if (activeThread.modelId === modelId) {
 			if (selectedModelIds.length > 0) {
 				onRemoveModel?.(modelId);
 			}
-			onModelPickerOpenChange(false);
+			closeModelPicker();
 			return;
 		}
 		if (!onCompareModelIdsChange) {
 			onUpdateModel(modelId);
-			onModelPickerOpenChange(false);
+			closeModelPicker();
 			return;
 		}
 		const nextSet = new Set(compareModelIdSet);
@@ -676,13 +738,14 @@ export function ChatHeader({
 			nextSet.add(modelId);
 		}
 		onCompareModelIdsChange(Array.from(nextSet));
-		onModelPickerOpenChange(false);
+		closeModelPicker();
 	};
 	const handleModelPickerDialogOpenChange = (open: boolean) => {
-		onModelPickerOpenChange(open);
 		if (!open) {
-			setModelSearchValue("");
+			closeModelPicker();
+			return;
 		}
+		onModelPickerOpenChange(true);
 	};
 	const focusModelSearchInput = useCallback(() => {
 		const input =
@@ -693,28 +756,9 @@ export function ChatHeader({
 		input?.focus({ preventScroll: true });
 	}, []);
 	const scheduleModelSearchFocus = useCallback(() => {
-		const timeoutIds: number[] = [];
-		let secondFrame: number | null = null;
-		focusModelSearchInput();
-		for (const delay of [0, 25, 75, 150, 250, 400]) {
-			timeoutIds.push(window.setTimeout(focusModelSearchInput, delay));
-		}
-		const firstFrame = requestAnimationFrame(() => {
-			secondFrame = requestAnimationFrame(() => {
-				focusModelSearchInput();
-				for (const delay of [25, 75, 150, 250, 400]) {
-					timeoutIds.push(window.setTimeout(focusModelSearchInput, delay));
-				}
-			});
-		});
+		const frame = requestAnimationFrame(focusModelSearchInput);
 		return () => {
-			cancelAnimationFrame(firstFrame);
-			if (secondFrame !== null) {
-				cancelAnimationFrame(secondFrame);
-			}
-			for (const timeoutId of timeoutIds) {
-				window.clearTimeout(timeoutId);
-			}
+			cancelAnimationFrame(frame);
 		};
 	}, [focusModelSearchInput]);
 	useEffect(() => {
@@ -1205,6 +1249,65 @@ export function ChatHeader({
 			</ModelSelectorItem>
 		);
 	};
+	const renderVirtualizedModelOption = (option: ModelOption) => (
+		<>
+			<Logo
+				id={option.orgId}
+				alt={option.orgId}
+				width={16}
+				height={16}
+				className={cn(
+					"shrink-0 rounded-none",
+					option.gatewayStatus === "inactive" && "grayscale",
+				)}
+			/>
+			{renderModelOptionContent(
+				option,
+				option.gatewayStatus === "inactive",
+			)}
+		</>
+	);
+	const handleModelSearchKeyDown = (event: KeyboardEvent<HTMLInputElement>) => {
+		if (hasModelSearchValue || selectableBrowseModelOptions.length === 0) {
+			return;
+		}
+		const currentIndex = Math.max(
+			0,
+			selectableBrowseModelOptions.findIndex(
+				(option) => option.modelId === resolvedActiveBrowseModelId,
+			),
+		);
+		let nextIndex = currentIndex;
+		switch (event.key) {
+			case "ArrowDown":
+				nextIndex = Math.min(
+					currentIndex + 1,
+					selectableBrowseModelOptions.length - 1,
+				);
+				break;
+			case "ArrowUp":
+				nextIndex = Math.max(currentIndex - 1, 0);
+				break;
+			case "Home":
+				nextIndex = 0;
+				break;
+			case "End":
+				nextIndex = selectableBrowseModelOptions.length - 1;
+				break;
+			case "Enter":
+				if (resolvedActiveBrowseModelId) {
+					event.preventDefault();
+					event.stopPropagation();
+					handleModelSelect(resolvedActiveBrowseModelId);
+				}
+				return;
+			default:
+				return;
+		}
+		event.preventDefault();
+		event.stopPropagation();
+		setActiveBrowseModelId(selectableBrowseModelOptions[nextIndex]?.modelId ?? null);
+	};
 
 	return (
 		<header className="flex items-center justify-between gap-2 border-b border-border px-3 py-3 md:px-5">
@@ -1279,6 +1382,14 @@ export function ChatHeader({
 							placeholder="Search models..."
 							value={modelSearchValue}
 							onValueChange={setModelSearchValue}
+							onKeyDown={handleModelSearchKeyDown}
+							aria-activedescendant={
+								hasModelSearchValue || !resolvedActiveBrowseModelId
+									? undefined
+									: getVirtualizedModelCatalogItemId(
+											resolvedActiveBrowseModelId,
+										)
+							}
 						/>
 						<div className="flex items-center gap-1 border-b border-border px-3 py-2">
 							<Button
@@ -1312,11 +1423,14 @@ export function ChatHeader({
 								New
 							</Button>
 						</div>
-						<ModelSelectorList className="max-h-[70vh]" viewportClassName="p-3">
-							<ModelSelectorEmpty>
-								No models found.
-							</ModelSelectorEmpty>
-							{hasModelSearchValue ? (
+						{hasModelSearchValue ? (
+							<ModelSelectorList
+								className="max-h-[70vh]"
+								viewportClassName="p-3"
+							>
+								<ModelSelectorEmpty>
+									No models found.
+								</ModelSelectorEmpty>
 								<ModelSelectorGroup
 									heading={`Results (${Math.min(25, searchResultTotalCount)}${searchResultTotalCount > 25 ? ` of ${searchResultTotalCount}` : ""})`}
 									className="pb-2 [&_[cmdk-group-heading]]:text-foreground [&_[cmdk-group-heading]]:font-semibold"
@@ -1327,48 +1441,23 @@ export function ChatHeader({
 										}),
 									)}
 								</ModelSelectorGroup>
-							) : null}
-							{!hasModelSearchValue && favoriteActiveOptions.length > 0 && (
-								<ModelSelectorGroup
-									heading="Favourites"
-									className="pb-2 [&_[cmdk-group-heading]]:text-foreground [&_[cmdk-group-heading]]:font-semibold"
-								>
-									{favoriteActiveOptions.map((option) =>
-										renderModelOptionItem(option),
-									)}
-								</ModelSelectorGroup>
-							)}
-							{!hasModelSearchValue &&
-								groupedActiveOptions.map((group, index) => (
-									<ModelSelectorGroup
-										key={`active-${group.heading}-${index}`}
-										heading={group.heading}
-										className="pb-2 [&_[cmdk-group-heading]]:text-foreground [&_[cmdk-group-heading]]:font-semibold"
-									>
-										{group.items.map((option) =>
-											renderModelOptionItem(option),
-										)}
-									</ModelSelectorGroup>
-								))}
-							{!hasModelSearchValue && comingSoonCount > 0 && (
-								<>
-									<ModelSelectorSeparator />
-									{groupedComingSoonOptions.map((group, index) => (
-										<ModelSelectorGroup
-											key={`coming-soon-${group.heading}-${index}`}
-											heading={`Coming soon · ${group.heading}`}
-											className="pb-2"
-										>
-											{group.items.map((option) =>
-												renderModelOptionItem(option, {
-													withComingSoonBadge: true,
-												}),
-											)}
-										</ModelSelectorGroup>
-									))}
-								</>
-							)}
-						</ModelSelectorList>
+							</ModelSelectorList>
+						) : (
+							<VirtualizedModelCatalog
+								sections={virtualizedModelSections}
+								getItemKey={getModelOptionKey}
+								activeItemKey={resolvedActiveBrowseModelId}
+								isItemDisabled={(option) =>
+									isModelDisabledForPicker(
+										option,
+										option.gatewayStatus === "inactive",
+									)
+								}
+								onActiveItemChange={setActiveBrowseModelId}
+								onSelectItem={(option) => handleModelSelect(option.modelId)}
+								renderItem={renderVirtualizedModelOption}
+							/>
+						)}
 					</ModelSelectorContent>
 				</ModelSelector>
 			</div>

--- a/apps/web/src/components/(chat)/ChatHeader.tsx
+++ b/apps/web/src/components/(chat)/ChatHeader.tsx
@@ -536,24 +536,6 @@ export function ChatHeader({
 		}));
 		return [...activeSections, ...comingSoonSections];
 	}, [favoriteActiveOptions, groupedActiveOptions, groupedComingSoonOptions]);
-	const selectableBrowseModelOptions = useMemo(
-		() => [
-			...favoriteActiveOptions,
-			...groupedActiveOptions.flatMap((group) => group.items),
-		],
-		[favoriteActiveOptions, groupedActiveOptions],
-	);
-	const resolvedActiveBrowseModelId = useMemo(() => {
-		if (
-			activeBrowseModelId &&
-			selectableBrowseModelOptions.some(
-				(option) => option.modelId === activeBrowseModelId,
-			)
-		) {
-			return activeBrowseModelId;
-		}
-		return selectableBrowseModelOptions[0]?.modelId ?? null;
-	}, [activeBrowseModelId, selectableBrowseModelOptions]);
 	const allModelOptions = useMemo(
 		() => [
 			...filteredActive,
@@ -691,6 +673,48 @@ export function ChatHeader({
 		(!requiredCapability ||
 			getModelCapabilities(modelId).includes(requiredCapability)) &&
 		(!requireAudioInput || supportsModelAudioInput(modelId));
+	const selectableBrowseModelOptions = useMemo(() => {
+		const seenModelIds = new Set<string>();
+		return [
+			...favoriteActiveOptions,
+			...groupedActiveOptions.flatMap((group) => group.items),
+		].filter((option) => {
+			const capabilityEndpoints =
+				modelCapabilitiesById?.[option.modelId] ?? ["responses"];
+			const capabilityCompatible =
+				(!requiredCapability ||
+					capabilityEndpoints.includes(requiredCapability)) &&
+				(!requireAudioInput ||
+					modelSupportsAudioInputById?.[option.modelId] === true);
+			if (
+				seenModelIds.has(option.modelId) ||
+				option.gatewayStatus === "inactive" ||
+				!capabilityCompatible
+			) {
+				return false;
+			}
+			seenModelIds.add(option.modelId);
+			return true;
+		});
+	}, [
+		favoriteActiveOptions,
+		groupedActiveOptions,
+		modelCapabilitiesById,
+		modelSupportsAudioInputById,
+		requireAudioInput,
+		requiredCapability,
+	]);
+	const resolvedActiveBrowseModelId = useMemo(() => {
+		if (
+			activeBrowseModelId &&
+			selectableBrowseModelOptions.some(
+				(option) => option.modelId === activeBrowseModelId,
+			)
+		) {
+			return activeBrowseModelId;
+		}
+		return selectableBrowseModelOptions[0]?.modelId ?? null;
+	}, [activeBrowseModelId, selectableBrowseModelOptions]);
 	const getIncompatibleCapabilityLabel = (modelId: string) => {
 		if (requireAudioInput && !supportsModelAudioInput(modelId)) {
 			return "Audio input";

--- a/apps/web/src/components/(chat)/ChatPlayground.tsx
+++ b/apps/web/src/components/(chat)/ChatPlayground.tsx
@@ -77,6 +77,7 @@ import {
 	getChangedSettings,
 	getEffectiveModelSettings,
 	getOrgId,
+	isGeneratedDefaultSystemPrompt,
 	normalizeServerTools,
 	normalizeBaseUrl,
 	nowIso,
@@ -2686,13 +2687,13 @@ function ChatPlaygroundContent({
 					currentOverrides[thread.modelId]?.displayName ?? "";
 				const nextDisplayName =
 					currentOverrides[primaryResolution.modelId]?.displayName ?? "";
-				const previousDefaultPrompt = buildDefaultSystemPrompt(
-					thread.modelId,
-					previousDisplayName,
-				);
 				if (
-					(thread.settings.systemPrompt ?? "").trim() ===
-					previousDefaultPrompt.trim()
+					!thread.settings.systemPrompt ||
+					isGeneratedDefaultSystemPrompt(
+						thread.settings.systemPrompt,
+						thread.modelId,
+						previousDisplayName,
+					)
 				) {
 					nextSystemPrompt = buildDefaultSystemPrompt(
 						primaryResolution.modelId,
@@ -3325,10 +3326,6 @@ function ChatPlaygroundContent({
 			const nextModelDisplayName =
 				activeThread.settings.modelOverridesById?.[modelId]
 					?.displayName ?? "";
-			const previousDefault = buildDefaultSystemPrompt(
-				activeThread.modelId,
-				currentModelDisplayName,
-			);
 			const nextCompareModelIds = Array.from(
 				new Set(
 					(activeThread.settings.compareModelIds ?? []).filter(
@@ -3345,7 +3342,11 @@ function ChatPlaygroundContent({
 			);
 			const nextSystemPrompt =
 				!activeThread.settings.systemPrompt ||
-				activeThread.settings.systemPrompt === previousDefault
+				isGeneratedDefaultSystemPrompt(
+					activeThread.settings.systemPrompt,
+					activeThread.modelId,
+					currentModelDisplayName,
+				)
 					? buildDefaultSystemPrompt(modelId, nextModelDisplayName)
 					: activeThread.settings.systemPrompt;
 			const nextModelOverrides = ensureModelOverridesForIds(
@@ -3539,13 +3540,13 @@ function ChatPlaygroundContent({
 				activeThread.settings.modelOverridesById?.[
 					nextPrimaryModelId
 				]?.displayName ?? "";
-			const previousDefault = buildDefaultSystemPrompt(
-				activeThread.modelId,
-				currentModelDisplayName,
-			);
 			const nextSystemPrompt =
 				!activeThread.settings.systemPrompt ||
-				activeThread.settings.systemPrompt === previousDefault
+				isGeneratedDefaultSystemPrompt(
+					activeThread.settings.systemPrompt,
+					activeThread.modelId,
+					currentModelDisplayName,
+				)
 					? buildDefaultSystemPrompt(
 							nextPrimaryModelId,
 							nextModelDisplayName,
@@ -3608,13 +3609,13 @@ function ChatPlaygroundContent({
 				activeThread.settings.modelOverridesById?.[
 					nextPrimaryModelId
 				]?.displayName ?? "";
-			const previousDefault = buildDefaultSystemPrompt(
-				activeThread.modelId,
-				currentModelDisplayName,
-			);
 			const nextSystemPrompt =
 				!activeThread.settings.systemPrompt ||
-				activeThread.settings.systemPrompt === previousDefault
+				isGeneratedDefaultSystemPrompt(
+					activeThread.settings.systemPrompt,
+					activeThread.modelId,
+					currentModelDisplayName,
+				)
 					? buildDefaultSystemPrompt(
 							nextPrimaryModelId,
 							nextModelDisplayName,
@@ -4197,10 +4198,6 @@ function ChatPlaygroundContent({
 						? existingModelOverrides.displayName
 						: "";
 				const nextDisplayName = partial.displayName;
-				const previousDefaultPrompt = buildDefaultSystemPrompt(
-					modelId,
-					previousDisplayName,
-				);
 				const nextDefaultPrompt = buildDefaultSystemPrompt(
 					modelId,
 					nextDisplayName,
@@ -4212,8 +4209,11 @@ function ChatPlaygroundContent({
 				const hasExplicitModelPrompt =
 					existingModelOverrides.systemPrompt !== undefined;
 				const isStillOnDefaultTemplate =
-					(currentEffectiveSystemPrompt ?? "").trim() ===
-					previousDefaultPrompt.trim();
+					isGeneratedDefaultSystemPrompt(
+						currentEffectiveSystemPrompt,
+						modelId,
+						previousDisplayName,
+					);
 				if (!hasExplicitModelPrompt || isStillOnDefaultTemplate) {
 					nextPartial.systemPrompt = nextDefaultPrompt;
 				}

--- a/apps/web/src/components/(chat)/ChatPlayground.tsx
+++ b/apps/web/src/components/(chat)/ChatPlayground.tsx
@@ -782,6 +782,7 @@ function ChatPlaygroundContent({
 	const createThreadWithSettings = useCallback(
 		async (modelId: string, settings: ChatSettings) => {
 			setError(null);
+			const previousActiveId = activeId;
 			const id = generateId();
 			const createdAt = nowIso();
 			const normalizedSettings =
@@ -811,11 +812,32 @@ function ChatPlaygroundContent({
 					modelOverridesById,
 				},
 			};
-			await upsertChat(newThread, "text");
 			setThreads((prev) => [newThread, ...prev]);
 			setActiveThread(newThread);
+			try {
+				await upsertChat(newThread, "text");
+			} catch (error) {
+				setThreads((prev) => prev.filter((thread) => thread.id !== id));
+				setActiveId((current) =>
+					current === id ? previousActiveId : current,
+				);
+				if (
+					typeof window !== "undefined" &&
+					window.localStorage.getItem(STORAGE_KEYS.activeChatId) === id
+				) {
+					if (previousActiveId) {
+						window.localStorage.setItem(
+							STORAGE_KEYS.activeChatId,
+							previousActiveId,
+						);
+					} else {
+						window.localStorage.removeItem(STORAGE_KEYS.activeChatId);
+					}
+				}
+				throw error;
+			}
 		},
-		[setActiveThread],
+		[activeId, setActiveThread],
 	);
 
 	const createThread = useCallback(async () => {

--- a/apps/web/src/components/(chat)/ChatPlayground.tsx
+++ b/apps/web/src/components/(chat)/ChatPlayground.tsx
@@ -83,6 +83,7 @@ import {
 	shouldRequestImageModalities,
 	type ChatResponseLayout,
 	type ChatApiTarget,
+	type NewChatModelPreference,
 	type PersonalizationSettings,
 	type SettingChange,
 } from "@/components/(chat)/playground/chat-playground-core";
@@ -500,8 +501,11 @@ function ChatPlaygroundContent({
 	const [pendingNewChat, setPendingNewChat] = useState<{
 		modelId: string;
 		settings: ChatSettings;
+		defaultSettings: ChatSettings;
 		changes: SettingChange[];
 	} | null>(null);
+	const [newChatModelPreference, setNewChatModelPreference] =
+		useState<NewChatModelPreference>("blank");
 	const [temporaryMode, setTemporaryMode] = useState(false);
 	const [composerRequiresAudioInput, setComposerRequiresAudioInput] =
 		useState(false);
@@ -706,6 +710,9 @@ function ChatPlaygroundContent({
 				window.localStorage.getItem(
 					STORAGE_KEYS.personalizationAccent,
 				) ?? "#111111";
+			const storedNewChatModelPreference = window.localStorage.getItem(
+				STORAGE_KEYS.newChatModelPreference,
+			);
 			if (!mounted) return;
 			window.localStorage.removeItem(STORAGE_KEYS.apiKey);
 			setApiTarget(storedApiTarget);
@@ -720,6 +727,9 @@ function ChatPlaygroundContent({
 				notes: storedPersonalNotes,
 				accentColor: storedAccent,
 			});
+			setNewChatModelPreference(
+				storedNewChatModelPreference === "selected" ? "selected" : "blank",
+			);
 
 			const [chats, storedTags] = await Promise.all([
 				getAllChats("text"),
@@ -841,7 +851,20 @@ function ChatPlaygroundContent({
 	);
 
 	const createThread = useCallback(async () => {
-		const selectedModel = "";
+		const shouldKeepSelectedModels =
+			newChatModelPreference === "selected" && Boolean(activeThread?.modelId);
+		const selectedModel = shouldKeepSelectedModels
+			? (activeThread?.modelId ?? "")
+			: "";
+		const selectedCompareModelIds = shouldKeepSelectedModels
+			? (activeThread?.settings.compareModelIds ?? [])
+			: [];
+		const defaultSettings: ChatSettings = {
+			...DEFAULT_SETTINGS,
+			systemPrompt: buildDefaultSystemPrompt(selectedModel),
+			compareMode: selectedCompareModelIds.length > 0,
+			compareModelIds: selectedCompareModelIds,
+		};
 		if (activeThread) {
 			const comparisonModelId = activeThread.modelId || selectedModel;
 			const comparisonModelDisplayName =
@@ -860,18 +883,20 @@ function ChatPlaygroundContent({
 				setPendingNewChat({
 					modelId: selectedModel,
 					settings: activeThread.settings,
+					defaultSettings,
 					changes,
 				});
 				setNewChatDialogOpen(true);
 				return;
 			}
 		}
-		const defaults: ChatSettings = {
-			...DEFAULT_SETTINGS,
-			systemPrompt: buildDefaultSystemPrompt(selectedModel),
-		};
-		await createThreadWithSettings(selectedModel, defaults);
-	}, [activeThread, createThreadWithSettings, modelDisplayNameById]);
+		await createThreadWithSettings(selectedModel, defaultSettings);
+	}, [
+		activeThread,
+		createThreadWithSettings,
+		modelDisplayNameById,
+		newChatModelPreference,
+	]);
 
 	const handleNewChatDecision = useCallback(
 		(useCurrent: boolean) => {
@@ -882,15 +907,25 @@ function ChatPlaygroundContent({
 			const modelId = pendingNewChat.modelId;
 			const settings = useCurrent
 				? pendingNewChat.settings
-				: {
-						...DEFAULT_SETTINGS,
-						systemPrompt: buildDefaultSystemPrompt(modelId),
-					};
+				: pendingNewChat.defaultSettings;
 			setNewChatDialogOpen(false);
 			setPendingNewChat(null);
 			void createThreadWithSettings(modelId, settings);
 		},
 		[pendingNewChat, createThreadWithSettings],
+	);
+
+	const handleNewChatModelPreferenceChange = useCallback(
+		(value: NewChatModelPreference) => {
+			setNewChatModelPreference(value);
+			if (typeof window !== "undefined") {
+				window.localStorage.setItem(
+					STORAGE_KEYS.newChatModelPreference,
+					value,
+				);
+			}
+		},
+		[],
 	);
 
 	const updateStoredThread = useCallback(
@@ -4333,6 +4368,10 @@ function ChatPlaygroundContent({
 					onSaveSettings={handleSaveSettings}
 					personalization={personalization}
 					onPersonalizationChange={setPersonalization}
+					newChatModelPreference={newChatModelPreference}
+					onNewChatModelPreferenceChange={
+						handleNewChatModelPreferenceChange
+					}
 					onExportChats={handleExportChats}
 					isAdmin={isAdmin}
 					debugEnabled={debugEnabled}

--- a/apps/web/src/components/(chat)/ChatPlayground.tsx
+++ b/apps/web/src/components/(chat)/ChatPlayground.tsx
@@ -794,6 +794,8 @@ function ChatPlaygroundContent({
 		async (modelId: string, settings: ChatSettings) => {
 			setError(null);
 			const previousActiveId = activeId;
+			const previousTemporaryMode = temporaryMode;
+			const previousTemporaryThread = temporaryThread;
 			const id = generateId();
 			const createdAt = nowIso();
 			const normalizedSettings =
@@ -829,6 +831,10 @@ function ChatPlaygroundContent({
 				await upsertChat(newThread, "text");
 			} catch (error) {
 				setThreads((prev) => prev.filter((thread) => thread.id !== id));
+				if (previousTemporaryMode && previousTemporaryThread) {
+					setTemporaryMode(true);
+					setTemporaryThread(previousTemporaryThread);
+				}
 				setActiveId((current) =>
 					current === id ? previousActiveId : current,
 				);
@@ -848,7 +854,12 @@ function ChatPlaygroundContent({
 				throw error;
 			}
 		},
-		[activeId, setActiveThread],
+		[
+			activeId,
+			setActiveThread,
+			temporaryMode,
+			temporaryThread,
+		],
 	);
 
 	const createThread = useCallback(async () => {

--- a/apps/web/src/components/(chat)/ChatPlayground.tsx
+++ b/apps/web/src/components/(chat)/ChatPlayground.tsx
@@ -4465,7 +4465,8 @@ function ChatPlaygroundContent({
 					responseLayout={responseLayout}
 				/>
 			</SidebarInset>
-			<ModelSettingsDialog
+			{modelSettingsOpen ? (
+				<ModelSettingsDialog
 				open={modelSettingsOpen}
 				onOpenChange={(open) => {
 					setModelSettingsOpen(open);
@@ -4504,7 +4505,8 @@ function ChatPlaygroundContent({
 				onReset={resetModelSettings}
 				onApplyToAll={applyModelSettingsToAll}
 				canApplyToAll={selectedModelIds.length > 1}
-			/>
+				/>
+			) : null}
 			<ChatSearchDialog
 				open={searchOpen}
 				onOpenChange={setSearchOpen}

--- a/apps/web/src/components/(chat)/ModelSettingsDialog.tsx
+++ b/apps/web/src/components/(chat)/ModelSettingsDialog.tsx
@@ -300,7 +300,13 @@ export function ModelSettingsDialog({
                 delete textCommitTimersRef.current[key];
             }
         }
-        setTextDraft(textDraftFromSettings(settings));
+        const nextDraft = textDraftFromSettings(settings);
+        setTextDraft((current) =>
+            current.displayName === nextDraft.displayName &&
+            current.systemPrompt === nextDraft.systemPrompt
+                ? current
+                : nextDraft
+        );
     }, [selectedModelId, settings.displayName, settings.systemPrompt]);
     useEffect(() => {
         return () => {
@@ -315,11 +321,15 @@ export function ModelSettingsDialog({
             }
         };
     }, []);
-    useEffect(() => {
-        if (!open) {
-            for (const key of TEXT_SETTING_KEYS) flushTextDraft(key);
-        }
-    }, [flushTextDraft, open]);
+    const handleDialogOpenChange = useCallback(
+        (nextOpen: boolean) => {
+            if (!nextOpen) {
+                for (const key of TEXT_SETTING_KEYS) flushTextDraft(key);
+            }
+            onOpenChange(nextOpen);
+        },
+        [flushTextDraft, onOpenChange]
+    );
     const filteredProviderOptions = supportedProvidersForModel
         ? providerOptions.filter((provider) =>
               supportedProvidersForModel.includes(provider.id)
@@ -426,7 +436,7 @@ export function ModelSettingsDialog({
     );
 
     return (
-        <Dialog open={open} onOpenChange={onOpenChange}>
+        <Dialog open={open} onOpenChange={handleDialogOpenChange}>
             <DialogContent
                 className={
                     modelPickerOpen

--- a/apps/web/src/components/(chat)/VirtualizedModelCatalog.test.ts
+++ b/apps/web/src/components/(chat)/VirtualizedModelCatalog.test.ts
@@ -30,4 +30,20 @@ describe("buildVirtualizedModelCatalogRows", () => {
 			},
 		]);
 	});
+
+	it("omits empty sections and their separators", () => {
+		const rows = buildVirtualizedModelCatalogRows(
+			[
+				{
+					key: "empty",
+					heading: "Coming soon",
+					items: [],
+					separatorBefore: true,
+				},
+			],
+			(item: { modelId: string }) => item.modelId,
+		);
+
+		expect(rows).toEqual([]);
+	});
 });

--- a/apps/web/src/components/(chat)/VirtualizedModelCatalog.test.ts
+++ b/apps/web/src/components/(chat)/VirtualizedModelCatalog.test.ts
@@ -1,0 +1,33 @@
+import { buildVirtualizedModelCatalogRows } from "./VirtualizedModelCatalog";
+
+describe("buildVirtualizedModelCatalogRows", () => {
+	it("flattens headings, items, and section separators with stable keys", () => {
+		const rows = buildVirtualizedModelCatalogRows(
+			[
+				{
+					key: "favorites",
+					heading: "Favourites",
+					items: [{ modelId: "openai/gpt-5" }],
+				},
+				{
+					key: "coming-soon",
+					heading: "Coming soon",
+					items: [{ modelId: "anthropic/claude-opus-5" }],
+					separatorBefore: true,
+				},
+			],
+			(item) => item.modelId,
+		);
+
+		expect(rows.map((row) => ({ type: row.type, key: row.key }))).toEqual([
+			{ type: "heading", key: "favorites-heading" },
+			{ type: "item", key: "favorites-openai/gpt-5" },
+			{ type: "separator", key: "coming-soon-separator" },
+			{ type: "heading", key: "coming-soon-heading" },
+			{
+				type: "item",
+				key: "coming-soon-anthropic/claude-opus-5",
+			},
+		]);
+	});
+});

--- a/apps/web/src/components/(chat)/VirtualizedModelCatalog.tsx
+++ b/apps/web/src/components/(chat)/VirtualizedModelCatalog.tsx
@@ -105,7 +105,7 @@ export function VirtualizedModelCatalog<T>({
 			className="max-h-[70vh]"
 			viewportClassName="p-3"
 			viewportRef={setScrollViewport}
-			style={{ height: `${Math.min(560, virtualizer.getTotalSize())}px` }}
+			style={{ height: `min(70vh, ${virtualizer.getTotalSize()}px)` }}
 		>
 			<div
 				role="listbox"

--- a/apps/web/src/components/(chat)/VirtualizedModelCatalog.tsx
+++ b/apps/web/src/components/(chat)/VirtualizedModelCatalog.tsx
@@ -22,6 +22,7 @@ export function buildVirtualizedModelCatalogRows<T>(
 	getItemKey: (item: T) => string,
 ): VirtualizedModelCatalogRow<T>[] {
 	return sections.flatMap((section) => {
+		if (section.items.length === 0) return [];
 		const rows: VirtualizedModelCatalogRow<T>[] = [];
 		if (section.separatorBefore) {
 			rows.push({ type: "separator", key: `${section.key}-separator` });
@@ -105,7 +106,7 @@ export function VirtualizedModelCatalog<T>({
 			className="max-h-[70vh]"
 			viewportClassName="p-3"
 			viewportRef={setScrollViewport}
-			style={{ height: `min(70vh, ${virtualizer.getTotalSize()}px)` }}
+			style={{ height: `min(70vh, ${virtualizer.getTotalSize() + 24}px)` }}
 		>
 			<div
 				role="listbox"

--- a/apps/web/src/components/(chat)/VirtualizedModelCatalog.tsx
+++ b/apps/web/src/components/(chat)/VirtualizedModelCatalog.tsx
@@ -1,0 +1,168 @@
+"use client";
+
+import { useEffect, useMemo, useState, type ReactNode } from "react";
+import { useVirtualizer } from "@tanstack/react-virtual";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import { cn } from "@/lib/utils";
+
+export type VirtualizedModelCatalogSection<T> = {
+	key: string;
+	heading: string;
+	items: T[];
+	separatorBefore?: boolean;
+};
+
+type VirtualizedModelCatalogRow<T> =
+	| { type: "heading"; key: string; heading: string }
+	| { type: "item"; key: string; item: T }
+	| { type: "separator"; key: string };
+
+export function buildVirtualizedModelCatalogRows<T>(
+	sections: VirtualizedModelCatalogSection<T>[],
+	getItemKey: (item: T) => string,
+): VirtualizedModelCatalogRow<T>[] {
+	return sections.flatMap((section) => {
+		const rows: VirtualizedModelCatalogRow<T>[] = [];
+		if (section.separatorBefore) {
+			rows.push({ type: "separator", key: `${section.key}-separator` });
+		}
+		rows.push({
+			type: "heading",
+			key: `${section.key}-heading`,
+			heading: section.heading,
+		});
+		rows.push(
+			...section.items.map((item) => ({
+				type: "item" as const,
+				key: `${section.key}-${getItemKey(item)}`,
+				item,
+			})),
+		);
+		return rows;
+	});
+}
+
+export function getVirtualizedModelCatalogItemId(itemKey: string): string {
+	return `chat-model-option-${itemKey.replace(/[^a-zA-Z0-9_-]/g, "-")}`;
+}
+
+type VirtualizedModelCatalogProps<T> = {
+	sections: VirtualizedModelCatalogSection<T>[];
+	getItemKey: (item: T) => string;
+	activeItemKey: string | null;
+	isItemDisabled: (item: T) => boolean;
+	onActiveItemChange: (itemKey: string) => void;
+	onSelectItem: (item: T) => void;
+	renderItem: (item: T) => ReactNode;
+};
+
+export function VirtualizedModelCatalog<T>({
+	sections,
+	getItemKey,
+	activeItemKey,
+	isItemDisabled,
+	onActiveItemChange,
+	onSelectItem,
+	renderItem,
+}: VirtualizedModelCatalogProps<T>) {
+	const [scrollViewport, setScrollViewport] =
+		useState<HTMLDivElement | null>(null);
+	const rows = useMemo(
+		() => buildVirtualizedModelCatalogRows(sections, getItemKey),
+		[sections, getItemKey],
+	);
+	const activeRowIndex = useMemo(
+		() =>
+			rows.findIndex(
+				(row) =>
+					row.type === "item" && getItemKey(row.item) === activeItemKey,
+			),
+		[activeItemKey, getItemKey, rows],
+	);
+	const virtualizer = useVirtualizer({
+		count: rows.length,
+		getScrollElement: () => scrollViewport,
+		estimateSize: (index) => {
+			const row = rows[index];
+			if (row?.type === "heading") return 32;
+			if (row?.type === "separator") return 9;
+			return 36;
+		},
+		overscan: 10,
+	});
+
+	useEffect(() => {
+		if (activeRowIndex < 0) return;
+		virtualizer.scrollToIndex(activeRowIndex, { align: "auto" });
+	}, [activeRowIndex, virtualizer]);
+
+	if (rows.length === 0) {
+		return <div className="py-6 text-center text-sm">No models found.</div>;
+	}
+
+	return (
+		<ScrollArea
+			className="max-h-[70vh]"
+			viewportClassName="p-3"
+			viewportRef={setScrollViewport}
+			style={{ height: `${Math.min(560, virtualizer.getTotalSize())}px` }}
+		>
+			<div
+				role="listbox"
+				aria-label="Suggestions"
+				className="relative w-full"
+				style={{ height: `${virtualizer.getTotalSize()}px` }}
+			>
+				{virtualizer.getVirtualItems().map((virtualRow) => {
+					const row = rows[virtualRow.index];
+					if (!row) return null;
+
+					return (
+						<div
+							key={row.key}
+							className="absolute left-0 top-0 w-full"
+							style={{ transform: `translateY(${virtualRow.start}px)` }}
+						>
+							{row.type === "heading" ? (
+								<div className="flex h-8 items-center px-3 text-xs font-semibold text-foreground">
+									{row.heading}
+								</div>
+							) : row.type === "separator" ? (
+								<div className="my-1 h-px bg-border/50" />
+							) : (
+								<div
+									id={getVirtualizedModelCatalogItemId(
+										getItemKey(row.item),
+									)}
+									role="option"
+									aria-selected={getItemKey(row.item) === activeItemKey}
+									aria-disabled={isItemDisabled(row.item)}
+									data-selected={
+										getItemKey(row.item) === activeItemKey
+											? "true"
+											: undefined
+									}
+									className={cn(
+										"relative flex min-h-8 cursor-default select-none items-center gap-2 rounded-xl px-2 py-1 text-sm outline-hidden",
+										"data-[selected=true]:bg-muted data-[selected=true]:text-foreground",
+										isItemDisabled(row.item) &&
+											"pointer-events-none opacity-50",
+									)}
+									onMouseMove={() =>
+										onActiveItemChange(getItemKey(row.item))
+									}
+									onMouseDown={(event) => event.preventDefault()}
+									onClick={() => {
+										if (!isItemDisabled(row.item)) onSelectItem(row.item);
+									}}
+								>
+									{renderItem(row.item)}
+								</div>
+							)}
+						</div>
+					);
+				})}
+			</div>
+		</ScrollArea>
+	);
+}

--- a/apps/web/src/components/(chat)/playground/chat-playground-core.test.ts
+++ b/apps/web/src/components/(chat)/playground/chat-playground-core.test.ts
@@ -1,7 +1,9 @@
 import {
+	DEFAULT_SETTINGS,
 	buildDefaultSystemPrompt,
 	buildServerToolDefinitions,
 	estimatePromptTokenCount,
+	getChangedSettings,
 	isGeneratedDefaultSystemPrompt,
 	normalizeServerTools,
 } from "./chat-playground-core";
@@ -51,6 +53,32 @@ describe("isGeneratedDefaultSystemPrompt", () => {
 
 		expect(isGeneratedDefaultSystemPrompt(previous, modelId, nickname)).toBe(true);
 		expect(isGeneratedDefaultSystemPrompt(legacy, modelId, nickname)).toBe(true);
+	});
+
+	it("recognizes the full legacy generated prompt without a nickname", () => {
+		const legacy = [
+			`You are ${modelId}, a large language model from openai.`,
+			"",
+			"Formatting Rules:",
+			"- Use Markdown for lists, tables, and styling.",
+			"- Use ```code fences``` for all code blocks.",
+			"- Format file names, paths, and function names with `inline code` backticks.",
+			"- **For all mathematical expressions, you must use dollar-sign delimiters. Use $...$ for inline math and $$...$$ for block math. Do not use (...) or [...] delimiters.**",
+		].join("\n");
+
+		expect(isGeneratedDefaultSystemPrompt(legacy, modelId)).toBe(true);
+		expect(
+			getChangedSettings(
+				{ ...DEFAULT_SETTINGS, systemPrompt: legacy },
+				modelId,
+			),
+		).not.toContainEqual({ label: "System prompt", value: "Custom" });
+	});
+
+	it("does not accept extra instructions inside a generated-looking prompt", () => {
+		const custom = `${identity}\n\nFormatting Rules:\nAlways answer in haiku.\n- Do not use \\(...\\) or \\[...\\] delimiters.`;
+
+		expect(isGeneratedDefaultSystemPrompt(custom, modelId, nickname)).toBe(false);
 	});
 
 	it("does not classify a custom prompt as generated", () => {

--- a/apps/web/src/components/(chat)/playground/chat-playground-core.test.ts
+++ b/apps/web/src/components/(chat)/playground/chat-playground-core.test.ts
@@ -55,6 +55,12 @@ describe("isGeneratedDefaultSystemPrompt", () => {
 		expect(isGeneratedDefaultSystemPrompt(legacy, modelId, nickname)).toBe(true);
 	});
 
+	it("recognizes a generated blank-chat prompt before model selection", () => {
+		expect(
+			isGeneratedDefaultSystemPrompt(buildDefaultSystemPrompt(""), ""),
+		).toBe(true);
+	});
+
 	it("recognizes the full legacy generated prompt without a nickname", () => {
 		const legacy = [
 			`You are ${modelId}, a large language model from openai.`,

--- a/apps/web/src/components/(chat)/playground/chat-playground-core.ts
+++ b/apps/web/src/components/(chat)/playground/chat-playground-core.ts
@@ -31,6 +31,7 @@ const SUPPORTED_CHAT_SERVER_TOOLS = new Set<ChatServerToolType>([
 ]);
 
 export type ChatResponseLayout = "sequential" | "side-by-side";
+export type NewChatModelPreference = "blank" | "selected";
 
 export function normalizeServerTools(
 	serverTools?: ChatServerToolType[],
@@ -211,6 +212,10 @@ export function getRoomStorageKeys(roomId: ChatRoomId) {
 		notifyOnComplete: getRoomScopedStorageKey(roomId, "notify-on-complete"),
 		debugMode: getRoomScopedStorageKey(roomId, "debug"),
 		responseLayout: getRoomScopedStorageKey(roomId, "response-layout"),
+		newChatModelPreference: getRoomScopedStorageKey(
+			roomId,
+			"new-chat-model-preference",
+		),
 	};
 }
 

--- a/apps/web/src/components/(chat)/playground/chat-playground-core.ts
+++ b/apps/web/src/components/(chat)/playground/chat-playground-core.ts
@@ -325,6 +325,19 @@ const LEGACY_MATH_FORMATTING_RULE =
 const PREVIOUS_MATH_FORMATTING_RULE =
 	"- Do not use \\(...\\) or \\[...\\] delimiters.";
 
+const PREVIOUS_MATH_FORMATTING_RULES = [
+	"- Use dollar-sign delimiters for all mathematical expressions: $...$ for inline math and $$...$$ for block math.",
+	"- Put the $$ block-math delimiters on their own lines.",
+	"- Use valid LaTeX inside delimiters. Escape special characters: write percentages as $80\\%$, never $80%$.",
+	PREVIOUS_MATH_FORMATTING_RULE,
+] as const;
+
+const HISTORIC_FORMATTING_RULES = [
+	"- Use Markdown for lists, tables, and styling.",
+	"- Use ```code fences``` for all code blocks.",
+	"- Format file names, paths, and function names with `inline code` backticks.",
+] as const;
+
 const COMPACT_FORMATTING_RULE =
 	"Markdown; ```code fences```; `backticks` for code, filenames, paths, and functions. Use $...$ or $$...$$ only for typeset math; put $$ delimiters on their own lines. Keep numbers, percentages, and currency plain. Use valid LaTeX: escape % in math (e.g. $80\\%$); no \\(...\\) or \\[...\\].";
 
@@ -365,18 +378,30 @@ export function isGeneratedDefaultSystemPrompt(
 
 	const safeModelId = modelId || "AI model";
 	const orgLabel = formatOrgLabel(getOrgId(safeModelId));
-	const generatedPrefix = `You are ${safeModelId}, known as: `;
-	const generatedSuffixes = [
-		`, a large language model from ${orgLabel}.\n\nFormatting:`,
-		`, a large language model from ${orgLabel}.\n\nFormatting Rules:`,
-	];
-	return (
-		normalizedPrompt.startsWith(generatedPrefix) &&
-		generatedSuffixes.some((suffix) => normalizedPrompt.includes(suffix)) &&
-		(normalizedPrompt.endsWith(COMPACT_FORMATTING_RULE) ||
-			normalizedPrompt.endsWith(PREVIOUS_MATH_FORMATTING_RULE) ||
-			normalizedPrompt.endsWith(LEGACY_MATH_FORMATTING_RULE))
-	);
+	const separatorIndex = normalizedPrompt.indexOf("\n\n");
+	if (separatorIndex < 0) return false;
+
+	const identityLine = normalizedPrompt.slice(0, separatorIndex);
+	const formattingSection = normalizedPrompt.slice(separatorIndex + 2);
+	const identitySuffix = `, a large language model from ${orgLabel}.`;
+	const hasGeneratedIdentity =
+		identityLine === `You are ${safeModelId}${identitySuffix}` ||
+		(identityLine.startsWith(`You are ${safeModelId}, known as: `) &&
+			identityLine.endsWith(identitySuffix));
+	if (!hasGeneratedIdentity) return false;
+
+	const historicFormattingSections = new Set([
+		`Formatting: ${COMPACT_FORMATTING_RULE}`,
+		["Formatting Rules:", ...HISTORIC_FORMATTING_RULES, LEGACY_MATH_FORMATTING_RULE].join("\n"),
+		[
+			"Formatting Rules:",
+			...HISTORIC_FORMATTING_RULES,
+			...PREVIOUS_MATH_FORMATTING_RULES,
+		].join("\n"),
+		["Formatting Rules:", LEGACY_MATH_FORMATTING_RULE].join("\n"),
+		["Formatting Rules:", PREVIOUS_MATH_FORMATTING_RULE].join("\n"),
+	]);
+	return historicFormattingSections.has(formattingSection);
 }
 
 export function shouldRequestImageModalities(modelId: string) {


### PR DESCRIPTION
## Summary

- virtualize the unfiltered Chat model catalog so only the visible model rows mount
- prioritize picker dismissal ahead of the larger active-thread render when selecting a model
- activate newly configured chats optimistically while IndexedDB persistence completes, with rollback on failure
- reset picker search state consistently and replace repeated focus timers with a single animation-frame focus
- restore the previous picker height and correctly recognize historical generated system prompts
- add a locally persisted Personalization preference for blank new chats or retaining selected model(s)
- preserve bounded command-search results and keyboard selection behavior

## Performance

- production baseline: 369 mounted model options and 4,352 picker descendants
- local optimized picker: 23 mounted model options and 275 picker descendants

## Validation

- `pnpm --filter @phaseo/web test` (83 suites, 356 tests)
- `pnpm --filter @phaseo/web typecheck`
- targeted ESLint (0 errors; existing warnings plus the documented TanStack Virtual compiler opt-out)
- local verification of opening, search, close/reopen cleanup, Arrow/Enter selection, model selection, and the warmed Chat route
- Next.js production compilation and TypeScript completed; full prerender requires `SUPABASE_SERVICE_ROLE_KEY`, which is not present in the local ignored environment files

Created with Codex

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a faster, virtualized model catalog with search, keyboard navigation, and improved model selection.
  * Added a **New chats** setting to start with blank model settings or preserve the current chat’s selected models.
* **Bug Fixes**
  * Improved recognition of automatically generated system prompts, including legacy formats.
  * Prevented failed preference saves from leaving partially created chats.
* **Performance**
  * Reduced unnecessary updates in model settings and dialog interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->