### PR TITLE
Fix incremental catalogue imports

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -212,6 +212,9 @@ jobs:
     importer:
         name: Run importer on main
         runs-on: ubuntu-latest
+        concurrency:
+            group: importer-main
+            cancel-in-progress: false
         needs:
             - data
             - check-paths
@@ -239,6 +242,15 @@ jobs:
             - name: Install dependencies
               run: corepack pnpm install --frozen-lockfile
 
+            - name: Restore importer hash state
+              id: importer-state-cache
+              uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9
+              with:
+                  path: packages/data/catalog/src/data/.import-state.json
+                  key: importer-state-main-${{ github.run_id }}
+                  restore-keys: |
+                      importer-state-main-
+
             - name: Run importer (all sections)
               if: ${{ env.SUPABASE_SERVICE_ROLE_KEY != '' && env.NEXT_PUBLIC_SUPABASE_URL != '' }}
               env:
@@ -249,9 +261,17 @@ jobs:
                   set -euo pipefail
                   for attempt in 1 2 3; do
                     echo "Running importer attempt ${attempt}/3"
-                    if (cd apps/web && pnpm exec tsx scripts/importer/main.ts --section=all); then
+                    set +e
+                    (cd apps/web && pnpm exec tsx scripts/importer/main.ts --section=all)
+                    exit_code=$?
+                    set -e
+                    if [ "${exit_code}" -eq 0 ]; then
                       echo "Importer succeeded on attempt ${attempt}"
                       exit 0
+                    fi
+                    if [ "${exit_code}" -ne 75 ]; then
+                      echo "Importer failed with a deterministic error (exit ${exit_code}); not retrying."
+                      exit "${exit_code}"
                     fi
                     if [ "${attempt}" -lt 3 ]; then
                       sleep_for=$((attempt * 15))
@@ -261,6 +281,13 @@ jobs:
                   done
                   echo "Importer failed after 3 attempts"
                   exit 1
+
+            - name: Save importer hash state
+              if: success()
+              uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9
+              with:
+                  path: packages/data/catalog/src/data/.import-state.json
+                  key: ${{ steps.importer-state-cache.outputs.cache-primary-key }}
 
     sdk-gen:
         name: Generate SDKs

--- a/apps/web/scripts/importer/loaders/models.ts
+++ b/apps/web/scripts/importer/loaders/models.ts
@@ -162,10 +162,6 @@ export async function loadModels(
     tracker: ChangeTracker,
     { modelId }: { modelId: string | null }
 ) {
-    const supa = client();
-    const nowIso = new Date().toISOString();
-    const hasApiModelIdColumn = await dataModelsHasApiModelIdColumn(supa);
-    const existingBenchmarkIds = await loadExistingBenchmarkIds(supa);
     if (!modelId) tracker.touchPrefix(DIR_MODELS);
 
     // ---------- 1) Read ALL JSON up front (no DB reads) ----------
@@ -228,8 +224,17 @@ export async function loadModels(
     }
 
     const hasChanges = changedModels.size > 0 || deletedModels.length > 0;
-    const shouldReconcileAllModels = !modelId;
+    const shouldReconcileAllModels = tracker.isFullImport();
     if (!hasChanges && !shouldReconcileAllModels) return;
+
+    const supa = client();
+    const nowIso = new Date().toISOString();
+    const hasApiModelIdColumn = await dataModelsHasApiModelIdColumn(supa);
+    const existingBenchmarkIds = await loadExistingBenchmarkIds(supa);
+
+    console.log(
+        `[models-import] changed_models=${changedModels.size} deleted_models=${deletedModels.length} full_mode=${shouldReconcileAllModels ? "yes" : "no"}`
+    );
 
     // ---------- 2) UPSERT core models ----------
     const flushCoreRows = async (rows: Array<Record<string, any>>) => {
@@ -552,7 +557,7 @@ export async function loadModels(
 
     await flushCoreRows(coreRows);
 
-    if (!modelId) {
+    if (!modelId && (shouldReconcileAllModels || deletedModels.length > 0)) {
         await pruneRowsByColumn(supa, "data_model_links", "model_id", modelIds, "data_model_links");
         await pruneRowsByColumn(
             supa,

--- a/apps/web/scripts/importer/loaders/pricing.ts
+++ b/apps/web/scripts/importer/loaders/pricing.ts
@@ -11,6 +11,7 @@ import {
 } from "../supa";
 import { createHash } from "crypto";
 import { ChangeTracker } from "../state";
+import { addPricingSkuMetadata, buildPricingSkuRows } from "../pricingMetadata";
 
 function toFixed10(n: number) {
     // match numeric(20,10) for pricing rules storage
@@ -300,6 +301,10 @@ type PricingRuleRow = {
     effective_to: string | null;
     billing_timestamp_basis: PricingTimestampBasis;
     time_windows: PricingTimeWindow[];
+    sku_id: string;
+    tier_id: string;
+    tier_label: string;
+    tier_order: number;
 };
 
 export async function loadPricing(
@@ -370,7 +375,7 @@ export async function loadPricing(
                 if (ruleRows.length) pricingRuleKeys.add(computedKey);
 
                 const seenBuckets = new Map<string, number>(); // key: provider||model|capability|meter|prio|digest
-                const desiredRules: PricingRuleRow[] = [];
+                const desiredRulesWithoutSku: Omit<PricingRuleRow, "sku_id" | "tier_id" | "tier_label" | "tier_order">[] = [];
 
                 for (const r of ruleRows) {
                     const prio = r.priority ?? 100;
@@ -384,7 +389,7 @@ export async function loadPricing(
                     const unit = r.unit ?? "token";
                     const price_val = (r.price_per_unit ?? r.price_usd_per_unit ?? 0) as number;
 
-                    desiredRules.push({
+                    desiredRulesWithoutSku.push({
                         model_key: computedKey,
                         capability_id,
                         pricing_plan,
@@ -402,6 +407,7 @@ export async function loadPricing(
                         time_windows: normalizeTimeWindows(r.time_windows),
                     });
                 }
+                const desiredRules = addPricingSkuMetadata(desiredRulesWithoutSku);
 
                 if (modelId || forceFull || change.status !== "unchanged") {
                     capabilityState.ruleReplacements.push({ model_key: computedKey, rows: desiredRules });
@@ -455,6 +461,7 @@ export async function loadPricing(
         for (const del of deletedEntries) if (del.model_key) ruleDeletes.add(del.model_key);
 
         const rowsToInsert = ruleReplacements.flatMap(r => r.rows);
+        const skuRowsToInsert = buildPricingSkuRows(rowsToInsert);
 
         if (isDryRun()) {
             for (const key of ruleDeletes) {
@@ -462,6 +469,9 @@ export async function loadPricing(
             }
             for (const row of rowsToInsert) {
                 logWrite("public.data_api_pricing_rules", "INSERT", row, { onConflict: null });
+            }
+            for (const row of skuRowsToInsert) {
+                logWrite("public.data_api_pricing_skus", "UPSERT", row, { onConflict: "model_key,sku_id" });
             }
         } else {
             if (ruleDeletes.size) {
@@ -471,6 +481,23 @@ export async function loadPricing(
                         .delete()
                         .in("model_key", [...ruleDeletes]),
                     "prune data_api_pricing_rules (targeted)"
+                );
+                assertOk(
+                    await supa
+                        .from("data_api_pricing_skus")
+                        .delete()
+                        .in("model_key", [...ruleDeletes]),
+                    "prune data_api_pricing_skus (targeted)"
+                );
+            }
+
+            for (const group of chunk(skuRowsToInsert, 500)) {
+                if (!group.length) continue;
+                assertOk(
+                    await supa
+                        .from("data_api_pricing_skus")
+                        .upsert(group, { onConflict: "model_key,sku_id" }),
+                    "upsert data_api_pricing_skus"
                 );
             }
 

--- a/apps/web/scripts/importer/loaders/providers.ts
+++ b/apps/web/scripts/importer/loaders/providers.ts
@@ -1034,7 +1034,7 @@ export async function loadProviders(
         );
     }
 
-    const deletions = tracker.getDeleted(DIR_PROVIDERS);
+    const deletions = modelFilter ? [] : tracker.getDeleted(DIR_PROVIDERS);
     for (const deletion of deletions) {
         const linkedModelIds = Array.isArray(deletion.info.meta?.linked_model_ids)
             ? deletion.info.meta.linked_model_ids

--- a/apps/web/scripts/importer/loaders/providers.ts
+++ b/apps/web/scripts/importer/loaders/providers.ts
@@ -633,8 +633,8 @@ export async function loadProviders(
     tracker: ChangeTracker,
     opts?: { modelId?: string | null }
 ) {
-    tracker.touchPrefix(DIR_PROVIDERS);
     const modelFilter = opts?.modelId ?? null;
+    if (!modelFilter) tracker.touchPrefix(DIR_PROVIDERS);
     const dirs = await listDirs(DIR_PROVIDERS);
     const supa = client();
     const organisationColours = await loadOrganisationColours();
@@ -690,10 +690,13 @@ export async function loadProviders(
         notes: string | null;
     }> = [];
     let touched = false;
+    let providerModelsChanged = false;
     for (const d of dirs) {
         const fp = join(d, "api_provider.json");
         const { data: j, hash } = await readJsonWithHash<any>(fp);
-        const change = tracker.track(fp, hash, { api_provider_id: j.api_provider_id });
+        const change = modelFilter
+            ? { status: "unchanged" as const }
+            : tracker.track(fp, hash, { api_provider_id: j.api_provider_id });
 
         const sourceStatus = getProviderStatusFromSource(j as Record<string, unknown>);
         const parsedStatus = parseProviderStatus(sourceStatus.value);
@@ -819,14 +822,22 @@ export async function loadProviders(
                     ]).filter(Boolean)
                 )
             );
-            const modelsChange = tracker.track(modelsPath, modelsHash, {
-                api_provider_id: j.api_provider_id,
-                kind: "provider_models",
-                linked_model_ids: linkedModelIds,
-            });
-            if (modelsChange.status !== "unchanged") touched = true;
+            const modelsChange = modelFilter
+                ? { status: "unchanged" as const }
+                : tracker.track(modelsPath, modelsHash, {
+                    api_provider_id: j.api_provider_id,
+                    kind: "provider_models",
+                    linked_model_ids: linkedModelIds,
+                });
+            if (modelsChange.status !== "unchanged") {
+                touched = true;
+                providerModelsChanged = true;
+            }
             const shouldTouchProviderModels =
-                change.status !== "unchanged" || modelsChange.status !== "unchanged";
+                Boolean(modelFilter) ||
+                tracker.isFullImport() ||
+                change.status !== "unchanged" ||
+                modelsChange.status !== "unchanged";
 
             for (const model of models ?? []) {
                 const apiModelId =
@@ -885,7 +896,7 @@ export async function loadProviders(
                 }
                 const provider_api_model_id = model.provider_api_model_id;
                 providerModelIds.add(provider_api_model_id);
-                providerModelsToUpsert.push({
+                const providerModelRow = {
                     provider_api_model_id,
                     provider_id: j.api_provider_id,
                     api_model_id: apiModelId,
@@ -903,12 +914,16 @@ export async function loadProviders(
                     max_output_tokens: toNullableInt(model.max_output_tokens),
                     effective_from: toNullableIsoTimestamp(model.effective_from),
                     effective_to: toNullableIsoTimestamp(model.effective_to),
-                });
+                };
+                if (shouldTouchProviderModels) {
+                    providerModelsToUpsert.push(providerModelRow);
+                }
 
                 for (const cap of model.capabilities ?? []) {
                     if (!cap?.capability_id) continue;
                     const capability_id = cap.capability_id;
                     capabilityKeys.add(`${provider_api_model_id}::${capability_id}`);
+                    if (!shouldTouchProviderModels) continue;
                     capabilityRowsToUpsert.push({
                         provider_api_model_id,
                         capability_id,
@@ -1033,6 +1048,9 @@ export async function loadProviders(
         }
     }
     touched = touched || deletions.length > 0;
+    const shouldPruneProviderModels =
+        !modelFilter &&
+        (tracker.isFullImport() || providerModelsChanged || deletions.length > 0);
 
     if (touched) {
         await pruneRowsByColumn(supa, "data_api_providers", "api_provider_id", providerIds, "data_api_providers");
@@ -1076,7 +1094,7 @@ export async function loadProviders(
         }
     }
 
-    if (providerModelIds.size && !isDryRun() && !modelFilter) {
+    if (providerModelIds.size && !isDryRun() && shouldPruneProviderModels) {
         await pruneRowsByColumn(
             supa,
             "data_api_provider_models",
@@ -1086,7 +1104,7 @@ export async function loadProviders(
         );
     }
 
-    if (capabilityKeys.size && !isDryRun() && !modelFilter) {
+    if (capabilityKeys.size && !isDryRun() && shouldPruneProviderModels) {
         const keys = Array.from(capabilityKeys);
         for (const group of chunk(keys, 500)) {
             const providerIdsChunk = Array.from(

--- a/apps/web/scripts/importer/main.ts
+++ b/apps/web/scripts/importer/main.ts
@@ -1,5 +1,5 @@
 import "dotenv/config";
-import { isDryRun } from "./supa";
+import { isDryRun, isTransientImporterError } from "./supa";
 import { ChangeTracker } from "./state";
 import { cleanDeleted } from "./cleanup";
 import { loadModels } from "./loaders/models";
@@ -19,9 +19,10 @@ const getArgValue = (name: string) =>
 
 async function main() {
     const modelFilter = getArgValue("model");
-    const forcePricing = process.argv.includes("--full-pricing") || process.argv.includes("--full");
+    const forceFull = process.argv.includes("--full");
+    const forcePricing = process.argv.includes("--full-pricing") || forceFull;
     if (!modelFilter) await cleanDeleted();
-    const tracker = await ChangeTracker.init();
+    const tracker = await ChangeTracker.init(undefined, { forceFull });
     const requestedSection =
         process.argv.find(a => a.startsWith("--section="))?.split("=")[1] || "all";
     const section =
@@ -34,37 +35,46 @@ async function main() {
         process.exit(1);
     }
 
+    const timed = async (name: string, task: () => Promise<void>) => {
+        const startedAt = performance.now();
+        try {
+            await task();
+        } finally {
+            console.log(`[importer-timing] section=${name} duration_ms=${Math.round(performance.now() - startedAt)}`);
+        }
+    };
+
     const tasks: Record<string, (tracker: ChangeTracker) => Promise<void>> = {
-        families: loadFamilies,
-        models: tracker => loadModels(tracker, { modelId: modelFilter ?? null }),
+        families: tracker => timed("families", () => loadFamilies(tracker)),
+        models: tracker => timed("models", () => loadModels(tracker, { modelId: modelFilter ?? null })),
         pricing: tracker =>
-            loadPricing(tracker, { modelId: modelFilter ?? null, forceFull: forcePricing }),
+            timed("pricing", () => loadPricing(tracker, { modelId: modelFilter ?? null, forceFull: forcePricing })),
         model: async tracker => {
-            await loadModels(tracker, { modelId: modelFilter ?? null });
-            await loadProviders(tracker, { modelId: modelFilter ?? null });
-            await loadPricing(tracker, {
+            await timed("models", () => loadModels(tracker, { modelId: modelFilter ?? null }));
+            await timed("providers", () => loadProviders(tracker, { modelId: modelFilter ?? null }));
+            await timed("pricing", () => loadPricing(tracker, {
                 modelId: modelFilter ?? null,
                 forceFull: forcePricing,
-            });
+            }));
         },
-        benchmarks: loadBenchmarks,
-        organisations: loadOrganisations,
+        benchmarks: tracker => timed("benchmarks", () => loadBenchmarks(tracker)),
+        organisations: tracker => timed("organisations", () => loadOrganisations(tracker)),
         providers: async tracker => {
             // Keep provider model references valid by refreshing data_models first.
-            await loadModels(tracker, { modelId: null });
-            await loadProviders(tracker);
+            await timed("models", () => loadModels(tracker, { modelId: null }));
+            await timed("providers", () => loadProviders(tracker));
         },
-        aliases: loadAliases,
-        subscription_plans: loadSubscriptionPlans,
+        aliases: tracker => timed("aliases", () => loadAliases(tracker)),
+        subscription_plans: tracker => timed("subscription_plans", () => loadSubscriptionPlans(tracker)),
         all: async tracker => {
-            await loadOrganisations(tracker);
-            await loadBenchmarks(tracker);
-            await loadFamilies(tracker);
-            await loadModels(tracker, { modelId: null });
-            await loadAliases(tracker); // optional: if you have the aliases loader
-            await loadProviders(tracker);
-            await loadPricing(tracker, { modelId: null, forceFull: forcePricing });
-            await loadSubscriptionPlans(tracker);
+            await timed("organisations", () => loadOrganisations(tracker));
+            await timed("benchmarks", () => loadBenchmarks(tracker));
+            await timed("families", () => loadFamilies(tracker));
+            await timed("models", () => loadModels(tracker, { modelId: null }));
+            await timed("aliases", () => loadAliases(tracker));
+            await timed("providers", () => loadProviders(tracker));
+            await timed("pricing", () => loadPricing(tracker, { modelId: null, forceFull: forcePricing }));
+            await timed("subscription_plans", () => loadSubscriptionPlans(tracker));
         },
     };
     const fn = tasks[section];
@@ -78,7 +88,8 @@ async function main() {
 
     console.log(`>> Importing: ${section}`);
     if (modelFilter) console.log(`>> Model filter: ${modelFilter}`);
-    if (forcePricing) console.log(">> Full pricing import mode enabled.");
+    if (forceFull) console.log(">> Full import mode enabled; hashes will be ignored.");
+    else if (forcePricing) console.log(">> Full pricing import mode enabled.");
     await fn(tracker);
     await tracker.persist({ dryRun: isDryRun() });
     console.log(">> Done.");
@@ -91,5 +102,5 @@ main()
     })
     .catch(err => {
         console.error(err);
-        process.exit(1);
+        process.exit(isTransientImporterError(err) ? 75 : 1);
     });

--- a/apps/web/scripts/importer/pricingMetadata.test.ts
+++ b/apps/web/scripts/importer/pricingMetadata.test.ts
@@ -1,0 +1,64 @@
+import { addPricingSkuMetadata, buildPricingSkuRows } from "./pricingMetadata";
+
+describe("addPricingSkuMetadata", () => {
+    it("uses stable default metadata for an untiered rule", () => {
+        expect(addPricingSkuMetadata([{
+            pricing_plan: "standard",
+            meter: "input_text_tokens",
+            match: [],
+        }])).toEqual([expect.objectContaining({
+            sku_id: "input-text-tokens",
+            tier_id: "default",
+            tier_label: "Standard",
+            tier_order: 1,
+        })]);
+    });
+
+    it("shares tier metadata across meters with the same conditions", () => {
+        const lowerTier = [{ path: "input_tokens", op: "lte", value: 200_000 }];
+        const upperTier = [{ path: "input_tokens", op: "gt", value: 200_000 }];
+        const rows = addPricingSkuMetadata([
+            { pricing_plan: "standard", meter: "input_text_tokens", match: lowerTier },
+            { pricing_plan: "standard", meter: "output_text_tokens", match: lowerTier },
+            { pricing_plan: "standard", meter: "input_text_tokens", match: upperTier },
+        ]);
+
+        expect(rows.map(({ sku_id, tier_id, tier_order }) => ({ sku_id, tier_id, tier_order }))).toEqual([
+            { sku_id: "input-text-tokens", tier_id: "tier-1", tier_order: 1 },
+            { sku_id: "output-text-tokens", tier_id: "tier-1", tier_order: 1 },
+            { sku_id: "input-text-tokens", tier_id: "tier-2", tier_order: 2 },
+        ]);
+    });
+
+    it("builds one parent SKU row per model and meter", () => {
+        const rows = addPricingSkuMetadata([
+            {
+                model_key: "provider:model:text.generate",
+                capability_id: "text.generate",
+                pricing_plan: "standard",
+                meter: "input_text_tokens",
+                unit: "token",
+                match: [],
+            },
+            {
+                model_key: "provider:model:text.generate",
+                capability_id: "text.generate",
+                pricing_plan: "batch",
+                meter: "input_text_tokens",
+                unit: "token",
+                match: [],
+            },
+        ]);
+
+        expect(buildPricingSkuRows(rows)).toEqual([
+            expect.objectContaining({
+                model_key: "provider:model:text.generate",
+                sku_id: "input-text-tokens",
+                label: "Input Text",
+                display_order: 10,
+                unit_label: "/M tokens",
+                display_multiplier: 1_000_000,
+            }),
+        ]);
+    });
+});

--- a/apps/web/scripts/importer/pricingMetadata.ts
+++ b/apps/web/scripts/importer/pricingMetadata.ts
@@ -1,0 +1,145 @@
+type PricingMetadataSource = {
+    pricing_plan: string;
+    meter: string;
+    match: unknown[];
+};
+
+export type PricingSkuMetadata = {
+    sku_id: string;
+    tier_id: string;
+    tier_label: string;
+    tier_order: number;
+};
+
+export type PricingSkuRow = {
+    model_key: string;
+    capability_id: string;
+    sku_id: string;
+    label: string;
+    kind: string;
+    display_order: number;
+    unit_label: string;
+    display_multiplier: number | null;
+    description: null;
+    is_billable: true;
+    derived_from_sku_id: null;
+    derived_quantity: null;
+    metadata: {
+        calculator_input: {
+            key: string;
+            label: string;
+            type: "number";
+        };
+    };
+};
+
+function deepSortObjectKeys(value: unknown): unknown {
+    if (Array.isArray(value)) return value.map(deepSortObjectKeys);
+    if (value && typeof value === "object") {
+        const sorted: Record<string, unknown> = {};
+        for (const key of Object.keys(value).sort()) {
+            sorted[key] = deepSortObjectKeys((value as Record<string, unknown>)[key]);
+        }
+        return sorted;
+    }
+    return value;
+}
+
+function matchSignature(match: unknown[]) {
+    return JSON.stringify(deepSortObjectKeys(match));
+}
+
+function meterSku(meter: string) {
+    return meter
+        .trim()
+        .toLowerCase()
+        .replace(/[^a-z0-9]+/g, "-")
+        .replace(/^-+|-+$/g, "") || "usage";
+}
+
+function meterLabel(meter: string) {
+    const labels: Record<string, string> = {
+        input_text_tokens: "Input Text",
+        cached_read_text_tokens: "Cache Read",
+        cached_write_text_tokens: "Cache Write",
+        output_text_tokens: "Output Text",
+    };
+    return labels[meter] ?? meter
+        .replace(/_tokens?$/, " Tokens")
+        .replace(/_/g, " ")
+        .replace(/\b\w/g, (character) => character.toUpperCase());
+}
+
+function meterDisplayOrder(meter: string) {
+    if (meter.startsWith("input_")) return 10;
+    if (meter.startsWith("cached_read_")) return 20;
+    if (meter.startsWith("cached_write_")) return 30;
+    if (meter.startsWith("output_")) return 40;
+    return 100;
+}
+
+export function addPricingSkuMetadata<T extends PricingMetadataSource>(
+    rows: T[]
+): Array<T & PricingSkuMetadata> {
+    const signaturesByPlan = new Map<string, string[]>();
+
+    for (const row of rows) {
+        const signature = matchSignature(row.match);
+        const signatures = signaturesByPlan.get(row.pricing_plan) ?? [];
+        if (!signatures.includes(signature)) signatures.push(signature);
+        signaturesByPlan.set(row.pricing_plan, signatures);
+    }
+
+    return rows.map((row) => {
+        const signatures = signaturesByPlan.get(row.pricing_plan) ?? [];
+        const tierIndex = Math.max(0, signatures.indexOf(matchSignature(row.match)));
+        const hasMultipleTiers = signatures.length > 1;
+        const tierOrder = hasMultipleTiers ? tierIndex + 1 : 1;
+
+        return {
+            ...row,
+            sku_id: meterSku(row.meter),
+            tier_id: hasMultipleTiers ? `tier-${tierOrder}` : "default",
+            tier_label: hasMultipleTiers ? `Tier ${tierOrder}` : "Standard",
+            tier_order: tierOrder,
+        };
+    });
+}
+
+export function buildPricingSkuRows<T extends PricingMetadataSource & PricingSkuMetadata & {
+    model_key: string;
+    capability_id: string;
+    unit: string;
+}>(rows: T[]): PricingSkuRow[] {
+    const byKey = new Map<string, PricingSkuRow>();
+
+    for (const row of rows) {
+        const key = `${row.model_key}::${row.sku_id}`;
+        if (byKey.has(key)) continue;
+        const label = meterLabel(row.meter);
+        const isToken = row.unit === "token";
+        byKey.set(key, {
+            model_key: row.model_key,
+            capability_id: row.capability_id,
+            sku_id: row.sku_id,
+            label,
+            kind: row.unit,
+            display_order: meterDisplayOrder(row.meter),
+            unit_label: isToken ? "/M tokens" : `/${row.unit}`,
+            display_multiplier: isToken ? 1_000_000 : null,
+            description: null,
+            is_billable: true,
+            derived_from_sku_id: null,
+            derived_quantity: null,
+            metadata: {
+                calculator_input: {
+                    key: row.meter,
+                    label,
+                    type: "number",
+                },
+            },
+        });
+    }
+
+    return Array.from(byKey.values());
+}

--- a/apps/web/scripts/importer/state.test.ts
+++ b/apps/web/scripts/importer/state.test.ts
@@ -1,0 +1,41 @@
+import { promises as fs } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+
+jest.mock("./paths", () => ({ DATA_ROOT: process.cwd() }));
+
+import { ChangeTracker } from "./state";
+
+describe("ChangeTracker", () => {
+    let directory: string;
+    let statePath: string;
+    let dataPath: string;
+
+    beforeEach(async () => {
+        directory = await fs.mkdtemp(join(tmpdir(), "phaseo-import-state-"));
+        statePath = join(directory, "state.json");
+        dataPath = join(directory, "model.json");
+
+        const initial = await ChangeTracker.init(statePath);
+        initial.track(dataPath, "same-hash", { model_id: "example/model" });
+        await initial.persist();
+    });
+
+    afterEach(async () => {
+        await fs.rm(directory, { recursive: true, force: true });
+    });
+
+    it("keeps files with matching hashes unchanged by default", async () => {
+        const tracker = await ChangeTracker.init(statePath);
+
+        expect(tracker.isFullImport()).toBe(false);
+        expect(tracker.track(dataPath, "same-hash").status).toBe("unchanged");
+    });
+
+    it("treats matching hashes as changed during a full import", async () => {
+        const tracker = await ChangeTracker.init(statePath, { forceFull: true });
+
+        expect(tracker.isFullImport()).toBe(true);
+        expect(tracker.track(dataPath, "same-hash").status).toBe("changed");
+    });
+});

--- a/apps/web/scripts/importer/state.ts
+++ b/apps/web/scripts/importer/state.ts
@@ -47,14 +47,25 @@ export class ChangeTracker {
     private next: PersistedState;
     private touchedPrefixes = new Set<string>();
 
-    private constructor(prev: PersistedState, private statePath: string) {
+    private constructor(
+        prev: PersistedState,
+        private statePath: string,
+        private forceFull: boolean
+    ) {
         this.prev = prev;
         this.next = { version: prev.version, files: {} };
     }
 
-    static async init(statePath: string = DEFAULT_STATE_PATH) {
+    static async init(
+        statePath: string = DEFAULT_STATE_PATH,
+        { forceFull = false }: { forceFull?: boolean } = {}
+    ) {
         const prev = await loadPersistedState(statePath);
-        return new ChangeTracker(prev, statePath);
+        return new ChangeTracker(prev, statePath, forceFull);
+    }
+
+    isFullImport() {
+        return this.forceFull;
     }
 
     touchPrefix(prefix: string) {
@@ -70,6 +81,9 @@ export class ChangeTracker {
         const previous = this.prev.files[norm];
         if (!previous) {
             return { path: norm, status: "added", current };
+        }
+        if (this.forceFull) {
+            return { path: norm, status: "changed", previous, current };
         }
         if (previous.hash !== hash) {
             return { path: norm, status: "changed", previous, current };

--- a/apps/web/scripts/importer/supa.test.ts
+++ b/apps/web/scripts/importer/supa.test.ts
@@ -1,4 +1,19 @@
-import { touchModelTimestamps } from "./supa";
+import {
+    ImporterDatabaseError,
+    isTransientImporterError,
+    touchModelTimestamps,
+} from "./supa";
+
+describe("isTransientImporterError", () => {
+    it("retries transient database and network failures", () => {
+        expect(isTransientImporterError(new ImporterDatabaseError("upsert", { code: "40001" }))).toBe(true);
+        expect(isTransientImporterError(new Error("fetch failed: connection reset"))).toBe(true);
+    });
+
+    it("does not retry deterministic constraint failures", () => {
+        expect(isTransientImporterError(new ImporterDatabaseError("upsert", { code: "23505" }))).toBe(false);
+    });
+});
 
 describe("touchModelTimestamps", () => {
     it("updates unique trimmed model ids in batches", async () => {

--- a/apps/web/scripts/importer/supa.ts
+++ b/apps/web/scripts/importer/supa.ts
@@ -52,13 +52,52 @@ function formatSupabaseError(error: any): string {
     if (/fetch failed|network|timed out|timeout/i.test(normalized)) {
         return `${normalized} | network_hint=check Supabase reachability and NEXT_PUBLIC_SUPABASE_URL`;
     }
+    if (/ux_model_links_model_platform/i.test(normalized)) {
+        return `${normalized} | schema_hint=production is missing migration 20260708110000_add_model_link_titles.sql`;
+    }
     return normalized;
+}
+
+export class ImporterDatabaseError extends Error {
+    readonly code: string | null;
+    readonly status: number | null;
+
+    constructor(ctx: string, error: any) {
+        super(`${ctx}: ${formatSupabaseError(error)}`);
+        this.name = "ImporterDatabaseError";
+        this.code = typeof error?.code === "string" ? error.code : null;
+        this.status = typeof error?.status === "number" ? error.status : null;
+        this.cause = error;
+    }
+}
+
+export function isTransientImporterError(error: unknown): boolean {
+    const value = error as { code?: unknown; status?: unknown; message?: unknown; cause?: any };
+    const code = typeof value?.code === "string"
+        ? value.code
+        : typeof value?.cause?.code === "string"
+            ? value.cause.code
+            : "";
+    const status = typeof value?.status === "number"
+        ? value.status
+        : typeof value?.cause?.status === "number"
+            ? value.cause.status
+            : null;
+    const message = typeof value?.message === "string" ? value.message : String(error);
+
+    return (
+        /^(08|40P01|40001|53|57P0)/.test(code) ||
+        status === 408 ||
+        status === 429 ||
+        (status !== null && status >= 500) ||
+        /fetch failed|network|timed out|timeout|connection reset|socket hang up/i.test(message)
+    );
 }
 
 /** Small helper to throw on Supabase errors with context */
 export function assertOk<T>(res: { data: T | null, error: any }, ctx: string) {
     if (res.error) {
-        throw new Error(`${ctx}: ${formatSupabaseError(res.error)}`);
+        throw new ImporterDatabaseError(ctx, res.error);
     }
     return res.data as T;
 }

--- a/apps/web/src/app/(dashboard)/models/actions.ts
+++ b/apps/web/src/app/(dashboard)/models/actions.ts
@@ -19,6 +19,10 @@ import {
   normalizeModelStatus,
   type CapabilityStatusOption,
 } from "@/lib/models/editorOptions"
+import {
+  addPricingSkuMetadata,
+  buildPricingSkuRows,
+} from "@/lib/pricing/pricingMetadata"
 
 const CORE_TYPE_OPTIONS = MODEL_MODALITY_OPTIONS
 const MODEL_DETAIL_NAME_OPTIONS = [
@@ -255,6 +259,17 @@ async function deletePricingRulesForProviderPairs(
     if (error) {
       console.error("[updateModel] Error deleting pricing rules for pair:", pair, error)
       throw new Error(error.message)
+    }
+
+    const { error: skuError } = await supabase
+      .from("data_api_pricing_skus")
+      .delete()
+      .gte("model_key", modelKeyPrefix)
+      .lt("model_key", `${modelKeyPrefix}\uffff`)
+
+    if (skuError) {
+      console.error("[updateModel] Error deleting pricing SKUs for pair:", pair, skuError)
+      throw new Error(skuError.message)
     }
   }
 }
@@ -546,7 +561,7 @@ export async function updateModel(payload: ModelUpdatePayload) {
   const normalizedPricingRules =
     pricing_rules === undefined
       ? undefined
-      : pricing_rules
+      : addPricingSkuMetadata(pricing_rules
           .filter((rule) => rule.provider_id && rule.meter)
           .map((rule) => {
             const capabilityId = rule.capability_id?.trim() || "text.generate"
@@ -576,7 +591,7 @@ export async function updateModel(payload: ModelUpdatePayload) {
               effective_to: rule.effective_to ?? null,
               updated_at: nowIso,
             }
-          })
+          }))
 
   if (provider_models !== undefined) {
     const { data: existingProviderModelRows, error: existingProviderModelRowsError } = await supabase
@@ -900,6 +915,16 @@ export async function updateModel(payload: ModelUpdatePayload) {
     }
 
     if (normalizedPricingRules.length > 0) {
+      const pricingSkuRows = buildPricingSkuRows(normalizedPricingRules)
+      const { error: skuUpsertError } = await supabase
+        .from("data_api_pricing_skus")
+        .upsert(pricingSkuRows, { onConflict: "model_key,sku_id" })
+
+      if (skuUpsertError) {
+        console.error("[updateModel] Error upserting pricing SKUs:", skuUpsertError)
+        throw new Error(skuUpsertError.message)
+      }
+
       const { error: insertPricingError } = await supabase
         .from("data_api_pricing_rules")
         .insert(
@@ -917,6 +942,10 @@ export async function updateModel(payload: ModelUpdatePayload) {
             priority: rule.priority,
             effective_from: rule.effective_from,
             effective_to: rule.effective_to,
+            sku_id: rule.sku_id,
+            tier_id: rule.tier_id,
+            tier_label: rule.tier_label,
+            tier_order: rule.tier_order,
             updated_at: rule.updated_at,
           }))
         )

--- a/apps/web/src/lib/pricing/pricingMetadata.ts
+++ b/apps/web/src/lib/pricing/pricingMetadata.ts
@@ -1,0 +1,6 @@
+export {
+  addPricingSkuMetadata,
+  buildPricingSkuRows,
+  type PricingSkuMetadata,
+  type PricingSkuRow,
+} from "../../../scripts/importer/pricingMetadata"

--- a/packages/data/catalog/src/data/.import-state.json
+++ b/packages/data/catalog/src/data/.import-state.json
@@ -2,7 +2,7 @@
   "version": 1,
   "files": {
     "../../packages/data/catalog/src/data/models/ibm/granite-4.1-8b/model.json": {
-      "hash": "5701e0b8e3b935523390650871e53a40",
+      "hash": "71deba358c7f402c2a21cbcc3a08ef71",
       "meta": {
         "model_id": "ibm/granite-4.1-8b",
         "organisation_id": "ibm",
@@ -21,7 +21,12 @@
       "hash": "8f49e6fce3404cb4522ee6de0a406a6b",
       "meta": {
         "api_provider_id": "ai21",
-        "kind": "provider_models"
+        "kind": "provider_models",
+        "linked_model_ids": [
+          "ai21/jamba-large-1.7",
+          "ai21/jamba-mini-1.7",
+          "ai21/jamba-mini-2"
+        ]
       }
     },
     "../../packages/data/catalog/src/data/api_providers/aion-labs/api_provider.json": {
@@ -31,7 +36,7 @@
       }
     },
     "../../packages/data/catalog/src/data/api_providers/aion-labs/models.json": {
-      "hash": "1edba5dbfdf09dfcc234af212ec6e23c",
+      "hash": "bfe1949e5abd50e5aff50d85a87409c9",
       "meta": {
         "api_provider_id": "aion-labs",
         "kind": "provider_models",
@@ -41,6 +46,7 @@
           "aion-labs/aion-2.0",
           "aion-labs/aion-2.5",
           "aion-labs/aion-3.0",
+          "aion-labs/aion-3.0-mini",
           "aion-labs/aion-rp-llama-3.1-8b"
         ]
       }
@@ -176,13 +182,13 @@
       }
     },
     "../../packages/data/catalog/src/data/api_providers/amazon-bedrock/api_provider.json": {
-      "hash": "0f1d3cc522313c56324e238036dd2a62",
+      "hash": "5a3ea9aebc6ab3360c6c809c58be1d37",
       "meta": {
         "api_provider_id": "amazon-bedrock"
       }
     },
     "../../packages/data/catalog/src/data/api_providers/amazon-bedrock/models.json": {
-      "hash": "7682a19278dae04e1b787f7c4fad1c5e",
+      "hash": "47ffea57addf7f540e2b023edd29894a",
       "meta": {
         "api_provider_id": "amazon-bedrock",
         "kind": "provider_models",
@@ -234,13 +240,34 @@
           "z-ai/glm-4.7",
           "z-ai/glm-4.7-flash",
           "z-ai/glm-5",
-          "x-ai/grok-4.3",
-          "anthropic/claude-fable-5"
+          "spacex-ai/grok-4.3",
+          "anthropic/claude-fable-5",
+          "anthropic/claude-mythos-5",
+          "anthropic/claude-mythos-preview",
+          "deepseek/deepseek-v3.2",
+          "deepseek/deepseek-v3.1",
+          "mistral/devstral-2.0",
+          "mistral/magistral-small-1.2",
+          "mistral/ministral-3.0-14b",
+          "mistral/ministral-3.0-8b",
+          "mistral/ministral-3.0-3b",
+          "mistral/mistral-large-3.0",
+          "mistral/voxtral-mini",
+          "mistral/voxtral-small",
+          "moonshotai/kimi-k2-thinking",
+          "nvidia/nemotron-nano-9b-v2",
+          "nvidia/nvidia-nemotron-nano-12b-v2-vl",
+          "openai/gpt-5.5",
+          "openai/gpt-5.4",
+          "qwen/qwen3-coder-480b-a35b",
+          "openai/gpt-5.6-sol",
+          "openai/gpt-5.6-terra",
+          "openai/gpt-5.6-luna"
         ]
       }
     },
     "../../packages/data/catalog/src/data/api_providers/anthropic/api_provider.json": {
-      "hash": "8e0866f414271ec26a8346f7bd7cb11a",
+      "hash": "2ffbc87c693a677d44c7f87b54d8fba4",
       "meta": {
         "api_provider_id": "anthropic"
       }
@@ -299,7 +326,7 @@
       }
     },
     "../../packages/data/catalog/src/data/api_providers/atlascloud/models.json": {
-      "hash": "890ac5bf02636d94dac1511307a93f01",
+      "hash": "ae5e375022648cb83ef47c2dce828edf",
       "meta": {
         "api_provider_id": "atlascloud",
         "kind": "provider_models",
@@ -372,21 +399,35 @@
           "z-ai/glm-5.2",
           "z-ai/glm-5-turbo",
           "kwaipilot/kat-coder-pro-v2",
+          "kwaipilot/kat-coder-air-v2.5",
+          "kwaipilot/kat-coder-pro-v2.5",
           "tencent/hy3"
         ]
       }
     },
     "../../packages/data/catalog/src/data/api_providers/azure/api_provider.json": {
-      "hash": "ab3752c4b9cb280b5373e8075b631a3e",
+      "hash": "83ba3632bc292a6d8bf4ff21e6d65aa7",
       "meta": {
         "api_provider_id": "azure"
       }
     },
     "../../packages/data/catalog/src/data/api_providers/azure/models.json": {
-      "hash": "3624cde93c55550a8e997961f9f894e9",
+      "hash": "d59540b5dc042271b0e5e75b977b34c3",
       "meta": {
         "api_provider_id": "azure",
-        "kind": "provider_models"
+        "kind": "provider_models",
+        "linked_model_ids": [
+          "openai/gpt-5-nano",
+          "openai/gpt-oss-120b",
+          "microsoft/mai-image-2",
+          "microsoft/mai-image-2.5",
+          "microsoft/mai-image-2.5-flash",
+          "microsoft/mai-image-2e",
+          "microsoft/mai-transcribe-1",
+          "microsoft/mai-transcribe-1.5",
+          "microsoft/mai-voice-1",
+          "microsoft/mai-voice-2"
+        ]
       }
     },
     "../../packages/data/catalog/src/data/api_providers/baseten/api_provider.json": {
@@ -396,11 +437,12 @@
       }
     },
     "../../packages/data/catalog/src/data/api_providers/baseten/models.json": {
-      "hash": "aa2dc75b4cc58cf7001f90985884c702",
+      "hash": "23c94446b6a0b48a411d09b38c2b7e8e",
       "meta": {
         "api_provider_id": "baseten",
         "kind": "provider_models",
         "linked_model_ids": [
+          "thinking-machines/inkling",
           "deepseek/deepseek-v3-2025-03-24",
           "deepseek/deepseek-v3-0324",
           "deepseek/deepseek-v3.1",
@@ -434,7 +476,18 @@
       "hash": "a22e04a38633edf36c78144e1a730f93",
       "meta": {
         "api_provider_id": "black-forest-labs",
-        "kind": "provider_models"
+        "kind": "provider_models",
+        "linked_model_ids": [
+          "black-forest-labs/flux-1.1-pro",
+          "black-forest-labs/flux-1.1-pro-ultra",
+          "black-forest-labs/flux-1-kontext-max",
+          "black-forest-labs/flux-1-kontext-pro",
+          "black-forest-labs/flux-2-flex",
+          "black-forest-labs/flux-2-klein-4b",
+          "black-forest-labs/flux-2-klein-9b",
+          "black-forest-labs/flux-2-max",
+          "black-forest-labs/flux-2-pro"
+        ]
       }
     },
     "../../packages/data/catalog/src/data/api_providers/byteplus/api_provider.json": {
@@ -551,11 +604,28 @@
       "hash": "a36cd31cfc131df82e8f6f8e0ae7124c",
       "meta": {
         "api_provider_id": "cohere",
-        "kind": "provider_models"
+        "kind": "provider_models",
+        "linked_model_ids": [
+          "cohere/command-a",
+          "cohere/command-a-plus",
+          "cohere/command-a-reasoning",
+          "cohere/command-a-translate",
+          "cohere/command-a-vision",
+          "cohere/command-r",
+          "cohere/command-r-7b",
+          "cohere/command-r7b",
+          "cohere/command-r-plus",
+          "cohere/tiny-aya-global",
+          "cohere/tiny-aya-fire",
+          "cohere/tiny-aya-water",
+          "cohere/tiny-aya-earth",
+          "cohere/north-mini-code-1-0",
+          "cohere/north-mini-code-1-0:free"
+        ]
       }
     },
     "../../packages/data/catalog/src/data/api_providers/crofai/api_provider.json": {
-      "hash": "1f9b8278c4872017045f27bf1a1cb109",
+      "hash": "86d526e08b781d88c65f9445593e499d",
       "meta": {
         "api_provider_id": "crofai"
       }
@@ -608,7 +678,7 @@
       }
     },
     "../../packages/data/catalog/src/data/api_providers/deepinfra/api_provider.json": {
-      "hash": "f104bb1276353f75d06a15cb40e1ac31",
+      "hash": "25990f7553da4074231c9f709c2d143c",
       "meta": {
         "api_provider_id": "deepinfra"
       }
@@ -704,7 +774,13 @@
       "hash": "bd344c0912a835ab92bb18553c45c203",
       "meta": {
         "api_provider_id": "deepseek",
-        "kind": "provider_models"
+        "kind": "provider_models",
+        "linked_model_ids": [
+          "deepseek/deepseek-v3.2",
+          "deepseek/deepseek-v3.2-thinking",
+          "deepseek/deepseek-v4-flash",
+          "deepseek/deepseek-v4-pro"
+        ]
       }
     },
     "../../packages/data/catalog/src/data/api_providers/elevenlabs/api_provider.json": {
@@ -1018,7 +1094,7 @@
       }
     },
     "../../packages/data/catalog/src/data/api_providers/groq/models.json": {
-      "hash": "a7a9eb262cbe1b22f37cd1f5b4e5bec1",
+      "hash": "1e47f4c86ea00e6ea1101195ba7a00c7",
       "meta": {
         "api_provider_id": "groq",
         "kind": "provider_models",
@@ -1114,7 +1190,12 @@
       "hash": "89a5ac5976b71ecbb34604131e1b65fa",
       "meta": {
         "api_provider_id": "infermatic",
-        "kind": "provider_models"
+        "kind": "provider_models",
+        "linked_model_ids": [
+          "qwen/qwen3-235b-a22b-thinking-2507",
+          "qwen/qwen3-30b-a3b",
+          "meta/llama-3.2-11b-vision"
+        ]
       }
     },
     "../../packages/data/catalog/src/data/api_providers/inflection/api_provider.json": {
@@ -1145,7 +1226,26 @@
       "hash": "7efa205ae8dcff4fbab7bd8fb693fdbf",
       "meta": {
         "api_provider_id": "ionrouter",
-        "kind": "provider_models"
+        "kind": "provider_models",
+        "linked_model_ids": [
+          "z-ai/glm-5",
+          "moonshotai/kimi-k2.5",
+          "minimax/minimax-m2.5",
+          "qwen/qwen3.5-122b-a10b",
+          "openai/gpt-oss-120b",
+          "qwen/qwen3.5-35b-a3b",
+          "qwen/qwen3.5-27b",
+          "qwen/qwen3-30b-a3b",
+          "qwen/qwen2.5-32b",
+          "qwen/qwen3-14b",
+          "qwen/qwen2.5-14b",
+          "qwen/qwen3-8b",
+          "qwen/qwen2.5-7b",
+          "qwen/qwen3-vl-8b",
+          "qwen/qwen3-vl-30b-a3b",
+          "qwen/qwen2.5-vl-7b",
+          "allenai/molmo-2-8b"
+        ]
       }
     },
     "../../packages/data/catalog/src/data/api_providers/liquid-ai/api_provider.json": {
@@ -1155,16 +1255,21 @@
       }
     },
     "../../packages/data/catalog/src/data/api_providers/meta/api_provider.json": {
-      "hash": "44ac9940dc2a8c1c2e63b65096b5bbc2",
+      "hash": "86846d6577f7057f128e09a761620b7d",
       "meta": {
         "api_provider_id": "meta"
       }
     },
     "../../packages/data/catalog/src/data/api_providers/meta/models.json": {
-      "hash": "6415859613b1fb7395367014f8179faf",
+      "hash": "abd540aa4e18745f74ff7eb5344ed700",
       "meta": {
         "api_provider_id": "meta",
-        "kind": "provider_models"
+        "kind": "provider_models",
+        "linked_model_ids": [
+          "meta/muse-spark",
+          "meta/muse-spark-contemplating",
+          "meta/muse-spark-1.1"
+        ]
       }
     },
     "../../packages/data/catalog/src/data/api_providers/minimax/api_provider.json": {
@@ -1222,7 +1327,11 @@
       "hash": "aecfe47a24398ae852fc11589f736813",
       "meta": {
         "api_provider_id": "minimax-lightning",
-        "kind": "provider_models"
+        "kind": "provider_models",
+        "linked_model_ids": [
+          "minimax/minimax-m2.1",
+          "minimax/minimax-m2.7"
+        ]
       }
     },
     "../../packages/data/catalog/src/data/api_providers/mistral/api_provider.json": {
@@ -1289,7 +1398,7 @@
       }
     },
     "../../packages/data/catalog/src/data/api_providers/moonshotai/models.json": {
-      "hash": "1d36a875d9b796538a5687245cbb635c",
+      "hash": "41650e9688982634a96aa7bc549e2b29",
       "meta": {
         "api_provider_id": "moonshotai",
         "kind": "provider_models",
@@ -1307,7 +1416,8 @@
           "moonshotai/moonshot-v1-128k",
           "moonshotai/moonshot-v1-8k-vision-preview",
           "moonshotai/moonshot-v1-32k-vision-preview",
-          "moonshotai/moonshot-v1-128k-vision-preview"
+          "moonshotai/moonshot-v1-128k-vision-preview",
+          "moonshotai/kimi-k3"
         ]
       }
     },
@@ -1321,7 +1431,12 @@
       "hash": "0c66f8b92551e2192daf440acf2d0320",
       "meta": {
         "api_provider_id": "moonshotai-turbo",
-        "kind": "provider_models"
+        "kind": "provider_models",
+        "linked_model_ids": [
+          "moonshotai/kimi-k2",
+          "moonshotai/kimi-k2-0905",
+          "moonshotai/kimi-k2-thinking"
+        ]
       }
     },
     "../../packages/data/catalog/src/data/api_providers/morph/api_provider.json": {
@@ -1430,7 +1545,22 @@
       "hash": "6bcd25a494abaa238a49cb29d550a4bc",
       "meta": {
         "api_provider_id": "nextbit",
-        "kind": "provider_models"
+        "kind": "provider_models",
+        "linked_model_ids": [
+          "google/gemma-2-27b",
+          "z-ai/glm-4.7",
+          "openai/gpt-oss-20b",
+          "nous/hermes-3-llama-3.1-70b",
+          "nousresearch/hermes-3-llama-3.1-70b",
+          "moonshotai/kimi-k2.5",
+          "mooonshotai/kimi-k2.5",
+          "microsoft/phi-4",
+          "minimax/minimax-m2.5",
+          "qwen/qwen3-14b",
+          "qwen/qwen3-30b",
+          "qwen/qwq-32b",
+          "mistral/mistral-8b-2512"
+        ]
       }
     },
     "../../packages/data/catalog/src/data/api_providers/nousresearch/api_provider.json": {
@@ -1446,7 +1576,7 @@
       }
     },
     "../../packages/data/catalog/src/data/api_providers/novita/models.json": {
-      "hash": "47667fd6a2574e8955d4ebe41bad4278",
+      "hash": "ab08736961cffdfde6e203ff399b1d37",
       "meta": {
         "api_provider_id": "novita",
         "kind": "provider_models",
@@ -1556,13 +1686,13 @@
       }
     },
     "../../packages/data/catalog/src/data/api_providers/openai/api_provider.json": {
-      "hash": "5a89f771756075d57bc65d989ed2d547",
+      "hash": "e9f00d8dce91c1e20e7abee70b1a8611",
       "meta": {
         "api_provider_id": "openai"
       }
     },
     "../../packages/data/catalog/src/data/api_providers/openai/models.json": {
-      "hash": "ff0bcd129a75144267cfbbc2aad50e5b",
+      "hash": "a679bbe5693a7a722af2b91217d1a6ad",
       "meta": {
         "api_provider_id": "openai",
         "kind": "provider_models",
@@ -1636,8 +1766,11 @@
           "openai/gpt-5-nano",
           "openai/gpt-5-pro",
           "openai/gpt-5.6-luna",
+          "openai/gpt-5.6-luna-pro",
           "openai/gpt-5.6-sol",
+          "openai/gpt-5.6-sol-pro",
           "openai/gpt-5.6-terra",
+          "openai/gpt-5.6-terra-pro",
           "openai/gpt-audio",
           "openai/gpt-audio-1.5",
           "openai/gpt-audio-mini-2025-10-06",
@@ -1645,6 +1778,8 @@
           "openai/gpt-image-1.5",
           "openai/gpt-image-2",
           "openai/gpt-image-1-mini",
+          "openai/gpt-live-1",
+          "openai/gpt-live-1-mini",
           "openai/gpt-realtime",
           "openai/gpt-realtime-1.5",
           "openai/gpt-realtime-2",
@@ -1726,7 +1861,7 @@
       }
     },
     "../../packages/data/catalog/src/data/api_providers/siliconflow/models.json": {
-      "hash": "c20eb859dccc463f7e1e06290624a4ff",
+      "hash": "aa1d978a047c854124b4e16a8cbd2c9d",
       "meta": {
         "api_provider_id": "siliconflow",
         "kind": "provider_models",
@@ -1785,6 +1920,8 @@
           "qwen/qwq-32b",
           "stepfun/step-3.5-flash",
           "tencent/hunyuan-a13b-instruct",
+          "tencent/hy3",
+          "tencent/hy3:free",
           "tencent/hy3-preview",
           "z-ai/glm-4.5-air",
           "z-ai/glm-4.6",
@@ -1833,7 +1970,19 @@
       "hash": "26fde6d4875f2f405d7198818f6b587f",
       "meta": {
         "api_provider_id": "suno",
-        "kind": "provider_models"
+        "kind": "provider_models",
+        "linked_model_ids": [
+          "suno/suno-v4",
+          "suno/suno-v4.5",
+          "suno/suno-v4.5+",
+          "suno/suno-v4.5-all",
+          "suno/suno-v5",
+          "suno/v4",
+          "suno/v4.5",
+          "suno/v4.5+",
+          "suno/v4.5-all",
+          "suno/v5"
+        ]
       }
     },
     "../../packages/data/catalog/src/data/api_providers/together/api_provider.json": {
@@ -1887,7 +2036,7 @@
       }
     },
     "../../packages/data/catalog/src/data/api_providers/venice/models.json": {
-      "hash": "3e0eb765602578e2d053d96199dcf73c",
+      "hash": "f3a47818af78807e1a37290aefa04ded",
       "meta": {
         "api_provider_id": "venice",
         "kind": "provider_models",
@@ -1943,12 +2092,12 @@
           "qwen/qwen3-vl-235b-a22b",
           "venice/venice-uncensored",
           "venice/venice-uncensored-1.1",
-          "x-ai/grok-4.1-fast",
-          "x-ai/grok-4.20",
-          "x-ai/grok-4.20-beta-0309",
-          "x-ai/grok-4.20-multi-agent-beta",
-          "x-ai/grok-4.20-multi-agent-beta-0309",
-          "x-ai/grok-code-fast-1",
+          "spacex-ai/grok-4.1-fast",
+          "spacex-ai/grok-4.20",
+          "spacex-ai/grok-4.20-beta-0309",
+          "spacex-ai/grok-4.20-multi-agent-beta",
+          "spacex-ai/grok-4.20-multi-agent-beta-0309",
+          "spacex-ai/grok-code-fast-1",
           "z-ai/glm-4.6",
           "z-ai/glm-4.7",
           "z-ai/glm-4.7-flash",
@@ -1962,8 +2111,8 @@
           "qwen/qwen3.6-35b-a3b",
           "openai/gpt-5.5",
           "openai/gpt-5.5-pro",
-          "x-ai/grok-4.3",
-          "x-ai/grok-build-0.1",
+          "spacex-ai/grok-4.3",
+          "spacex-ai/grok-build-0.1",
           "qwen/qwen3.5-397b-a17b",
           "qwen/qwen3.6-27b",
           "inception/mercury-2",
@@ -2013,7 +2162,37 @@
       "hash": "10834689bd140c4b4d4a9b3fefeacfae",
       "meta": {
         "api_provider_id": "voyage",
-        "kind": "provider_models"
+        "kind": "provider_models",
+        "linked_model_ids": [
+          "voyage/voyage-4-large",
+          "voyage/voyage-4",
+          "voyage/voyage-4-lite",
+          "voyage/voyage-context-3",
+          "voyage/voyage-code-3",
+          "voyage/voyage-finance-2",
+          "voyage/voyage-law-2",
+          "voyage/voyage-code-2",
+          "voyage/voyage-3-large",
+          "voyage/voyage-3.5",
+          "voyage/voyage-3.5-lite",
+          "voyage/voyage-multilingual-2",
+          "voyage/voyage-large-2-instruct",
+          "voyage/voyage-large-2",
+          "voyage/voyage-01",
+          "voyage/voyage-lite-01",
+          "voyage/voyage-lite-01-instruct",
+          "voyage/voyage-02",
+          "voyage/voyage-lite-02-instruct",
+          "voyage/voyage-2",
+          "voyage/voyage-3",
+          "voyage/voyage-3-lite",
+          "voyage/rerank-1",
+          "voyage/rerank-2",
+          "voyage/rerank-lite-1",
+          "voyage/rerank-2-lite",
+          "voyage/voyage-multimodal-3.5",
+          "voyage/voyage-multimodal-3"
+        ]
       }
     },
     "../../packages/data/catalog/src/data/api_providers/weights-and-biases/api_provider.json": {
@@ -2064,43 +2243,6 @@
           "z-ai/glm-4.5",
           "z-ai/glm-5",
           "z-ai/glm-5.1"
-        ]
-      }
-    },
-    "../../packages/data/catalog/src/data/api_providers/x-ai/api_provider.json": {
-      "hash": "8a0ef918b7e47a45dab4ee7693d7d83d",
-      "meta": {
-        "api_provider_id": "x-ai"
-      }
-    },
-    "../../packages/data/catalog/src/data/api_providers/x-ai/models.json": {
-      "hash": "b78af96866fa61d53dc917506e8b9d5e",
-      "meta": {
-        "api_provider_id": "x-ai",
-        "kind": "provider_models",
-        "linked_model_ids": [
-          "x-ai/grok-2-vision-1212",
-          "x-ai/grok-2-vision",
-          "x-ai/grok-3",
-          "x-ai/grok-3-mini",
-          "x-ai/grok-4",
-          "x-ai/grok-4.1-non-thinking",
-          "x-ai/grok-4.1",
-          "x-ai/grok-4.1-thinking",
-          "x-ai/grok-4.20",
-          "x-ai/grok-4.20-beta-0309",
-          "x-ai/grok-4.20-multi-agent-beta",
-          "x-ai/grok-4.20-multi-agent-beta-0309",
-          "x-ai/grok-4.3",
-          "x-ai/grok-code-fast-1",
-          "x-ai/grok-imagine-image",
-          "x-ai/grok-tts",
-          "x-ai/grok-imagine-image-pro",
-          "x-ai/grok-imagine-image-quality",
-          "x-ai/grok-imagine-video",
-          "x-ai/grok-imagine-video-1.5-preview",
-          "x-ai/grok-build-0.1",
-          "x-ai/grok-imagine-video-1.5"
         ]
       }
     },
@@ -2172,7 +2314,7 @@
       }
     },
     "../../packages/data/catalog/src/data/models/mistral/mistral-medium-3.5/model.json": {
-      "hash": "0f421d240490aa1ef23c2e5364a6720b",
+      "hash": "7e26416e11fe46705abe685311ef87fe",
       "meta": {
         "model_id": "mistral/mistral-medium-3.5",
         "organisation_id": "mistral",
@@ -5827,7 +5969,7 @@
       }
     },
     "../../packages/data/catalog/src/data/organisations/crofai/organisation.json": {
-      "hash": "7b5c40cdc4434399aa8c6e667e1bd13c",
+      "hash": "a96af8d2644d5f7580fbdb6020ed296a",
       "meta": {
         "organisation_id": "crofai"
       }
@@ -5887,7 +6029,7 @@
       }
     },
     "../../packages/data/catalog/src/data/organisations/kwaipilot/organisation.json": {
-      "hash": "e9122afc46783038bcc1e4b4c219de5e",
+      "hash": "28cb0172b5f250a36871ab0f6f5b0d9f",
       "meta": {
         "organisation_id": "kwaipilot"
       }
@@ -6031,7 +6173,7 @@
       }
     },
     "../../packages/data/catalog/src/data/organisations/venice/organisation.json": {
-      "hash": "7f682b6d878e288b8b18b3a4b27d15ee",
+      "hash": "87119a438d1284f12ad2e80ab6fff2a3",
       "meta": {
         "organisation_id": "venice"
       }
@@ -6046,12 +6188,6 @@
       "hash": "04704d252eea33f2cc2358ddd6b0f4f2",
       "meta": {
         "organisation_id": "voyage"
-      }
-    },
-    "../../packages/data/catalog/src/data/organisations/x-ai/organisation.json": {
-      "hash": "1d6d82ed33939489fb363127a97fc767",
-      "meta": {
-        "organisation_id": "x-ai"
       }
     },
     "../../packages/data/catalog/src/data/organisations/xiaomi/organisation.json": {
@@ -6431,7 +6567,7 @@
       }
     },
     "../../packages/data/catalog/src/data/models/ai21/jamba-large-1.5/model.json": {
-      "hash": "20f4ccc97861169dd64be31fff7aa2e5",
+      "hash": "ea6fb2bcef5cb3a4380fb3417ab285b6",
       "meta": {
         "model_id": "ai21/jamba-large-1.5",
         "organisation_id": "ai21",
@@ -6441,7 +6577,7 @@
       }
     },
     "../../packages/data/catalog/src/data/models/ai21/jamba-large-1.6/model.json": {
-      "hash": "32f16e0e646f5eb25cf1e7bf50233c0e",
+      "hash": "d2c6a2032b959bc83ea676e3bc95a381",
       "meta": {
         "model_id": "ai21/jamba-large-1.6",
         "organisation_id": "ai21",
@@ -6451,7 +6587,7 @@
       }
     },
     "../../packages/data/catalog/src/data/models/ai21/jamba-large-1.7/model.json": {
-      "hash": "8bba005c4dfbb8572937735ef7be9b64",
+      "hash": "d790793f4f54036aab06bfa732b4a0db",
       "meta": {
         "model_id": "ai21/jamba-large-1.7",
         "organisation_id": "ai21",
@@ -6461,7 +6597,7 @@
       }
     },
     "../../packages/data/catalog/src/data/models/ai21/jamba-mini-1.5/model.json": {
-      "hash": "a42ac7a2161685789ba8556ccdb5ab43",
+      "hash": "74a41ce76bc151802e3a75ded8e34079",
       "meta": {
         "model_id": "ai21/jamba-mini-1.5",
         "organisation_id": "ai21",
@@ -6471,7 +6607,7 @@
       }
     },
     "../../packages/data/catalog/src/data/models/ai21/jamba-mini-1.6/model.json": {
-      "hash": "7b4f838d22fa6d0202f642e78d614fa3",
+      "hash": "4294eca05d1eb632d417b4c469c2dee1",
       "meta": {
         "model_id": "ai21/jamba-mini-1.6",
         "organisation_id": "ai21",
@@ -6481,7 +6617,7 @@
       }
     },
     "../../packages/data/catalog/src/data/models/ai21/jamba-mini-1.7/model.json": {
-      "hash": "05b69136eff29d60d61c9922d146c7be",
+      "hash": "a2d5fea54cdd859a99d4f09441ea6f9b",
       "meta": {
         "model_id": "ai21/jamba-mini-1.7",
         "organisation_id": "ai21",
@@ -6501,7 +6637,7 @@
       }
     },
     "../../packages/data/catalog/src/data/models/ai21/jamba-reasoning-3b/model.json": {
-      "hash": "ab98bd80c862b5f188b5fe0407341d80",
+      "hash": "a1cfc0455b797fcdea912051a9fc55ec",
       "meta": {
         "model_id": "ai21/jamba-reasoning-3b",
         "organisation_id": "ai21",
@@ -6511,7 +6647,7 @@
       }
     },
     "../../packages/data/catalog/src/data/models/aion-labs/aion-1.0/model.json": {
-      "hash": "46729e7f378d426b71965d4537f58424",
+      "hash": "5be7ea1c4680c8fe635c4c1c4220ae4a",
       "meta": {
         "model_id": "aion-labs/aion-1.0",
         "organisation_id": "aion-labs",
@@ -6521,7 +6657,7 @@
       }
     },
     "../../packages/data/catalog/src/data/models/aion-labs/aion-1.0-mini/model.json": {
-      "hash": "5d94a6f1c3176b5fc80d8361b82e5bd4",
+      "hash": "6f3420a8ba5c7871f6c4a7824ea5629f",
       "meta": {
         "model_id": "aion-labs/aion-1.0-mini",
         "organisation_id": "aion-labs",
@@ -6601,7 +6737,7 @@
       }
     },
     "../../packages/data/catalog/src/data/models/allenai/olmo-3-32b-think/model.json": {
-      "hash": "a8a7a8e2acd23ba6f4f5ee94ccf25c27",
+      "hash": "f449208fb722e7fb7db3724e8913c8c3",
       "meta": {
         "model_id": "allenai/olmo-3-32b-think",
         "organisation_id": "allenai",
@@ -6611,7 +6747,7 @@
       }
     },
     "../../packages/data/catalog/src/data/models/allenai/olmo-3-7b-instruct/model.json": {
-      "hash": "4c0b98709835d1a34d443be8e39905a3",
+      "hash": "ab18bad482ee119d659ef0c243ed2fb0",
       "meta": {
         "model_id": "allenai/olmo-3-7b-instruct",
         "organisation_id": "allenai",
@@ -6621,7 +6757,7 @@
       }
     },
     "../../packages/data/catalog/src/data/models/allenai/olmo-3-7b-think/model.json": {
-      "hash": "9bf8803b05fc2dc744b28b4bcbacd134",
+      "hash": "b11a2abe1c361b989eb4672f52f71003",
       "meta": {
         "model_id": "allenai/olmo-3-7b-think",
         "organisation_id": "allenai",
@@ -6651,7 +6787,7 @@
       }
     },
     "../../packages/data/catalog/src/data/models/amazon/nova-2-lite/model.json": {
-      "hash": "51c158f62bdb042984a2eb949c868265",
+      "hash": "e27a1ce426f9db88f0d26ba7583b25e6",
       "meta": {
         "model_id": "amazon/nova-2-lite",
         "organisation_id": "amazon",
@@ -6661,7 +6797,7 @@
       }
     },
     "../../packages/data/catalog/src/data/models/amazon/nova-2-omni/model.json": {
-      "hash": "60ad34440ea18ae38ab02fc9c64c7eb2",
+      "hash": "9369addafd2e2a27754d4d21e72e0a40",
       "meta": {
         "model_id": "amazon/nova-2-omni",
         "organisation_id": "amazon",
@@ -6671,7 +6807,7 @@
       }
     },
     "../../packages/data/catalog/src/data/models/amazon/nova-2-pro/model.json": {
-      "hash": "b9c2d79162a6c3e5920db03bd8222b36",
+      "hash": "f81d052a9df7ddae2e3ead1dafc566a8",
       "meta": {
         "model_id": "amazon/nova-2-pro",
         "organisation_id": "amazon",
@@ -6681,7 +6817,7 @@
       }
     },
     "../../packages/data/catalog/src/data/models/amazon/nova-2-sonic/model.json": {
-      "hash": "0a0ce3608f2878640b78b3c5c41aa638",
+      "hash": "f447650e94430814ceb629f1969942c4",
       "meta": {
         "model_id": "amazon/nova-2-sonic",
         "organisation_id": "amazon",
@@ -6701,7 +6837,7 @@
       }
     },
     "../../packages/data/catalog/src/data/models/amazon/nova-lite-1.0/model.json": {
-      "hash": "c87d56efe77ff828aef1c97897259985",
+      "hash": "d4bec9afe53a0ae64649b05b518d18f7",
       "meta": {
         "model_id": "amazon/nova-lite-1.0",
         "organisation_id": "amazon",
@@ -6711,7 +6847,7 @@
       }
     },
     "../../packages/data/catalog/src/data/models/amazon/nova-micro-1.0/model.json": {
-      "hash": "3c96fb6855eff60ad5b377ba0134ee63",
+      "hash": "ef935e5bf2c6247ad17a2add6ec78841",
       "meta": {
         "model_id": "amazon/nova-micro-1.0",
         "organisation_id": "amazon",
@@ -6721,7 +6857,7 @@
       }
     },
     "../../packages/data/catalog/src/data/models/amazon/nova-multimodal-embeddings/model.json": {
-      "hash": "e8670e5e335c7d0baed629e7ae1208ea",
+      "hash": "8548bf2553350613cb9c52d4f7932ff2",
       "meta": {
         "model_id": "amazon/nova-multimodal-embeddings",
         "organisation_id": "amazon",
@@ -6731,7 +6867,7 @@
       }
     },
     "../../packages/data/catalog/src/data/models/amazon/nova-premier/model.json": {
-      "hash": "7e60d969ca1152a2feb5c591697b34a4",
+      "hash": "bd4209279ca85fb71e49daa96f764d25",
       "meta": {
         "model_id": "amazon/nova-premier",
         "organisation_id": "amazon",
@@ -6741,7 +6877,7 @@
       }
     },
     "../../packages/data/catalog/src/data/models/amazon/nova-pro-1.0/model.json": {
-      "hash": "84c5fcdc74fb5b4a73f6bcd381bd5a56",
+      "hash": "a5ae49cf2f8ddef39b3ecab6ce853d0a",
       "meta": {
         "model_id": "amazon/nova-pro-1.0",
         "organisation_id": "amazon",
@@ -6811,7 +6947,7 @@
       }
     },
     "../../packages/data/catalog/src/data/models/anthropic/claude-2.0/model.json": {
-      "hash": "a5316516ea14dd8cf95c26bee79d3eef",
+      "hash": "9f558e6782d695a2f5d98b1957ad9173",
       "meta": {
         "model_id": "anthropic/claude-2.0",
         "organisation_id": "anthropic",
@@ -6821,7 +6957,7 @@
       }
     },
     "../../packages/data/catalog/src/data/models/anthropic/claude-2.1/model.json": {
-      "hash": "8810c095e99925c7329b9dc6bf97ad0d",
+      "hash": "713bc8e5b2cfe5a7d84727c949f8fe54",
       "meta": {
         "model_id": "anthropic/claude-2.1",
         "organisation_id": "anthropic",
@@ -6831,7 +6967,7 @@
       }
     },
     "../../packages/data/catalog/src/data/models/anthropic/claude-3-haiku/model.json": {
-      "hash": "9ac82795123e1c3432e96355a9bc896a",
+      "hash": "a8176be9f702b5283afbfc55d8ae491d",
       "meta": {
         "model_id": "anthropic/claude-3-haiku",
         "organisation_id": "anthropic",
@@ -6841,7 +6977,7 @@
       }
     },
     "../../packages/data/catalog/src/data/models/anthropic/claude-3-opus/model.json": {
-      "hash": "7faa64399e4294a06c502e5abfe9458e",
+      "hash": "c0e7c2d865258b2a062b270b88dc9ecb",
       "meta": {
         "model_id": "anthropic/claude-3-opus",
         "organisation_id": "anthropic",
@@ -6851,7 +6987,7 @@
       }
     },
     "../../packages/data/catalog/src/data/models/anthropic/claude-3-sonnet/model.json": {
-      "hash": "a85fd0728af48b1058708897df7d25ca",
+      "hash": "4a86e2221fba5007b7e28a709789d197",
       "meta": {
         "model_id": "anthropic/claude-3-sonnet",
         "organisation_id": "anthropic",
@@ -6861,7 +6997,7 @@
       }
     },
     "../../packages/data/catalog/src/data/models/anthropic/claude-3.5-haiku/model.json": {
-      "hash": "648cf05c13bbbba2a73a1d692f8bf916",
+      "hash": "0961d14520486c7a19eb6cefd9ee34ca",
       "meta": {
         "model_id": "anthropic/claude-3.5-haiku",
         "organisation_id": "anthropic",
@@ -6871,7 +7007,7 @@
       }
     },
     "../../packages/data/catalog/src/data/models/anthropic/claude-3.5-sonnet-2024-06-20/model.json": {
-      "hash": "d005617a60a2eda9ed85406a74fbf9cb",
+      "hash": "4787246642449ce02aaf2309c325e6f7",
       "meta": {
         "model_id": "anthropic/claude-3.5-sonnet-2024-06-20",
         "organisation_id": "anthropic",
@@ -6891,7 +7027,7 @@
       }
     },
     "../../packages/data/catalog/src/data/models/anthropic/claude-3.7-sonnet/model.json": {
-      "hash": "4efe408f4ebbd85e2599532e9a1fcbf7",
+      "hash": "34789b00748fd38fdffa05b265e189de",
       "meta": {
         "model_id": "anthropic/claude-3.7-sonnet",
         "organisation_id": "anthropic",
@@ -6901,7 +7037,7 @@
       }
     },
     "../../packages/data/catalog/src/data/models/anthropic/claude-haiku-4.5/model.json": {
-      "hash": "fbad9bc21ccbe4dd9edbb5ea5a59cda8",
+      "hash": "a3d73cf43b5d9b27dd02b47c4988193a",
       "meta": {
         "model_id": "anthropic/claude-haiku-4.5",
         "organisation_id": "anthropic",
@@ -6941,7 +7077,7 @@
       }
     },
     "../../packages/data/catalog/src/data/models/anthropic/claude-mythos-preview/model.json": {
-      "hash": "6ec5a21a74e127cc369d9df404e11b00",
+      "hash": "4c843ba0cc0daa6f58c59600a1fd4c08",
       "meta": {
         "model_id": "anthropic/claude-mythos-preview",
         "organisation_id": "anthropic",
@@ -6951,7 +7087,7 @@
       }
     },
     "../../packages/data/catalog/src/data/models/anthropic/claude-opus-4/model.json": {
-      "hash": "8c31c1e7d5738d913335941d0aa532e6",
+      "hash": "9a92f688e2913e4603d4431b87134c91",
       "meta": {
         "model_id": "anthropic/claude-opus-4",
         "organisation_id": "anthropic",
@@ -6961,7 +7097,7 @@
       }
     },
     "../../packages/data/catalog/src/data/models/anthropic/claude-opus-4.1/model.json": {
-      "hash": "b46cabac59d4bfcf248aeb0ecbc6ae45",
+      "hash": "51d55ea9f94592037f0a90c577a88448",
       "meta": {
         "model_id": "anthropic/claude-opus-4.1",
         "organisation_id": "anthropic",
@@ -6971,7 +7107,7 @@
       }
     },
     "../../packages/data/catalog/src/data/models/anthropic/claude-opus-4.5/model.json": {
-      "hash": "71992f77f2c62ea9cf92a31de142e01e",
+      "hash": "51ff9fb69e766cb1e37b1e27271a4369",
       "meta": {
         "model_id": "anthropic/claude-opus-4.5",
         "organisation_id": "anthropic",
@@ -6991,7 +7127,7 @@
       }
     },
     "../../packages/data/catalog/src/data/models/anthropic/claude-opus-4.7/model.json": {
-      "hash": "dfc0e133b494ce3f38b7b98ad0942268",
+      "hash": "0413a9794770b26a6349a6a8bd9ee31d",
       "meta": {
         "model_id": "anthropic/claude-opus-4.7",
         "organisation_id": "anthropic",
@@ -7001,7 +7137,7 @@
       }
     },
     "../../packages/data/catalog/src/data/models/anthropic/claude-sonnet-4/model.json": {
-      "hash": "9bd8a1ca1f9bb50962af224b96008eae",
+      "hash": "3bd541e513cfdfd804863d401d6dca37",
       "meta": {
         "model_id": "anthropic/claude-sonnet-4",
         "organisation_id": "anthropic",
@@ -7011,7 +7147,7 @@
       }
     },
     "../../packages/data/catalog/src/data/models/anthropic/claude-sonnet-4.5/model.json": {
-      "hash": "3c132b803d8ed161ae77fb26fa37be39",
+      "hash": "1ff6d54e82429cd3d0386134d82b83a3",
       "meta": {
         "model_id": "anthropic/claude-sonnet-4.5",
         "organisation_id": "anthropic",
@@ -7041,7 +7177,7 @@
       }
     },
     "../../packages/data/catalog/src/data/models/arcee-ai/trinity-large-thinking/model.json": {
-      "hash": "794ca795d1bf7a258df4f6eaa4793d11",
+      "hash": "b9dd993bfbeebbb5ea972ecf5f7302f8",
       "meta": {
         "model_id": "arcee-ai/trinity-large-thinking",
         "organisation_id": "arcee-ai",
@@ -7421,7 +7557,7 @@
       }
     },
     "../../packages/data/catalog/src/data/models/bytedance/seed-2.0-code-preview-2026-02-15/model.json": {
-      "hash": "430c4585e82c4056ad23101dfe1e17b0",
+      "hash": "15d5ee6b4b15029877ea9d136a648d66",
       "meta": {
         "model_id": "bytedance/seed-2.0-code-preview-2026-02-15",
         "organisation_id": "bytedance",
@@ -7431,7 +7567,7 @@
       }
     },
     "../../packages/data/catalog/src/data/models/bytedance/seed-2.0-lite/model.json": {
-      "hash": "35b1f910ad1c32d61dc6d922d59d62ec",
+      "hash": "f7e1e12d8e7c2261ea45e23a98249212",
       "meta": {
         "model_id": "bytedance/seed-2.0-lite",
         "organisation_id": "bytedance",
@@ -7441,7 +7577,7 @@
       }
     },
     "../../packages/data/catalog/src/data/models/bytedance/seed-2.0-mini/model.json": {
-      "hash": "3c34f3ebc384597780ccbe3243068a77",
+      "hash": "76bd1f31c8597c7f11043e73ba568982",
       "meta": {
         "model_id": "bytedance/seed-2.0-mini",
         "organisation_id": "bytedance",
@@ -7451,7 +7587,7 @@
       }
     },
     "../../packages/data/catalog/src/data/models/bytedance/seed-2.0-pro/model.json": {
-      "hash": "315e124c62bde9b4bc94cc69c16b12ae",
+      "hash": "4f3e7372f6e3753a2beecef91d164e38",
       "meta": {
         "model_id": "bytedance/seed-2.0-pro",
         "organisation_id": "bytedance",
@@ -7531,7 +7667,7 @@
       }
     },
     "../../packages/data/catalog/src/data/models/bytedance/seedance-2.0/model.json": {
-      "hash": "8f5271dc60c346dc46a3b765054017d0",
+      "hash": "f4c103f9a33543dd7fba0909d0cae2ed",
       "meta": {
         "model_id": "bytedance/seedance-2.0",
         "organisation_id": "bytedance",
@@ -7541,7 +7677,7 @@
       }
     },
     "../../packages/data/catalog/src/data/models/bytedance/seedance-2.0-fast/model.json": {
-      "hash": "df7590dcfb36de7964ef2f5faea4cfc2",
+      "hash": "fafab2452a82f05e4609a74cd1ddedc5",
       "meta": {
         "model_id": "bytedance/seedance-2.0-fast",
         "organisation_id": "bytedance",
@@ -7551,7 +7687,7 @@
       }
     },
     "../../packages/data/catalog/src/data/models/bytedance/seedance-2.0-mini-260615/model.json": {
-      "hash": "f1f5d86cd27782254a83997e3174542b",
+      "hash": "0cfb98f21f20f70c932d52ecb718263a",
       "meta": {
         "model_id": "bytedance/seedance-2.0-mini-260615",
         "organisation_id": "bytedance",
@@ -7639,7 +7775,7 @@
       }
     },
     "../../packages/data/catalog/src/data/models/cohere/command/model.json": {
-      "hash": "6bb5cf17e2ecb03d3926cb049f88a3ab",
+      "hash": "371643ede93ceec68202168d28801bc8",
       "meta": {
         "model_id": "cohere/command",
         "organisation_id": "cohere",
@@ -7649,11 +7785,13 @@
       }
     },
     "../../packages/data/catalog/src/data/models/cohere/command-a/model.json": {
-      "hash": "8bb85b03fbe0b6988dd49f6f8634a606",
+      "hash": "69e8f0480562594d55aa93c6e62035dc",
       "meta": {
         "model_id": "cohere/command-a",
         "organisation_id": "cohere",
-        "previous_model_id": "cohere/command-r-2024-08-30"
+        "previous_model_id": "cohere/command-r-2024-08-30",
+        "api_model_id": "cohere/command-a",
+        "has_page_notice": false
       }
     },
     "../../packages/data/catalog/src/data/models/cohere/command-a-reasoning/model.json": {
@@ -7687,7 +7825,7 @@
       }
     },
     "../../packages/data/catalog/src/data/models/cohere/command-light/model.json": {
-      "hash": "f431b33b6d95c0599fe9a81ad4908cff",
+      "hash": "8003a9f921dd875bbf6c2d1944fa3662",
       "meta": {
         "model_id": "cohere/command-light",
         "organisation_id": "cohere",
@@ -7697,7 +7835,7 @@
       }
     },
     "../../packages/data/catalog/src/data/models/cohere/command-r--2024-04-04/model.json": {
-      "hash": "549241c1b87d77dbcf8aa9609c7d0171",
+      "hash": "357a5317f2037c59137f45e0a0607fb9",
       "meta": {
         "model_id": "cohere/command-r+-2024-04-04",
         "organisation_id": "cohere",
@@ -7717,7 +7855,7 @@
       }
     },
     "../../packages/data/catalog/src/data/models/cohere/command-r-2024-03-11/model.json": {
-      "hash": "579124b1fd9c6a54c6a1e7a0777ab6a3",
+      "hash": "469d591b78881e5c1e78dedde06c4be8",
       "meta": {
         "model_id": "cohere/command-r-2024-03-11",
         "organisation_id": "cohere",
@@ -7737,7 +7875,7 @@
       }
     },
     "../../packages/data/catalog/src/data/models/cohere/command-r-7b/model.json": {
-      "hash": "43a380555c8787d6df78186308f40bee",
+      "hash": "503fc853d7f87477babcc15730651cb8",
       "meta": {
         "model_id": "cohere/command-r-7b",
         "organisation_id": "cohere",
@@ -7931,7 +8069,7 @@
       }
     },
     "../../packages/data/catalog/src/data/models/crofai/greg/model.json": {
-      "hash": "2bec9c94def783418c67a0e5b858819e",
+      "hash": "b20e8a2fbaebcfef33e034e393d498ca",
       "meta": {
         "model_id": "crofai/greg",
         "organisation_id": "crofai",
@@ -7951,7 +8089,7 @@
       }
     },
     "../../packages/data/catalog/src/data/models/cursor/composer-1.5/model.json": {
-      "hash": "d054687058be2b96b4e791cb4147dc21",
+      "hash": "0b1d9380fc997059e166ef4442e9e763",
       "meta": {
         "model_id": "cursor/composer-1.5",
         "organisation_id": "cursor",
@@ -8021,7 +8159,7 @@
       }
     },
     "../../packages/data/catalog/src/data/models/deepseek/deepseek-r1-2025-01-20/model.json": {
-      "hash": "c9861e8603367fb27f2b96f670ca8c9e",
+      "hash": "c0dfd02240e2bc9e0965dce9c4bfd825",
       "meta": {
         "model_id": "deepseek/deepseek-r1-2025-01-20",
         "organisation_id": "deepseek",
@@ -8081,7 +8219,7 @@
       }
     },
     "../../packages/data/catalog/src/data/models/deepseek/deepseek-v2.5-2024-09-05/model.json": {
-      "hash": "739af5aa99c629a1fcf4fe87b09a951b",
+      "hash": "bbaec5e71a897abeb0629b62a2412216",
       "meta": {
         "model_id": "deepseek/deepseek-v2.5-2024-09-05",
         "organisation_id": "deepseek",
@@ -8111,7 +8249,7 @@
       }
     },
     "../../packages/data/catalog/src/data/models/deepseek/deepseek-v3-2024-12-26/model.json": {
-      "hash": "b4eb1445d38d047dbd622be471f0fa17",
+      "hash": "11c78d0d6783c9845606d5be9b072d18",
       "meta": {
         "model_id": "deepseek/deepseek-v3-2024-12-26",
         "organisation_id": "deepseek",
@@ -8181,7 +8319,7 @@
       }
     },
     "../../packages/data/catalog/src/data/models/deepseek/deepseek-v3.2-speciale/model.json": {
-      "hash": "349c9668187192cb16392ed31cdff849",
+      "hash": "536dc34678c06bb1e04a441358def795",
       "meta": {
         "model_id": "deepseek/deepseek-v3.2-speciale",
         "organisation_id": "deepseek",
@@ -8209,7 +8347,7 @@
       }
     },
     "../../packages/data/catalog/src/data/models/deepseek/deepseek-vl2/model.json": {
-      "hash": "63321ac230ab508777e4dc0ca2b9874f",
+      "hash": "98faa46290ae3e980cf20099b1519588",
       "meta": {
         "model_id": "deepseek/deepseek-vl2",
         "organisation_id": "deepseek",
@@ -8219,7 +8357,7 @@
       }
     },
     "../../packages/data/catalog/src/data/models/deepseek/deepseek-vl2-small/model.json": {
-      "hash": "5716b593eef93910518d7698ff90d3e1",
+      "hash": "22fa297e0167637eec7816a56050d28c",
       "meta": {
         "model_id": "deepseek/deepseek-vl2-small",
         "organisation_id": "deepseek",
@@ -8229,7 +8367,7 @@
       }
     },
     "../../packages/data/catalog/src/data/models/deepseek/deepseek-vl2-tiny/model.json": {
-      "hash": "5675e17ee3ccaa688c9aceb0c98fd19a",
+      "hash": "2f0a4266058bdee95d4e51f53974fea4",
       "meta": {
         "model_id": "deepseek/deepseek-vl2-tiny",
         "organisation_id": "deepseek",
@@ -8399,7 +8537,7 @@
       }
     },
     "../../packages/data/catalog/src/data/models/essential-ai/rnj-1/model.json": {
-      "hash": "536bc0cf284dd43215f51b5cb1b59eba",
+      "hash": "d0e13e24d19e4e6bd8b68f46a868a2b5",
       "meta": {
         "model_id": "essential-ai/rnj-1",
         "organisation_id": "essential-ai",
@@ -8429,7 +8567,7 @@
       }
     },
     "../../packages/data/catalog/src/data/models/google/deep-research-max-preview-04-2026/model.json": {
-      "hash": "7bd42f077ddf1712fe86f8f4bb0a67d0",
+      "hash": "dd3c17781e286a649cf9e006f666eee0",
       "meta": {
         "model_id": "google/deep-research-max-preview-04-2026",
         "organisation_id": "google",
@@ -8439,7 +8577,7 @@
       }
     },
     "../../packages/data/catalog/src/data/models/google/deep-research-preview-04-2026/model.json": {
-      "hash": "cfc231860bdc690c0b0033e52db9123b",
+      "hash": "228c3557852a9f013159975f55bc16ef",
       "meta": {
         "model_id": "google/deep-research-preview-04-2026",
         "organisation_id": "google",
@@ -8479,7 +8617,7 @@
       }
     },
     "../../packages/data/catalog/src/data/models/google/gemini-1.0-pro/model.json": {
-      "hash": "cba8701492e84850eb91167d6143bda6",
+      "hash": "c2876ebf2fbbc49f58116d5f51f704fe",
       "meta": {
         "model_id": "google/gemini-1.0-pro",
         "organisation_id": "google",
@@ -8519,7 +8657,7 @@
       }
     },
     "../../packages/data/catalog/src/data/models/google/gemini-1.5-flash-002/model.json": {
-      "hash": "40039fbbcb41c85b371f246fa8d863d7",
+      "hash": "9b28633bccfab91ad2345057773cda2f",
       "meta": {
         "model_id": "google/gemini-1.5-flash-002",
         "organisation_id": "google",
@@ -8529,7 +8667,7 @@
       }
     },
     "../../packages/data/catalog/src/data/models/google/gemini-1.5-flash-8b/model.json": {
-      "hash": "a79234409b8c04c2686ff13df3b571c3",
+      "hash": "e078e070a7acf2ddef149b24994562fc",
       "meta": {
         "model_id": "google/gemini-1.5-flash-8b",
         "organisation_id": "google",
@@ -8609,7 +8747,7 @@
       }
     },
     "../../packages/data/catalog/src/data/models/google/gemini-2.0-flash/model.json": {
-      "hash": "512084be4823846b52ca99cb6c75b55b",
+      "hash": "b579c9fea279fb99b2885ac4874f5395",
       "meta": {
         "model_id": "google/gemini-2.0-flash",
         "organisation_id": "google",
@@ -8639,7 +8777,7 @@
       }
     },
     "../../packages/data/catalog/src/data/models/google/gemini-2.0-flash-lite/model.json": {
-      "hash": "51113f90f94b8f2a9f69053456634217",
+      "hash": "8c8be5c460bd06e9ca788a5e6c331e48",
       "meta": {
         "model_id": "google/gemini-2.0-flash-lite",
         "organisation_id": "google",
@@ -8739,7 +8877,7 @@
       }
     },
     "../../packages/data/catalog/src/data/models/google/gemini-2.5-flash-lite-preview-2025-06-17/model.json": {
-      "hash": "e3c8e019aba23979aa5cf81587f282ef",
+      "hash": "8b4a6b7f9007fb85838dcd06df9bfea8",
       "meta": {
         "model_id": "google/gemini-2.5-flash-lite-preview-2025-06-17",
         "organisation_id": "google",
@@ -8769,7 +8907,7 @@
       }
     },
     "../../packages/data/catalog/src/data/models/google/gemini-2.5-flash-preview-2025-04-17/model.json": {
-      "hash": "977b2285f5bec15af8f5890bd5f86fa6",
+      "hash": "1cf9513a8dcccdccfa6bceabebe6b3bc",
       "meta": {
         "model_id": "google/gemini-2.5-flash-preview-2025-04-17",
         "organisation_id": "google",
@@ -8779,7 +8917,7 @@
       }
     },
     "../../packages/data/catalog/src/data/models/google/gemini-2.5-flash-preview-2025-05-20/model.json": {
-      "hash": "e1a75bf35a30d0d60c2acd39153ed1a8",
+      "hash": "4845b43b93c812f18bc9754910229a88",
       "meta": {
         "model_id": "google/gemini-2.5-flash-preview-2025-05-20",
         "organisation_id": "google",
@@ -8879,7 +9017,7 @@
       }
     },
     "../../packages/data/catalog/src/data/models/google/gemini-3-flash-preview/model.json": {
-      "hash": "2ea831bd2a67abf90d88cf83fc84ff10",
+      "hash": "c036c20ed21b94cd5150044121e0dfa6",
       "meta": {
         "model_id": "google/gemini-3-flash-preview",
         "organisation_id": "google",
@@ -8899,7 +9037,7 @@
       }
     },
     "../../packages/data/catalog/src/data/models/google/gemini-3-pro-preview/model.json": {
-      "hash": "11fd674e4424cf88103be1edcf700416",
+      "hash": "741ea2176b98a7977267b1044d36f3e1",
       "meta": {
         "model_id": "google/gemini-3-pro-preview",
         "organisation_id": "google",
@@ -8909,7 +9047,7 @@
       }
     },
     "../../packages/data/catalog/src/data/models/google/gemini-3.1-flash-image-preview/model.json": {
-      "hash": "1717d8459678f33cb202ea88e69c15c4",
+      "hash": "3ab9816a07557c6e8b8a19868467321a",
       "meta": {
         "model_id": "google/gemini-3.1-flash-image-preview",
         "organisation_id": "google",
@@ -8919,7 +9057,7 @@
       }
     },
     "../../packages/data/catalog/src/data/models/google/gemini-3.1-flash-lite-preview/model.json": {
-      "hash": "721b54bc841bbc8c0c7b7fd7b6b0b449",
+      "hash": "bf5fc1d25038fd683e2590a5fea510f1",
       "meta": {
         "model_id": "google/gemini-3.1-flash-lite-preview",
         "organisation_id": "google",
@@ -8929,7 +9067,7 @@
       }
     },
     "../../packages/data/catalog/src/data/models/google/gemini-3.1-flash-tts-preview/model.json": {
-      "hash": "90c1b88a8ed129c2b574ff92703fc70d",
+      "hash": "ff6eb51498e4b1cf4c6d5660987c9ecb",
       "meta": {
         "model_id": "google/gemini-3.1-flash-tts-preview",
         "organisation_id": "google",
@@ -8939,7 +9077,7 @@
       }
     },
     "../../packages/data/catalog/src/data/models/google/gemini-3.1-pro-preview/model.json": {
-      "hash": "548ffe097ba2c4fda58cad63d0820514",
+      "hash": "83d2d82d14c7e42b2adced963a35811c",
       "meta": {
         "model_id": "google/gemini-3.1-pro-preview",
         "organisation_id": "google",
@@ -8959,7 +9097,7 @@
       }
     },
     "../../packages/data/catalog/src/data/models/google/gemini-diffusion/model.json": {
-      "hash": "5fe8bc5db2054596009de13d3f47d753",
+      "hash": "d0e6fcf25f215212b299f6093272e518",
       "meta": {
         "model_id": "google/gemini-diffusion",
         "organisation_id": "google",
@@ -8969,7 +9107,7 @@
       }
     },
     "../../packages/data/catalog/src/data/models/google/gemini-embedding-001/model.json": {
-      "hash": "d19b0fc30263fce0fcbd290b6240f78e",
+      "hash": "d036c0c37ca0b1d85d282e8ad058d515",
       "meta": {
         "model_id": "google/gemini-embedding-001",
         "organisation_id": "google",
@@ -8979,7 +9117,7 @@
       }
     },
     "../../packages/data/catalog/src/data/models/google/gemini-embedding-2-preview/model.json": {
-      "hash": "b25bf87cd084d0ed549c0fe1244844dd",
+      "hash": "150a6c72ba4ca80c842b8c135b301623",
       "meta": {
         "model_id": "google/gemini-embedding-2-preview",
         "organisation_id": "google",
@@ -9049,7 +9187,7 @@
       }
     },
     "../../packages/data/catalog/src/data/models/google/gemini-robotics-er-1.6-preview/model.json": {
-      "hash": "3b2b116f416f209ddc8f9586185bbf81",
+      "hash": "3df7a79b1484f9d9bab4f71d0db5cd56",
       "meta": {
         "model_id": "google/gemini-robotics-er-1.6-preview",
         "organisation_id": "google",
@@ -9079,7 +9217,7 @@
       }
     },
     "../../packages/data/catalog/src/data/models/google/gemma-2-27b/model.json": {
-      "hash": "f79cb7d0120c570945eed288e97041d7",
+      "hash": "cb5d3f3158ccf5d6ca8adae00bb18952",
       "meta": {
         "model_id": "google/gemma-2-27b",
         "organisation_id": "google",
@@ -9099,7 +9237,7 @@
       }
     },
     "../../packages/data/catalog/src/data/models/google/gemma-2-9b/model.json": {
-      "hash": "7399f7bab772e8fccace439e998f18c8",
+      "hash": "091e95538c16e5ed844093d7ba7c1f55",
       "meta": {
         "model_id": "google/gemma-2-9b",
         "organisation_id": "google",
@@ -9109,7 +9247,7 @@
       }
     },
     "../../packages/data/catalog/src/data/models/google/gemma-3-12b/model.json": {
-      "hash": "fd3625c36455131c57b5eb1cec41ec14",
+      "hash": "aaa80dacfd5fda682c3484c8437c75fe",
       "meta": {
         "model_id": "google/gemma-3-12b",
         "organisation_id": "google",
@@ -9119,7 +9257,7 @@
       }
     },
     "../../packages/data/catalog/src/data/models/google/gemma-3-1b/model.json": {
-      "hash": "0db1d6b704fe6548b3d2cf35c0b27845",
+      "hash": "19904e0ae85d8c2cb224e5fdf20cfe5a",
       "meta": {
         "model_id": "google/gemma-3-1b",
         "organisation_id": "google",
@@ -9139,7 +9277,7 @@
       }
     },
     "../../packages/data/catalog/src/data/models/google/gemma-3-27b/model.json": {
-      "hash": "0eae38c91c8df67dcc20c4afd04097c1",
+      "hash": "1234b570a32bbb9da4f6b83e8fe07a0b",
       "meta": {
         "model_id": "google/gemma-3-27b",
         "organisation_id": "google",
@@ -9149,7 +9287,7 @@
       }
     },
     "../../packages/data/catalog/src/data/models/google/gemma-3-4b/model.json": {
-      "hash": "e716099c7434a92cdbe4eca803011520",
+      "hash": "9e26bf9324b0550b75822335536c6426",
       "meta": {
         "model_id": "google/gemma-3-4b",
         "organisation_id": "google",
@@ -9759,7 +9897,7 @@
       }
     },
     "../../packages/data/catalog/src/data/models/ibm/granite-3.3-2b-instruct/model.json": {
-      "hash": "77dbc5e7debbf3bddae3f194d511f84a",
+      "hash": "2fea3782840af7ca3d83f4a497605ad3",
       "meta": {
         "model_id": "ibm/granite-3.3-2b-instruct",
         "organisation_id": "ibm",
@@ -9769,7 +9907,7 @@
       }
     },
     "../../packages/data/catalog/src/data/models/ibm/granite-3.3-8b-instruct/model.json": {
-      "hash": "99f78c5f44c9b5cc18ca30ffefe0d9e5",
+      "hash": "1e1ad3fb5cd8a077df95e6bfc9add375",
       "meta": {
         "model_id": "ibm/granite-3.3-8b-instruct",
         "organisation_id": "ibm",
@@ -9849,7 +9987,7 @@
       }
     },
     "../../packages/data/catalog/src/data/models/ibm/granite-4.0-tiny-preview/model.json": {
-      "hash": "399f054657d7846819ce9f515a2e3c77",
+      "hash": "3d0ece1d02247f31ac5c12975425dd40",
       "meta": {
         "model_id": "ibm/granite-4.0-tiny-preview",
         "organisation_id": "ibm",
@@ -9859,7 +9997,7 @@
       }
     },
     "../../packages/data/catalog/src/data/models/ibm/granite-4.1-30b/model.json": {
-      "hash": "5e5d4f17ebed8607c453f02e57879e57",
+      "hash": "bf1f191afc15555f4813608d965295b7",
       "meta": {
         "model_id": "ibm/granite-4.1-30b",
         "organisation_id": "ibm",
@@ -9869,7 +10007,7 @@
       }
     },
     "../../packages/data/catalog/src/data/models/ibm/granite-4.1-3b/model.json": {
-      "hash": "77524a1c9b68685e34b8e64bc7a7daa8",
+      "hash": "8197e7541cda80d51b2b025aa9d2ab3c",
       "meta": {
         "model_id": "ibm/granite-4.1-3b",
         "organisation_id": "ibm",
@@ -10109,7 +10247,7 @@
       }
     },
     "../../packages/data/catalog/src/data/models/inclusionai/ling-flash-2.0/model.json": {
-      "hash": "e67649a56b002a83bf0a73a4f17386db",
+      "hash": "b71e21ae0b0132bca1743512e1413c39",
       "meta": {
         "model_id": "inclusionai/ling-flash-2.0",
         "organisation_id": "inclusionai",
@@ -10119,7 +10257,7 @@
       }
     },
     "../../packages/data/catalog/src/data/models/inclusionai/ring-1t-2.5/model.json": {
-      "hash": "86923c952354121389c8ade38551c0b9",
+      "hash": "e65cedb41b8dc47d1526e78b191d85d1",
       "meta": {
         "model_id": "inclusionai/ring-1t-2.5",
         "organisation_id": "inclusionai",
@@ -10129,7 +10267,7 @@
       }
     },
     "../../packages/data/catalog/src/data/models/inclusionai/ring-flash-2.0/model.json": {
-      "hash": "50183224023d2629426dfbe3ffc456ab",
+      "hash": "e0a328d527907a8433aaa1fe4560f484",
       "meta": {
         "model_id": "inclusionai/ring-flash-2.0",
         "organisation_id": "inclusionai",
@@ -10139,7 +10277,7 @@
       }
     },
     "../../packages/data/catalog/src/data/models/inflection/inflection-3-pi/model.json": {
-      "hash": "9c67d11c8a4ff72d48c520aeb8624f89",
+      "hash": "583d7839a49605a8457b9a4764180bb1",
       "meta": {
         "model_id": "inflection/inflection-3-pi",
         "organisation_id": "inflection",
@@ -10149,7 +10287,7 @@
       }
     },
     "../../packages/data/catalog/src/data/models/inflection/inflection-3-productivity/model.json": {
-      "hash": "c2df6fe29444fd9ce9f8485035581b1f",
+      "hash": "de710880d7ed4608ada3035a6ca5891c",
       "meta": {
         "model_id": "inflection/inflection-3-productivity",
         "organisation_id": "inflection",
@@ -10159,7 +10297,7 @@
       }
     },
     "../../packages/data/catalog/src/data/models/inflection/pi-3.1-preview/model.json": {
-      "hash": "b79690a517742574f5f2e50d66d9a07f",
+      "hash": "6d014c40eddc749770c70372a5419498",
       "meta": {
         "model_id": "inflection/pi-3.1-preview",
         "organisation_id": "inflection",
@@ -10199,7 +10337,7 @@
       }
     },
     "../../packages/data/catalog/src/data/models/lg/exaone-3.0/model.json": {
-      "hash": "632b57dae78311dfef96c1a50898342c",
+      "hash": "93029fc8a430dfa9fc829199db357cc0",
       "meta": {
         "model_id": "lg/exaone-3.0",
         "organisation_id": "lg",
@@ -10209,7 +10347,7 @@
       }
     },
     "../../packages/data/catalog/src/data/models/lg/exaone-3.5-2.4b/model.json": {
-      "hash": "821fd0b55992124d8bf98b70403e4638",
+      "hash": "49a8554649536cf9d9eb990043dd857d",
       "meta": {
         "model_id": "lg/exaone-3.5-2.4b",
         "organisation_id": "lg",
@@ -10219,7 +10357,7 @@
       }
     },
     "../../packages/data/catalog/src/data/models/lg/exaone-3.5-32b/model.json": {
-      "hash": "d83c09a6a67b012b6c2d30c1d649d245",
+      "hash": "50ed6b36108ec1fdb22479c37cae7ba9",
       "meta": {
         "model_id": "lg/exaone-3.5-32b",
         "organisation_id": "lg",
@@ -10229,7 +10367,7 @@
       }
     },
     "../../packages/data/catalog/src/data/models/lg/exaone-3.5-7.8b/model.json": {
-      "hash": "0c35366649348851fe63c5de2ad0d480",
+      "hash": "c2f2dcfd05bd668ffdd54d0ef9594b0a",
       "meta": {
         "model_id": "lg/exaone-3.5-7.8b",
         "organisation_id": "lg",
@@ -10239,7 +10377,7 @@
       }
     },
     "../../packages/data/catalog/src/data/models/lg/exaone-4.0-1.2b/model.json": {
-      "hash": "bbfd65baa9c6d25cd877c2df21bb9990",
+      "hash": "41b1dd0378367621a489128e6d5013b2",
       "meta": {
         "model_id": "lg/exaone-4.0-1.2b",
         "organisation_id": "lg",
@@ -10249,7 +10387,7 @@
       }
     },
     "../../packages/data/catalog/src/data/models/lg/exaone-4.0-32b/model.json": {
-      "hash": "ce1de5d036ca25a5b2066256cf768bb3",
+      "hash": "efaf5a1acc95e0022636cba686a9c253",
       "meta": {
         "model_id": "lg/exaone-4.0-32b",
         "organisation_id": "lg",
@@ -10259,7 +10397,7 @@
       }
     },
     "../../packages/data/catalog/src/data/models/lg/exaone-deep-2.4b/model.json": {
-      "hash": "af5a6bb3f1ed1a84573c3bf957063ab2",
+      "hash": "0500a661bddede6a1e43d5461c7956f5",
       "meta": {
         "model_id": "lg/exaone-deep-2.4b",
         "organisation_id": "lg",
@@ -10269,7 +10407,7 @@
       }
     },
     "../../packages/data/catalog/src/data/models/lg/exaone-deep-32b/model.json": {
-      "hash": "b623170c7efdd129cef9df1aa2d3ca5b",
+      "hash": "b559a7643e0a671d1f8c197ef3e24beb",
       "meta": {
         "model_id": "lg/exaone-deep-32b",
         "organisation_id": "lg",
@@ -10279,7 +10417,7 @@
       }
     },
     "../../packages/data/catalog/src/data/models/lg/exaone-deep-7.8b/model.json": {
-      "hash": "ba2aa93d92ba844fa59f4309f1608419",
+      "hash": "b18dfe353ec3aa5e0e6be083231cd0bd",
       "meta": {
         "model_id": "lg/exaone-deep-7.8b",
         "organisation_id": "lg",
@@ -10619,7 +10757,7 @@
       }
     },
     "../../packages/data/catalog/src/data/models/meta/muse-spark/model.json": {
-      "hash": "8e384bcf7fec4922fcd40b116c36918a",
+      "hash": "51be25e39cbb317651f3a9896e596293",
       "meta": {
         "model_id": "meta/muse-spark",
         "organisation_id": "meta",
@@ -10629,7 +10767,7 @@
       }
     },
     "../../packages/data/catalog/src/data/models/meta/muse-spark-contemplating/model.json": {
-      "hash": "a5498f9b64eb30c826548d78cdba9bfc",
+      "hash": "8b1b3328ad4dd533b58522625530d2ba",
       "meta": {
         "model_id": "meta/muse-spark-contemplating",
         "organisation_id": "meta",
@@ -10729,7 +10867,7 @@
       }
     },
     "../../packages/data/catalog/src/data/models/microsoft/phi-3.5-mini-instruct/model.json": {
-      "hash": "c72f698ea1bb4f43a622222a81a3c771",
+      "hash": "43a32639fcf00c0b975ee3f55a1141d4",
       "meta": {
         "model_id": "microsoft/phi-3.5-mini-instruct",
         "organisation_id": "microsoft",
@@ -10739,7 +10877,7 @@
       }
     },
     "../../packages/data/catalog/src/data/models/microsoft/phi-3.5-moe-instruct/model.json": {
-      "hash": "f5ebc8f5b84dc65ff27a3a6339711aa8",
+      "hash": "aef62558cb1beb6ebf896d64e5c3d13c",
       "meta": {
         "model_id": "microsoft/phi-3.5-moe-instruct",
         "organisation_id": "microsoft",
@@ -10749,7 +10887,7 @@
       }
     },
     "../../packages/data/catalog/src/data/models/microsoft/phi-3.5-vision-instruct/model.json": {
-      "hash": "a07cd52ae3e5f46a0e99fd5d173304b3",
+      "hash": "f3a13a01873906aab3ffc6a712b00bdd",
       "meta": {
         "model_id": "microsoft/phi-3.5-vision-instruct",
         "organisation_id": "microsoft",
@@ -10759,7 +10897,7 @@
       }
     },
     "../../packages/data/catalog/src/data/models/microsoft/phi-4/model.json": {
-      "hash": "2465092fd90199de90c4e8050b680b47",
+      "hash": "0e49e8fd55d16a8413ac5c9a00e69d40",
       "meta": {
         "model_id": "microsoft/phi-4",
         "organisation_id": "microsoft",
@@ -10769,7 +10907,7 @@
       }
     },
     "../../packages/data/catalog/src/data/models/microsoft/phi-4-mini/model.json": {
-      "hash": "38fee1bc7b6ffe5ee165ee35ef533bda",
+      "hash": "8c6f5f580e91d93a0f3b36930bd94080",
       "meta": {
         "model_id": "microsoft/phi-4-mini",
         "organisation_id": "microsoft",
@@ -10789,7 +10927,7 @@
       }
     },
     "../../packages/data/catalog/src/data/models/microsoft/phi-4-mini-reasoning/model.json": {
-      "hash": "0b76cb7f8fe99863b94e58727d4b1cf8",
+      "hash": "5c2ebb16652a9e860eae8232578047d5",
       "meta": {
         "model_id": "microsoft/phi-4-mini-reasoning",
         "organisation_id": "microsoft",
@@ -10799,7 +10937,7 @@
       }
     },
     "../../packages/data/catalog/src/data/models/microsoft/phi-4-multimodal-instruct/model.json": {
-      "hash": "0974023a118643cc58c32140c5bbcc87",
+      "hash": "1d2420fb41df0a430af98340209e4b50",
       "meta": {
         "model_id": "microsoft/phi-4-multimodal-instruct",
         "organisation_id": "microsoft",
@@ -10809,7 +10947,7 @@
       }
     },
     "../../packages/data/catalog/src/data/models/microsoft/phi-4-reasoning/model.json": {
-      "hash": "e46d01a10eb9df6f2b7cd2501ef51682",
+      "hash": "67c0213ac794260e2481cdcc68929e10",
       "meta": {
         "model_id": "microsoft/phi-4-reasoning",
         "organisation_id": "microsoft",
@@ -10819,7 +10957,7 @@
       }
     },
     "../../packages/data/catalog/src/data/models/microsoft/phi-4-reasoning-plus/model.json": {
-      "hash": "1f88db7a8ce4556bfec8b1c2528bb917",
+      "hash": "c495cbefa2ec482dd899835320d2b209",
       "meta": {
         "model_id": "microsoft/phi-4-reasoning-plus",
         "organisation_id": "microsoft",
@@ -10889,7 +11027,7 @@
       }
     },
     "../../packages/data/catalog/src/data/models/minimax/minimax-m1-40k/model.json": {
-      "hash": "bcd3fc89681a7b5a3de32fa2f2a6ce72",
+      "hash": "292cac713737b005a97b81e8f7492f00",
       "meta": {
         "model_id": "minimax/minimax-m1-40k",
         "organisation_id": "minimax",
@@ -10939,7 +11077,7 @@
       }
     },
     "../../packages/data/catalog/src/data/models/minimax/minimax-m2.5/model.json": {
-      "hash": "84c38a7fbcf4b6733ede75ae4f130487",
+      "hash": "27cd315d586f148316d7044b223b9faa",
       "meta": {
         "model_id": "minimax/minimax-m2.5",
         "organisation_id": "minimax",
@@ -10959,7 +11097,7 @@
       }
     },
     "../../packages/data/catalog/src/data/models/minimax/minimax-m2.7/model.json": {
-      "hash": "a7fbbee885cc1b142fa756dc12c69fba",
+      "hash": "b4cf522049ef0db06c7995d9f9e8eaac",
       "meta": {
         "model_id": "minimax/minimax-m2.7",
         "organisation_id": "minimax",
@@ -11129,7 +11267,7 @@
       }
     },
     "../../packages/data/catalog/src/data/models/mistral/codestral-2024-05-29/model.json": {
-      "hash": "4dbb7ee65b51c36b9043ab2a60d2d882",
+      "hash": "7e7146b7d784479610be4deee4f0e344",
       "meta": {
         "model_id": "mistral/codestral-2024-05-29",
         "organisation_id": "mistral",
@@ -11179,7 +11317,7 @@
       }
     },
     "../../packages/data/catalog/src/data/models/mistral/devstral-medium-1.0/model.json": {
-      "hash": "d449eac4720b666d8b9ad1ea3e31ce7f",
+      "hash": "81f33dea1d32363b87240400a8bc2001",
       "meta": {
         "model_id": "mistral/devstral-medium-1.0",
         "organisation_id": "mistral",
@@ -11199,7 +11337,7 @@
       }
     },
     "../../packages/data/catalog/src/data/models/mistral/devstral-small-1.1/model.json": {
-      "hash": "b8bbf235e709ef26ed378a3ba6bd00b4",
+      "hash": "e7f6bf53ebb5b52b231a0721f8afd30f",
       "meta": {
         "model_id": "mistral/devstral-small-1.1",
         "organisation_id": "mistral",
@@ -11229,7 +11367,7 @@
       }
     },
     "../../packages/data/catalog/src/data/models/mistral/magistral-medium-1.0/model.json": {
-      "hash": "64480fc4f2e590892e2e04e51acacd61",
+      "hash": "1f0abd87586c66ddd89b649ab2693703",
       "meta": {
         "model_id": "mistral/magistral-medium-1.0",
         "organisation_id": "mistral",
@@ -11259,7 +11397,7 @@
       }
     },
     "../../packages/data/catalog/src/data/models/mistral/magistral-small-1.0/model.json": {
-      "hash": "e9a90218cbc8a58e5d3b3c6de4c63f91",
+      "hash": "788fd51ee87d2dbbcfae9987ae0415e5",
       "meta": {
         "model_id": "mistral/magistral-small-1.0",
         "organisation_id": "mistral",
@@ -11319,7 +11457,7 @@
       }
     },
     "../../packages/data/catalog/src/data/models/mistral/ministral-3.0-14b/model.json": {
-      "hash": "faed254bc7dd72f1b9e231d1279abe04",
+      "hash": "61f516c981c3283f2f23d6f5fbb9289d",
       "meta": {
         "model_id": "mistral/ministral-3.0-14b",
         "organisation_id": "mistral",
@@ -11329,7 +11467,7 @@
       }
     },
     "../../packages/data/catalog/src/data/models/mistral/ministral-3.0-3b/model.json": {
-      "hash": "afb7cbdff70888f208eadd90453a0620",
+      "hash": "84b13fa611781bbc262c6460d889c720",
       "meta": {
         "model_id": "mistral/ministral-3.0-3b",
         "organisation_id": "mistral",
@@ -11339,7 +11477,7 @@
       }
     },
     "../../packages/data/catalog/src/data/models/mistral/ministral-3.0-8b/model.json": {
-      "hash": "0a92e9c88f0a76d1a975e30bfefd6b36",
+      "hash": "07877be84926ebae04f8b96a648bebe7",
       "meta": {
         "model_id": "mistral/ministral-3.0-8b",
         "organisation_id": "mistral",
@@ -11359,7 +11497,7 @@
       }
     },
     "../../packages/data/catalog/src/data/models/mistral/ministral-8b/model.json": {
-      "hash": "6b059baec924992ef36c1a64a9ac2d84",
+      "hash": "dbbeb6a9a3de89b12d3099b8aceefed6",
       "meta": {
         "model_id": "mistral/ministral-8b",
         "organisation_id": "mistral",
@@ -11439,7 +11577,7 @@
       }
     },
     "../../packages/data/catalog/src/data/models/mistral/mistral-large-2.0/model.json": {
-      "hash": "f494b675708c6dfd9a61082a26cc1d8a",
+      "hash": "07c7ee8a79427f250530851fb721dd84",
       "meta": {
         "model_id": "mistral/mistral-large-2.0",
         "organisation_id": "mistral",
@@ -11459,7 +11597,7 @@
       }
     },
     "../../packages/data/catalog/src/data/models/mistral/mistral-large-3.0/model.json": {
-      "hash": "9103e4328d54c5b32d6bd4212b6696d9",
+      "hash": "fa1a1e1e21d7a21c1949c93621e39418",
       "meta": {
         "model_id": "mistral/mistral-large-3.0",
         "organisation_id": "mistral",
@@ -11519,7 +11657,7 @@
       }
     },
     "../../packages/data/catalog/src/data/models/mistral/mistral-nemo-12b/model.json": {
-      "hash": "9acce876d4d708ab80904a69443a5e9b",
+      "hash": "3dbb4174fac63f90d3a9008d7c06dadc",
       "meta": {
         "model_id": "mistral/mistral-nemo-12b",
         "organisation_id": "mistral",
@@ -11579,7 +11717,7 @@
       }
     },
     "../../packages/data/catalog/src/data/models/mistral/mistral-small-2.0/model.json": {
-      "hash": "6e493c973c6cc40b49510d6122a3a171",
+      "hash": "6cdf75678bca8818e9a9eec656b6a314",
       "meta": {
         "model_id": "mistral/mistral-small-2.0",
         "organisation_id": "mistral",
@@ -11599,7 +11737,7 @@
       }
     },
     "../../packages/data/catalog/src/data/models/mistral/mistral-small-3.0/model.json": {
-      "hash": "2f116bc8a07aaa5b606ff9498b260cd6",
+      "hash": "60e4267d534740187e891a075626d790",
       "meta": {
         "model_id": "mistral/mistral-small-3.0",
         "organisation_id": "mistral",
@@ -11609,7 +11747,7 @@
       }
     },
     "../../packages/data/catalog/src/data/models/mistral/mistral-small-3.1/model.json": {
-      "hash": "155b196bce59ec135cf9e1fd96e4f798",
+      "hash": "c9ab379f766bd2efc7fbd307811592de",
       "meta": {
         "model_id": "mistral/mistral-small-3.1",
         "organisation_id": "mistral",
@@ -11619,7 +11757,7 @@
       }
     },
     "../../packages/data/catalog/src/data/models/mistral/mistral-small-3.2/model.json": {
-      "hash": "c7f53277b96f98801e55b0cea19e65e4",
+      "hash": "7094da7b423447280f1233af6f6b854d",
       "meta": {
         "model_id": "mistral/mistral-small-3.2",
         "organisation_id": "mistral",
@@ -11679,7 +11817,7 @@
       }
     },
     "../../packages/data/catalog/src/data/models/mistral/pixtral-12b/model.json": {
-      "hash": "daa92ea6d27c4efebfd1318d2ef6b099",
+      "hash": "70c62ed04b93cede105eb13f2a82e1ad",
       "meta": {
         "model_id": "mistral/pixtral-12b",
         "organisation_id": "mistral",
@@ -11689,7 +11827,7 @@
       }
     },
     "../../packages/data/catalog/src/data/models/mistral/pixtral-large/model.json": {
-      "hash": "4f043c6ca4773e4795c6bd536fd3ac55",
+      "hash": "3f84d51e62250ba89f5e942f8d0c655b",
       "meta": {
         "model_id": "mistral/pixtral-large",
         "organisation_id": "mistral",
@@ -11749,7 +11887,7 @@
       }
     },
     "../../packages/data/catalog/src/data/models/moonshotai/kimi-k1.5/model.json": {
-      "hash": "6be638d00b1bac2315c3826f9b104acd",
+      "hash": "4710d28cfc6b33c58290cdec019da14c",
       "meta": {
         "model_id": "moonshotai/kimi-k1.5",
         "organisation_id": "moonshotai",
@@ -11769,7 +11907,7 @@
       }
     },
     "../../packages/data/catalog/src/data/models/moonshotai/kimi-k2-2025-07-11/model.json": {
-      "hash": "ec3f79dd8d3ead0ca1ffabb0777db3f6",
+      "hash": "74e5b5ffafb56a8233d6464755a3cdc5",
       "meta": {
         "model_id": "moonshotai/kimi-k2-2025-07-11",
         "organisation_id": "moonshotai",
@@ -11779,7 +11917,7 @@
       }
     },
     "../../packages/data/catalog/src/data/models/moonshotai/kimi-k2-thinking/model.json": {
-      "hash": "25f4f49a6f82c153c53cc3d6e31bfbf4",
+      "hash": "69b75424d9fa9e3d853bd3a4b0d3befb",
       "meta": {
         "model_id": "moonshotai/kimi-k2-thinking",
         "organisation_id": "moonshotai",
@@ -11859,7 +11997,7 @@
       }
     },
     "../../packages/data/catalog/src/data/models/morph/morph-compactor/model.json": {
-      "hash": "5fa82855d7c6b8e7e3b73d23e4b8045c",
+      "hash": "335ff5c6bfa6f93cb7c82150d523d8d2",
       "meta": {
         "model_id": "morph/morph-compactor",
         "organisation_id": "morph",
@@ -11869,7 +12007,7 @@
       }
     },
     "../../packages/data/catalog/src/data/models/morph/morph-embedding-v4/model.json": {
-      "hash": "967e5f351b9980c4bc838157f1490a90",
+      "hash": "74d5c1c5c8f8bc6418afba7d5648fe67",
       "meta": {
         "model_id": "morph/morph-embedding-v4",
         "organisation_id": "morph",
@@ -11879,7 +12017,7 @@
       }
     },
     "../../packages/data/catalog/src/data/models/morph/morph-rerank-v4/model.json": {
-      "hash": "c9fea3e626533de9c03c9060569851ea",
+      "hash": "e42099a5c386fca21ea7c03e4de80f09",
       "meta": {
         "model_id": "morph/morph-rerank-v4",
         "organisation_id": "morph",
@@ -11889,7 +12027,7 @@
       }
     },
     "../../packages/data/catalog/src/data/models/morph/morph-v3-fast/model.json": {
-      "hash": "fecaaae775c260be973a5a3baa37ebfc",
+      "hash": "cbaf18a6d86cc2f38e1ddf1b0100513b",
       "meta": {
         "model_id": "morph/morph-v3-fast",
         "organisation_id": "morph",
@@ -11899,7 +12037,7 @@
       }
     },
     "../../packages/data/catalog/src/data/models/morph/morph-v3-large/model.json": {
-      "hash": "3330f188109383ccb030cf9e279be7d3",
+      "hash": "0ed15983fa987e73cbb5bb7cb62aa8e0",
       "meta": {
         "model_id": "morph/morph-v3-large",
         "organisation_id": "morph",
@@ -11909,7 +12047,7 @@
       }
     },
     "../../packages/data/catalog/src/data/models/morph/morph-warp-grep-v2.1/model.json": {
-      "hash": "e1f3942a928c7e2a131aabf17b468b05",
+      "hash": "512a5ed59eec2b69b9abd4b56494356c",
       "meta": {
         "model_id": "morph/morph-warp-grep-v2.1",
         "organisation_id": "morph",
@@ -12099,7 +12237,7 @@
       }
     },
     "../../packages/data/catalog/src/data/models/nous/nouscoder-14b/model.json": {
-      "hash": "284e17c2bed469daba82fde3ff3b7f1e",
+      "hash": "d7409ff1c77a59f84060578d4df687dd",
       "meta": {
         "model_id": "nous/nouscoder-14b",
         "organisation_id": "nous",
@@ -12119,7 +12257,7 @@
       }
     },
     "../../packages/data/catalog/src/data/models/nvidia/llama-3.1-nemotron-70b-instruct/model.json": {
-      "hash": "3fb8545e88cb0c2ca6e37883a5f7c4c2",
+      "hash": "b736527ddd1bdedc9c4510f2238cff71",
       "meta": {
         "model_id": "nvidia/llama-3.1-nemotron-70b-instruct",
         "organisation_id": "nvidia",
@@ -12139,7 +12277,7 @@
       }
     },
     "../../packages/data/catalog/src/data/models/nvidia/llama-3.1-nemotron-nano-8b-v1/model.json": {
-      "hash": "9a2a212de2e75896ed50e0c7251e71b8",
+      "hash": "d00218f9a699b8af5ecc7cd90849d989",
       "meta": {
         "model_id": "nvidia/llama-3.1-nemotron-nano-8b-v1",
         "organisation_id": "nvidia",
@@ -12149,7 +12287,7 @@
       }
     },
     "../../packages/data/catalog/src/data/models/nvidia/llama-3.1-nemotron-ultra-253b-v1/model.json": {
-      "hash": "9807d03e301f7826ad897960c3f36f2f",
+      "hash": "9b5b824b2ac255a4f49a420d52749727",
       "meta": {
         "model_id": "nvidia/llama-3.1-nemotron-ultra-253b-v1",
         "organisation_id": "nvidia",
@@ -12159,7 +12297,7 @@
       }
     },
     "../../packages/data/catalog/src/data/models/nvidia/llama-3.3-nemotron-super-49b-v1/model.json": {
-      "hash": "a9470b09a6ffb1e6e13729e75dc09756",
+      "hash": "93968577c6445a7099222caef344d991",
       "meta": {
         "model_id": "nvidia/llama-3.3-nemotron-super-49b-v1",
         "organisation_id": "nvidia",
@@ -12189,7 +12327,7 @@
       }
     },
     "../../packages/data/catalog/src/data/models/nvidia/nemotron-3-nano-omni-30b-a3b-reasoning/model.json": {
-      "hash": "27e485d5340401a2f6ef8e876507541e",
+      "hash": "e74cfcf093edb662677f19c1cf79d445",
       "meta": {
         "model_id": "nvidia/nemotron-3-nano-omni-30b-a3b-reasoning",
         "organisation_id": "nvidia",
@@ -12319,7 +12457,7 @@
       }
     },
     "../../packages/data/catalog/src/data/models/openai/chatgpt-4o/model.json": {
-      "hash": "53703b9a5a17778e9235643f4135e502",
+      "hash": "c5ad36b9055929da481f15bfc1abbb08",
       "meta": {
         "model_id": "openai/chatgpt-4o",
         "organisation_id": "openai",
@@ -12429,7 +12567,7 @@
       }
     },
     "../../packages/data/catalog/src/data/models/openai/codex-mini/model.json": {
-      "hash": "1ce179454fd2cb0c252e06a27072e9e5",
+      "hash": "7044dfbe05c88dbc41320000281b4fc8",
       "meta": {
         "model_id": "openai/codex-mini",
         "organisation_id": "openai",
@@ -12515,7 +12653,7 @@
       }
     },
     "../../packages/data/catalog/src/data/models/openai/gpt-2/model.json": {
-      "hash": "8344c1d1586b207aa845a640a6cfcd78",
+      "hash": "78d6da1123ddf230af3100508afad39a",
       "meta": {
         "model_id": "openai/gpt-2",
         "organisation_id": "openai",
@@ -12525,7 +12663,7 @@
       }
     },
     "../../packages/data/catalog/src/data/models/openai/gpt-3/model.json": {
-      "hash": "7c0d3222422d07685ba1b64262e1fab4",
+      "hash": "7c17eb344d5580849634aa0a526a33b9",
       "meta": {
         "model_id": "openai/gpt-3",
         "organisation_id": "openai",
@@ -12565,7 +12703,7 @@
       }
     },
     "../../packages/data/catalog/src/data/models/openai/gpt-3.5-turbo-2023-11-06/model.json": {
-      "hash": "bfc4d22d25b2efe83e579342c81963aa",
+      "hash": "aa460eed8863393087f72fd59f6c7c48",
       "meta": {
         "model_id": "openai/gpt-3.5-turbo-2023-11-06",
         "organisation_id": "openai",
@@ -12575,7 +12713,7 @@
       }
     },
     "../../packages/data/catalog/src/data/models/openai/gpt-3.5-turbo-2024-01-25/model.json": {
-      "hash": "3c12e1c98ae5b9b097d8f5f444cbe7db",
+      "hash": "30ab55e16792c18b34a9067f52f16fe3",
       "meta": {
         "model_id": "openai/gpt-3.5-turbo-2024-01-25",
         "organisation_id": "openai",
@@ -12585,7 +12723,7 @@
       }
     },
     "../../packages/data/catalog/src/data/models/openai/gpt-3.5-turbo-instruct/model.json": {
-      "hash": "3e4e7dce99fa56eeec3bce14e159dfbd",
+      "hash": "156cf93baf807a4cec87f6a8b550414f",
       "meta": {
         "model_id": "openai/gpt-3.5-turbo-instruct",
         "organisation_id": "openai",
@@ -12595,7 +12733,7 @@
       }
     },
     "../../packages/data/catalog/src/data/models/openai/gpt-4/model.json": {
-      "hash": "c64f68898d3be04e134cfd8a58ab2ccb",
+      "hash": "7f2ede26134ca1604144d8b3f1c01ceb",
       "meta": {
         "model_id": "openai/gpt-4",
         "organisation_id": "openai",
@@ -12605,7 +12743,7 @@
       }
     },
     "../../packages/data/catalog/src/data/models/openai/gpt-4-2023-03-14/model.json": {
-      "hash": "bc90eea0dd1aa1fae18791359208d95e",
+      "hash": "07beeee4f83721b51e0bcd98e3b21f5e",
       "meta": {
         "model_id": "openai/gpt-4-2023-03-14",
         "organisation_id": "openai",
@@ -12655,7 +12793,7 @@
       }
     },
     "../../packages/data/catalog/src/data/models/openai/gpt-4-turbo-2023-03-14/model.json": {
-      "hash": "39044afe270c41149f6808b3453cc1d6",
+      "hash": "673250498cd19b1b73c38c5f4c56cf78",
       "meta": {
         "model_id": "openai/gpt-4-turbo-2023-03-14",
         "organisation_id": "openai",
@@ -12705,7 +12843,7 @@
       }
     },
     "../../packages/data/catalog/src/data/models/openai/gpt-4.5/model.json": {
-      "hash": "015e982084b0adb43abbaa9b445fcda6",
+      "hash": "6790617410518b08ae19c1264a7ee9af",
       "meta": {
         "model_id": "openai/gpt-4.5",
         "organisation_id": "openai",
@@ -12715,7 +12853,7 @@
       }
     },
     "../../packages/data/catalog/src/data/models/openai/gpt-4o/model.json": {
-      "hash": "9549f48e95da88e02a922fc351d4ab0e",
+      "hash": "43bf89fff831e49e8d9f0d319d7fbfd5",
       "meta": {
         "model_id": "openai/gpt-4o",
         "organisation_id": "openai",
@@ -12725,7 +12863,7 @@
       }
     },
     "../../packages/data/catalog/src/data/models/openai/gpt-4o-2024-05-13/model.json": {
-      "hash": "0806c390d8e1150624c5bf097e6451c4",
+      "hash": "9927ea2a756912b4066323b8d4a96246",
       "meta": {
         "model_id": "openai/gpt-4o-2024-05-13",
         "organisation_id": "openai",
@@ -12735,7 +12873,7 @@
       }
     },
     "../../packages/data/catalog/src/data/models/openai/gpt-4o-2024-08-06/model.json": {
-      "hash": "6854effde754ebb0801e6cbd052a3c2f",
+      "hash": "a99d653352ac3a6437a1a3f063ecd977",
       "meta": {
         "model_id": "openai/gpt-4o-2024-08-06",
         "organisation_id": "openai",
@@ -12745,7 +12883,7 @@
       }
     },
     "../../packages/data/catalog/src/data/models/openai/gpt-4o-audio/model.json": {
-      "hash": "5342a2deaa074e50dac1843b5d151452",
+      "hash": "a25b5a5509969fd21d8b25e0c9314c39",
       "meta": {
         "model_id": "openai/gpt-4o-audio",
         "organisation_id": "openai",
@@ -12755,7 +12893,7 @@
       }
     },
     "../../packages/data/catalog/src/data/models/openai/gpt-4o-audio-2024-10-01/model.json": {
-      "hash": "3018540ca9b7d98f6ea9e0bcb599084d",
+      "hash": "bcc09a89f6b85551ce3b7eb31a03e56c",
       "meta": {
         "model_id": "openai/gpt-4o-audio-2024-10-01",
         "organisation_id": "openai",
@@ -12765,7 +12903,7 @@
       }
     },
     "../../packages/data/catalog/src/data/models/openai/gpt-4o-audio-2024-12-17/model.json": {
-      "hash": "34e562078e7cffe3a5afe7824b9a158f",
+      "hash": "4b0205779e20056a7b4cd1f18bd73ff1",
       "meta": {
         "model_id": "openai/gpt-4o-audio-2024-12-17",
         "organisation_id": "openai",
@@ -12915,7 +13053,7 @@
       }
     },
     "../../packages/data/catalog/src/data/models/openai/gpt-5/model.json": {
-      "hash": "3ed05368575c15956ae06991c6b9922c",
+      "hash": "99366a80b0e9dcf2aa9d91924aa8eac8",
       "meta": {
         "model_id": "openai/gpt-5",
         "organisation_id": "openai",
@@ -12925,7 +13063,7 @@
       }
     },
     "../../packages/data/catalog/src/data/models/openai/gpt-5-chat/model.json": {
-      "hash": "abc546d05f406324d3e1b590ed4b4e1c",
+      "hash": "a8eb99cd046a44a590b0de8d1a6746b1",
       "meta": {
         "model_id": "openai/gpt-5-chat",
         "organisation_id": "openai",
@@ -12955,7 +13093,7 @@
       }
     },
     "../../packages/data/catalog/src/data/models/openai/gpt-5-mini/model.json": {
-      "hash": "f236fcbb6c759eed849d75735d6a6ab8",
+      "hash": "809bf4ce39ffc9fe7fe71c47bda9c2bc",
       "meta": {
         "model_id": "openai/gpt-5-mini",
         "organisation_id": "openai",
@@ -12965,7 +13103,7 @@
       }
     },
     "../../packages/data/catalog/src/data/models/openai/gpt-5-nano/model.json": {
-      "hash": "79f84a77d1ef02ed1cd995601ce3691b",
+      "hash": "eb3a667e727567534012128898df010e",
       "meta": {
         "model_id": "openai/gpt-5-nano",
         "organisation_id": "openai",
@@ -12995,7 +13133,7 @@
       }
     },
     "../../packages/data/catalog/src/data/models/openai/gpt-5.1/model.json": {
-      "hash": "d2f1abd54be4b47af92d15f671c09c8f",
+      "hash": "97ce1156d59b0710315a000a07c7f18e",
       "meta": {
         "model_id": "openai/gpt-5.1",
         "organisation_id": "openai",
@@ -13025,7 +13163,7 @@
       }
     },
     "../../packages/data/catalog/src/data/models/openai/gpt-5.1-codex-max/model.json": {
-      "hash": "ab2e4ae280ffe7947651e74294f50475",
+      "hash": "758470c8e4bfb62f27c5898948f2d214",
       "meta": {
         "model_id": "openai/gpt-5.1-codex-max",
         "organisation_id": "openai",
@@ -13045,7 +13183,7 @@
       }
     },
     "../../packages/data/catalog/src/data/models/openai/gpt-5.2/model.json": {
-      "hash": "03fc8cabe2ba6dbd02e2802cb57554e3",
+      "hash": "aa3d616f4d4ad81ed85ad7a6de978fde",
       "meta": {
         "model_id": "openai/gpt-5.2",
         "organisation_id": "openai",
@@ -13055,7 +13193,7 @@
       }
     },
     "../../packages/data/catalog/src/data/models/openai/gpt-5.2-chat/model.json": {
-      "hash": "7843b8529f43315a82a75b9b5283a584",
+      "hash": "f0fccf2022cce435c95c45fa2542b3d3",
       "meta": {
         "model_id": "openai/gpt-5.2-chat",
         "organisation_id": "openai",
@@ -13065,7 +13203,7 @@
       }
     },
     "../../packages/data/catalog/src/data/models/openai/gpt-5.2-codex/model.json": {
-      "hash": "b9d6401775af6505d0d5aa9646a6fecf",
+      "hash": "f25acc25cee81fd14ac9c5ab5f32eb37",
       "meta": {
         "model_id": "openai/gpt-5.2-codex",
         "organisation_id": "openai",
@@ -13085,7 +13223,7 @@
       }
     },
     "../../packages/data/catalog/src/data/models/openai/gpt-5.2-pro/model.json": {
-      "hash": "f6980d7410d1a8b40ce97d7b2cc4d0b0",
+      "hash": "d0fd7228cfecd5ffd88c3800db24a3e1",
       "meta": {
         "model_id": "openai/gpt-5.2-pro",
         "organisation_id": "openai",
@@ -13095,7 +13233,7 @@
       }
     },
     "../../packages/data/catalog/src/data/models/openai/gpt-5.3-chat/model.json": {
-      "hash": "59c6f5300b3f22037013b652892a1e2a",
+      "hash": "4e647df1459e5dbb2692dd613fe2e57d",
       "meta": {
         "model_id": "openai/gpt-5.3-chat",
         "organisation_id": "openai",
@@ -13115,7 +13253,7 @@
       }
     },
     "../../packages/data/catalog/src/data/models/openai/gpt-5.3-codex-spark/model.json": {
-      "hash": "379f4fcc7dfa266f1707a4dd8168b3a2",
+      "hash": "eda37f5b661615668f18a0f013f010a2",
       "meta": {
         "model_id": "openai/gpt-5.3-codex-spark",
         "organisation_id": "openai",
@@ -13125,7 +13263,7 @@
       }
     },
     "../../packages/data/catalog/src/data/models/openai/gpt-5.4/model.json": {
-      "hash": "6074f39733c209b3375350cd8cc58c32",
+      "hash": "df925aa4f778fdbcef73950f7bc6ebd4",
       "meta": {
         "model_id": "openai/gpt-5.4",
         "organisation_id": "openai",
@@ -13135,7 +13273,7 @@
       }
     },
     "../../packages/data/catalog/src/data/models/openai/gpt-5.4-cyber/model.json": {
-      "hash": "8936d1a876531f298e629dfe417023fd",
+      "hash": "21303852145e5d7581f3448b1f29a41a",
       "meta": {
         "model_id": "openai/gpt-5.4-cyber",
         "organisation_id": "openai",
@@ -13145,7 +13283,7 @@
       }
     },
     "../../packages/data/catalog/src/data/models/openai/gpt-5.4-mini/model.json": {
-      "hash": "a506648d09de4566de01f731a9b7751f",
+      "hash": "15016b05ec1c2e780102e6d2f2a10126",
       "meta": {
         "model_id": "openai/gpt-5.4-mini",
         "organisation_id": "openai",
@@ -13155,7 +13293,7 @@
       }
     },
     "../../packages/data/catalog/src/data/models/openai/gpt-5.4-nano/model.json": {
-      "hash": "6dea4d7866835fc6df3cfb9e2e3f3b4c",
+      "hash": "83a2567e47d1a7ff6e36b69046cd3886",
       "meta": {
         "model_id": "openai/gpt-5.4-nano",
         "organisation_id": "openai",
@@ -13165,7 +13303,7 @@
       }
     },
     "../../packages/data/catalog/src/data/models/openai/gpt-5.4-pro/model.json": {
-      "hash": "3ef8208aef972b9539dea0874cb4e0d6",
+      "hash": "48c96b51a9510ec0e81bb2022fe7448f",
       "meta": {
         "model_id": "openai/gpt-5.4-pro",
         "organisation_id": "openai",
@@ -13175,7 +13313,7 @@
       }
     },
     "../../packages/data/catalog/src/data/models/openai/gpt-5.5/model.json": {
-      "hash": "c6a584a923d598ee05dbd469df0f38a4",
+      "hash": "cbd55d7ea61b95edd7a0b03258b17d7b",
       "meta": {
         "model_id": "openai/gpt-5.5",
         "organisation_id": "openai",
@@ -13185,7 +13323,7 @@
       }
     },
     "../../packages/data/catalog/src/data/models/openai/gpt-5.5-cyber/model.json": {
-      "hash": "757c53da4b3a878589deb2c96cc620b3",
+      "hash": "03403c4b0c13c678904b8ca8343aa025",
       "meta": {
         "model_id": "openai/gpt-5.5-cyber",
         "organisation_id": "openai",
@@ -13195,7 +13333,7 @@
       }
     },
     "../../packages/data/catalog/src/data/models/openai/gpt-5.5-pro/model.json": {
-      "hash": "5532191ba9969bb6a3d3515bb6e8d75c",
+      "hash": "ffd9212647db0082d0a95daf2cff3f0b",
       "meta": {
         "model_id": "openai/gpt-5.5-pro",
         "organisation_id": "openai",
@@ -13215,7 +13353,7 @@
       }
     },
     "../../packages/data/catalog/src/data/models/openai/gpt-audio-1.5/model.json": {
-      "hash": "de8a4925b832f502d02e884dd1e9ed2f",
+      "hash": "357a78a38d58472091bd904bc2255c83",
       "meta": {
         "model_id": "openai/gpt-audio-1.5",
         "organisation_id": "openai",
@@ -13265,7 +13403,7 @@
       }
     },
     "../../packages/data/catalog/src/data/models/openai/gpt-image-1.5/model.json": {
-      "hash": "5a8c08b0e9a928a22dc11dec6af480c1",
+      "hash": "725621e2c980eac9cc426f3d55dc0010",
       "meta": {
         "model_id": "openai/gpt-image-1.5",
         "organisation_id": "openai",
@@ -13275,7 +13413,7 @@
       }
     },
     "../../packages/data/catalog/src/data/models/openai/gpt-image-2/model.json": {
-      "hash": "c74a2b04e9ad24746c410826f67385f8",
+      "hash": "cfafd67753b688f7d77bb11943039ea5",
       "meta": {
         "model_id": "openai/gpt-image-2",
         "organisation_id": "openai",
@@ -13285,7 +13423,7 @@
       }
     },
     "../../packages/data/catalog/src/data/models/openai/gpt-oss-120b/model.json": {
-      "hash": "215192679f7fcf61b18dc32dbea9c42f",
+      "hash": "417da90bbf50d6c4a8a43c3afd498b91",
       "meta": {
         "model_id": "openai/gpt-oss-120b",
         "organisation_id": "openai",
@@ -13295,7 +13433,7 @@
       }
     },
     "../../packages/data/catalog/src/data/models/openai/gpt-oss-20b/model.json": {
-      "hash": "f9f726ea46f15027d01fe28111c157a1",
+      "hash": "b1646c5cb52b51cacec914c7c89ed6df",
       "meta": {
         "model_id": "openai/gpt-oss-20b",
         "organisation_id": "openai",
@@ -13335,7 +13473,7 @@
       }
     },
     "../../packages/data/catalog/src/data/models/openai/gpt-realtime-1.5/model.json": {
-      "hash": "e9312f615b0f56e5293eec29b89eb6b1",
+      "hash": "cc7784fcb127622cbde79c567882b95b",
       "meta": {
         "model_id": "openai/gpt-realtime-1.5",
         "organisation_id": "openai",
@@ -13365,7 +13503,7 @@
       }
     },
     "../../packages/data/catalog/src/data/models/openai/gpt-rosalind/model.json": {
-      "hash": "a5cac06ba5aead5d7f550f26f8d4db3f",
+      "hash": "6267db95ebd4dd2a1abf7dc65005cade",
       "meta": {
         "model_id": "openai/gpt-rosalind",
         "organisation_id": "openai",
@@ -13415,7 +13553,7 @@
       }
     },
     "../../packages/data/catalog/src/data/models/openai/o3/model.json": {
-      "hash": "87eb0bb3d05e14390e76bc46f520df36",
+      "hash": "4c4de4d580c2d6bf098f2e2c3ae3f959",
       "meta": {
         "model_id": "openai/o3",
         "organisation_id": "openai",
@@ -13425,7 +13563,7 @@
       }
     },
     "../../packages/data/catalog/src/data/models/openai/o3-deep-research/model.json": {
-      "hash": "670e16622be61b676121a89e573e6f4a",
+      "hash": "97e58490bba8396a193fdda878731ef1",
       "meta": {
         "model_id": "openai/o3-deep-research",
         "organisation_id": "openai",
@@ -13435,7 +13573,7 @@
       }
     },
     "../../packages/data/catalog/src/data/models/openai/o3-mini/model.json": {
-      "hash": "95de35352a3d418ab012178f8857d304",
+      "hash": "a06032fee1b6013dc1ad2cfa7ac5c638",
       "meta": {
         "model_id": "openai/o3-mini",
         "organisation_id": "openai",
@@ -13455,7 +13593,7 @@
       }
     },
     "../../packages/data/catalog/src/data/models/openai/o3-pro/model.json": {
-      "hash": "40e934e897e0ae9c1ef32bec93c27e48",
+      "hash": "fe54a3bfbb1e33982141d8fc02332085",
       "meta": {
         "model_id": "openai/o3-pro",
         "organisation_id": "openai",
@@ -13465,7 +13603,7 @@
       }
     },
     "../../packages/data/catalog/src/data/models/openai/o4-mini/model.json": {
-      "hash": "b43461e5b359b24de23d5602fe2fb378",
+      "hash": "9b51651f6483011faf6e6e4a592782a7",
       "meta": {
         "model_id": "openai/o4-mini",
         "organisation_id": "openai",
@@ -13475,7 +13613,7 @@
       }
     },
     "../../packages/data/catalog/src/data/models/openai/o4-mini-deep-research/model.json": {
-      "hash": "b0ad66fc334d577dfe7ac100f52f4f99",
+      "hash": "1d2da5c14a2b9b27be10e66c41bae446",
       "meta": {
         "model_id": "openai/o4-mini-deep-research",
         "organisation_id": "openai",
@@ -13835,7 +13973,7 @@
       }
     },
     "../../packages/data/catalog/src/data/models/poolside/laguna-m.1/model.json": {
-      "hash": "9944c3c8cae7750f0f2226b2aa315194",
+      "hash": "310ac29ae19cc2c21908464bd9e13405",
       "meta": {
         "model_id": "poolside/laguna-m.1",
         "organisation_id": "poolside",
@@ -13845,7 +13983,7 @@
       }
     },
     "../../packages/data/catalog/src/data/models/poolside/laguna-xs.2/model.json": {
-      "hash": "dcdc3e8cfe6985f66071ea750932308f",
+      "hash": "0eb70ee2e0f96df6670720ba648cc785",
       "meta": {
         "model_id": "poolside/laguna-xs.2",
         "organisation_id": "poolside",
@@ -13885,7 +14023,7 @@
       }
     },
     "../../packages/data/catalog/src/data/models/qwen/qvq-72b-preview/model.json": {
-      "hash": "5f3c96280d1871d644fb0964297c5253",
+      "hash": "f376d5c481363130e88a7a656d90ede3",
       "meta": {
         "model_id": "qwen/qvq-72b-preview",
         "organisation_id": "qwen",
@@ -14715,7 +14853,7 @@
       }
     },
     "../../packages/data/catalog/src/data/models/qwen/qwen2.5-vl-32b/model.json": {
-      "hash": "94bd174b9f016aae3c3959d437b409be",
+      "hash": "73157f4fcb23e2992125d932e0689e78",
       "meta": {
         "model_id": "qwen/qwen2.5-vl-32b",
         "organisation_id": "qwen",
@@ -14735,7 +14873,7 @@
       }
     },
     "../../packages/data/catalog/src/data/models/qwen/qwen2.5-vl-72b/model.json": {
-      "hash": "8f72af72bffd72828d47b17758b32307",
+      "hash": "52ffcb70bc1a59017d10b501e4a0245e",
       "meta": {
         "model_id": "qwen/qwen2.5-vl-72b",
         "organisation_id": "qwen",
@@ -15703,7 +15841,7 @@
       }
     },
     "../../packages/data/catalog/src/data/models/qwen/qwen3.6-35b-a3b/model.json": {
-      "hash": "4cb2daba91ff2a7d48f0f0e42d6e0bb5",
+      "hash": "ae2726b8e75df626b4a1948bf6dfcc0b",
       "meta": {
         "model_id": "qwen/qwen3.6-35b-a3b",
         "organisation_id": "qwen",
@@ -15733,7 +15871,7 @@
       }
     },
     "../../packages/data/catalog/src/data/models/qwen/qwq-32b/model.json": {
-      "hash": "bd3198bca976008561b6d5a86ebf885f",
+      "hash": "ff86ea9f88d103eadc358f00d0a6ec51",
       "meta": {
         "model_id": "qwen/qwq-32b",
         "organisation_id": "qwen",
@@ -15743,7 +15881,7 @@
       }
     },
     "../../packages/data/catalog/src/data/models/qwen/qwq-32b-preview/model.json": {
-      "hash": "2483b8aef4614dd2ebc32bbfd69c39d4",
+      "hash": "90ef6b58f544c550f421a03c4379d69a",
       "meta": {
         "model_id": "qwen/qwq-32b-preview",
         "organisation_id": "qwen",
@@ -15783,7 +15921,7 @@
       }
     },
     "../../packages/data/catalog/src/data/models/qwen/wan2.7-t2v/model.json": {
-      "hash": "7b96c23d9ceea7b0337266852d58ebca",
+      "hash": "d76487529bcc2a391c91bb1c4728d764",
       "meta": {
         "model_id": "qwen/wan2.7-t2v",
         "organisation_id": "qwen",
@@ -15953,7 +16091,7 @@
       }
     },
     "../../packages/data/catalog/src/data/models/tencent/hy3-preview/model.json": {
-      "hash": "e74c541dfd8671372b1d9cb950c52f2c",
+      "hash": "2e1a19579283823675b91f96fdc06f32",
       "meta": {
         "model_id": "tencent/hy3-preview",
         "organisation_id": "tencent",
@@ -16362,262 +16500,6 @@
         "has_page_notice": false
       }
     },
-    "../../packages/data/catalog/src/data/models/x-ai/grok-0/model.json": {
-      "hash": "0204786683a508710a99e945045a18d8",
-      "meta": {
-        "model_id": "x-ai/grok-0",
-        "organisation_id": "x-ai",
-        "previous_model_id": null,
-        "api_model_id": "x-ai/grok-0",
-        "has_page_notice": false
-      }
-    },
-    "../../packages/data/catalog/src/data/models/x-ai/grok-1/model.json": {
-      "hash": "0418f102c410dc1c7fa2919ec9fa78d5",
-      "meta": {
-        "model_id": "x-ai/grok-1",
-        "organisation_id": "x-ai",
-        "previous_model_id": "x-ai/grok-0",
-        "api_model_id": "x-ai/grok-1",
-        "has_page_notice": false
-      }
-    },
-    "../../packages/data/catalog/src/data/models/x-ai/grok-1.5/model.json": {
-      "hash": "b0246fe6d11da5a5a60aa16f31d65156",
-      "meta": {
-        "model_id": "x-ai/grok-1.5",
-        "organisation_id": "x-ai",
-        "previous_model_id": "x-ai/grok-1",
-        "api_model_id": "x-ai/grok-1.5",
-        "has_page_notice": false
-      }
-    },
-    "../../packages/data/catalog/src/data/models/x-ai/grok-1.5v/model.json": {
-      "hash": "dff3acd5e5add9c2a41fea1394c6be15",
-      "meta": {
-        "model_id": "x-ai/grok-1.5v",
-        "organisation_id": "x-ai",
-        "previous_model_id": null,
-        "api_model_id": "x-ai/grok-1.5v",
-        "has_page_notice": false
-      }
-    },
-    "../../packages/data/catalog/src/data/models/x-ai/grok-2/model.json": {
-      "hash": "7247828e643c6237fcf4766718805af5",
-      "meta": {
-        "model_id": "x-ai/grok-2",
-        "organisation_id": "x-ai",
-        "previous_model_id": "x-ai/grok-1-5-2024-03-28",
-        "api_model_id": "x-ai/grok-2",
-        "has_page_notice": false
-      }
-    },
-    "../../packages/data/catalog/src/data/models/x-ai/grok-2-image-1212/model.json": {
-      "hash": "14849cd6a3d3f670f6f1cc3e910204f2",
-      "meta": {
-        "model_id": "x-ai/grok-2-image-1212",
-        "organisation_id": "x-ai",
-        "previous_model_id": null,
-        "api_model_id": "x-ai/grok-2-image-1212",
-        "has_page_notice": false
-      }
-    },
-    "../../packages/data/catalog/src/data/models/x-ai/grok-2-mini/model.json": {
-      "hash": "e1a35ba0b5b17730e2360cd2bacc5f60",
-      "meta": {
-        "model_id": "x-ai/grok-2-mini",
-        "organisation_id": "x-ai",
-        "previous_model_id": null,
-        "api_model_id": "x-ai/grok-2-mini",
-        "has_page_notice": false
-      }
-    },
-    "../../packages/data/catalog/src/data/models/x-ai/grok-2-vision-1212/model.json": {
-      "hash": "4c55f539c2473eb0373798af4e02616b",
-      "meta": {
-        "model_id": "x-ai/grok-2-vision-1212",
-        "organisation_id": "x-ai",
-        "previous_model_id": null,
-        "api_model_id": "x-ai/grok-2-vision-1212",
-        "has_page_notice": false
-      }
-    },
-    "../../packages/data/catalog/src/data/models/x-ai/grok-3/model.json": {
-      "hash": "945894ab3e3c1826a66d418faac291da",
-      "meta": {
-        "model_id": "x-ai/grok-3",
-        "organisation_id": "x-ai",
-        "previous_model_id": "x-ai/grok-3-beta-2025-02-19",
-        "api_model_id": "x-ai/grok-3",
-        "has_page_notice": false
-      }
-    },
-    "../../packages/data/catalog/src/data/models/x-ai/grok-3-beta/model.json": {
-      "hash": "e5afa26a19bc5f3abd0949c1a84e3fc2",
-      "meta": {
-        "model_id": "x-ai/grok-3-beta",
-        "organisation_id": "x-ai",
-        "previous_model_id": "x-ai/grok-2-2024-08-13",
-        "api_model_id": "x-ai/grok-3-beta",
-        "has_page_notice": false
-      }
-    },
-    "../../packages/data/catalog/src/data/models/x-ai/grok-3-mini/model.json": {
-      "hash": "3dc8819224302f4ff78eb21f65777675",
-      "meta": {
-        "model_id": "x-ai/grok-3-mini",
-        "organisation_id": "x-ai",
-        "previous_model_id": "x-ai/grok-3-mini-beta-2025-02-19",
-        "api_model_id": "x-ai/grok-3-mini",
-        "has_page_notice": false
-      }
-    },
-    "../../packages/data/catalog/src/data/models/x-ai/grok-3-mini-beta/model.json": {
-      "hash": "ed12e55c4cde1d3c218b7b4c62fb52e0",
-      "meta": {
-        "model_id": "x-ai/grok-3-mini-beta",
-        "organisation_id": "x-ai",
-        "previous_model_id": "x-ai/grok-2-mini-2024-08-13",
-        "api_model_id": "x-ai/grok-3-mini-beta",
-        "has_page_notice": false
-      }
-    },
-    "../../packages/data/catalog/src/data/models/x-ai/grok-4/model.json": {
-      "hash": "d24d958295d52f5d04a4819ba27863f2",
-      "meta": {
-        "model_id": "x-ai/grok-4",
-        "organisation_id": "x-ai",
-        "previous_model_id": "x-ai/grok-3-2025-04-18",
-        "api_model_id": "x-ai/grok-4",
-        "has_page_notice": false
-      }
-    },
-    "../../packages/data/catalog/src/data/models/x-ai/grok-4-fast-non-reasoning/model.json": {
-      "hash": "5a310a518286c98798f95ca23b120bcd",
-      "meta": {
-        "model_id": "x-ai/grok-4-fast-non-reasoning",
-        "organisation_id": "x-ai",
-        "previous_model_id": null,
-        "api_model_id": "x-ai/grok-4-fast-non-reasoning",
-        "has_page_notice": false
-      }
-    },
-    "../../packages/data/catalog/src/data/models/x-ai/grok-4-fast-reasoning/model.json": {
-      "hash": "1ab4134d1f2907bb43e1c476de316f82",
-      "meta": {
-        "model_id": "x-ai/grok-4-fast-reasoning",
-        "organisation_id": "x-ai",
-        "previous_model_id": null,
-        "api_model_id": "x-ai/grok-4-fast-reasoning",
-        "has_page_notice": false
-      }
-    },
-    "../../packages/data/catalog/src/data/models/x-ai/grok-4-heavy/model.json": {
-      "hash": "e503cf178ab99d90bcda70a81a7ab496",
-      "meta": {
-        "model_id": "x-ai/grok-4-heavy",
-        "organisation_id": "x-ai",
-        "previous_model_id": null,
-        "api_model_id": "x-ai/grok-4-heavy",
-        "has_page_notice": false
-      }
-    },
-    "../../packages/data/catalog/src/data/models/x-ai/grok-4.1-fast/model.json": {
-      "hash": "253ee45236831b8e12264ddc476f3601",
-      "meta": {
-        "model_id": "x-ai/grok-4.1-fast",
-        "organisation_id": "x-ai",
-        "previous_model_id": null,
-        "api_model_id": "x-ai/grok-4.1-fast",
-        "has_page_notice": false
-      }
-    },
-    "../../packages/data/catalog/src/data/models/x-ai/grok-4.1-non-thinking/model.json": {
-      "hash": "a27df89348b4bd415efc6720a48d7708",
-      "meta": {
-        "model_id": "x-ai/grok-4.1-non-thinking",
-        "organisation_id": "x-ai",
-        "previous_model_id": "x-ai/grok-4-fast-non-reasoning-2025-09-20",
-        "api_model_id": "x-ai/grok-4.1-non-thinking",
-        "has_page_notice": false
-      }
-    },
-    "../../packages/data/catalog/src/data/models/x-ai/grok-4.1-thinking/model.json": {
-      "hash": "99886734c97536d1ac2a5b1be43c8049",
-      "meta": {
-        "model_id": "x-ai/grok-4.1-thinking",
-        "organisation_id": "x-ai",
-        "previous_model_id": "x-ai/grok-4-fast-reasoning-2025-09-20",
-        "api_model_id": "x-ai/grok-4.1-thinking",
-        "has_page_notice": false
-      }
-    },
-    "../../packages/data/catalog/src/data/models/x-ai/grok-4.20/model.json": {
-      "hash": "5f9113ee78864f1d4d848df262fb93e8",
-      "meta": {
-        "model_id": "x-ai/grok-4.20",
-        "organisation_id": "x-ai",
-        "previous_model_id": "x-ai/grok-4-1-non-thinking-2025-11-17",
-        "api_model_id": "x-ai/grok-4.20",
-        "has_page_notice": false
-      }
-    },
-    "../../packages/data/catalog/src/data/models/x-ai/grok-4.20-multi-agent-beta/model.json": {
-      "hash": "a4a7530a2c839bcbaa8b5965b6a68ed0",
-      "meta": {
-        "model_id": "x-ai/grok-4.20-multi-agent-beta",
-        "organisation_id": "x-ai",
-        "previous_model_id": "x-ai/grok-4-1-non-thinking-2025-11-17"
-      }
-    },
-    "../../packages/data/catalog/src/data/models/x-ai/grok-4.3/model.json": {
-      "hash": "0669145ad8c9cae6bbe73b160e73d579",
-      "meta": {
-        "model_id": "x-ai/grok-4.3",
-        "organisation_id": "x-ai",
-        "previous_model_id": "x-ai/grok-4.20",
-        "api_model_id": "x-ai/grok-4.3",
-        "has_page_notice": false
-      }
-    },
-    "../../packages/data/catalog/src/data/models/x-ai/grok-code-fast-1/model.json": {
-      "hash": "1a6e25c1bbf8cb9d4d9abfb656f729a7",
-      "meta": {
-        "model_id": "x-ai/grok-code-fast-1",
-        "organisation_id": "x-ai",
-        "previous_model_id": null,
-        "api_model_id": "x-ai/grok-code-fast-1",
-        "has_page_notice": false
-      }
-    },
-    "../../packages/data/catalog/src/data/models/x-ai/grok-imagine-image/model.json": {
-      "hash": "66ce251d399416a96ce8d12ec77bb14e",
-      "meta": {
-        "model_id": "x-ai/grok-imagine-image",
-        "organisation_id": "x-ai",
-        "previous_model_id": null,
-        "api_model_id": "x-ai/grok-imagine-image",
-        "has_page_notice": false
-      }
-    },
-    "../../packages/data/catalog/src/data/models/x-ai/grok-imagine-image-pro/model.json": {
-      "hash": "70751ac1d0627c08893d290b6cbe1b08",
-      "meta": {
-        "model_id": "x-ai/grok-imagine-image-pro",
-        "organisation_id": "x-ai",
-        "previous_model_id": null
-      }
-    },
-    "../../packages/data/catalog/src/data/models/x-ai/grok-imagine-video/model.json": {
-      "hash": "f31c01ea04125ee121243917a544aac5",
-      "meta": {
-        "model_id": "x-ai/grok-imagine-video",
-        "organisation_id": "x-ai",
-        "previous_model_id": null,
-        "api_model_id": "x-ai/grok-imagine-video",
-        "has_page_notice": false
-      }
-    },
     "../../packages/data/catalog/src/data/models/xiaomi/mimo-v2-flash/model.json": {
       "hash": "994afa5de3d9f54c779102e59116de65",
       "meta": {
@@ -16659,7 +16541,7 @@
       }
     },
     "../../packages/data/catalog/src/data/models/xiaomi/mimo-v2.5/model.json": {
-      "hash": "5e100631cf9433a9aaabb2b5c7eef177",
+      "hash": "37c28e2e58de3dc8722014f6414ac097",
       "meta": {
         "model_id": "xiaomi/mimo-v2.5",
         "organisation_id": "xiaomi",
@@ -16669,7 +16551,7 @@
       }
     },
     "../../packages/data/catalog/src/data/models/xiaomi/mimo-v2.5-pro/model.json": {
-      "hash": "ef01ca1472fe3cc3dc34fff414dc0c63",
+      "hash": "1296806b2b02809b5968b71c8bbbc4ee",
       "meta": {
         "model_id": "xiaomi/mimo-v2.5-pro",
         "organisation_id": "xiaomi",
@@ -16679,7 +16561,7 @@
       }
     },
     "../../packages/data/catalog/src/data/models/xiaomi/mimo-v2.5-tts/model.json": {
-      "hash": "a85d3c0743e22187faa84aad3e3c34ab",
+      "hash": "678c3bbc7a331982f7315028e8fa4023",
       "meta": {
         "model_id": "xiaomi/mimo-v2.5-tts",
         "organisation_id": "xiaomi",
@@ -16819,7 +16701,7 @@
       }
     },
     "../../packages/data/catalog/src/data/models/z-ai/glm-4.6v/model.json": {
-      "hash": "257bdef6839ad8880e5e30c99fa6d2f1",
+      "hash": "de9d9c1c167f000852266de610c6ec11",
       "meta": {
         "model_id": "z-ai/glm-4.6v",
         "organisation_id": "z-ai",
@@ -16829,7 +16711,7 @@
       }
     },
     "../../packages/data/catalog/src/data/models/z-ai/glm-4.6v-flash/model.json": {
-      "hash": "ed919a05c5800038af4fce5aac16e650",
+      "hash": "23d4acd98baeb05dbfd931524088c5f2",
       "meta": {
         "model_id": "z-ai/glm-4.6v-flash",
         "organisation_id": "z-ai",
@@ -16899,7 +16781,7 @@
       }
     },
     "../../packages/data/catalog/src/data/models/z-ai/glm-5.1/model.json": {
-      "hash": "ab124b2b38aeac42fc8078f0dc0afa3e",
+      "hash": "c10e3eee8324c377c0cd72e005c09748",
       "meta": {
         "model_id": "z-ai/glm-5.1",
         "organisation_id": "z-ai",
@@ -16909,7 +16791,7 @@
       }
     },
     "../../packages/data/catalog/src/data/models/z-ai/glm-5v-turbo/model.json": {
-      "hash": "61a73f3a1cf97eb9b4be8faf7a60982b",
+      "hash": "ca70071b16d7273e6dc0f0f814108735",
       "meta": {
         "model_id": "z-ai/glm-5v-turbo",
         "organisation_id": "z-ai",
@@ -16953,7 +16835,7 @@
       }
     },
     "../../packages/data/catalog/src/data/aliases/openai-gpt-latest/alias.json": {
-      "hash": "1c9a3deb6a18645d1cf4d32fde1c6580",
+      "hash": "2a23d2a818a029f6daba075d1adec00b",
       "meta": {
         "alias_slug": "openai/gpt-latest"
       }
@@ -16971,7 +16853,7 @@
       }
     },
     "../../packages/data/catalog/src/data/aliases/openai-gpt-pro-latest/alias.json": {
-      "hash": "27ab7817321981019ca7f1361a2e9980",
+      "hash": "26e3b5e3ff69b7dbc667aff6e68d670a",
       "meta": {
         "alias_slug": "openai/gpt-pro-latest"
       }
@@ -16995,7 +16877,7 @@
       }
     },
     "../../packages/data/catalog/src/data/pricing/aion-labs/aion-labs-aion-1.0/text.generate/pricing.json": {
-      "hash": "3cd1810e45d6aeb233c75d270d63a095",
+      "hash": "15fe768742f28e94718e051d5bed93f0",
       "meta": {
         "api_provider_id": "aion-labs",
         "capability_id": "text.generate",
@@ -17004,7 +16886,7 @@
       }
     },
     "../../packages/data/catalog/src/data/pricing/aion-labs/aion-labs-aion-1.0-mini/text.generate/pricing.json": {
-      "hash": "c1f8ae4e535cdca6180203e376f5bebb",
+      "hash": "3f5a7100802d04ba66ac7dc7b2feeb5d",
       "meta": {
         "api_provider_id": "aion-labs",
         "capability_id": "text.generate",
@@ -17067,7 +16949,7 @@
       }
     },
     "../../packages/data/catalog/src/data/pricing/akashml/minimax-minimax-m2.5/text.generate/pricing.json": {
-      "hash": "a847dbfcb46dc6c4941a7c4fb3fab7ef",
+      "hash": "65ec8d5ac65e7399089363b173a2a541",
       "meta": {
         "api_provider_id": "akashml",
         "capability_id": "text.generate",
@@ -17400,7 +17282,7 @@
       }
     },
     "../../packages/data/catalog/src/data/pricing/alibaba-cloud/qwen-qwen3.6-35b-a3b/text.generate/pricing.json": {
-      "hash": "f370ab57f618b070b422c92b366146ff",
+      "hash": "4f45334a1b4b413a903cb54625d6e29b",
       "meta": {
         "api_provider_id": "alibaba-cloud",
         "capability_id": "text.generate",
@@ -17499,7 +17381,7 @@
       }
     },
     "../../packages/data/catalog/src/data/pricing/amazon-bedrock/anthropic-claude-3-haiku/text.generate/pricing.json": {
-      "hash": "e00b84c7d66b80823b8b15801082ecd4",
+      "hash": "47ef86f1d01b8fe57d687c89cf7acb9b",
       "meta": {
         "api_provider_id": "amazon-bedrock",
         "capability_id": "text.generate",
@@ -17508,7 +17390,7 @@
       }
     },
     "../../packages/data/catalog/src/data/pricing/amazon-bedrock/anthropic-claude-haiku-4.5/text.generate/pricing.json": {
-      "hash": "7550e5efee92f0b5f61e9e90bf0b7ac0",
+      "hash": "1e592ca4729cf8320380680dfcc1f044",
       "meta": {
         "api_provider_id": "amazon-bedrock",
         "capability_id": "text.generate",
@@ -17517,7 +17399,7 @@
       }
     },
     "../../packages/data/catalog/src/data/pricing/amazon-bedrock/anthropic-claude-opus-4.5/text.generate/pricing.json": {
-      "hash": "7eae80709af884678a0724f123590da0",
+      "hash": "d859e5ae2dce9eb0104af0a1b0b63242",
       "meta": {
         "api_provider_id": "amazon-bedrock",
         "capability_id": "text.generate",
@@ -17526,7 +17408,7 @@
       }
     },
     "../../packages/data/catalog/src/data/pricing/amazon-bedrock/anthropic-claude-opus-4.6/text.generate/pricing.json": {
-      "hash": "6bc424e22c3f1def869974c23a5bae0f",
+      "hash": "f70ef086b8cec73f3bc7d40b482f485f",
       "meta": {
         "api_provider_id": "amazon-bedrock",
         "capability_id": "text.generate",
@@ -17535,7 +17417,7 @@
       }
     },
     "../../packages/data/catalog/src/data/pricing/amazon-bedrock/anthropic-claude-opus-4.7/text.generate/pricing.json": {
-      "hash": "19a1f68ede16e5e5c0d024a24ba24b02",
+      "hash": "ecb6ab0dc96d861ace28757f17e366db",
       "meta": {
         "api_provider_id": "amazon-bedrock",
         "capability_id": "text.generate",
@@ -17544,7 +17426,7 @@
       }
     },
     "../../packages/data/catalog/src/data/pricing/amazon-bedrock/anthropic-claude-sonnet-4/text.generate/pricing.json": {
-      "hash": "07479f8ae0374d00cb99a67747e127f3",
+      "hash": "0c3d95e3e449995e0df4ae1fe22a5db4",
       "meta": {
         "api_provider_id": "amazon-bedrock",
         "capability_id": "text.generate",
@@ -17553,7 +17435,7 @@
       }
     },
     "../../packages/data/catalog/src/data/pricing/amazon-bedrock/anthropic-claude-sonnet-4.5/text.generate/pricing.json": {
-      "hash": "61edabf95ed376b654a914a308337b06",
+      "hash": "91dc125b36ff51187a1a5900216c3d97",
       "meta": {
         "api_provider_id": "amazon-bedrock",
         "capability_id": "text.generate",
@@ -17562,7 +17444,7 @@
       }
     },
     "../../packages/data/catalog/src/data/pricing/amazon-bedrock/anthropic-claude-sonnet-4.6/text.generate/pricing.json": {
-      "hash": "32b38c6797ea5e4d72bc46f412b7b00d",
+      "hash": "aa0e1c68fd1ffb2ae9bb98d0094e3b93",
       "meta": {
         "api_provider_id": "amazon-bedrock",
         "capability_id": "text.generate",
@@ -17733,7 +17615,7 @@
       }
     },
     "../../packages/data/catalog/src/data/pricing/anthropic/anthropic-claude-3-haiku/text.generate/pricing.json": {
-      "hash": "6ffb291968dcf66e7876a12bb268c4ca",
+      "hash": "eafde4914dd9c60808b62afbd61b8f57",
       "meta": {
         "api_provider_id": "anthropic",
         "capability_id": "text.generate",
@@ -17751,7 +17633,7 @@
       }
     },
     "../../packages/data/catalog/src/data/pricing/anthropic/anthropic-claude-3.5-haiku/text.generate/pricing.json": {
-      "hash": "dc53ef0d5366fe07196cfe5942d13087",
+      "hash": "051cdc8eb608b113c4de71b1e270b7d4",
       "meta": {
         "api_provider_id": "anthropic",
         "capability_id": "text.generate",
@@ -17760,7 +17642,7 @@
       }
     },
     "../../packages/data/catalog/src/data/pricing/anthropic/anthropic-claude-3.7-sonnet/text.generate/pricing.json": {
-      "hash": "6e37488fc6eef683a50af1ced22a4748",
+      "hash": "b636a7d95c058ebdbd421e62c358c586",
       "meta": {
         "api_provider_id": "anthropic",
         "capability_id": "text.generate",
@@ -17769,7 +17651,7 @@
       }
     },
     "../../packages/data/catalog/src/data/pricing/anthropic/anthropic-claude-haiku-4.5/text.generate/pricing.json": {
-      "hash": "e557ed72d0dff72abd4b0d6aee293d4e",
+      "hash": "555babf7742f6d983196e50b4cd33e2e",
       "meta": {
         "api_provider_id": "anthropic",
         "capability_id": "text.generate",
@@ -17787,7 +17669,7 @@
       }
     },
     "../../packages/data/catalog/src/data/pricing/anthropic/anthropic-claude-opus-4/text.generate/pricing.json": {
-      "hash": "384f9aec91cc7fd2be82e8c8fbb8c40d",
+      "hash": "817928622e0b5488f393c6969ae3af87",
       "meta": {
         "api_provider_id": "anthropic",
         "capability_id": "text.generate",
@@ -17796,7 +17678,7 @@
       }
     },
     "../../packages/data/catalog/src/data/pricing/anthropic/anthropic-claude-opus-4.1/text.generate/pricing.json": {
-      "hash": "f17cb5d5a66ee7e40488e4032dc34d4a",
+      "hash": "d768993ea9ed8f2e3ebcfbe464dcd10f",
       "meta": {
         "api_provider_id": "anthropic",
         "capability_id": "text.generate",
@@ -17805,7 +17687,7 @@
       }
     },
     "../../packages/data/catalog/src/data/pricing/anthropic/anthropic-claude-opus-4.5/text.generate/pricing.json": {
-      "hash": "74e41060e15ecd5eab19cf74534ebfe9",
+      "hash": "96e9a3774c01912fe77113cdfc94aa90",
       "meta": {
         "api_provider_id": "anthropic",
         "capability_id": "text.generate",
@@ -17814,7 +17696,7 @@
       }
     },
     "../../packages/data/catalog/src/data/pricing/anthropic/anthropic-claude-opus-4.6/text.generate/pricing.json": {
-      "hash": "d7c828813b43e50d05da2fe4fe08718a",
+      "hash": "9d5f3e30a3f1c0f887ff94103f0baf75",
       "meta": {
         "api_provider_id": "anthropic",
         "capability_id": "text.generate",
@@ -17823,7 +17705,7 @@
       }
     },
     "../../packages/data/catalog/src/data/pricing/anthropic/anthropic-claude-opus-4.7/text.generate/pricing.json": {
-      "hash": "435f030e580fa95fa6105a39236fa043",
+      "hash": "9833de8a8c4d46631a4d1d52effbd170",
       "meta": {
         "api_provider_id": "anthropic",
         "capability_id": "text.generate",
@@ -17832,7 +17714,7 @@
       }
     },
     "../../packages/data/catalog/src/data/pricing/anthropic/anthropic-claude-sonnet-4/text.generate/pricing.json": {
-      "hash": "4d6c37772df179b7283b6d430dc19cd7",
+      "hash": "fd52b3140f6143d3b5d4d595a0caa0c9",
       "meta": {
         "api_provider_id": "anthropic",
         "capability_id": "text.generate",
@@ -17841,7 +17723,7 @@
       }
     },
     "../../packages/data/catalog/src/data/pricing/anthropic/anthropic-claude-sonnet-4.5/text.generate/pricing.json": {
-      "hash": "985051c7fdb11d6eae7e4dfa49a4a13d",
+      "hash": "fea0cbaee383e8c6eff00424668cbb5d",
       "meta": {
         "api_provider_id": "anthropic",
         "capability_id": "text.generate",
@@ -17850,7 +17732,7 @@
       }
     },
     "../../packages/data/catalog/src/data/pricing/anthropic/anthropic-claude-sonnet-4.6/text.generate/pricing.json": {
-      "hash": "28a978f88e99dc39991284f8659d39fd",
+      "hash": "52873cbdc68445b3ba3847c0c27e0dc0",
       "meta": {
         "api_provider_id": "anthropic",
         "capability_id": "text.generate",
@@ -17976,7 +17858,7 @@
       }
     },
     "../../packages/data/catalog/src/data/pricing/atlascloud/meituan-longcat-flash-cat/text.generate/pricing.json": {
-      "hash": "b4c88a1d7f4d59c81a0642edce32c4f7",
+      "hash": "6a3569770e7cd671ebb33389088d66e8",
       "meta": {
         "api_provider_id": "atlascloud",
         "capability_id": "text.generate",
@@ -18066,7 +17948,7 @@
       }
     },
     "../../packages/data/catalog/src/data/pricing/atlascloud/moonshotai-kimi-k2.7-code/text.generate/pricing.json": {
-      "hash": "ee54855af5e2dad0cd1f396c3d6f91a4",
+      "hash": "5680d5fbbee73f38ab40ab5f779f606b",
       "meta": {
         "api_provider_id": "atlascloud",
         "capability_id": "text.generate",
@@ -18867,7 +18749,7 @@
       }
     },
     "../../packages/data/catalog/src/data/pricing/crofai/crofai-greg/text.generate/pricing.json": {
-      "hash": "7f5a1e57377b091ba3b20a0d576d58ee",
+      "hash": "fccdac1fc142b75d1a0be86eed5e6006",
       "meta": {
         "api_provider_id": "crofai",
         "capability_id": "text.generate",
@@ -18876,7 +18758,7 @@
       }
     },
     "../../packages/data/catalog/src/data/pricing/crofai/deepseek-deepseek-v3.2/text.generate/pricing.json": {
-      "hash": "e84f9d96b75c05ee4b7f27ebbf2295df",
+      "hash": "da0995ccccc48381051c34b67cf22d40",
       "meta": {
         "api_provider_id": "crofai",
         "capability_id": "text.generate",
@@ -18894,7 +18776,7 @@
       }
     },
     "../../packages/data/catalog/src/data/pricing/crofai/deepseek-deepseek-v4-pro/text.generate/pricing.json": {
-      "hash": "571d845919db27728485a6981cc27869",
+      "hash": "8d02c96abe3fc4087f73a4dd28dab84a",
       "meta": {
         "api_provider_id": "crofai",
         "capability_id": "text.generate",
@@ -18984,7 +18866,7 @@
       }
     },
     "../../packages/data/catalog/src/data/pricing/crofai/qwen-qwen3.5-9b-chat/text.generate/pricing.json": {
-      "hash": "c428ee2bca6372fd1de7ed14464dd1e1",
+      "hash": "14525956cce5a60af387d122f0d90af3",
       "meta": {
         "api_provider_id": "crofai",
         "capability_id": "text.generate",
@@ -19029,7 +18911,7 @@
       }
     },
     "../../packages/data/catalog/src/data/pricing/crofai/z-ai-glm-5.1/text.generate/pricing.json": {
-      "hash": "2b9dfb847110d3277b6bcc821c086c54",
+      "hash": "d1a06f1385a21bc8bf69bf45d53ae5ba",
       "meta": {
         "api_provider_id": "crofai",
         "capability_id": "text.generate",
@@ -19110,7 +18992,7 @@
       }
     },
     "../../packages/data/catalog/src/data/pricing/deepinfra/deepseek-deepseek-v3-0324/text.generate/pricing.json": {
-      "hash": "77528743399f2e7ea6a575c844ac54f5",
+      "hash": "0cf07d39e1a2c52fd596a087d843fc9a",
       "meta": {
         "api_provider_id": "deepinfra",
         "capability_id": "text.generate",
@@ -19146,7 +19028,7 @@
       }
     },
     "../../packages/data/catalog/src/data/pricing/deepinfra/deepseek-deepseek-v4-flash/text.generate/pricing.json": {
-      "hash": "7facb5936eedd555a3e09be7d112151d",
+      "hash": "5fc9df4a88155335439ca1e830d18383",
       "meta": {
         "api_provider_id": "deepinfra",
         "capability_id": "text.generate",
@@ -19155,7 +19037,7 @@
       }
     },
     "../../packages/data/catalog/src/data/pricing/deepinfra/deepseek-deepseek-v4-pro/text.generate/pricing.json": {
-      "hash": "b997fd00553ee1e2f191c539a3caf2a1",
+      "hash": "211de6bf25d9001dfd57266008867bbe",
       "meta": {
         "api_provider_id": "deepinfra",
         "capability_id": "text.generate",
@@ -19218,7 +19100,7 @@
       }
     },
     "../../packages/data/catalog/src/data/pricing/deepinfra/meta-llama-4-scout/text.generate/pricing.json": {
-      "hash": "c8015921329e2c02b8e75102cbc5577d",
+      "hash": "58dccb1f47b9ebd983cc3349d28db7fe",
       "meta": {
         "api_provider_id": "deepinfra",
         "capability_id": "text.generate",
@@ -19317,7 +19199,7 @@
       }
     },
     "../../packages/data/catalog/src/data/pricing/deepinfra/nousresearch-hermes-3-llama-3.1-70b/text.generate/pricing.json": {
-      "hash": "d16499ee3ff6e000aace43197769fc21",
+      "hash": "53f2ee40b56e4a9d070c8dbeb889dd23",
       "meta": {
         "api_provider_id": "deepinfra",
         "capability_id": "text.generate",
@@ -19362,7 +19244,7 @@
       }
     },
     "../../packages/data/catalog/src/data/pricing/deepinfra/nvidia-nemotron-3-super-120b-a12b/text.generate/pricing.json": {
-      "hash": "3ad4752864990d8aa9a405cfd83f0faf",
+      "hash": "0c930a71dbd2df4d9e4f128c707cb3bf",
       "meta": {
         "api_provider_id": "deepinfra",
         "capability_id": "text.generate",
@@ -19407,7 +19289,7 @@
       }
     },
     "../../packages/data/catalog/src/data/pricing/deepinfra/qwen-qwen3-235b-a22b-2507/text.generate/pricing.json": {
-      "hash": "aba768f22994b7f316675b043636d215",
+      "hash": "e2de92559952142471756069067df8f9",
       "meta": {
         "api_provider_id": "deepinfra",
         "capability_id": "text.generate",
@@ -19425,7 +19307,7 @@
       }
     },
     "../../packages/data/catalog/src/data/pricing/deepinfra/qwen-qwen3-30b-a3b/text.generate/pricing.json": {
-      "hash": "8499bf715659ac8811858560b9a63a84",
+      "hash": "a459b93fdaf406682c331c0ae1c9bdb4",
       "meta": {
         "api_provider_id": "deepinfra",
         "capability_id": "text.generate",
@@ -19506,7 +19388,7 @@
       }
     },
     "../../packages/data/catalog/src/data/pricing/deepinfra/qwen-qwen3.5-122b-a10b/text.generate/pricing.json": {
-      "hash": "fd79ee98f6bd25e7b63a88f22a8d24ad",
+      "hash": "d50a900e8d568e3a3c7edd526265ecd0",
       "meta": {
         "api_provider_id": "deepinfra",
         "capability_id": "text.generate",
@@ -19533,7 +19415,7 @@
       }
     },
     "../../packages/data/catalog/src/data/pricing/deepinfra/qwen-qwen3.5-35b-a3b/text.generate/pricing.json": {
-      "hash": "cfad22fef2bf2f2e7d43ddbfda2c5610",
+      "hash": "78720415d82b51b03fe3780babe47960",
       "meta": {
         "api_provider_id": "deepinfra",
         "capability_id": "text.generate",
@@ -19542,7 +19424,7 @@
       }
     },
     "../../packages/data/catalog/src/data/pricing/deepinfra/qwen-qwen3.5-397b-a17b/text.generate/pricing.json": {
-      "hash": "e88c144a878d2cba0816fed93b65a864",
+      "hash": "f605ed244ee9356cdc2c464236933269",
       "meta": {
         "api_provider_id": "deepinfra",
         "capability_id": "text.generate",
@@ -19641,7 +19523,7 @@
       }
     },
     "../../packages/data/catalog/src/data/pricing/deepseek/deepseek-deepseek-v4-flash/text.generate/pricing.json": {
-      "hash": "34fe5e971a30dc33c189287db4518f9a",
+      "hash": "9369c2924e67f4d1008329bb6fb2bede",
       "meta": {
         "api_provider_id": "deepseek",
         "capability_id": "text.generate",
@@ -19650,7 +19532,7 @@
       }
     },
     "../../packages/data/catalog/src/data/pricing/deepseek/deepseek-deepseek-v4-pro/text.generate/pricing.json": {
-      "hash": "026e905286f4e7dac769f37ae8875090",
+      "hash": "be66bdf432a81c2a744f6dea4665b8b5",
       "meta": {
         "api_provider_id": "deepseek",
         "capability_id": "text.generate",
@@ -20334,7 +20216,7 @@
       }
     },
     "../../packages/data/catalog/src/data/pricing/google-ai-studio/google-gemma-3-12b-free/text.generate/pricing.json": {
-      "hash": "477f1dc416e43ffdbaa0c3e3fd0cf968",
+      "hash": "a0f36461e07563835061d4dd99acb527",
       "meta": {
         "api_provider_id": "google-ai-studio",
         "capability_id": "text.generate",
@@ -20343,7 +20225,7 @@
       }
     },
     "../../packages/data/catalog/src/data/pricing/google-ai-studio/google-gemma-3-1b-free/text.generate/pricing.json": {
-      "hash": "5de0cec9cca7852378a4d5a6b42ae40b",
+      "hash": "0a7fba6ccb646b22824ae945305182a7",
       "meta": {
         "api_provider_id": "google-ai-studio",
         "capability_id": "text.generate",
@@ -20352,7 +20234,7 @@
       }
     },
     "../../packages/data/catalog/src/data/pricing/google-ai-studio/google-gemma-3-27b-free/text.generate/pricing.json": {
-      "hash": "473cc72aa6a167f6841ee46056ea811c",
+      "hash": "93a63ca1316a7f0d6360c5f9181502d3",
       "meta": {
         "api_provider_id": "google-ai-studio",
         "capability_id": "text.generate",
@@ -20361,7 +20243,7 @@
       }
     },
     "../../packages/data/catalog/src/data/pricing/google-ai-studio/google-gemma-3-4b-free/text.generate/pricing.json": {
-      "hash": "5488651efc29acdbe9d2a7ccb7a6b5e6",
+      "hash": "9894b33138c8f6a1203ab5b03ddb1e4b",
       "meta": {
         "api_provider_id": "google-ai-studio",
         "capability_id": "text.generate",
@@ -20370,7 +20252,7 @@
       }
     },
     "../../packages/data/catalog/src/data/pricing/google-ai-studio/google-gemma-3n-e2b-free/text.generate/pricing.json": {
-      "hash": "306702f9a309b31f14b3adf74682aec2",
+      "hash": "d4d6e327d9234c300225665f0da55e4d",
       "meta": {
         "api_provider_id": "google-ai-studio",
         "capability_id": "text.generate",
@@ -20379,7 +20261,7 @@
       }
     },
     "../../packages/data/catalog/src/data/pricing/google-ai-studio/google-gemma-3n-e4b-free/text.generate/pricing.json": {
-      "hash": "98ae7c5423039f7a624b2d0bb55a5c80",
+      "hash": "34bbe69b3b5b2ff55793af05b3a5fe5a",
       "meta": {
         "api_provider_id": "google-ai-studio",
         "capability_id": "text.generate",
@@ -20424,7 +20306,7 @@
       }
     },
     "../../packages/data/catalog/src/data/pricing/google-vertex/anthropic-claude-3-haiku/text.generate/pricing.json": {
-      "hash": "707717c8403e00d731d9d1d87a0169cc",
+      "hash": "291784690936d3e96e5f02ba7aae13a4",
       "meta": {
         "api_provider_id": "google-vertex",
         "capability_id": "text.generate",
@@ -20433,7 +20315,7 @@
       }
     },
     "../../packages/data/catalog/src/data/pricing/google-vertex/anthropic-claude-3.5-haiku/text.generate/pricing.json": {
-      "hash": "1d88132e950535ed9be170215755567b",
+      "hash": "2e3ca60255fdd857424de07e393a8187",
       "meta": {
         "api_provider_id": "google-vertex",
         "capability_id": "text.generate",
@@ -20451,7 +20333,7 @@
       }
     },
     "../../packages/data/catalog/src/data/pricing/google-vertex/anthropic-claude-haiku-4.5/text.generate/pricing.json": {
-      "hash": "d21bd37b658bf774aa45b579314daab1",
+      "hash": "9cd7e771e2fd98d9776035e715f93ffd",
       "meta": {
         "api_provider_id": "google-vertex",
         "capability_id": "text.generate",
@@ -20460,7 +20342,7 @@
       }
     },
     "../../packages/data/catalog/src/data/pricing/google-vertex/anthropic-claude-opus-4/text.generate/pricing.json": {
-      "hash": "6ecabbdcc20a8c926476bbf2a08a84e1",
+      "hash": "f3305c032bc9b87575226f3e12de5645",
       "meta": {
         "api_provider_id": "google-vertex",
         "capability_id": "text.generate",
@@ -20469,7 +20351,7 @@
       }
     },
     "../../packages/data/catalog/src/data/pricing/google-vertex/anthropic-claude-opus-4.1/text.generate/pricing.json": {
-      "hash": "2a10328c4157822756827b99daa9a16e",
+      "hash": "e3f3f9d6b099fe623049f701d356b4cd",
       "meta": {
         "api_provider_id": "google-vertex",
         "capability_id": "text.generate",
@@ -20478,7 +20360,7 @@
       }
     },
     "../../packages/data/catalog/src/data/pricing/google-vertex/anthropic-claude-opus-4.5/text.generate/pricing.json": {
-      "hash": "13ca508dcc4e5e80ce79817181fae34b",
+      "hash": "e7090aa7731dfc93a9189cccf178bd95",
       "meta": {
         "api_provider_id": "google-vertex",
         "capability_id": "text.generate",
@@ -20487,7 +20369,7 @@
       }
     },
     "../../packages/data/catalog/src/data/pricing/google-vertex/anthropic-claude-opus-4.6/text.generate/pricing.json": {
-      "hash": "a1163e12b16e3dc8736f84e62698013d",
+      "hash": "2e268e458535dbb491a0b31e43964f8f",
       "meta": {
         "api_provider_id": "google-vertex",
         "capability_id": "text.generate",
@@ -20496,7 +20378,7 @@
       }
     },
     "../../packages/data/catalog/src/data/pricing/google-vertex/anthropic-claude-opus-4.7/text.generate/pricing.json": {
-      "hash": "936d0b76ac8b0cbab860c3f03d23fda1",
+      "hash": "ccaddb4eb653e9b8f2bc133f262bd9da",
       "meta": {
         "api_provider_id": "google-vertex",
         "capability_id": "text.generate",
@@ -20505,7 +20387,7 @@
       }
     },
     "../../packages/data/catalog/src/data/pricing/google-vertex/anthropic-claude-sonnet-4/text.generate/pricing.json": {
-      "hash": "0213e2e5464dc993a0dfd23df67759a7",
+      "hash": "4c76eb2dae499e6cfc7f90a0fab80aef",
       "meta": {
         "api_provider_id": "google-vertex",
         "capability_id": "text.generate",
@@ -20514,7 +20396,7 @@
       }
     },
     "../../packages/data/catalog/src/data/pricing/google-vertex/anthropic-claude-sonnet-4.5/text.generate/pricing.json": {
-      "hash": "1c8d5450ec2c9e2a49f9f340767b2313",
+      "hash": "5c77e1ba2529cae448de84e5e6948a22",
       "meta": {
         "api_provider_id": "google-vertex",
         "capability_id": "text.generate",
@@ -20523,7 +20405,7 @@
       }
     },
     "../../packages/data/catalog/src/data/pricing/google-vertex/anthropic-claude-sonnet-4.6/text.generate/pricing.json": {
-      "hash": "8457c7030740a2c4bc036a8667bbe714",
+      "hash": "445d64a683054c12f47e173f9780a11a",
       "meta": {
         "api_provider_id": "google-vertex",
         "capability_id": "text.generate",
@@ -21639,7 +21521,7 @@
       }
     },
     "../../packages/data/catalog/src/data/pricing/nebius-token-factory/primeintellect-intellect-3/text.generate/pricing.json": {
-      "hash": "85932becb4f15a2d2bd073a876f83a31",
+      "hash": "2fb8a95443df045c2f0f9087fbfd9ce7",
       "meta": {
         "api_provider_id": "nebius-token-factory",
         "capability_id": "text.generate",
@@ -21774,7 +21656,7 @@
       }
     },
     "../../packages/data/catalog/src/data/pricing/nebius-token-factory/z-ai-glm-5/text.generate/pricing.json": {
-      "hash": "abdb8250708144ca5ad176bdd3880c39",
+      "hash": "7cfaad3b89ce24232c3cacca2e7886e9",
       "meta": {
         "api_provider_id": "nebius-token-factory",
         "capability_id": "text.generate",
@@ -23304,7 +23186,7 @@
       }
     },
     "../../packages/data/catalog/src/data/pricing/poolside/poolside-laguna-xs.2-free/text.generate/pricing.json": {
-      "hash": "48243bf2e0c1e628d90b18e3bbf7fa5c",
+      "hash": "e5f0fc911d30205e859648e957b7a74b",
       "meta": {
         "api_provider_id": "poolside",
         "capability_id": "text.generate",
@@ -24374,42 +24256,6 @@
         "model_key": "venice:venice/venice-uncensored-1.1:text.generate"
       }
     },
-    "../../packages/data/catalog/src/data/pricing/venice/x-ai-grok-4.1-fast/text.generate/pricing.json": {
-      "hash": "3cb6127f48e2e11080bf81e488314da5",
-      "meta": {
-        "api_provider_id": "venice",
-        "capability_id": "text.generate",
-        "model_id": "x-ai/grok-4.1-fast",
-        "model_key": "venice:x-ai/grok-4.1-fast:text.generate"
-      }
-    },
-    "../../packages/data/catalog/src/data/pricing/venice/x-ai-grok-4.20-beta-0309/text.generate/pricing.json": {
-      "hash": "171fd2fd1882e5962fac5b8d6e17aea4",
-      "meta": {
-        "api_provider_id": "venice",
-        "capability_id": "text.generate",
-        "model_id": "x-ai/grok-4.20-beta-0309",
-        "model_key": "venice:x-ai/grok-4.20-beta-0309:text.generate"
-      }
-    },
-    "../../packages/data/catalog/src/data/pricing/venice/x-ai-grok-4.20-multi-agent-beta-0309/text.generate/pricing.json": {
-      "hash": "1cc4f2bff7826f28db905d1e06c60d78",
-      "meta": {
-        "api_provider_id": "venice",
-        "capability_id": "text.generate",
-        "model_id": "x-ai/grok-4.20-multi-agent-beta-0309",
-        "model_key": "venice:x-ai/grok-4.20-multi-agent-beta-0309:text.generate"
-      }
-    },
-    "../../packages/data/catalog/src/data/pricing/venice/x-ai-grok-code-fast-1/text.generate/pricing.json": {
-      "hash": "44decc0f496d4796946e3d452121962e",
-      "meta": {
-        "api_provider_id": "venice",
-        "capability_id": "text.generate",
-        "model_id": "x-ai/grok-code-fast-1",
-        "model_key": "venice:x-ai/grok-code-fast-1:text.generate"
-      }
-    },
     "../../packages/data/catalog/src/data/pricing/venice/z-ai-glm-4.6/text.generate/pricing.json": {
       "hash": "a4a591cba55035feb7b2483647c0dc7e",
       "meta": {
@@ -24959,134 +24805,8 @@
         "model_key": "weights-and-biases:z-ai/glm-5:text.generate"
       }
     },
-    "../../packages/data/catalog/src/data/pricing/x-ai/x-ai-grok-2-vision/text.generate/pricing.json": {
-      "hash": "de31cae71919ffe0367a187bf3a1ad50",
-      "meta": {
-        "api_provider_id": "x-ai",
-        "capability_id": "text.generate",
-        "model_id": "x-ai/grok-2-vision",
-        "model_key": "x-ai:x-ai/grok-2-vision:text.generate"
-      }
-    },
-    "../../packages/data/catalog/src/data/pricing/x-ai/x-ai-grok-3/text.generate/pricing.json": {
-      "hash": "909011c74c776894e75d17e221447cab",
-      "meta": {
-        "api_provider_id": "x-ai",
-        "capability_id": "text.generate",
-        "model_id": "x-ai/grok-3",
-        "model_key": "x-ai:x-ai/grok-3:text.generate"
-      }
-    },
-    "../../packages/data/catalog/src/data/pricing/x-ai/x-ai-grok-3-mini/text.generate/pricing.json": {
-      "hash": "9f84c718a980d139355303360750c410",
-      "meta": {
-        "api_provider_id": "x-ai",
-        "capability_id": "text.generate",
-        "model_id": "x-ai/grok-3-mini",
-        "model_key": "x-ai:x-ai/grok-3-mini:text.generate"
-      }
-    },
-    "../../packages/data/catalog/src/data/pricing/x-ai/x-ai-grok-4/text.generate/pricing.json": {
-      "hash": "e878ff2642cb2ce667564454be0074d5",
-      "meta": {
-        "api_provider_id": "x-ai",
-        "capability_id": "text.generate",
-        "model_id": "x-ai/grok-4",
-        "model_key": "x-ai:x-ai/grok-4:text.generate"
-      }
-    },
-    "../../packages/data/catalog/src/data/pricing/x-ai/x-ai-grok-4.1/text.generate/pricing.json": {
-      "hash": "f7f549c5979aeb974a75e1e7b24c643c",
-      "meta": {
-        "api_provider_id": "x-ai",
-        "capability_id": "text.generate",
-        "model_id": "x-ai/grok-4.1",
-        "model_key": "x-ai:x-ai/grok-4.1:text.generate"
-      }
-    },
-    "../../packages/data/catalog/src/data/pricing/x-ai/x-ai-grok-4.1-thinking/text.generate/pricing.json": {
-      "hash": "92fe7fce2ee545d5e865095ba591011a",
-      "meta": {
-        "api_provider_id": "x-ai",
-        "capability_id": "text.generate",
-        "model_id": "x-ai/grok-4.1-thinking",
-        "model_key": "x-ai:x-ai/grok-4.1-thinking:text.generate"
-      }
-    },
-    "../../packages/data/catalog/src/data/pricing/x-ai/x-ai-grok-4.20-beta-0309/text.generate/pricing.json": {
-      "hash": "ed9f9dab20cd70f1bd2788feab011830",
-      "meta": {
-        "api_provider_id": "x-ai",
-        "capability_id": "text.generate",
-        "model_id": "x-ai/grok-4.20-beta-0309",
-        "model_key": "x-ai:x-ai/grok-4.20-beta-0309:text.generate"
-      }
-    },
-    "../../packages/data/catalog/src/data/pricing/x-ai/x-ai-grok-4.20-multi-agent-beta-0309/text.generate/pricing.json": {
-      "hash": "9455e7c819f73f96a056158720690eec",
-      "meta": {
-        "api_provider_id": "x-ai",
-        "capability_id": "text.generate",
-        "model_id": "x-ai/grok-4.20-multi-agent-beta-0309",
-        "model_key": "x-ai:x-ai/grok-4.20-multi-agent-beta-0309:text.generate"
-      }
-    },
-    "../../packages/data/catalog/src/data/pricing/x-ai/x-ai-grok-4.3/text.generate/pricing.json": {
-      "hash": "74807de435e158d15bcf5e4c49b576a7",
-      "meta": {
-        "api_provider_id": "x-ai",
-        "capability_id": "text.generate",
-        "model_id": "x-ai/grok-4.3",
-        "model_key": "x-ai:x-ai/grok-4.3:text.generate"
-      }
-    },
-    "../../packages/data/catalog/src/data/pricing/x-ai/x-ai-grok-code-fast-1/text.generate/pricing.json": {
-      "hash": "d1d0aeb76202e837fcc13c47bebdfa00",
-      "meta": {
-        "api_provider_id": "x-ai",
-        "capability_id": "text.generate",
-        "model_id": "x-ai/grok-code-fast-1",
-        "model_key": "x-ai:x-ai/grok-code-fast-1:text.generate"
-      }
-    },
-    "../../packages/data/catalog/src/data/pricing/x-ai/x-ai-grok-imagine-image/image.edit/pricing.json": {
-      "hash": "4b9872b4897387b352c89730b9cea21a",
-      "meta": {
-        "api_provider_id": "x-ai",
-        "capability_id": "image.edit",
-        "model_id": "x-ai/grok-imagine-image",
-        "model_key": "x-ai:x-ai/grok-imagine-image:image.edit"
-      }
-    },
-    "../../packages/data/catalog/src/data/pricing/x-ai/x-ai-grok-imagine-image/image.generate/pricing.json": {
-      "hash": "86fa3220f6da85c4ab046b1d917f656c",
-      "meta": {
-        "api_provider_id": "x-ai",
-        "capability_id": "image.generate",
-        "model_id": "x-ai/grok-imagine-image",
-        "model_key": "x-ai:x-ai/grok-imagine-image:image.generate"
-      }
-    },
-    "../../packages/data/catalog/src/data/pricing/x-ai/x-ai-grok-imagine-video/video.edit/pricing.json": {
-      "hash": "423869df2dd36ffa51d5b093882e39a3",
-      "meta": {
-        "api_provider_id": "x-ai",
-        "capability_id": "video.edit",
-        "model_id": "x-ai/grok-imagine-video",
-        "model_key": "x-ai:x-ai/grok-imagine-video:video.edit"
-      }
-    },
-    "../../packages/data/catalog/src/data/pricing/x-ai/x-ai-grok-imagine-video/video.generate/pricing.json": {
-      "hash": "919ab498e408aa2498894ce6282e53dc",
-      "meta": {
-        "api_provider_id": "x-ai",
-        "capability_id": "video.generate",
-        "model_id": "x-ai/grok-imagine-video",
-        "model_key": "x-ai:x-ai/grok-imagine-video:video.generate"
-      }
-    },
     "../../packages/data/catalog/src/data/pricing/xiaomi/xiaomi-mimo-v2-flash/text.generate/pricing.json": {
-      "hash": "3d3d6d7363cf6458df6b1f2fe4556068",
+      "hash": "f83af6829f431dbcb7b43274f2c1d056",
       "meta": {
         "api_provider_id": "xiaomi",
         "capability_id": "text.generate",
@@ -25104,7 +24824,7 @@
       }
     },
     "../../packages/data/catalog/src/data/pricing/xiaomi/xiaomi-mimo-v2-omni/text.generate/pricing.json": {
-      "hash": "24beb3f72dbaf7c33ab16a10cc3d4b3b",
+      "hash": "b5d18b679a74656846c350c3d81bfb90",
       "meta": {
         "api_provider_id": "xiaomi",
         "capability_id": "text.generate",
@@ -25113,7 +24833,7 @@
       }
     },
     "../../packages/data/catalog/src/data/pricing/xiaomi/xiaomi-mimo-v2-pro/text.generate/pricing.json": {
-      "hash": "04ec6f4058d7cd394e664999069acb63",
+      "hash": "bec21f2e5c41512d2893e0afcceb9626",
       "meta": {
         "api_provider_id": "xiaomi",
         "capability_id": "text.generate",
@@ -25122,7 +24842,7 @@
       }
     },
     "../../packages/data/catalog/src/data/pricing/xiaomi/xiaomi-mimo-v2-tts-free/audio.speech/pricing.json": {
-      "hash": "05e2b11b23353dd265cc90382b45e819",
+      "hash": "64d28c074cebcaeb530a73247e12b687",
       "meta": {
         "api_provider_id": "xiaomi",
         "capability_id": "audio.speech",
@@ -25275,31 +24995,65 @@
       }
     },
     "../../packages/data/catalog/src/data/subscription_plans/chatgpt-free/plan.json": {
-      "hash": "aecb700f552c7920a84fa36b2b5ee66a",
+      "hash": "bba0ad99c7f1d03520c987410dfbdc6d",
       "meta": {
         "plan_id": "chatgpt-free",
-        "organisation_id": "openai"
+        "organisation_id": "openai",
+        "model_ids": [
+          "openai/chatgpt-image-latest",
+          "openai/chat-latest",
+          "openai/gpt-5-mini",
+          "openai/gpt-5.5",
+          "openai/gpt-5.1-codex-max",
+          "openai/gpt-5.1-codex-mini"
+        ]
       }
     },
     "../../packages/data/catalog/src/data/subscription_plans/chatgpt-go/plan.json": {
-      "hash": "ee81f20563370f79926c108240fcb09d",
+      "hash": "555bb8fe8cbb8b2f5f784dd1d23d0d9c",
       "meta": {
         "plan_id": "chatgpt-go",
-        "organisation_id": "openai"
+        "organisation_id": "openai",
+        "model_ids": [
+          "openai/chatgpt-image-latest",
+          "openai/chat-latest",
+          "openai/gpt-5-mini",
+          "openai/gpt-5.5",
+          "openai/gpt-5.1-codex-max",
+          "openai/gpt-5.1-codex-mini"
+        ]
       }
     },
     "../../packages/data/catalog/src/data/subscription_plans/chatgpt-plus/plan.json": {
-      "hash": "4b3b6baa5ac30e14002fc335b731d12b",
+      "hash": "ec25f302e42dba8e4e75122e512f467e",
       "meta": {
         "plan_id": "chatgpt-plus",
-        "organisation_id": "openai"
+        "organisation_id": "openai",
+        "model_ids": [
+          "openai/chatgpt-image-latest",
+          "openai/chat-latest",
+          "openai/gpt-5.5",
+          "openai/gpt-5-mini",
+          "openai/o3-deep-research",
+          "openai/gpt-5.1-codex-max",
+          "openai/gpt-5.1-codex-mini"
+        ]
       }
     },
     "../../packages/data/catalog/src/data/subscription_plans/chatgpt-pro/plan.json": {
-      "hash": "6197f94392c28cb48438323c701828fb",
+      "hash": "32a8f41d182c4ea868ca73920970bee8",
       "meta": {
         "plan_id": "chatgpt-pro",
-        "organisation_id": "openai"
+        "organisation_id": "openai",
+        "model_ids": [
+          "openai/chatgpt-image-latest",
+          "openai/chat-latest",
+          "openai/gpt-5.5",
+          "openai/gpt-5.5-pro",
+          "openai/o3-deep-research",
+          "openai/gpt-5.1-codex-max",
+          "openai/gpt-5.1-codex-mini"
+        ]
       }
     },
     "../../packages/data/catalog/src/data/subscription_plans/claude-free/plan.json": {
@@ -25331,31 +25085,47 @@
       }
     },
     "../../packages/data/catalog/src/data/subscription_plans/google-ai-free/plan.json": {
-      "hash": "7b2d5455b24a31e3efc768fb1c42193e",
+      "hash": "c500583fd7c39038521c1e789f3678a8",
       "meta": {
         "plan_id": "google-ai-free",
-        "organisation_id": "google"
+        "organisation_id": "google",
+        "model_ids": [
+          "google/gemini-3-flash-preview",
+          "google/gemini-3.1-pro-preview"
+        ]
       }
     },
     "../../packages/data/catalog/src/data/subscription_plans/google-ai-plus/plan.json": {
-      "hash": "e1f139a8cd79e46630b68d7cf4083bde",
+      "hash": "020c9e9626d6ea5f4e1c425e47472b65",
       "meta": {
         "plan_id": "google-ai-plus",
-        "organisation_id": "google"
+        "organisation_id": "google",
+        "model_ids": [
+          "google/gemini-3-flash-preview",
+          "google/gemini-3.1-pro-preview"
+        ]
       }
     },
     "../../packages/data/catalog/src/data/subscription_plans/google-ai-pro/plan.json": {
-      "hash": "5bcba66c9be78f1589efd08ca9e93556",
+      "hash": "ffd67f765cb10f8f9c75ae7b9353546d",
       "meta": {
         "plan_id": "google-ai-pro",
-        "organisation_id": "google"
+        "organisation_id": "google",
+        "model_ids": [
+          "google/gemini-3-flash-preview",
+          "google/gemini-3.1-pro-preview"
+        ]
       }
     },
     "../../packages/data/catalog/src/data/subscription_plans/google-ai-ultra/plan.json": {
-      "hash": "003005f63c9c2ce4286130d86fda0b4c",
+      "hash": "358ec57ddc8378d970374325afa94311",
       "meta": {
         "plan_id": "google-ai-ultra",
-        "organisation_id": "google"
+        "organisation_id": "google",
+        "model_ids": [
+          "google/gemini-3-flash-preview",
+          "google/gemini-3.1-pro-preview"
+        ]
       }
     },
     "../../packages/data/catalog/src/data/subscription_plans/minimax-token-max/plan.json": {
@@ -25408,24 +25178,40 @@
       }
     },
     "../../packages/data/catalog/src/data/subscription_plans/mistral-pro/plan.json": {
-      "hash": "60ae501cf8eccd9a8aa2acbf5e71ad41",
+      "hash": "7b4895074e2beeb9619d945241c5e86a",
       "meta": {
         "plan_id": "mistral-pro",
-        "organisation_id": "mistral"
+        "organisation_id": "mistral",
+        "model_ids": [
+          "mistral/mistral-small-4",
+          "mistral/codestral",
+          "mistral/devstral-2.0"
+        ]
       }
     },
     "../../packages/data/catalog/src/data/subscription_plans/mistral-team/plan.json": {
-      "hash": "d310aa9e8638019f14678911d653eb8b",
+      "hash": "c50a79cc859bcc5c52c803c265ede882",
       "meta": {
         "plan_id": "mistral-team",
-        "organisation_id": "mistral"
+        "organisation_id": "mistral",
+        "model_ids": [
+          "mistral/mistral-small-4",
+          "mistral/codestral",
+          "mistral/devstral-2.0"
+        ]
       }
     },
     "../../packages/data/catalog/src/data/subscription_plans/moonshotai-kimi-tier0/plan.json": {
-      "hash": "8b0f0f75942fbc8329eb07dcce62f003",
+      "hash": "aa9ccaef0c34d6ada7c0f9c4e2fd7bad",
       "meta": {
         "plan_id": "moonshotai-kimi-tier0",
-        "organisation_id": "moonshotai"
+        "organisation_id": "moonshotai",
+        "model_ids": [
+          "moonshotai/kimi-k2.5",
+          "moonshotai/kimi-k2.6-code-preview",
+          "moonshotai/kimi-k2.6",
+          "moonshotai/kimi-k2.7-code"
+        ]
       }
     },
     "../../packages/data/catalog/src/data/subscription_plans/perplexity-free/plan.json": {
@@ -25436,17 +25222,32 @@
       }
     },
     "../../packages/data/catalog/src/data/subscription_plans/perplexity-max/plan.json": {
-      "hash": "ad26eaa352a045cae54ad67c3331da6e",
+      "hash": "2751042297aeae0451d215b19594c509",
       "meta": {
         "plan_id": "perplexity-max",
-        "organisation_id": "perplexity"
+        "organisation_id": "perplexity",
+        "model_ids": [
+          "openai/gpt-5.2",
+          "anthropic/claude-sonnet-4.5",
+          "anthropic/claude-opus-4.5",
+          "google/gemini-3.1-pro-preview",
+          "spacex-ai/grok-4.1-fast",
+          "moonshotai/kimi-k2.5"
+        ]
       }
     },
     "../../packages/data/catalog/src/data/subscription_plans/perplexity-pro/plan.json": {
-      "hash": "dd82a752f8d239284d53b3cc700b0eb2",
+      "hash": "c23831ef70a3dd55199a25e42b63ed4a",
       "meta": {
         "plan_id": "perplexity-pro",
-        "organisation_id": "perplexity"
+        "organisation_id": "perplexity",
+        "model_ids": [
+          "openai/gpt-5.2",
+          "anthropic/claude-sonnet-4.5",
+          "google/gemini-3.1-pro-preview",
+          "spacex-ai/grok-4.1-fast",
+          "moonshotai/kimi-k2.5"
+        ]
       }
     },
     "../../packages/data/catalog/src/data/subscription_plans/stepfun-flash-max/plan.json": {
@@ -25478,77 +25279,127 @@
       }
     },
     "../../packages/data/catalog/src/data/subscription_plans/supergrok/plan.json": {
-      "hash": "0cec8bae2b8ada295b567da9092f3ff0",
+      "hash": "c175b9cf7e7647a3d7fdefc22da24750",
       "meta": {
         "plan_id": "supergrok",
-        "organisation_id": "x-ai"
+        "organisation_id": "spacex-ai",
+        "model_ids": [
+          "spacex-ai/grok-4.1-fast",
+          "spacex-ai/grok-4.3"
+        ]
       }
     },
     "../../packages/data/catalog/src/data/subscription_plans/supergrok-basic/plan.json": {
-      "hash": "96728451814c96972336f9ef899d9b7c",
+      "hash": "f82c337bdc288929848c227b4aab6f9e",
       "meta": {
         "plan_id": "supergrok-basic",
-        "organisation_id": "x-ai"
+        "organisation_id": "spacex-ai",
+        "model_ids": [
+          "spacex-ai/grok-4.1-fast"
+        ]
       }
     },
     "../../packages/data/catalog/src/data/subscription_plans/supergrok-heavy/plan.json": {
-      "hash": "5be62c1864b1cabe0cfa6ccc9cd7d1a0",
+      "hash": "da04491dbd54018df6c80eb78e5c9c18",
       "meta": {
         "plan_id": "supergrok-heavy",
-        "organisation_id": "x-ai"
+        "organisation_id": "spacex-ai",
+        "model_ids": [
+          "spacex-ai/grok-4.1-fast",
+          "spacex-ai/grok-4.3",
+          "spacex-ai/grok-4-heavy"
+        ]
       }
     },
     "../../packages/data/catalog/src/data/subscription_plans/xiaomi-mimo-lite/plan.json": {
-      "hash": "2ba09910b40253d1653cb0da2cf6f968",
+      "hash": "69f3c6937dbbc72a8b760e4306006aa9",
       "meta": {
         "plan_id": "xiaomi-mimo-lite",
-        "organisation_id": "xiaomi"
+        "organisation_id": "xiaomi",
+        "model_ids": [
+          "xiaomi/mimo-v2.5-pro",
+          "xiaomi/mimo-v2.5",
+          "xiaomi/mimo-v2.5-tts"
+        ]
       }
     },
     "../../packages/data/catalog/src/data/subscription_plans/xiaomi-mimo-max/plan.json": {
-      "hash": "aac2a60eb03d1712bb0a35e4d7ab06ed",
+      "hash": "7814f76faee4ab5462441fcd51da3ed9",
       "meta": {
         "plan_id": "xiaomi-mimo-max",
-        "organisation_id": "xiaomi"
+        "organisation_id": "xiaomi",
+        "model_ids": [
+          "xiaomi/mimo-v2.5-pro",
+          "xiaomi/mimo-v2.5",
+          "xiaomi/mimo-v2.5-tts"
+        ]
       }
     },
     "../../packages/data/catalog/src/data/subscription_plans/xiaomi-mimo-pro/plan.json": {
-      "hash": "c050e56bd971e34bba6aa1737e427449",
+      "hash": "9afa4093f8818f82c3d600eba933d260",
       "meta": {
         "plan_id": "xiaomi-mimo-pro",
-        "organisation_id": "xiaomi"
+        "organisation_id": "xiaomi",
+        "model_ids": [
+          "xiaomi/mimo-v2.5-pro",
+          "xiaomi/mimo-v2.5",
+          "xiaomi/mimo-v2.5-tts"
+        ]
       }
     },
     "../../packages/data/catalog/src/data/subscription_plans/xiaomi-mimo-standard/plan.json": {
-      "hash": "c485ddb3d15a4e2f32f919f706e89a7d",
+      "hash": "36894228f24a7145b277c3b69b93a6a7",
       "meta": {
         "plan_id": "xiaomi-mimo-standard",
-        "organisation_id": "xiaomi"
+        "organisation_id": "xiaomi",
+        "model_ids": [
+          "xiaomi/mimo-v2.5-pro",
+          "xiaomi/mimo-v2.5",
+          "xiaomi/mimo-v2.5-tts"
+        ]
       }
     },
     "../../packages/data/catalog/src/data/subscription_plans/z-ai-glm-coding-lite/plan.json": {
-      "hash": "5231545691c4a058b9ed903b0bb6f118",
+      "hash": "f3013c574c5859e944f4db6761d16401",
       "meta": {
         "plan_id": "z-ai-glm-coding-lite",
-        "organisation_id": "z-ai"
+        "organisation_id": "z-ai",
+        "model_ids": [
+          "z-ai/glm-5.2",
+          "z-ai/glm-5-turbo",
+          "z-ai/glm-4.7",
+          "z-ai/glm-4.5-air"
+        ]
       }
     },
     "../../packages/data/catalog/src/data/subscription_plans/z-ai-glm-coding-max/plan.json": {
-      "hash": "298a38e3adf5a1d76f7707015765eb88",
+      "hash": "5a3ed87224733ac0990a12bc8579a30b",
       "meta": {
         "plan_id": "z-ai-glm-coding-max",
-        "organisation_id": "z-ai"
+        "organisation_id": "z-ai",
+        "model_ids": [
+          "z-ai/glm-5.2",
+          "z-ai/glm-5-turbo",
+          "z-ai/glm-4.7",
+          "z-ai/glm-4.5-air"
+        ]
       }
     },
     "../../packages/data/catalog/src/data/subscription_plans/z-ai-glm-coding-pro/plan.json": {
-      "hash": "3d3ccdab3c9fdaeff9f1228ae25e25bd",
+      "hash": "1caa46366832f2fdeea8aa252e85e2ec",
       "meta": {
         "plan_id": "z-ai-glm-coding-pro",
-        "organisation_id": "z-ai"
+        "organisation_id": "z-ai",
+        "model_ids": [
+          "z-ai/glm-5.2",
+          "z-ai/glm-5-turbo",
+          "z-ai/glm-4.7",
+          "z-ai/glm-4.5-air"
+        ]
       }
     },
     "../../packages/data/catalog/src/data/models/deepseek/deepseek-v4-flash/model.json": {
-      "hash": "879f2c4b476cf37f6bbaa1c5b0900e07",
+      "hash": "d5adc3ab565f34a156028fc5ceb9618a",
       "meta": {
         "model_id": "deepseek/deepseek-v4-flash",
         "organisation_id": "deepseek",
@@ -25558,7 +25409,7 @@
       }
     },
     "../../packages/data/catalog/src/data/models/deepseek/deepseek-v4-pro/model.json": {
-      "hash": "91461424e3fcc97fd1d2ec5238b45bdb",
+      "hash": "e754aef91248c6005d73a5871be9f4cc",
       "meta": {
         "model_id": "deepseek/deepseek-v4-pro",
         "organisation_id": "deepseek",
@@ -25568,7 +25419,7 @@
       }
     },
     "../../packages/data/catalog/src/data/models/cohere/command-r/model.json": {
-      "hash": "1b9f6e9b7fbeec9c9123e7c80f7a4c32",
+      "hash": "a0ac534d8393587754d30e8fa6a25f79",
       "meta": {
         "model_id": "cohere/command-r",
         "organisation_id": "cohere",
@@ -25578,7 +25429,7 @@
       }
     },
     "../../packages/data/catalog/src/data/models/qwen/qwen3.6-27b/model.json": {
-      "hash": "17f4f6c60fd9ae0c1861348bf351f6c5",
+      "hash": "66c7d81fb6714bbb9f7e22ed4bc480ca",
       "meta": {
         "model_id": "qwen/qwen3.6-27b",
         "organisation_id": "qwen",
@@ -25912,7 +25763,7 @@
       }
     },
     "../../packages/data/catalog/src/data/pricing/gmicloud/deepseek-deepseek-v3.1/text.generate/pricing.json": {
-      "hash": "3458487cab82f83063441e48fd1cc25f",
+      "hash": "cb61d41d6f7dec648b242b42f532d617",
       "meta": {
         "api_provider_id": "gmicloud",
         "capability_id": "text.generate",
@@ -25921,7 +25772,7 @@
       }
     },
     "../../packages/data/catalog/src/data/pricing/gmicloud/deepseek-deepseek-v3.1-terminus/text.generate/pricing.json": {
-      "hash": "8baa89d625b329820a962f66b216c12a",
+      "hash": "ad1084bea0185daaae39f324d40133c5",
       "meta": {
         "api_provider_id": "gmicloud",
         "capability_id": "text.generate",
@@ -25930,7 +25781,7 @@
       }
     },
     "../../packages/data/catalog/src/data/pricing/gmicloud/deepseek-deepseek-v3.2-exp/text.generate/pricing.json": {
-      "hash": "80a986b0fab94a6a01a155803bdedfa0",
+      "hash": "c07cabc9179c42715c3f1dbb9d4e8cf6",
       "meta": {
         "api_provider_id": "gmicloud",
         "capability_id": "text.generate",
@@ -26047,7 +25898,7 @@
       }
     },
     "../../packages/data/catalog/src/data/pricing/openai/openai-gpt-image-2/image.edit/pricing.json": {
-      "hash": "465ec0c93ca9e9caafa457793c828c0f",
+      "hash": "1b79cefe63e7a201adff392c2d701c9f",
       "meta": {
         "api_provider_id": "openai",
         "capability_id": "image.edit",
@@ -26056,7 +25907,7 @@
       }
     },
     "../../packages/data/catalog/src/data/pricing/openai/openai-gpt-image-2/image.generate/pricing.json": {
-      "hash": "2cd41d8d3868eb5ff20ab1d655e9aa47",
+      "hash": "25f014c49573014a2a5b00508b97486f",
       "meta": {
         "api_provider_id": "openai",
         "capability_id": "image.generate",
@@ -26230,7 +26081,7 @@
       }
     },
     "../../packages/data/catalog/src/data/models/google/gemini-embedding-2/model.json": {
-      "hash": "573a1ec3d12e21476ac431e05dfe4750",
+      "hash": "6038b713170529e12e8a4d1429fccf2c",
       "meta": {
         "model_id": "google/gemini-embedding-2",
         "organisation_id": "google",
@@ -26240,7 +26091,7 @@
       }
     },
     "../../packages/data/catalog/src/data/models/inclusionai/ling-2.6-1t/model.json": {
-      "hash": "cb5995813b395a8dc94157eb7ce2799b",
+      "hash": "0e94bc499ca29760dca79211a71d5da9",
       "meta": {
         "model_id": "inclusionai/ling-2.6-1t",
         "organisation_id": "inclusionai",
@@ -26380,15 +26231,6 @@
         "family_id": "openai/gpt-5.5"
       }
     },
-    "../../packages/data/catalog/src/data/pricing/x-ai/x-ai-grok-imagine-image-pro/image.generate/pricing.json": {
-      "hash": "bacf13626aa4bb0c93659e365b2d828b",
-      "meta": {
-        "api_provider_id": "x-ai",
-        "capability_id": "image.generate",
-        "model_id": "x-ai/grok-imagine-image-pro",
-        "model_key": "x-ai:x-ai/grok-imagine-image-pro:image.generate"
-      }
-    },
     "../../packages/data/catalog/src/data/pricing/openai/openai-gpt-4o-mini-tts/audio.speech/pricing.json": {
       "hash": "e67db164428c288f8886a3b4e59c2823",
       "meta": {
@@ -26435,7 +26277,7 @@
       }
     },
     "../../packages/data/catalog/src/data/models/openai/chat-latest/model.json": {
-      "hash": "0b787be4b9a937f83bce23d908c74208",
+      "hash": "f49f460af5021918ff6b845483edc879",
       "meta": {
         "model_id": "openai/chat-latest",
         "organisation_id": "openai",
@@ -26465,34 +26307,6 @@
         "alias_slug": "moonshotai/kimi-latest"
       }
     },
-    "../../packages/data/catalog/src/data/models/x-ai/grok-imagine-image-quality/model.json": {
-      "hash": "19301ebedb6849206651d0705c6c9e3f",
-      "meta": {
-        "model_id": "x-ai/grok-imagine-image-quality",
-        "organisation_id": "x-ai",
-        "previous_model_id": null,
-        "api_model_id": "x-ai/grok-imagine-image-quality",
-        "has_page_notice": false
-      }
-    },
-    "../../packages/data/catalog/src/data/pricing/x-ai/x-ai-grok-imagine-image-quality/image.edit/pricing.json": {
-      "hash": "7f83a974b92284ed5f93f11b37b93a5a",
-      "meta": {
-        "api_provider_id": "x-ai",
-        "capability_id": "image.edit",
-        "model_id": "x-ai/grok-imagine-image-quality",
-        "model_key": "x-ai:x-ai/grok-imagine-image-quality:image.edit"
-      }
-    },
-    "../../packages/data/catalog/src/data/pricing/x-ai/x-ai-grok-imagine-image-quality/image.generate/pricing.json": {
-      "hash": "953760ec2b9cf6f340ba84f63474be87",
-      "meta": {
-        "api_provider_id": "x-ai",
-        "capability_id": "image.generate",
-        "model_id": "x-ai/grok-imagine-image-quality",
-        "model_key": "x-ai:x-ai/grok-imagine-image-quality:image.generate"
-      }
-    },
     "../../packages/data/catalog/src/data/aliases/anthropic-claude-haiku-latest/alias.json": {
       "hash": "0ae40fe1136e3be854d5fef5c44a508b",
       "meta": {
@@ -26500,13 +26314,13 @@
       }
     },
     "../../packages/data/catalog/src/data/aliases/anthropic-claude-opus-latest/alias.json": {
-      "hash": "3c74b482e4876552908d2639d082e59b",
+      "hash": "3248a6060123b2e703625ba2a79f495c",
       "meta": {
         "alias_slug": "anthropic/claude-opus-latest"
       }
     },
     "../../packages/data/catalog/src/data/aliases/anthropic-claude-sonnet-latest/alias.json": {
-      "hash": "b0e7db95aaaa73a59ca48cdccc785ac8",
+      "hash": "d471522c248983d5a7fdacd0860f5233",
       "meta": {
         "alias_slug": "anthropic/claude-sonnet-latest"
       }
@@ -26542,7 +26356,7 @@
       }
     },
     "../../packages/data/catalog/src/data/aliases/minimax-minimax-latest/alias.json": {
-      "hash": "85e46bd7421d41c6c887f7cbd79b62ac",
+      "hash": "b5ecafb3be290899da4b57b022b49cc4",
       "meta": {
         "alias_slug": "minimax/minimax-latest"
       }
@@ -26557,12 +26371,6 @@
       "hash": "3798537eef054756a29aacaaa4a88018",
       "meta": {
         "alias_slug": "openai/gpt-image-latest"
-      }
-    },
-    "../../packages/data/catalog/src/data/aliases/x-ai-grok-latest/alias.json": {
-      "hash": "77123e9b14aa43955e59f3cfcf84d000",
-      "meta": {
-        "alias_slug": "x-ai/grok-latest"
       }
     },
     "../../packages/data/catalog/src/data/aliases/z-ai-glm-latest/alias.json": {
@@ -26584,7 +26392,7 @@
       }
     },
     "../../packages/data/catalog/src/data/models/aion-labs/aion-3.0/model.json": {
-      "hash": "09b81c22c0f9ecf74a2e51dcfa597494",
+      "hash": "45056a23d4143c124e9ab385b48f9b5b",
       "meta": {
         "model_id": "aion-labs/aion-3.0",
         "organisation_id": "aion-labs",
@@ -26594,7 +26402,7 @@
       }
     },
     "../../packages/data/catalog/src/data/models/google/gemini-3.1-flash-lite/model.json": {
-      "hash": "6e2bc97c8e27e69994ae85a46c06001e",
+      "hash": "3d52923c854c902b59ed11af74fbcf49",
       "meta": {
         "model_id": "google/gemini-3.1-flash-lite",
         "organisation_id": "google",
@@ -26604,15 +26412,17 @@
       }
     },
     "../../packages/data/catalog/src/data/models/inception/mercury-edit-2/model.json": {
-      "hash": "e0696a7b3182a7063e18f63450bae85f",
+      "hash": "4bf094bd5116597ee00cf1f9ec290eef",
       "meta": {
         "model_id": "inception/mercury-edit-2",
         "organisation_id": "inception",
-        "previous_model_id": null
+        "previous_model_id": null,
+        "api_model_id": "inception/mercury-edit-2",
+        "has_page_notice": false
       }
     },
     "../../packages/data/catalog/src/data/models/openai/gpt-realtime-2/model.json": {
-      "hash": "db88539e5469489c62ce32c491495431",
+      "hash": "7399553ec254b6cea6095881a8b7a825",
       "meta": {
         "model_id": "openai/gpt-realtime-2",
         "organisation_id": "openai",
@@ -26622,7 +26432,7 @@
       }
     },
     "../../packages/data/catalog/src/data/models/openai/gpt-realtime-translate/model.json": {
-      "hash": "b4940027d43bf492b22628ca9f20469a",
+      "hash": "6905f077084634e323c618b19df70c8a",
       "meta": {
         "model_id": "openai/gpt-realtime-translate",
         "organisation_id": "openai",
@@ -26632,7 +26442,7 @@
       }
     },
     "../../packages/data/catalog/src/data/models/openai/gpt-realtime-whisper/model.json": {
-      "hash": "b09e65354f4875894244340eb23f22ae",
+      "hash": "57f9cf3423f698afb9a5a063ef7f56c5",
       "meta": {
         "model_id": "openai/gpt-realtime-whisper",
         "organisation_id": "openai",
@@ -26652,11 +26462,13 @@
       }
     },
     "../../packages/data/catalog/src/data/models/tencent/hunyuan-a13b-instruct/model.json": {
-      "hash": "f3e12bd213cf324b96463b2023923923",
+      "hash": "e36cf6335d4c9d21d37f387f220848fe",
       "meta": {
         "model_id": "tencent/hunyuan-a13b-instruct",
         "organisation_id": "tencent",
-        "previous_model_id": null
+        "previous_model_id": null,
+        "api_model_id": "tencent/hunyuan-a13b-instruct",
+        "has_page_notice": false
       }
     },
     "../../packages/data/catalog/src/data/api_providers/nebius-token-factory-fast/api_provider.json": {
@@ -26707,7 +26519,7 @@
       }
     },
     "../../packages/data/catalog/src/data/api_providers/openai-eu/api_provider.json": {
-      "hash": "dadb3e9bd0f99043eb63d73833fc001b",
+      "hash": "df302a168a2805d0b87da0705b74d66a",
       "meta": {
         "api_provider_id": "openai-eu"
       }
@@ -26728,7 +26540,7 @@
       }
     },
     "../../packages/data/catalog/src/data/api_providers/anthropic-us/api_provider.json": {
-      "hash": "d6975cd09542524d2027ad2e8b64e907",
+      "hash": "004e20650d890e6de7b06cea66d07e1d",
       "meta": {
         "api_provider_id": "anthropic-us"
       }
@@ -26749,7 +26561,7 @@
       }
     },
     "../../packages/data/catalog/src/data/pricing/alibaba-cloud/qwen-qwen-omni-turbo/text.generate/pricing.json": {
-      "hash": "6390466461bcb8b313b9dc5ec6a125fb",
+      "hash": "8224383ecd239022dc6cb9a0ae2fae70",
       "meta": {
         "api_provider_id": "alibaba-cloud",
         "capability_id": "text.generate",
@@ -26758,7 +26570,7 @@
       }
     },
     "../../packages/data/catalog/src/data/pricing/alibaba-cloud/qwen-qwen3-omni-flash-2025-09-15/text.generate/pricing.json": {
-      "hash": "6b34088709e53f4939040a33965884da",
+      "hash": "5c4674e09eb19bdeca45b9d2871d0ab2",
       "meta": {
         "api_provider_id": "alibaba-cloud",
         "capability_id": "text.generate",
@@ -26767,7 +26579,7 @@
       }
     },
     "../../packages/data/catalog/src/data/pricing/alibaba-cloud/qwen-qwen3-omni-flash-2025-12-01/text.generate/pricing.json": {
-      "hash": "7b35aea377d7e9bf9c8acddb95316769",
+      "hash": "31e781d0054b9ab00e7088195520672f",
       "meta": {
         "api_provider_id": "alibaba-cloud",
         "capability_id": "text.generate",
@@ -26830,7 +26642,7 @@
       }
     },
     "../../packages/data/catalog/src/data/pricing/anthropic-us/anthropic-claude-opus-4.6/text.generate/pricing.json": {
-      "hash": "391fba35638d6d54b5996867eb2df2d7",
+      "hash": "41adc1e419e33d9a61aa01e95cce27c6",
       "meta": {
         "api_provider_id": "anthropic-us",
         "capability_id": "text.generate",
@@ -26839,7 +26651,7 @@
       }
     },
     "../../packages/data/catalog/src/data/pricing/anthropic-us/anthropic-claude-opus-4.7/text.generate/pricing.json": {
-      "hash": "6454f61d57ec64f4b8394e0ebfde398a",
+      "hash": "af92c55dd97171c03bdc2feac20e4d73",
       "meta": {
         "api_provider_id": "anthropic-us",
         "capability_id": "text.generate",
@@ -26848,7 +26660,7 @@
       }
     },
     "../../packages/data/catalog/src/data/pricing/anthropic-us/anthropic-claude-sonnet-4.6/text.generate/pricing.json": {
-      "hash": "fd57925a03a1937b5bea5c5c90bbb2c1",
+      "hash": "a59ed5f80b7b2b2f1da0cbf1d8de67b4",
       "meta": {
         "api_provider_id": "anthropic-us",
         "capability_id": "text.generate",
@@ -26911,7 +26723,7 @@
       }
     },
     "../../packages/data/catalog/src/data/pricing/friendli/deepseek-deepseek-v3.1/text.generate/pricing.json": {
-      "hash": "245685c4a82a58961e4e4876a0302a70",
+      "hash": "f170ca979391620e7fd8fea7d11dfec9",
       "meta": {
         "api_provider_id": "friendli",
         "capability_id": "text.generate",
@@ -26920,7 +26732,7 @@
       }
     },
     "../../packages/data/catalog/src/data/pricing/friendli/google-gemma-4-31b/text.generate/pricing.json": {
-      "hash": "4616d862bd8198304ef6d169ff61ebab",
+      "hash": "4fcf9d951e9b8ca0bd5104537b8c3eae",
       "meta": {
         "api_provider_id": "friendli",
         "capability_id": "text.generate",
@@ -26992,7 +26804,7 @@
       }
     },
     "../../packages/data/catalog/src/data/pricing/google-ai-studio/google-veo-2/video.generate/pricing.json": {
-      "hash": "d12e014a2675d8e2057ca854d7bd54a7",
+      "hash": "a03bf3e2aa7c2b49fd12e68affe8a8fa",
       "meta": {
         "api_provider_id": "google-ai-studio",
         "capability_id": "video.generate",
@@ -27504,15 +27316,6 @@
         "model_key": "venice:qwen/qwen3.6-plus:text.generate"
       }
     },
-    "../../packages/data/catalog/src/data/pricing/venice/x-ai-grok-4.3/text.generate/pricing.json": {
-      "hash": "98de1b70b17d28024ee4f658f9776538",
-      "meta": {
-        "api_provider_id": "venice",
-        "capability_id": "text.generate",
-        "model_id": "x-ai/grok-4.3",
-        "model_key": "venice:x-ai/grok-4.3:text.generate"
-      }
-    },
     "../../packages/data/catalog/src/data/pricing/weights-and-biases/deepseek-deepseek-v4-flash/text.generate/pricing.json": {
       "hash": "bce5d2df5662e7140cc3ec3d24cba74a",
       "meta": {
@@ -27568,7 +27371,7 @@
       }
     },
     "../../packages/data/catalog/src/data/api_providers/anthropic-aws/api_provider.json": {
-      "hash": "44272d568b38e9f40b7b1127b88c851e",
+      "hash": "bd64a850434277bb679b08c3d7fed2e0",
       "meta": {
         "api_provider_id": "anthropic-aws"
       }
@@ -27600,7 +27403,7 @@
       }
     },
     "../../packages/data/catalog/src/data/pricing/anthropic-aws/anthropic-claude-3.5-haiku/text.generate/pricing.json": {
-      "hash": "b08f2651e8d2a50b139240f91f633ce9",
+      "hash": "864a848be1c2f40450bfa5d09a794e79",
       "meta": {
         "api_provider_id": "anthropic-aws",
         "capability_id": "text.generate",
@@ -27609,7 +27412,7 @@
       }
     },
     "../../packages/data/catalog/src/data/pricing/anthropic-aws/anthropic-claude-3.7-sonnet/text.generate/pricing.json": {
-      "hash": "4b050fe23c007254a5149afe6ea81fe8",
+      "hash": "cd8cab35819ff7c56242b56a6dc9da24",
       "meta": {
         "api_provider_id": "anthropic-aws",
         "capability_id": "text.generate",
@@ -27618,7 +27421,7 @@
       }
     },
     "../../packages/data/catalog/src/data/pricing/anthropic-aws/anthropic-claude-3-haiku/text.generate/pricing.json": {
-      "hash": "0d02ea3d5cad867c1177df777c071ffe",
+      "hash": "e4e0d71daabe47e2376df80cbd2ea30c",
       "meta": {
         "api_provider_id": "anthropic-aws",
         "capability_id": "text.generate",
@@ -27636,7 +27439,7 @@
       }
     },
     "../../packages/data/catalog/src/data/pricing/anthropic-aws/anthropic-claude-haiku-4.5/text.generate/pricing.json": {
-      "hash": "0b0a16fc92f9a63f0a60727656d4eba9",
+      "hash": "17a175c16be9b164312c3c40908bdd0d",
       "meta": {
         "api_provider_id": "anthropic-aws",
         "capability_id": "text.generate",
@@ -27654,7 +27457,7 @@
       }
     },
     "../../packages/data/catalog/src/data/pricing/anthropic-aws/anthropic-claude-opus-4/text.generate/pricing.json": {
-      "hash": "4f3bdb564980bdd614bccadc61b65d93",
+      "hash": "9b67bf7bacf9bba5bf3c1689d1c93e77",
       "meta": {
         "api_provider_id": "anthropic-aws",
         "capability_id": "text.generate",
@@ -27663,7 +27466,7 @@
       }
     },
     "../../packages/data/catalog/src/data/pricing/anthropic-aws/anthropic-claude-opus-4.1/text.generate/pricing.json": {
-      "hash": "f37c92c3e505cc49552d02ba45b41db0",
+      "hash": "5245856f8bd1f992d5efe98fa2cbe2d6",
       "meta": {
         "api_provider_id": "anthropic-aws",
         "capability_id": "text.generate",
@@ -27672,7 +27475,7 @@
       }
     },
     "../../packages/data/catalog/src/data/pricing/anthropic-aws/anthropic-claude-opus-4.5/text.generate/pricing.json": {
-      "hash": "90b2865a1761acf1e13a57ff1b64e0ec",
+      "hash": "65417751b0a14df32a44b531db126afd",
       "meta": {
         "api_provider_id": "anthropic-aws",
         "capability_id": "text.generate",
@@ -27681,7 +27484,7 @@
       }
     },
     "../../packages/data/catalog/src/data/pricing/anthropic-aws/anthropic-claude-opus-4.6/text.generate/pricing.json": {
-      "hash": "9835f7d97f63571ef9f14b3d6f4fc843",
+      "hash": "5f4b0e0e459e6f6b0cd194560db87de4",
       "meta": {
         "api_provider_id": "anthropic-aws",
         "capability_id": "text.generate",
@@ -27690,7 +27493,7 @@
       }
     },
     "../../packages/data/catalog/src/data/pricing/anthropic-aws/anthropic-claude-opus-4.7/text.generate/pricing.json": {
-      "hash": "9955dd8e9ae3d3e32ae1b32ff9488bd4",
+      "hash": "907374b7441441eca1de88ae41d25175",
       "meta": {
         "api_provider_id": "anthropic-aws",
         "capability_id": "text.generate",
@@ -27699,7 +27502,7 @@
       }
     },
     "../../packages/data/catalog/src/data/pricing/anthropic-aws/anthropic-claude-sonnet-4/text.generate/pricing.json": {
-      "hash": "d4826b1bc13cd0e0017c8bb5a8b57b70",
+      "hash": "53df5d9065b136c48ad0cac193d06dd1",
       "meta": {
         "api_provider_id": "anthropic-aws",
         "capability_id": "text.generate",
@@ -27708,7 +27511,7 @@
       }
     },
     "../../packages/data/catalog/src/data/pricing/anthropic-aws/anthropic-claude-sonnet-4.5/text.generate/pricing.json": {
-      "hash": "e7ff4487707a1dc4b92864b926a17f70",
+      "hash": "1b0baf8d991ce6c6370d1a89a21ba344",
       "meta": {
         "api_provider_id": "anthropic-aws",
         "capability_id": "text.generate",
@@ -27717,7 +27520,7 @@
       }
     },
     "../../packages/data/catalog/src/data/pricing/anthropic-aws/anthropic-claude-sonnet-4.6/text.generate/pricing.json": {
-      "hash": "35d3f05aa9ddc13a5c613475440e7d70",
+      "hash": "18f8f5dd288d3eff3d6e769751920e5f",
       "meta": {
         "api_provider_id": "anthropic-aws",
         "capability_id": "text.generate",
@@ -27726,7 +27529,7 @@
       }
     },
     "../../packages/data/catalog/src/data/api_providers/anthropic-aws-us/api_provider.json": {
-      "hash": "468ff037848dd5427fa8fc0b06d84449",
+      "hash": "06611cf4496c6f116a4a394a9452b160",
       "meta": {
         "api_provider_id": "anthropic-aws-us"
       }
@@ -27747,7 +27550,7 @@
       }
     },
     "../../packages/data/catalog/src/data/pricing/anthropic-aws-us/anthropic-claude-opus-4.6/text.generate/pricing.json": {
-      "hash": "1ab8725ed6abeb692f06abb0822e83e0",
+      "hash": "0b5bf71c38fb806edcbe9b39058c37d7",
       "meta": {
         "api_provider_id": "anthropic-aws-us",
         "capability_id": "text.generate",
@@ -27756,7 +27559,7 @@
       }
     },
     "../../packages/data/catalog/src/data/pricing/anthropic-aws-us/anthropic-claude-sonnet-4.6/text.generate/pricing.json": {
-      "hash": "dd8d849c4c8a5381ca45f17cb8faa18c",
+      "hash": "af0c1d4dab8bbc3a3f662f3e4dd17235",
       "meta": {
         "api_provider_id": "anthropic-aws-us",
         "capability_id": "text.generate",
@@ -27765,7 +27568,7 @@
       }
     },
     "../../packages/data/catalog/src/data/pricing/anthropic-aws-us/anthropic-claude-opus-4.7/text.generate/pricing.json": {
-      "hash": "a3132ee5de0b243fee80b25eae06f971",
+      "hash": "d9ebc4e6912fdba43d462c7e74a63b23",
       "meta": {
         "api_provider_id": "anthropic-aws-us",
         "capability_id": "text.generate",
@@ -27791,7 +27594,7 @@
       }
     },
     "../../packages/data/catalog/src/data/models/anthropic/claude-opus-4.7-fast/model.json": {
-      "hash": "ed2368fa4b4cf4b4f7df827196af9afb",
+      "hash": "cb4b174742756c39107c7fe51c36e1c3",
       "meta": {
         "model_id": "anthropic/claude-opus-4.7-fast",
         "organisation_id": "anthropic",
@@ -27813,7 +27616,7 @@
       }
     },
     "../../packages/data/catalog/src/data/benchmarks/deepswe/benchmark.json": {
-      "hash": "5f1d928a4869c2c01e1d0d98bc9851d2",
+      "hash": "2d5023345a46cbd054833a45603c9195",
       "meta": {
         "benchmark_id": "deepswe"
       }
@@ -27849,7 +27652,7 @@
       }
     },
     "../../packages/data/catalog/src/data/models/anthropic/claude-opus-4.8/model.json": {
-      "hash": "5fcf4b84ad877bdbae5590fa9961c4e5",
+      "hash": "9ffa6c9aab4099893fd7b71b5d8e2959",
       "meta": {
         "model_id": "anthropic/claude-opus-4.8",
         "organisation_id": "anthropic",
@@ -27875,7 +27678,7 @@
       }
     },
     "../../packages/data/catalog/src/data/models/cohere/command-a-plus/model.json": {
-      "hash": "ba4f239891b76604783ceed25dcdbda1",
+      "hash": "ca3d46e1e0e4e5f4e7be1269ab43c777",
       "meta": {
         "model_id": "cohere/command-a-plus",
         "organisation_id": "cohere",
@@ -27885,7 +27688,7 @@
       }
     },
     "../../packages/data/catalog/src/data/models/crofai/greg-1/model.json": {
-      "hash": "ee99f4c2dfc1d46c0af9ee83a3641c92",
+      "hash": "3950a88c9fb582ec2407092e304dfe9e",
       "meta": {
         "model_id": "crofai/greg-1",
         "organisation_id": "crofai",
@@ -27895,15 +27698,17 @@
       }
     },
     "../../packages/data/catalog/src/data/models/crofai/greg-1-mini/model.json": {
-      "hash": "ee057b399d561eec0d633de0919e04d1",
+      "hash": "64a1b2b8c6b06dac719209f06e3be108",
       "meta": {
         "model_id": "crofai/greg-1-mini",
         "organisation_id": "crofai",
-        "previous_model_id": null
+        "previous_model_id": null,
+        "api_model_id": "crofai/greg-1-mini",
+        "has_page_notice": false
       }
     },
     "../../packages/data/catalog/src/data/models/crofai/greg-1-super/model.json": {
-      "hash": "9323a5ca44628c84c03c287f22d895ad",
+      "hash": "29ddb01301ce1cd57fca8957e3603d3c",
       "meta": {
         "model_id": "crofai/greg-1-super",
         "organisation_id": "crofai",
@@ -27913,15 +27718,17 @@
       }
     },
     "../../packages/data/catalog/src/data/models/crofai/greg-rp/model.json": {
-      "hash": "5e0dbc5ea1939414e10d481020f7cb85",
+      "hash": "479ccff4832078ef352b988bbdb75d71",
       "meta": {
         "model_id": "crofai/greg-rp",
         "organisation_id": "crofai",
-        "previous_model_id": null
+        "previous_model_id": null,
+        "api_model_id": "crofai/greg-rp",
+        "has_page_notice": false
       }
     },
     "../../packages/data/catalog/src/data/models/cursor/composer-2.5/model.json": {
-      "hash": "606e8bee7c661c7245f32025bb0737ba",
+      "hash": "371fd26ec3547df2e911dd2952c73ff0",
       "meta": {
         "model_id": "cursor/composer-2.5",
         "organisation_id": "cursor",
@@ -27931,15 +27738,17 @@
       }
     },
     "../../packages/data/catalog/src/data/models/deepseek/deepseek-v4-pro-lightning/model.json": {
-      "hash": "2f3da3a4474efaa2a7d491362b5a0a8f",
+      "hash": "daa7f0ab1b6a4e640eb5f1ad9834ab90",
       "meta": {
         "model_id": "deepseek/deepseek-v4-pro-lightning",
         "organisation_id": "deepseek",
-        "previous_model_id": null
+        "previous_model_id": null,
+        "api_model_id": "deepseek/deepseek-v4-pro-lightning",
+        "has_page_notice": false
       }
     },
     "../../packages/data/catalog/src/data/models/google/gemini-2.5-flash/model.json": {
-      "hash": "fee009b493d7c9a27a6e53151a18ddce",
+      "hash": "850f4550260843828c5eb27fbbf820e0",
       "meta": {
         "model_id": "google/gemini-2.5-flash",
         "organisation_id": "google",
@@ -27949,7 +27758,7 @@
       }
     },
     "../../packages/data/catalog/src/data/models/google/gemini-2.5-flash-lite/model.json": {
-      "hash": "8b7087c2d0a9920b3143d58091a80f07",
+      "hash": "73b2aded39fe558e3a85bbe88caf0e5e",
       "meta": {
         "model_id": "google/gemini-2.5-flash-lite",
         "organisation_id": "google",
@@ -27967,15 +27776,17 @@
       }
     },
     "../../packages/data/catalog/src/data/models/google/gemini-3.1-flash-image/model.json": {
-      "hash": "29d7986e56c56fe13fc5736f1196a687",
+      "hash": "3d20f3a4af5349eab40873da5a822efe",
       "meta": {
         "model_id": "google/gemini-3.1-flash-image",
         "organisation_id": "google",
-        "previous_model_id": "google/gemini-3.1-flash-image-preview"
+        "previous_model_id": "google/gemini-3.1-flash-image-preview",
+        "api_model_id": "google/gemini-3.1-flash-image",
+        "has_page_notice": false
       }
     },
     "../../packages/data/catalog/src/data/models/google/gemini-3.5-flash/model.json": {
-      "hash": "178211beec6e460c092230a3725d3bb3",
+      "hash": "05bd97ebea78048a6d3aeb6f56e69d39",
       "meta": {
         "model_id": "google/gemini-3.5-flash",
         "organisation_id": "google",
@@ -27985,7 +27796,7 @@
       }
     },
     "../../packages/data/catalog/src/data/models/minimax/minimax-m3/model.json": {
-      "hash": "f1c4ff414a8b300252c66def331873dd",
+      "hash": "3469f90407611801ca501b718069f3a7",
       "meta": {
         "model_id": "minimax/minimax-m3",
         "organisation_id": "minimax",
@@ -27995,63 +27806,77 @@
       }
     },
     "../../packages/data/catalog/src/data/models/mistral/voxtral-tts/model.json": {
-      "hash": "c5fe15717c5096b8f351cfb393711bb9",
+      "hash": "c8230e1df57a4364c851e4948004ff8a",
       "meta": {
         "model_id": "mistral/voxtral-tts",
         "organisation_id": "mistral",
-        "previous_model_id": null
+        "previous_model_id": null,
+        "api_model_id": "mistral/voxtral-tts",
+        "has_page_notice": false
       }
     },
     "../../packages/data/catalog/src/data/models/moonshotai/moonshot-v1-128k/model.json": {
-      "hash": "83299f0967dc01d76e9c18d8e0c6a970",
+      "hash": "13a45c79a7fb4b8797df702d49854557",
       "meta": {
         "model_id": "moonshotai/moonshot-v1-128k",
         "organisation_id": "moonshotai",
-        "previous_model_id": null
+        "previous_model_id": null,
+        "api_model_id": "moonshotai/moonshot-v1-128k",
+        "has_page_notice": false
       }
     },
     "../../packages/data/catalog/src/data/models/moonshotai/moonshot-v1-128k-vision-preview/model.json": {
-      "hash": "d248d86e84e8009ab67f3795d5451c32",
+      "hash": "841220034584d8b9e9ac74bc34c0073e",
       "meta": {
         "model_id": "moonshotai/moonshot-v1-128k-vision-preview",
         "organisation_id": "moonshotai",
-        "previous_model_id": null
+        "previous_model_id": null,
+        "api_model_id": "moonshotai/moonshot-v1-128k-vision-preview",
+        "has_page_notice": false
       }
     },
     "../../packages/data/catalog/src/data/models/moonshotai/moonshot-v1-32k/model.json": {
-      "hash": "a962a8d1d84302febc70d43e68b6643b",
+      "hash": "3bcfdf43109b3fe7a4d421c354d9aa35",
       "meta": {
         "model_id": "moonshotai/moonshot-v1-32k",
         "organisation_id": "moonshotai",
-        "previous_model_id": null
+        "previous_model_id": null,
+        "api_model_id": "moonshotai/moonshot-v1-32k",
+        "has_page_notice": false
       }
     },
     "../../packages/data/catalog/src/data/models/moonshotai/moonshot-v1-32k-vision-preview/model.json": {
-      "hash": "39ab46f29130299f0802642b3a65c6ac",
+      "hash": "68e68ac8dcc9b768d5f1996bd1d4733e",
       "meta": {
         "model_id": "moonshotai/moonshot-v1-32k-vision-preview",
         "organisation_id": "moonshotai",
-        "previous_model_id": null
+        "previous_model_id": null,
+        "api_model_id": "moonshotai/moonshot-v1-32k-vision-preview",
+        "has_page_notice": false
       }
     },
     "../../packages/data/catalog/src/data/models/moonshotai/moonshot-v1-8k/model.json": {
-      "hash": "6777af0e3f67c8f651b0630e73e41448",
+      "hash": "f95706178880b0edf706656207bc3e20",
       "meta": {
         "model_id": "moonshotai/moonshot-v1-8k",
         "organisation_id": "moonshotai",
-        "previous_model_id": null
+        "previous_model_id": null,
+        "api_model_id": "moonshotai/moonshot-v1-8k",
+        "has_page_notice": false
       }
     },
     "../../packages/data/catalog/src/data/models/moonshotai/moonshot-v1-8k-vision-preview/model.json": {
-      "hash": "71cb8977206e5f16d26a16ef6f0ae02c",
+      "hash": "a5631139d843226c6730a895b5ca56e2",
       "meta": {
         "model_id": "moonshotai/moonshot-v1-8k-vision-preview",
         "organisation_id": "moonshotai",
-        "previous_model_id": null
+        "previous_model_id": null,
+        "api_model_id": "moonshotai/moonshot-v1-8k-vision-preview",
+        "has_page_notice": false
       }
     },
     "../../packages/data/catalog/src/data/models/nvidia/cosmos3-super-reasoner/model.json": {
-      "hash": "62406c13aa82c8db6ad62237cc77c88f",
+      "hash": "073dc2d276a1dc205df9ca39ab13abb8",
       "meta": {
         "model_id": "nvidia/cosmos3-super-reasoner",
         "organisation_id": "nvidia",
@@ -28061,7 +27886,7 @@
       }
     },
     "../../packages/data/catalog/src/data/models/nvidia/nemotron-3-ultra-550b-a55b/model.json": {
-      "hash": "f5fb890083279346bbb97e5d945667bd",
+      "hash": "2d46b570ecfacb20570ec6369329b6a7",
       "meta": {
         "model_id": "nvidia/nemotron-3-ultra-550b-a55b",
         "organisation_id": "nvidia",
@@ -28071,23 +27896,27 @@
       }
     },
     "../../packages/data/catalog/src/data/models/qwen/qwen3-livetranslate-flash-realtime/model.json": {
-      "hash": "ea93967231dccef3691f58c761219812",
+      "hash": "29104982c30dc4d133624bd48baeb37f",
       "meta": {
         "model_id": "qwen/qwen3-livetranslate-flash-realtime",
         "organisation_id": "qwen",
-        "previous_model_id": null
+        "previous_model_id": null,
+        "api_model_id": "qwen/qwen3-livetranslate-flash-realtime",
+        "has_page_notice": false
       }
     },
     "../../packages/data/catalog/src/data/models/qwen/qwen3.5-livetranslate-flash-realtime-2026-05-19/model.json": {
-      "hash": "382f0fa640e92c82e7cee925ca819709",
+      "hash": "178e547266d426b1c36b9e2da0de2af1",
       "meta": {
         "model_id": "qwen/qwen3.5-livetranslate-flash-realtime-2026-05-19",
         "organisation_id": "qwen",
-        "previous_model_id": "qwen/qwen3-livetranslate-flash-realtime"
+        "previous_model_id": "qwen/qwen3-livetranslate-flash-realtime",
+        "api_model_id": "qwen/qwen3.5-livetranslate-flash-realtime-2026-05-19",
+        "has_page_notice": false
       }
     },
     "../../packages/data/catalog/src/data/models/qwen/qwen3.7-max/model.json": {
-      "hash": "de4c80e1027cef95d39b17cccf005773",
+      "hash": "a3d5f2792f078cacd773473032fe9768",
       "meta": {
         "model_id": "qwen/qwen3.7-max",
         "organisation_id": "qwen",
@@ -28118,36 +27947,6 @@
         "model_id": "qwen/qwen3.7-plus-preview",
         "organisation_id": "qwen",
         "previous_model_id": "qwen/qwen3.6-plus"
-      }
-    },
-    "../../packages/data/catalog/src/data/models/x-ai/grok-build-0.1/model.json": {
-      "hash": "bb94d4d0e1bf6fc176238ddbaf652675",
-      "meta": {
-        "model_id": "x-ai/grok-build-0.1",
-        "organisation_id": "x-ai",
-        "previous_model_id": "x-ai/grok-code-fast-1",
-        "api_model_id": "x-ai/grok-build-0.1",
-        "has_page_notice": false
-      }
-    },
-    "../../packages/data/catalog/src/data/models/x-ai/grok-imagine-video-1.5-preview/model.json": {
-      "hash": "4cf70d2066b3ae70e928ad1cef3692eb",
-      "meta": {
-        "model_id": "x-ai/grok-imagine-video-1.5-preview",
-        "organisation_id": "x-ai",
-        "previous_model_id": "x-ai/grok-imagine-video",
-        "api_model_id": "x-ai/grok-imagine-video-1.5-preview",
-        "has_page_notice": false
-      }
-    },
-    "../../packages/data/catalog/src/data/models/x-ai/grok-tts/model.json": {
-      "hash": "28489c3b7bcbb608bf7c29d324cf5349",
-      "meta": {
-        "model_id": "x-ai/grok-tts",
-        "organisation_id": "x-ai",
-        "previous_model_id": null,
-        "api_model_id": "x-ai/grok-tts",
-        "has_page_notice": false
       }
     },
     "../../packages/data/catalog/src/data/api_providers/ovhcloud/api_provider.json": {
@@ -28255,7 +28054,7 @@
       }
     },
     "../../packages/data/catalog/src/data/pricing/anthropic/anthropic-claude-opus-4.8/text.generate/pricing.json": {
-      "hash": "ea9d2c47e4347c405d4a5609cf23872e",
+      "hash": "110d87159a6a30b06dc000472fe9d930",
       "meta": {
         "api_provider_id": "anthropic",
         "capability_id": "text.generate",
@@ -28264,7 +28063,7 @@
       }
     },
     "../../packages/data/catalog/src/data/pricing/anthropic-aws/anthropic-claude-opus-4.8/text.generate/pricing.json": {
-      "hash": "fa40038c00f52eb875c009af430f33a6",
+      "hash": "72986ce77f71fa167b70725570eed8f5",
       "meta": {
         "api_provider_id": "anthropic-aws",
         "capability_id": "text.generate",
@@ -28273,7 +28072,7 @@
       }
     },
     "../../packages/data/catalog/src/data/pricing/anthropic-aws-us/anthropic-claude-opus-4.8/text.generate/pricing.json": {
-      "hash": "814bba18d93f31de9c38a47f04b1f802",
+      "hash": "47271532de5cc47ed0e57ca35b14bf49",
       "meta": {
         "api_provider_id": "anthropic-aws-us",
         "capability_id": "text.generate",
@@ -28282,7 +28081,7 @@
       }
     },
     "../../packages/data/catalog/src/data/pricing/anthropic-us/anthropic-claude-opus-4.8/text.generate/pricing.json": {
-      "hash": "d598490dda8a19891610e78d61524cda",
+      "hash": "fbf81ceb4da19478219daa308a68c331",
       "meta": {
         "api_provider_id": "anthropic-us",
         "capability_id": "text.generate",
@@ -28327,7 +28126,7 @@
       }
     },
     "../../packages/data/catalog/src/data/pricing/crofai/crofai-greg-1/text.generate/pricing.json": {
-      "hash": "d185b4b46dce1718e66daec314959ffc",
+      "hash": "8523ca83f8b512be55c92f7b846f629a",
       "meta": {
         "api_provider_id": "crofai",
         "capability_id": "text.generate",
@@ -28345,7 +28144,7 @@
       }
     },
     "../../packages/data/catalog/src/data/pricing/crofai/crofai-greg-1-super/text.generate/pricing.json": {
-      "hash": "20d7bbc4830ea24f1451ead45a555968",
+      "hash": "63ab4b4c0a24c1c6d4839834aaa0c799",
       "meta": {
         "api_provider_id": "crofai",
         "capability_id": "text.generate",
@@ -28489,7 +28288,7 @@
       }
     },
     "../../packages/data/catalog/src/data/pricing/google-vertex/anthropic-claude-opus-4.8/text.generate/pricing.json": {
-      "hash": "495bbf63e6869258b6f084d868eccfce",
+      "hash": "4c5c13673abf9e28eef65cf6654aab2a",
       "meta": {
         "api_provider_id": "google-vertex",
         "capability_id": "text.generate",
@@ -28507,7 +28306,7 @@
       }
     },
     "../../packages/data/catalog/src/data/pricing/minimax/minimax-minimax-m3/text.generate/pricing.json": {
-      "hash": "9227be28b708a2dbdea8e5bafeaed05a",
+      "hash": "792cb6f262de1c9b808a67eee6a510e0",
       "meta": {
         "api_provider_id": "minimax",
         "capability_id": "text.generate",
@@ -28624,7 +28423,7 @@
       }
     },
     "../../packages/data/catalog/src/data/pricing/nebius-token-factory/nvidia-cosmos3-super-reasoner/text.generate/pricing.json": {
-      "hash": "14f8a7aac3a6f93e115ab62c505916b3",
+      "hash": "0b54a019df5bcf981d16ed8308b7aa16",
       "meta": {
         "api_provider_id": "nebius-token-factory",
         "capability_id": "text.generate",
@@ -28633,7 +28432,7 @@
       }
     },
     "../../packages/data/catalog/src/data/pricing/novita/minimax-minimax-m3/text.generate/pricing.json": {
-      "hash": "e95d528809e35ba47d28d6309559d1bc",
+      "hash": "4c4039fb740731957ef4929d619ff4a2",
       "meta": {
         "api_provider_id": "novita",
         "capability_id": "text.generate",
@@ -28642,7 +28441,7 @@
       }
     },
     "../../packages/data/catalog/src/data/pricing/novita/qwen-qwen3.6-35b-a3b/text.generate/pricing.json": {
-      "hash": "b7704a1354f32ce39e42f6edaaa154ef",
+      "hash": "69d4aea0f255bcb2b8ccc32835088aa8",
       "meta": {
         "api_provider_id": "novita",
         "capability_id": "text.generate",
@@ -28687,7 +28486,7 @@
       }
     },
     "../../packages/data/catalog/src/data/pricing/ovhcloud/meta-llama-3.3-70b/text.generate/pricing.json": {
-      "hash": "dce52eff42973017c198d161d920e79f",
+      "hash": "0a2aee925bf487201b64d42c12d55813",
       "meta": {
         "api_provider_id": "ovhcloud",
         "capability_id": "text.generate",
@@ -28696,7 +28495,7 @@
       }
     },
     "../../packages/data/catalog/src/data/pricing/ovhcloud/mistral-mistral-small-3.2/text.generate/pricing.json": {
-      "hash": "79562a3e8b64f3f317c3d212cf10be74",
+      "hash": "485fc9779d8cc217f362b7f221a1d5f3",
       "meta": {
         "api_provider_id": "ovhcloud",
         "capability_id": "text.generate",
@@ -28705,7 +28504,7 @@
       }
     },
     "../../packages/data/catalog/src/data/pricing/ovhcloud/openai-gpt-oss-120b/text.generate/pricing.json": {
-      "hash": "a24fca02410697080aeea7d342c7ec99",
+      "hash": "2c42ba7f66bed9a76e1327778dc28f40",
       "meta": {
         "api_provider_id": "ovhcloud",
         "capability_id": "text.generate",
@@ -28714,7 +28513,7 @@
       }
     },
     "../../packages/data/catalog/src/data/pricing/ovhcloud/qwen-qwen3-32b/text.generate/pricing.json": {
-      "hash": "c4930639b5e58a0a9e045ef5d2e2933a",
+      "hash": "b4ea42c9924edd928ff7cf5fb5327424",
       "meta": {
         "api_provider_id": "ovhcloud",
         "capability_id": "text.generate",
@@ -28723,7 +28522,7 @@
       }
     },
     "../../packages/data/catalog/src/data/pricing/ovhcloud/qwen-qwen3-embedding-8b/text.embed/pricing.json": {
-      "hash": "8919c875e727e61faf7ed88a216a05b0",
+      "hash": "47a0189ecd81ef714db591a9458caa5a",
       "meta": {
         "api_provider_id": "ovhcloud",
         "capability_id": "text.embed",
@@ -28732,7 +28531,7 @@
       }
     },
     "../../packages/data/catalog/src/data/pricing/ovhcloud/qwen-qwen3.5-9b/text.generate/pricing.json": {
-      "hash": "09e502f24f82a2e7da4dc357742b1862",
+      "hash": "e5d9ea4e57768847fe23c96f64844b7c",
       "meta": {
         "api_provider_id": "ovhcloud",
         "capability_id": "text.generate",
@@ -28741,7 +28540,7 @@
       }
     },
     "../../packages/data/catalog/src/data/pricing/scaleway/meta-llama-3.3-70b/text.generate/pricing.json": {
-      "hash": "f6a09e7bc7f1a82a75d9d89084a5bb2e",
+      "hash": "fc4c596ab2f094618efae9a31984995a",
       "meta": {
         "api_provider_id": "scaleway",
         "capability_id": "text.generate",
@@ -28750,7 +28549,7 @@
       }
     },
     "../../packages/data/catalog/src/data/pricing/scaleway/mistral-mistral-small-3.2/text.generate/pricing.json": {
-      "hash": "585b875c344e13a23c0548878cd96571",
+      "hash": "a0adf2508be49b9d5df61e9c8951fc3b",
       "meta": {
         "api_provider_id": "scaleway",
         "capability_id": "text.generate",
@@ -28759,7 +28558,7 @@
       }
     },
     "../../packages/data/catalog/src/data/pricing/scaleway/openai-gpt-oss-120b/text.generate/pricing.json": {
-      "hash": "802caca4825c4aac1f36d234beb0449e",
+      "hash": "07418f98ffc792c8a253af1900f0a797",
       "meta": {
         "api_provider_id": "scaleway",
         "capability_id": "text.generate",
@@ -28768,7 +28567,7 @@
       }
     },
     "../../packages/data/catalog/src/data/pricing/scaleway/qwen-qwen3-coder-30b-a3b/text.generate/pricing.json": {
-      "hash": "ba6a940193f1aa4d9df81924b005ac58",
+      "hash": "5b86e14a54e5cb617c5e0429377cea9f",
       "meta": {
         "api_provider_id": "scaleway",
         "capability_id": "text.generate",
@@ -28777,7 +28576,7 @@
       }
     },
     "../../packages/data/catalog/src/data/pricing/scaleway/qwen-qwen3-embedding-8b/text.embed/pricing.json": {
-      "hash": "eb20e1e587e625fcd01353010b07a18f",
+      "hash": "48a62370821eccfb95badd52f1271cb5",
       "meta": {
         "api_provider_id": "scaleway",
         "capability_id": "text.embed",
@@ -28786,7 +28585,7 @@
       }
     },
     "../../packages/data/catalog/src/data/pricing/venice/anthropic-claude-opus-4.7-fast/text.generate/pricing.json": {
-      "hash": "c244df517f346116aa95057607e919a4",
+      "hash": "b4fb5e7de5a8236112299e347da1840e",
       "meta": {
         "api_provider_id": "venice",
         "capability_id": "text.generate",
@@ -28822,7 +28621,7 @@
       }
     },
     "../../packages/data/catalog/src/data/pricing/venice/minimax-minimax-m3/text.generate/pricing.json": {
-      "hash": "32801eadb9a8e8538b28002c5b797794",
+      "hash": "04155fc381f3b174126c80d48e2c3dee",
       "meta": {
         "api_provider_id": "venice",
         "capability_id": "text.generate",
@@ -28848,15 +28647,6 @@
         "model_key": "venice:qwen/qwen3.7-max:text.generate"
       }
     },
-    "../../packages/data/catalog/src/data/pricing/venice/x-ai-grok-build-0.1/text.generate/pricing.json": {
-      "hash": "5ecdc50da3a1869c7cff273f16f1ae0c",
-      "meta": {
-        "api_provider_id": "venice",
-        "capability_id": "text.generate",
-        "model_id": "x-ai/grok-build-0.1",
-        "model_key": "venice:x-ai/grok-build-0.1:text.generate"
-      }
-    },
     "../../packages/data/catalog/src/data/pricing/weights-and-biases/deepseek-deepseek-v4-pro/text.generate/pricing.json": {
       "hash": "c811dcd6be023dde0bba6cab738f6a03",
       "meta": {
@@ -28875,42 +28665,6 @@
         "model_key": "weights-and-biases:qwen/qwen3.6-27b:text.generate"
       }
     },
-    "../../packages/data/catalog/src/data/pricing/x-ai/x-ai-grok-build-0.1/text.generate/pricing.json": {
-      "hash": "dfecb8de649bbe064b696e50d607af79",
-      "meta": {
-        "api_provider_id": "x-ai",
-        "capability_id": "text.generate",
-        "model_id": "x-ai/grok-build-0.1",
-        "model_key": "x-ai:x-ai/grok-build-0.1:text.generate"
-      }
-    },
-    "../../packages/data/catalog/src/data/pricing/x-ai/x-ai-grok-imagine-video-1.5-preview/video.edit/pricing.json": {
-      "hash": "087a2def1d7b7e54f31582da59bbdaa4",
-      "meta": {
-        "api_provider_id": "x-ai",
-        "capability_id": "video.edit",
-        "model_id": "x-ai/grok-imagine-video-1.5-preview",
-        "model_key": "x-ai:x-ai/grok-imagine-video-1.5-preview:video.edit"
-      }
-    },
-    "../../packages/data/catalog/src/data/pricing/x-ai/x-ai-grok-imagine-video-1.5-preview/video.generate/pricing.json": {
-      "hash": "35db620910ef797ee1c8f369b4872b34",
-      "meta": {
-        "api_provider_id": "x-ai",
-        "capability_id": "video.generate",
-        "model_id": "x-ai/grok-imagine-video-1.5-preview",
-        "model_key": "x-ai:x-ai/grok-imagine-video-1.5-preview:video.generate"
-      }
-    },
-    "../../packages/data/catalog/src/data/pricing/x-ai/x-ai-grok-tts/audio.speech/pricing.json": {
-      "hash": "3c42026421783a2dc2d828da7b369eb1",
-      "meta": {
-        "api_provider_id": "x-ai",
-        "capability_id": "audio.speech",
-        "model_id": "x-ai/grok-tts",
-        "model_key": "x-ai:x-ai/grok-tts:audio.speech"
-      }
-    },
     "../../packages/data/catalog/src/data/pricing/z-ai/z-ai-glm-5.1/text.generate/pricing.json": {
       "hash": "260eccb5d9df8055233ae07e05dc7843",
       "meta": {
@@ -28921,13 +28675,13 @@
       }
     },
     "../../packages/data/catalog/src/data/models/anthropic/claude-fable-5/model.json": {
-      "hash": "c4a73c5d90df23621189254350237b5b",
+      "hash": "508baca5a6e212dc34372e33f5dece75",
       "meta": {
         "model_id": "anthropic/claude-fable-5",
         "organisation_id": "anthropic",
         "previous_model_id": "anthropic/claude-opus-4.8",
         "api_model_id": "anthropic/claude-fable-5",
-        "has_page_notice": true
+        "has_page_notice": false
       }
     },
     "../../packages/data/catalog/src/data/api_providers/digitalocean/api_provider.json": {
@@ -28974,24 +28728,43 @@
       "hash": "246038e8b92c157c20fcb68a57312882",
       "meta": {
         "api_provider_id": "nvidia",
-        "kind": "provider_models"
+        "kind": "provider_models",
+        "linked_model_ids": [
+          "nvidia/nemotron-3-ultra-550b-a55b",
+          "nvidia/nemotron-3-super-120b-a12b",
+          "nvidia/nemotron-3-nano-30b-a3b",
+          "nvidia/nemotron-3-nano-omni-30b-a3b-reasoning"
+        ]
       }
     },
     "../../packages/data/catalog/src/data/api_providers/thinking-machines/api_provider.json": {
-      "hash": "c0d744d1e183b3b3e1978408cc7a1490",
+      "hash": "78e95916bd3e9caea0ee296ea1a7e740",
       "meta": {
         "api_provider_id": "thinking-machines"
       }
     },
     "../../packages/data/catalog/src/data/api_providers/thinking-machines/models.json": {
-      "hash": "a566a1e9733c535d39c188c2915340ad",
+      "hash": "e0c8778be75e9c61c90c88e9b09550e9",
       "meta": {
         "api_provider_id": "thinking-machines",
-        "kind": "provider_models"
+        "kind": "provider_models",
+        "linked_model_ids": [
+          "thinking-machines/inkling",
+          "thinking-machines/inkling-64k",
+          "openai/gpt-oss-20b",
+          "openai/gpt-oss-120b",
+          "nvidia/nemotron-3-nano-30b-a3b",
+          "nvidia/nemotron-3-super-120b-a12b",
+          "nvidia/nemotron-3-ultra-550b-a55b",
+          "qwen/qwen3.5-4b",
+          "qwen/qwen3.5-397b-a17b",
+          "qwen/qwen3.6-27b",
+          "qwen/qwen3.6-35b-a3b"
+        ]
       }
     },
     "../../packages/data/catalog/src/data/models/crofai/greg-2-super/model.json": {
-      "hash": "a0fc77650b1d6be9b224051f89e28c10",
+      "hash": "83770aa00c930645130fe9db513d16ee",
       "meta": {
         "model_id": "crofai/greg-2-super",
         "organisation_id": "crofai",
@@ -29001,7 +28774,7 @@
       }
     },
     "../../packages/data/catalog/src/data/models/crofai/greg-2-ultra/model.json": {
-      "hash": "a84aa209ab302d8956287b7930da8968",
+      "hash": "09696acca442851cfd9a109a3460fe22",
       "meta": {
         "model_id": "crofai/greg-2-ultra",
         "organisation_id": "crofai",
@@ -29011,7 +28784,7 @@
       }
     },
     "../../packages/data/catalog/src/data/pricing/crofai/z-ai-glm-5.2/text.generate/pricing.json": {
-      "hash": "cd74a885c5fedf83416b55671bb5423e",
+      "hash": "28a69f46215aa558617cc483c4630a94",
       "meta": {
         "api_provider_id": "crofai",
         "capability_id": "text.generate",
@@ -29020,7 +28793,7 @@
       }
     },
     "../../packages/data/catalog/src/data/pricing/crofai/crofai-greg-2-super/text.generate/pricing.json": {
-      "hash": "86f722244431d3fb14f1474a1ac16c69",
+      "hash": "f9a63a49ca108f92af03ae624c4fb2d6",
       "meta": {
         "api_provider_id": "crofai",
         "capability_id": "text.generate",
@@ -29029,73 +28802,12 @@
       }
     },
     "../../packages/data/catalog/src/data/pricing/crofai/crofai-greg-2-ultra/text.generate/pricing.json": {
-      "hash": "e51dda0818d18c7d7acd5ea266253fd8",
+      "hash": "9f38eae9362f24e697d3242eea8fe74a",
       "meta": {
         "api_provider_id": "crofai",
         "capability_id": "text.generate",
         "model_id": "crofai/greg-2-ultra",
         "model_key": "crofai:crofai/greg-2-ultra:text.generate"
-      }
-    },
-    "../../packages/data/catalog/src/data/api_providers/amazon-bedrock/api_provider.json": {
-      "hash": "58cbab47258b7a103713f90900b51b12",
-      "meta": {
-        "api_provider_id": "amazon-bedrock"
-      }
-    },
-    "../../packages/data/catalog/src/data/api_providers/amazon-bedrock/models.json": {
-      "hash": "5fce86e1523a5b24b30713ac271e2db7",
-      "meta": {
-        "api_provider_id": "amazon-bedrock",
-        "kind": "provider_models",
-        "linked_model_ids": [
-          "anthropic/claude-sonnet-5",
-          "anthropic/claude-mythos-5",
-          "anthropic/claude-fable-5",
-          "anthropic/claude-mythos-preview",
-          "anthropic/claude-haiku-4.5",
-          "anthropic/claude-opus-4.7",
-          "anthropic/claude-opus-4.8",
-          "deepseek/deepseek-v3.2",
-          "deepseek/deepseek-v3.1",
-          "google/gemma-3-12b",
-          "google/gemma-3-27b",
-          "google/gemma-3-4b",
-          "minimax/minimax-m2",
-          "minimax/minimax-m2.1",
-          "minimax/minimax-m2.5",
-          "mistral/devstral-2.0",
-          "mistral/magistral-small-1.2",
-          "mistral/ministral-3.0-14b",
-          "mistral/ministral-3.0-8b",
-          "mistral/ministral-3.0-3b",
-          "mistral/mistral-large-3.0",
-          "mistral/voxtral-mini",
-          "mistral/voxtral-small",
-          "moonshotai/kimi-k2-thinking",
-          "moonshotai/kimi-k2.5",
-          "nvidia/nemotron-nano-9b-v2",
-          "nvidia/nvidia-nemotron-nano-12b-v2-vl",
-          "nvidia/nemotron-3-nano-30b-a3b",
-          "nvidia/nemotron-3-super-120b-a12b",
-          "openai/gpt-5.5",
-          "openai/gpt-5.4",
-          "openai/gpt-oss-safeguard-120b",
-          "openai/gpt-oss-safeguard-20b",
-          "openai/gpt-oss-120b",
-          "openai/gpt-oss-20b",
-          "qwen/qwen3-235b-a22b-2507",
-          "qwen/qwen3-32b",
-          "qwen/qwen3-coder-480b-a35b",
-          "qwen/qwen3-coder-next",
-          "qwen/qwen3-next-80b-a3b-instruct",
-          "qwen/qwen3-vl-235b-a22b-instruct",
-          "qwen/qwen3-coder-30b-a3b",
-          "x-ai/grok-4.3",
-          "z-ai/glm-4.7",
-          "z-ai/glm-4.7-flash",
-          "z-ai/glm-5"
-        ]
       }
     },
     "../../packages/data/catalog/src/data/api_providers/inceptron/models.json": {
@@ -29148,7 +28860,7 @@
       }
     },
     "../../packages/data/catalog/src/data/pricing/novita/tencent-hy3-free/text.generate/pricing.json": {
-      "hash": "d97d416352a38a2ff2e9584887a1bc17",
+      "hash": "8328f04174d49a16168d769060dd9c52",
       "meta": {
         "api_provider_id": "novita",
         "capability_id": "text.generate",
@@ -29157,7 +28869,7 @@
       }
     },
     "../../packages/data/catalog/src/data/models/anthropic/claude-mythos-5/model.json": {
-      "hash": "d814482debc16fddc336575d33fc0873",
+      "hash": "c704ec1ee485818b06aed9c8d2475d9e",
       "meta": {
         "model_id": "anthropic/claude-mythos-5",
         "organisation_id": "anthropic",
@@ -29167,7 +28879,7 @@
       }
     },
     "../../packages/data/catalog/src/data/models/anthropic/claude-sonnet-5/model.json": {
-      "hash": "1be2196ca5cefd62fcc6b4cb5f2da428",
+      "hash": "14565d4528f6ee2ec101d6b1ff112bff",
       "meta": {
         "model_id": "anthropic/claude-sonnet-5",
         "organisation_id": "anthropic",
@@ -29187,7 +28899,7 @@
       }
     },
     "../../packages/data/catalog/src/data/models/bytedance/stable-diffusion-xl-lightning/model.json": {
-      "hash": "3a18ded0180342fc4bf4e8794de6b593",
+      "hash": "2e186e0d3d7c47be8f1435dcbec58fcb",
       "meta": {
         "model_id": "bytedance/stable-diffusion-xl-lightning",
         "organisation_id": "bytedance",
@@ -29197,7 +28909,7 @@
       }
     },
     "../../packages/data/catalog/src/data/models/cohere/north-mini-code-1-0/model.json": {
-      "hash": "9d7649048ae12e0813a6dff3408c9dd8",
+      "hash": "17918c19a1af79f73a412b829ccae958",
       "meta": {
         "model_id": "cohere/north-mini-code-1-0",
         "organisation_id": "cohere",
@@ -29227,7 +28939,7 @@
       }
     },
     "../../packages/data/catalog/src/data/models/google/diffusiongemma-26b-a4b-it/model.json": {
-      "hash": "771c72ff5c56c49d522d0f971f438461",
+      "hash": "d52002586012d264d067128d4bde72cf",
       "meta": {
         "model_id": "google/diffusiongemma-26b-a4b-it",
         "organisation_id": "google",
@@ -29237,7 +28949,7 @@
       }
     },
     "../../packages/data/catalog/src/data/models/google/gemini-2.5-flash-native-audio-preview-2025-12-12/model.json": {
-      "hash": "935790e677ecd17734b9b4fbdf203cc4",
+      "hash": "7761d6e1940245dcbd0ef963a6662ebd",
       "meta": {
         "model_id": "google/gemini-2.5-flash-native-audio-preview-2025-12-12",
         "organisation_id": "google",
@@ -29247,7 +28959,7 @@
       }
     },
     "../../packages/data/catalog/src/data/models/google/gemini-2.5-pro/model.json": {
-      "hash": "c90217478e5fada9935aefd30fdb81b9",
+      "hash": "1284d4d848c71a83b55d70440e2135f3",
       "meta": {
         "model_id": "google/gemini-2.5-pro",
         "organisation_id": "google",
@@ -29257,7 +28969,7 @@
       }
     },
     "../../packages/data/catalog/src/data/models/google/gemini-3.1-flash-lite-image/model.json": {
-      "hash": "d4552e185311a289b241a183e35ace37",
+      "hash": "d670a4ad77590be1ff0b2dba4a67973a",
       "meta": {
         "model_id": "google/gemini-3.1-flash-lite-image",
         "organisation_id": "google",
@@ -29267,7 +28979,7 @@
       }
     },
     "../../packages/data/catalog/src/data/models/google/gemini-3.5-live-translate-preview/model.json": {
-      "hash": "1d404d9b32524ce3a2aaeac35186aa51",
+      "hash": "d5a2301e02cffd45ec4c411e34122852",
       "meta": {
         "model_id": "google/gemini-3.5-live-translate-preview",
         "organisation_id": "google",
@@ -29277,7 +28989,7 @@
       }
     },
     "../../packages/data/catalog/src/data/models/google/gemini-3.5-pro/model.json": {
-      "hash": "4454a60832a6232783372d68902d3bc0",
+      "hash": "ee6aace18ff8aa81bef7bec0e0d9131b",
       "meta": {
         "model_id": "google/gemini-3.5-pro",
         "organisation_id": "google",
@@ -29287,7 +28999,7 @@
       }
     },
     "../../packages/data/catalog/src/data/models/google/gemini-omni-flash-preview/model.json": {
-      "hash": "607ccf3965317c8d1cd4b502db09edcd",
+      "hash": "09398315a8079a3659f341b8f9c6a8dc",
       "meta": {
         "model_id": "google/gemini-omni-flash-preview",
         "organisation_id": "google",
@@ -29307,7 +29019,7 @@
       }
     },
     "../../packages/data/catalog/src/data/models/google/gemma-4-12b/model.json": {
-      "hash": "27538af9b811aa95455a9f36da4e2135",
+      "hash": "fce8f34553bbf6dc3e0bfac0a81cc53d",
       "meta": {
         "model_id": "google/gemma-4-12b",
         "organisation_id": "google",
@@ -29327,7 +29039,7 @@
       }
     },
     "../../packages/data/catalog/src/data/models/meituan/longcat-2.0/model.json": {
-      "hash": "d6ffcab1fb9aa3dac84350fd38714437",
+      "hash": "fe1a30e927f8c527f9ae1e4585da0729",
       "meta": {
         "model_id": "meituan/longcat-2.0",
         "organisation_id": "meituan",
@@ -29397,7 +29109,7 @@
       }
     },
     "../../packages/data/catalog/src/data/models/meta/m2m100-1.2b/model.json": {
-      "hash": "b5b0aee5ff37ca9e440d025617ac57e6",
+      "hash": "8da22744582d39f147603c648c5aa109",
       "meta": {
         "model_id": "meta/m2m100-1.2b",
         "organisation_id": "meta",
@@ -29407,7 +29119,7 @@
       }
     },
     "../../packages/data/catalog/src/data/models/microsoft/resnet-50/model.json": {
-      "hash": "64275904a5d059962bab297d0770e39f",
+      "hash": "167dae663b4afe5249286d0e582d0fa2",
       "meta": {
         "model_id": "microsoft/resnet-50",
         "organisation_id": "microsoft",
@@ -29417,7 +29129,7 @@
       }
     },
     "../../packages/data/catalog/src/data/models/mistral/leanstral-1.5/model.json": {
-      "hash": "c40199adcb026300ee0b453dd411b370",
+      "hash": "8c1fba4184364df08f1205c0fa256e57",
       "meta": {
         "model_id": "mistral/leanstral-1.5",
         "organisation_id": "mistral",
@@ -29447,7 +29159,7 @@
       }
     },
     "../../packages/data/catalog/src/data/models/mistral/ocr-4/model.json": {
-      "hash": "f49922165a0d2f21296ae3b78eed83d5",
+      "hash": "e27c61bfeb83811fe18f7dec411a5fca",
       "meta": {
         "model_id": "mistral/ocr-4",
         "organisation_id": "mistral",
@@ -29457,7 +29169,7 @@
       }
     },
     "../../packages/data/catalog/src/data/models/moonshotai/kimi-k2.7-code/model.json": {
-      "hash": "ff16236f787cb9f5a660f0e50f9c5b82",
+      "hash": "e03692405136de71f460840202739162",
       "meta": {
         "model_id": "moonshotai/kimi-k2.7-code",
         "organisation_id": "moonshotai",
@@ -29467,7 +29179,7 @@
       }
     },
     "../../packages/data/catalog/src/data/models/nex-agi/nex-n2-mini/model.json": {
-      "hash": "7f026791084f3da4e512e42a22aafea0",
+      "hash": "3e1995460c6b5e44beb53022fde99edd",
       "meta": {
         "model_id": "nex-agi/nex-n2-mini",
         "organisation_id": "nex-agi",
@@ -29477,7 +29189,7 @@
       }
     },
     "../../packages/data/catalog/src/data/models/nex-agi/nex-n2-pro/model.json": {
-      "hash": "99404b7268b1b2bfd85b231a2037065a",
+      "hash": "2e68db55e197bafb25d7de5b717da6de",
       "meta": {
         "model_id": "nex-agi/nex-n2-pro",
         "organisation_id": "nex-agi",
@@ -29507,7 +29219,7 @@
       }
     },
     "../../packages/data/catalog/src/data/models/openai/gpt-5.6-luna/model.json": {
-      "hash": "3aa546ee4452111faa007b419e489b6a",
+      "hash": "f527746546cba2bf1bd3ed7e93c54611",
       "meta": {
         "model_id": "openai/gpt-5.6-luna",
         "organisation_id": "openai",
@@ -29517,7 +29229,7 @@
       }
     },
     "../../packages/data/catalog/src/data/models/openai/gpt-5.6-sol/model.json": {
-      "hash": "5b1a628634950e1ed64f781dd6203d3e",
+      "hash": "9f1ce2d3b151bd6cb94f6216ecc26f69",
       "meta": {
         "model_id": "openai/gpt-5.6-sol",
         "organisation_id": "openai",
@@ -29527,7 +29239,7 @@
       }
     },
     "../../packages/data/catalog/src/data/models/openai/gpt-5.6-terra/model.json": {
-      "hash": "15c2a3d9e542e43788aa84f20b846fd4",
+      "hash": "fec0b9f9a22920dfcc79e734338ede95",
       "meta": {
         "model_id": "openai/gpt-5.6-terra",
         "organisation_id": "openai",
@@ -29547,7 +29259,7 @@
       }
     },
     "../../packages/data/catalog/src/data/models/poolside/laguna-xs-2.1/model.json": {
-      "hash": "fa349b39cd3f04d69564e0a8c0b8b9a1",
+      "hash": "f18c674baac895179958cf404569527a",
       "meta": {
         "model_id": "poolside/laguna-xs-2.1",
         "organisation_id": "poolside",
@@ -29597,7 +29309,7 @@
       }
     },
     "../../packages/data/catalog/src/data/models/stepfun/step-3.7-flash/model.json": {
-      "hash": "977281a195f64a9a417559bc2374410c",
+      "hash": "e0736527961460e835fd812a25fc60a7",
       "meta": {
         "model_id": "stepfun/step-3.7-flash",
         "organisation_id": "stepfun",
@@ -29607,7 +29319,7 @@
       }
     },
     "../../packages/data/catalog/src/data/models/windsurf/swe-1/model.json": {
-      "hash": "3f57884d61669c0636b85d283f4842ee",
+      "hash": "66ec40cbfc8a47bc152df1ac0f82d49d",
       "meta": {
         "model_id": "windsurf/swe-1",
         "organisation_id": "windsurf",
@@ -29617,7 +29329,7 @@
       }
     },
     "../../packages/data/catalog/src/data/models/windsurf/swe-1-mini/model.json": {
-      "hash": "a59dd4c81e658ca8ccbd0557f56ae3aa",
+      "hash": "94d9914e225e99e48f025c69a5d0bbb2",
       "meta": {
         "model_id": "windsurf/swe-1-mini",
         "organisation_id": "windsurf",
@@ -29627,7 +29339,7 @@
       }
     },
     "../../packages/data/catalog/src/data/models/windsurf/swe-1.5/model.json": {
-      "hash": "ddae4fb033f288f71381d0156b1f2532",
+      "hash": "eab3b77b17fa66e7cb1bfd4f1001a794",
       "meta": {
         "model_id": "windsurf/swe-1.5",
         "organisation_id": "windsurf",
@@ -29637,7 +29349,7 @@
       }
     },
     "../../packages/data/catalog/src/data/models/windsurf/swe-1.6/model.json": {
-      "hash": "c53fa1b476ec2a17ae885e5b63a1691e",
+      "hash": "3dfc8cb3d99bae20cac596c572ef20c6",
       "meta": {
         "model_id": "windsurf/swe-1.6",
         "organisation_id": "windsurf",
@@ -29647,7 +29359,7 @@
       }
     },
     "../../packages/data/catalog/src/data/models/windsurf/swe-1.6-fast/model.json": {
-      "hash": "bf15ba27def986e09557e136b06ea0c3",
+      "hash": "786b5a8cbf6e012e4edf6142927e6890",
       "meta": {
         "model_id": "windsurf/swe-1.6-fast",
         "organisation_id": "windsurf",
@@ -29657,7 +29369,7 @@
       }
     },
     "../../packages/data/catalog/src/data/models/windsurf/swe-grep/model.json": {
-      "hash": "4bf380eb4eaf8bb06628144776a76814",
+      "hash": "51476043135ed8ef18f3cd418f62ceda",
       "meta": {
         "model_id": "windsurf/swe-grep",
         "organisation_id": "windsurf",
@@ -29666,18 +29378,8 @@
         "has_page_notice": false
       }
     },
-    "../../packages/data/catalog/src/data/models/x-ai/grok-imagine-video-1.5/model.json": {
-      "hash": "571c8417a3d181d1feb52f2ecb0ac8aa",
-      "meta": {
-        "model_id": "x-ai/grok-imagine-video-1.5",
-        "organisation_id": "x-ai",
-        "previous_model_id": "x-ai/grok-imagine-video-1.5-preview",
-        "api_model_id": "x-ai/grok-imagine-video-1.5",
-        "has_page_notice": false
-      }
-    },
     "../../packages/data/catalog/src/data/models/z-ai/glm-5.2/model.json": {
-      "hash": "d63c1fdc046b5463d418371422e6944d",
+      "hash": "574b2bfcfb88847185e529b0da09a2b2",
       "meta": {
         "model_id": "z-ai/glm-5.2",
         "organisation_id": "z-ai",
@@ -29687,7 +29389,7 @@
       }
     },
     "../../packages/data/catalog/src/data/models/tencent/hy3/model.json": {
-      "hash": "6ab163a8035d592516d34a5a6e011226",
+      "hash": "2a18edce69c31a1506d449227eb99579",
       "meta": {
         "model_id": "tencent/hy3",
         "organisation_id": "tencent",
@@ -29696,22 +29398,3320 @@
         "has_page_notice": false
       }
     },
-    "../../packages/data/catalog/src/data/pricing/atlascloud/tencent-hy3-free/text.generate/pricing.json": {
-      "hash": "66a7d98622cb76faf052388e78be1c34",
-      "meta": {
-        "api_provider_id": "atlascloud",
-        "capability_id": "text.generate",
-        "model_id": "tencent/hy3:free",
-        "model_key": "atlascloud:tencent/hy3:free:text.generate"
-      }
-    },
     "../../packages/data/catalog/src/data/pricing/atlascloud/tencent-hy3/text.generate/pricing.json": {
-      "hash": "e3c050cdf57db7237c285a777fa5f10d",
+      "hash": "2343845f3f1757c7db454b1e777d8f96",
       "meta": {
         "api_provider_id": "atlascloud",
         "capability_id": "text.generate",
         "model_id": "tencent/hy3",
         "model_key": "atlascloud:tencent/hy3:text.generate"
+      }
+    },
+    "../../packages/data/catalog/src/data/api_providers/ambient/api_provider.json": {
+      "hash": "f259aa241387f414f60e9398421a59b9",
+      "meta": {
+        "api_provider_id": "ambient"
+      }
+    },
+    "../../packages/data/catalog/src/data/api_providers/ambient/models.json": {
+      "hash": "5a90f06fcf8b19cc5e64bdac5d1a4a4e",
+      "meta": {
+        "api_provider_id": "ambient",
+        "kind": "provider_models",
+        "linked_model_ids": [
+          "z-ai/glm-5.1",
+          "z-ai/glm-5.2",
+          "z-ai/glm-4.5-air",
+          "openai/gpt-oss-120b",
+          "openai/gpt-oss-20b",
+          "moonshotai/kimi-k2.5",
+          "moonshotai/kimi-k2.6",
+          "moonshotai/kimi-k2.7-code",
+          "nvidia/nemotron-3-nano-30b-a3b",
+          "qwen/qwen3-next-80b-a3b-instruct",
+          "qwen/qwen3.5-35b-a3b",
+          "qwen/qwen3.6-27b",
+          "qwen/qwen3.6-35b-a3b"
+        ]
+      }
+    },
+    "../../packages/data/catalog/src/data/api_providers/avian/api_provider.json": {
+      "hash": "9e84a9e52faf510164eda6ab4870fc3e",
+      "meta": {
+        "api_provider_id": "avian"
+      }
+    },
+    "../../packages/data/catalog/src/data/api_providers/avian/models.json": {
+      "hash": "91f3834f14d3765a41641eb2d5aa6043",
+      "meta": {
+        "api_provider_id": "avian",
+        "kind": "provider_models",
+        "linked_model_ids": [
+          "deepseek/deepseek-v4-flash",
+          "deepseek/deepseek-v4-pro",
+          "deepseek/deepseek-v3.2",
+          "minimax/minimax-m2.5",
+          "z-ai/glm-5",
+          "z-ai/glm-5.1",
+          "moonshotai/kimi-k2.5",
+          "moonshotai/kimi-k2.6"
+        ]
+      }
+    },
+    "../../packages/data/catalog/src/data/api_providers/baidu/api_provider.json": {
+      "hash": "189d21ec28906140c1fed01b15d98d3f",
+      "meta": {
+        "api_provider_id": "baidu"
+      }
+    },
+    "../../packages/data/catalog/src/data/api_providers/darkbloom/api_provider.json": {
+      "hash": "3d55b6136be6f31da481c97f08d07d0d",
+      "meta": {
+        "api_provider_id": "darkbloom"
+      }
+    },
+    "../../packages/data/catalog/src/data/api_providers/featherless/api_provider.json": {
+      "hash": "cf130952f766b49c2e86e796af97b5c9",
+      "meta": {
+        "api_provider_id": "featherless"
+      }
+    },
+    "../../packages/data/catalog/src/data/api_providers/inference-net/api_provider.json": {
+      "hash": "fb69467bdbe99694a270ea2ff38eae35",
+      "meta": {
+        "api_provider_id": "inference-net"
+      }
+    },
+    "../../packages/data/catalog/src/data/api_providers/mancer/api_provider.json": {
+      "hash": "11cb6be15c19b5233798b2e575005456",
+      "meta": {
+        "api_provider_id": "mancer"
+      }
+    },
+    "../../packages/data/catalog/src/data/api_providers/mara/api_provider.json": {
+      "hash": "9ea61bf83f5d5fe66ecd14274b446049",
+      "meta": {
+        "api_provider_id": "mara"
+      }
+    },
+    "../../packages/data/catalog/src/data/api_providers/reka/api_provider.json": {
+      "hash": "287167b22911c0aa9a7a05afcddcbfff",
+      "meta": {
+        "api_provider_id": "reka"
+      }
+    },
+    "../../packages/data/catalog/src/data/api_providers/relace/api_provider.json": {
+      "hash": "60472633f4c0980c18ce4d74c0a51986",
+      "meta": {
+        "api_provider_id": "relace"
+      }
+    },
+    "../../packages/data/catalog/src/data/api_providers/sakana/api_provider.json": {
+      "hash": "e38bcdf26e0109b19bd07199c63cd0db",
+      "meta": {
+        "api_provider_id": "sakana"
+      }
+    },
+    "../../packages/data/catalog/src/data/api_providers/sakana/models.json": {
+      "hash": "ffa286415a3407d88d1a116b0afef3e6",
+      "meta": {
+        "api_provider_id": "sakana",
+        "kind": "provider_models",
+        "linked_model_ids": [
+          "sakana/fugu",
+          "sakana/fugu-ultra"
+        ]
+      }
+    },
+    "../../packages/data/catalog/src/data/api_providers/spacex-ai/api_provider.json": {
+      "hash": "e2ecdba152abcbc8c6d464118ac4ba30",
+      "meta": {
+        "api_provider_id": "spacex-ai"
+      }
+    },
+    "../../packages/data/catalog/src/data/api_providers/spacex-ai/models.json": {
+      "hash": "f6990b333d28bdd3ff0be98d78534aab",
+      "meta": {
+        "api_provider_id": "spacex-ai",
+        "kind": "provider_models",
+        "linked_model_ids": [
+          "spacex-ai/grok-2-vision-1212",
+          "spacex-ai/grok-2-vision",
+          "spacex-ai/grok-3",
+          "spacex-ai/grok-3-mini",
+          "spacex-ai/grok-4",
+          "spacex-ai/grok-4.1-non-thinking",
+          "spacex-ai/grok-4.1",
+          "spacex-ai/grok-4.1-thinking",
+          "spacex-ai/grok-4.20",
+          "spacex-ai/grok-4.20-beta-0309",
+          "spacex-ai/grok-4.20-multi-agent-beta",
+          "spacex-ai/grok-4.20-multi-agent-beta-0309",
+          "spacex-ai/grok-4.3",
+          "spacex-ai/grok-4.5",
+          "spacex-ai/grok-code-fast-1",
+          "spacex-ai/grok-imagine-image",
+          "spacex-ai/grok-tts",
+          "spacex-ai/grok-imagine-image-pro",
+          "spacex-ai/grok-imagine-image-quality",
+          "spacex-ai/grok-imagine-video",
+          "spacex-ai/grok-imagine-video-1.5-preview",
+          "spacex-ai/grok-build-0.1",
+          "spacex-ai/grok-imagine-video-1.5"
+        ]
+      }
+    },
+    "../../packages/data/catalog/src/data/api_providers/streamlake/api_provider.json": {
+      "hash": "bc69c7ef0c4389ed68a81afbd5752ee8",
+      "meta": {
+        "api_provider_id": "streamlake"
+      }
+    },
+    "../../packages/data/catalog/src/data/api_providers/streamlake/models.json": {
+      "hash": "86f78fb76db7df9c78196a087a5a2cb5",
+      "meta": {
+        "api_provider_id": "streamlake",
+        "kind": "provider_models",
+        "linked_model_ids": [
+          "kwaipilot/kat-coder-air-v2.5",
+          "kwaipilot/kat-coder-pro-v2.5",
+          "kwaipilot/kat-coder-air-v1",
+          "kwaipilot/kat-coder-pro-v1"
+        ]
+      }
+    },
+    "../../packages/data/catalog/src/data/api_providers/switchpoint/api_provider.json": {
+      "hash": "08db0e601f1aa8c3cf0ca06e07f4e3de",
+      "meta": {
+        "api_provider_id": "switchpoint"
+      }
+    },
+    "../../packages/data/catalog/src/data/api_providers/upstage/api_provider.json": {
+      "hash": "b5db248f86add512c7f82bb9db4f31b0",
+      "meta": {
+        "api_provider_id": "upstage"
+      }
+    },
+    "../../packages/data/catalog/src/data/api_providers/wafer/api_provider.json": {
+      "hash": "8eaa4093b8ed82c6be6af10d5dddd87e",
+      "meta": {
+        "api_provider_id": "wafer"
+      }
+    },
+    "../../packages/data/catalog/src/data/api_providers/wafer/models.json": {
+      "hash": "700089dcf12dcd48e0a83c6fe7ea469a",
+      "meta": {
+        "api_provider_id": "wafer",
+        "kind": "provider_models",
+        "linked_model_ids": [
+          "z-ai/glm-5.1",
+          "z-ai/glm-5.2",
+          "moonshotai/kimi-k2.6",
+          "minimax/minimax-m3",
+          "qwen/qwen3.5-397b-a17b"
+        ]
+      }
+    },
+    "../../packages/data/catalog/src/data/models/moonshotai/kimi-k3/model.json": {
+      "hash": "84ac547bb79bc4595cbdb4f5662f8ce7",
+      "meta": {
+        "model_id": "moonshotai/kimi-k3",
+        "organisation_id": "moonshotai",
+        "previous_model_id": "moonshotai/kimi-k2.6",
+        "api_model_id": "moonshotai/kimi-k3",
+        "has_page_notice": false
+      }
+    },
+    "../../packages/data/catalog/src/data/pricing/amazon-bedrock/openai-gpt-5.6-luna/text.generate/pricing.json": {
+      "hash": "b56d6dc6250fe569a9aa50304a5c0900",
+      "meta": {
+        "api_provider_id": "amazon-bedrock",
+        "capability_id": "text.generate",
+        "model_id": "openai/gpt-5.6-luna",
+        "model_key": "amazon-bedrock:openai/gpt-5.6-luna:text.generate"
+      }
+    },
+    "../../packages/data/catalog/src/data/pricing/openai/openai-gpt-5.6-luna/batch/pricing.json": {
+      "hash": "11dabfd9d031d15a182d10fe4adbf56b",
+      "meta": {
+        "api_provider_id": "openai",
+        "capability_id": "batch",
+        "model_id": "openai/gpt-5.6-luna",
+        "model_key": "openai:openai/gpt-5.6-luna:batch"
+      }
+    },
+    "../../packages/data/catalog/src/data/pricing/openai/openai-gpt-5.6-luna/text.generate/pricing.json": {
+      "hash": "1b73f5c8bdd3a9c7e8a66b46207a4805",
+      "meta": {
+        "api_provider_id": "openai",
+        "capability_id": "text.generate",
+        "model_id": "openai/gpt-5.6-luna",
+        "model_key": "openai:openai/gpt-5.6-luna:text.generate"
+      }
+    },
+    "../../packages/data/catalog/src/data/organisations/github/organisation.json": {
+      "hash": "5750df0a037d80f78e3bcfcc48a3ac8d",
+      "meta": {
+        "organisation_id": "github"
+      }
+    },
+    "../../packages/data/catalog/src/data/organisations/nex-agi/organisation.json": {
+      "hash": "e2e159a68c150df71f3e99ef80325627",
+      "meta": {
+        "organisation_id": "nex-agi"
+      }
+    },
+    "../../packages/data/catalog/src/data/organisations/poe/organisation.json": {
+      "hash": "2a1a64fd4b107544423473980c3a0aec",
+      "meta": {
+        "organisation_id": "poe"
+      }
+    },
+    "../../packages/data/catalog/src/data/organisations/sakana/organisation.json": {
+      "hash": "8b2abe883c6a9161d409181a33e5b32c",
+      "meta": {
+        "organisation_id": "sakana"
+      }
+    },
+    "../../packages/data/catalog/src/data/organisations/spacex-ai/organisation.json": {
+      "hash": "35444d9fcefa632316484a167efe7795",
+      "meta": {
+        "organisation_id": "spacex-ai"
+      }
+    },
+    "../../packages/data/catalog/src/data/organisations/thinking-machines/organisation.json": {
+      "hash": "83dab7c65a272de87b2623cbfd96cf24",
+      "meta": {
+        "organisation_id": "thinking-machines"
+      }
+    },
+    "../../packages/data/catalog/src/data/organisations/windsurf/organisation.json": {
+      "hash": "8ffaee2924bdfa80996466d566a9e44b",
+      "meta": {
+        "organisation_id": "windsurf"
+      }
+    },
+    "../../packages/data/catalog/src/data/benchmarks/automationbench/benchmark.json": {
+      "hash": "f411368f17d78b5e8c35c750d52956e1",
+      "meta": {
+        "benchmark_id": "automationbench"
+      }
+    },
+    "../../packages/data/catalog/src/data/benchmarks/biomysterybench/benchmark.json": {
+      "hash": "058c6c7cc60e26efabfffd6e5069dcc1",
+      "meta": {
+        "benchmark_id": "biomysterybench"
+      }
+    },
+    "../../packages/data/catalog/src/data/benchmarks/blueprint-bench-2/benchmark.json": {
+      "hash": "0f1e9fa19563d3d48e98c68c58aaffe3",
+      "meta": {
+        "benchmark_id": "blueprint-bench-2"
+      }
+    },
+    "../../packages/data/catalog/src/data/benchmarks/exploitbench-cap/benchmark.json": {
+      "hash": "76d0332120db268a4827695b23ca94fe",
+      "meta": {
+        "benchmark_id": "exploitbench-cap"
+      }
+    },
+    "../../packages/data/catalog/src/data/benchmarks/financeagent-v2/benchmark.json": {
+      "hash": "0980b035ba3d3e85e821ede1daba082b",
+      "meta": {
+        "benchmark_id": "financeagent-v2"
+      }
+    },
+    "../../packages/data/catalog/src/data/benchmarks/frontiercode-diamond/benchmark.json": {
+      "hash": "c67978fd8d72574c25e2695ba38704d3",
+      "meta": {
+        "benchmark_id": "frontiercode-diamond"
+      }
+    },
+    "../../packages/data/catalog/src/data/benchmarks/gdp-pdf/benchmark.json": {
+      "hash": "11ef342455d7f8aa4b8e3ed924df3e64",
+      "meta": {
+        "benchmark_id": "gdp-pdf"
+      }
+    },
+    "../../packages/data/catalog/src/data/benchmarks/jobbench/benchmark.json": {
+      "hash": "dcd1c2809a7170dcb3bf8022302890c2",
+      "meta": {
+        "benchmark_id": "jobbench"
+      }
+    },
+    "../../packages/data/catalog/src/data/benchmarks/legal-agent-benchmark/benchmark.json": {
+      "hash": "1b193ce300ba73110a73f0d30c406ea1",
+      "meta": {
+        "benchmark_id": "legal-agent-benchmark"
+      }
+    },
+    "../../packages/data/catalog/src/data/families/anthropic-claude-5/family.json": {
+      "hash": "278653cfcd123fda44d23cd43f0d57e5",
+      "meta": {
+        "family_id": "anthropic/claude-5"
+      }
+    },
+    "../../packages/data/catalog/src/data/families/anthropic-claude-fable/family.json": {
+      "hash": "d0a1d707b9119d7cedaa603508f20da4",
+      "meta": {
+        "family_id": "anthropic/claude-fable"
+      }
+    },
+    "../../packages/data/catalog/src/data/families/anthropic-claude-mythos/family.json": {
+      "hash": "3e20727a34e7abb554b502e2c4a2079c",
+      "meta": {
+        "family_id": "anthropic/claude-mythos"
+      }
+    },
+    "../../packages/data/catalog/src/data/families/google-gemini-3.5/family.json": {
+      "hash": "443908292f7fee64dd44fc5ecb762211",
+      "meta": {
+        "family_id": "google/gemini-3.5"
+      }
+    },
+    "../../packages/data/catalog/src/data/families/google-gemini-omni/family.json": {
+      "hash": "024e4a3ea8c0dfbd8112159373576048",
+      "meta": {
+        "family_id": "google/gemini-omni"
+      }
+    },
+    "../../packages/data/catalog/src/data/families/microsoft-mai/family.json": {
+      "hash": "ffcfd82a5d86ff1bc1f725179f9e0fea",
+      "meta": {
+        "family_id": "microsoft/mai"
+      }
+    },
+    "../../packages/data/catalog/src/data/families/openai-gpt-5.6/family.json": {
+      "hash": "2ff6e2da39565503b6fe8f4d7d4be6f1",
+      "meta": {
+        "family_id": "openai/gpt-5.6"
+      }
+    },
+    "../../packages/data/catalog/src/data/families/sakana-fugu/family.json": {
+      "hash": "0aff58179151e381458a582592f80849",
+      "meta": {
+        "family_id": "sakana/fugu"
+      }
+    },
+    "../../packages/data/catalog/src/data/models/aion-labs/aion-3.0-mini/model.json": {
+      "hash": "ed57186a370ef1c46c07af43d528c5bd",
+      "meta": {
+        "model_id": "aion-labs/aion-3.0-mini",
+        "organisation_id": "aion-labs",
+        "previous_model_id": "aion-labs/aion-1.0-mini",
+        "api_model_id": "aion-labs/aion-3.0-mini",
+        "has_page_notice": false
+      }
+    },
+    "../../packages/data/catalog/src/data/models/kwaipilot/kat-coder-air-v1/model.json": {
+      "hash": "3faa4a08e1b5a4cfa1bf348eefbd0a0c",
+      "meta": {
+        "model_id": "kwaipilot/kat-coder-air-v1",
+        "organisation_id": "kwaipilot",
+        "previous_model_id": null,
+        "api_model_id": "kwaipilot/kat-coder-air-v1",
+        "has_page_notice": false
+      }
+    },
+    "../../packages/data/catalog/src/data/models/kwaipilot/kat-coder-air-v2.5/model.json": {
+      "hash": "6cf9acb6f15ac919078f4c7372f31101",
+      "meta": {
+        "model_id": "kwaipilot/kat-coder-air-v2.5",
+        "organisation_id": "kwaipilot",
+        "previous_model_id": null,
+        "api_model_id": "kwaipilot/kat-coder-air-v2.5",
+        "has_page_notice": false
+      }
+    },
+    "../../packages/data/catalog/src/data/models/kwaipilot/kat-coder-pro-v1/model.json": {
+      "hash": "92c974c5b1b66dcc5e4c57f6688a1bf4",
+      "meta": {
+        "model_id": "kwaipilot/kat-coder-pro-v1",
+        "organisation_id": "kwaipilot",
+        "previous_model_id": null,
+        "api_model_id": "kwaipilot/kat-coder-pro-v1",
+        "has_page_notice": false
+      }
+    },
+    "../../packages/data/catalog/src/data/models/kwaipilot/kat-coder-pro-v2.5/model.json": {
+      "hash": "41843d4136e3b227af3d7b320e8f39b3",
+      "meta": {
+        "model_id": "kwaipilot/kat-coder-pro-v2.5",
+        "organisation_id": "kwaipilot",
+        "previous_model_id": "kwaipilot/kat-coder-pro-v2",
+        "api_model_id": "kwaipilot/kat-coder-pro-v2.5",
+        "has_page_notice": false
+      }
+    },
+    "../../packages/data/catalog/src/data/models/meta/muse-image/model.json": {
+      "hash": "66029d05a6a7bbab844818de8c3ff8e1",
+      "meta": {
+        "model_id": "meta/muse-image",
+        "organisation_id": "meta",
+        "previous_model_id": null,
+        "api_model_id": "meta/muse-image",
+        "has_page_notice": false
+      }
+    },
+    "../../packages/data/catalog/src/data/models/meta/muse-spark-1.1/model.json": {
+      "hash": "95b100a428a18bcc2889f2b249e65f4a",
+      "meta": {
+        "model_id": "meta/muse-spark-1.1",
+        "organisation_id": "meta",
+        "previous_model_id": "meta/muse-spark",
+        "api_model_id": "meta/muse-spark-1.1",
+        "has_page_notice": true
+      }
+    },
+    "../../packages/data/catalog/src/data/models/meta/muse-video/model.json": {
+      "hash": "9972f771865c997963b0c2e6252cd6c1",
+      "meta": {
+        "model_id": "meta/muse-video",
+        "organisation_id": "meta",
+        "previous_model_id": null,
+        "api_model_id": "meta/muse-video",
+        "has_page_notice": false
+      }
+    },
+    "../../packages/data/catalog/src/data/models/microsoft/mai-code-1-flash/model.json": {
+      "hash": "018dd81ce0680db9765fad0f1792cec6",
+      "meta": {
+        "model_id": "microsoft/mai-code-1-flash",
+        "organisation_id": "microsoft",
+        "previous_model_id": null,
+        "api_model_id": "microsoft/mai-code-1-flash",
+        "has_page_notice": false
+      }
+    },
+    "../../packages/data/catalog/src/data/models/microsoft/mai-image-2/model.json": {
+      "hash": "005d774e7a885b775c77106f3d8ab0c9",
+      "meta": {
+        "model_id": "microsoft/mai-image-2",
+        "organisation_id": "microsoft",
+        "previous_model_id": null,
+        "api_model_id": "microsoft/mai-image-2",
+        "has_page_notice": false
+      }
+    },
+    "../../packages/data/catalog/src/data/models/microsoft/mai-image-2.5/model.json": {
+      "hash": "43f86dc93888bef388ec5dccbf74f874",
+      "meta": {
+        "model_id": "microsoft/mai-image-2.5",
+        "organisation_id": "microsoft",
+        "previous_model_id": null,
+        "api_model_id": "microsoft/mai-image-2.5",
+        "has_page_notice": false
+      }
+    },
+    "../../packages/data/catalog/src/data/models/microsoft/mai-image-2.5-flash/model.json": {
+      "hash": "5d247f0449c9c516620fe1e0d7665a3b",
+      "meta": {
+        "model_id": "microsoft/mai-image-2.5-flash",
+        "organisation_id": "microsoft",
+        "previous_model_id": null,
+        "api_model_id": "microsoft/mai-image-2.5-flash",
+        "has_page_notice": false
+      }
+    },
+    "../../packages/data/catalog/src/data/models/microsoft/mai-image-2e/model.json": {
+      "hash": "206e588a2bace1ba5f1fed1f5287ff51",
+      "meta": {
+        "model_id": "microsoft/mai-image-2e",
+        "organisation_id": "microsoft",
+        "previous_model_id": "microsoft/mai-image-2",
+        "api_model_id": "microsoft/mai-image-2e",
+        "has_page_notice": false
+      }
+    },
+    "../../packages/data/catalog/src/data/models/microsoft/mai-thinking-1/model.json": {
+      "hash": "f440bc40a7822ef0fa91dbee1e434a7f",
+      "meta": {
+        "model_id": "microsoft/mai-thinking-1",
+        "organisation_id": "microsoft",
+        "previous_model_id": null,
+        "api_model_id": "microsoft/mai-thinking-1",
+        "has_page_notice": false
+      }
+    },
+    "../../packages/data/catalog/src/data/models/microsoft/mai-transcribe-1/model.json": {
+      "hash": "ac817f38c68b6b31878cdae88bf7c86c",
+      "meta": {
+        "model_id": "microsoft/mai-transcribe-1",
+        "organisation_id": "microsoft",
+        "previous_model_id": null,
+        "api_model_id": "microsoft/mai-transcribe-1",
+        "has_page_notice": false
+      }
+    },
+    "../../packages/data/catalog/src/data/models/microsoft/mai-transcribe-1.5/model.json": {
+      "hash": "c34f71f70985d9f67d2bfa6664a6aef4",
+      "meta": {
+        "model_id": "microsoft/mai-transcribe-1.5",
+        "organisation_id": "microsoft",
+        "previous_model_id": null,
+        "api_model_id": "microsoft/mai-transcribe-1.5",
+        "has_page_notice": false
+      }
+    },
+    "../../packages/data/catalog/src/data/models/microsoft/mai-voice-1/model.json": {
+      "hash": "b246fe9fb6c0298dd46224864a293067",
+      "meta": {
+        "model_id": "microsoft/mai-voice-1",
+        "organisation_id": "microsoft",
+        "previous_model_id": null,
+        "api_model_id": "microsoft/mai-voice-1",
+        "has_page_notice": false
+      }
+    },
+    "../../packages/data/catalog/src/data/models/microsoft/mai-voice-2/model.json": {
+      "hash": "20883169ac2267a87a18c42dbe2ec055",
+      "meta": {
+        "model_id": "microsoft/mai-voice-2",
+        "organisation_id": "microsoft",
+        "previous_model_id": null,
+        "api_model_id": "microsoft/mai-voice-2",
+        "has_page_notice": false
+      }
+    },
+    "../../packages/data/catalog/src/data/models/microsoft/mai-voice-2-flash/model.json": {
+      "hash": "e5e0b285796e465328f963e72496270c",
+      "meta": {
+        "model_id": "microsoft/mai-voice-2-flash",
+        "organisation_id": "microsoft",
+        "previous_model_id": null,
+        "api_model_id": "microsoft/mai-voice-2-flash",
+        "has_page_notice": false
+      }
+    },
+    "../../packages/data/catalog/src/data/models/microsoft/phi-3-mini-4k-instruct/model.json": {
+      "hash": "f231eb2ce1f7a0feaeb0342a2aee1c56",
+      "meta": {
+        "model_id": "microsoft/phi-3-mini-4k-instruct",
+        "organisation_id": "microsoft",
+        "previous_model_id": null,
+        "api_model_id": "microsoft/phi-3-mini-4k-instruct",
+        "has_page_notice": false
+      }
+    },
+    "../../packages/data/catalog/src/data/models/microsoft/phi-4-reasoning-vision-15b/model.json": {
+      "hash": "f9cbd1374c9d10a629aa27a3c0f198a5",
+      "meta": {
+        "model_id": "microsoft/phi-4-reasoning-vision-15b",
+        "organisation_id": "microsoft",
+        "previous_model_id": "microsoft/phi-4-reasoning",
+        "api_model_id": "microsoft/phi-4-reasoning-vision-15b",
+        "has_page_notice": false
+      }
+    },
+    "../../packages/data/catalog/src/data/models/microsoft/phi-ground/model.json": {
+      "hash": "72286fe918f7842671b23143a26e2219",
+      "meta": {
+        "model_id": "microsoft/phi-ground",
+        "organisation_id": "microsoft",
+        "previous_model_id": null,
+        "api_model_id": "microsoft/phi-ground",
+        "has_page_notice": false
+      }
+    },
+    "../../packages/data/catalog/src/data/models/microsoft/phi-ground-any/model.json": {
+      "hash": "ca450d936488cbaec1ba7a6a4f306c8e",
+      "meta": {
+        "model_id": "microsoft/phi-ground-any",
+        "organisation_id": "microsoft",
+        "previous_model_id": "microsoft/phi-ground",
+        "api_model_id": "microsoft/phi-ground-any",
+        "has_page_notice": false
+      }
+    },
+    "../../packages/data/catalog/src/data/models/microsoft/phi-mini-moe-instruct/model.json": {
+      "hash": "742730956f8e223daf2b91b4e0cbc0ea",
+      "meta": {
+        "model_id": "microsoft/phi-mini-moe-instruct",
+        "organisation_id": "microsoft",
+        "previous_model_id": null,
+        "api_model_id": "microsoft/phi-mini-moe-instruct",
+        "has_page_notice": false
+      }
+    },
+    "../../packages/data/catalog/src/data/models/microsoft/phi-tiny-moe-instruct/model.json": {
+      "hash": "7dac799cff614c7b26a5b6445daa1904",
+      "meta": {
+        "model_id": "microsoft/phi-tiny-moe-instruct",
+        "organisation_id": "microsoft",
+        "previous_model_id": null,
+        "api_model_id": "microsoft/phi-tiny-moe-instruct",
+        "has_page_notice": false
+      }
+    },
+    "../../packages/data/catalog/src/data/models/openai/gpt-5.6-luna-pro/model.json": {
+      "hash": "1bb1507a358e41cff0116ba9f6efff30",
+      "meta": {
+        "model_id": "openai/gpt-5.6-luna-pro",
+        "organisation_id": "openai",
+        "previous_model_id": null,
+        "api_model_id": "openai/gpt-5.6-luna-pro",
+        "has_page_notice": false
+      }
+    },
+    "../../packages/data/catalog/src/data/models/openai/gpt-5.6-sol-pro/model.json": {
+      "hash": "dc3e257fde7aa8a571806aafd091e45e",
+      "meta": {
+        "model_id": "openai/gpt-5.6-sol-pro",
+        "organisation_id": "openai",
+        "previous_model_id": null,
+        "api_model_id": "openai/gpt-5.6-sol-pro",
+        "has_page_notice": false
+      }
+    },
+    "../../packages/data/catalog/src/data/models/openai/gpt-5.6-terra-pro/model.json": {
+      "hash": "f9bb6511401af4602c9fac53fe072910",
+      "meta": {
+        "model_id": "openai/gpt-5.6-terra-pro",
+        "organisation_id": "openai",
+        "previous_model_id": null,
+        "api_model_id": "openai/gpt-5.6-terra-pro",
+        "has_page_notice": false
+      }
+    },
+    "../../packages/data/catalog/src/data/models/openai/gpt-live-1/model.json": {
+      "hash": "13b825fa9826288c82e5f359976aa5d1",
+      "meta": {
+        "model_id": "openai/gpt-live-1",
+        "organisation_id": "openai",
+        "previous_model_id": "openai/gpt-realtime-2",
+        "api_model_id": "openai/gpt-live-1",
+        "has_page_notice": true
+      }
+    },
+    "../../packages/data/catalog/src/data/models/openai/gpt-live-1-mini/model.json": {
+      "hash": "afa10c372f7c9ac392bcba47eafcdcdd",
+      "meta": {
+        "model_id": "openai/gpt-live-1-mini",
+        "organisation_id": "openai",
+        "previous_model_id": "openai/gpt-realtime-mini",
+        "api_model_id": "openai/gpt-live-1-mini",
+        "has_page_notice": true
+      }
+    },
+    "../../packages/data/catalog/src/data/models/openai/gpt-realtime-2.1/model.json": {
+      "hash": "3a0d06baa795abb671f8b8781a2c23e0",
+      "meta": {
+        "model_id": "openai/gpt-realtime-2.1",
+        "organisation_id": "openai",
+        "previous_model_id": "openai/gpt-realtime-2",
+        "api_model_id": "openai/gpt-realtime-2.1",
+        "has_page_notice": false
+      }
+    },
+    "../../packages/data/catalog/src/data/models/openai/gpt-realtime-2.1-mini/model.json": {
+      "hash": "d4828f6cf4f0d633d51bb081737156f4",
+      "meta": {
+        "model_id": "openai/gpt-realtime-2.1-mini",
+        "organisation_id": "openai",
+        "previous_model_id": "openai/gpt-realtime-mini",
+        "api_model_id": "openai/gpt-realtime-2.1-mini",
+        "has_page_notice": false
+      }
+    },
+    "../../packages/data/catalog/src/data/models/openai/gpt-red/model.json": {
+      "hash": "0a0e761d00fa78f1f82bf00cc9e38151",
+      "meta": {
+        "model_id": "openai/gpt-red",
+        "organisation_id": "openai",
+        "previous_model_id": null,
+        "api_model_id": "openai/gpt-red",
+        "has_page_notice": false
+      }
+    },
+    "../../packages/data/catalog/src/data/models/sakana/fugu/model.json": {
+      "hash": "2b95c61afd01f187365baee93a28cb30",
+      "meta": {
+        "model_id": "sakana/fugu",
+        "organisation_id": "sakana",
+        "previous_model_id": null,
+        "api_model_id": "sakana/fugu",
+        "has_page_notice": false
+      }
+    },
+    "../../packages/data/catalog/src/data/models/sakana/fugu-ultra/model.json": {
+      "hash": "291ed6fedb6c83ede96f7c0b6db9d707",
+      "meta": {
+        "model_id": "sakana/fugu-ultra",
+        "organisation_id": "sakana",
+        "previous_model_id": null,
+        "api_model_id": "sakana/fugu-ultra",
+        "has_page_notice": false
+      }
+    },
+    "../../packages/data/catalog/src/data/models/spacex-ai/grok-0/model.json": {
+      "hash": "696258111d2ef027ecdfdedeab6f1dc6",
+      "meta": {
+        "model_id": "spacex-ai/grok-0",
+        "organisation_id": "spacex-ai",
+        "previous_model_id": null,
+        "api_model_id": "spacex-ai/grok-0",
+        "has_page_notice": false
+      }
+    },
+    "../../packages/data/catalog/src/data/models/spacex-ai/grok-1/model.json": {
+      "hash": "c3b4725f3862c0bbd664a7477a5d6817",
+      "meta": {
+        "model_id": "spacex-ai/grok-1",
+        "organisation_id": "spacex-ai",
+        "previous_model_id": "spacex-ai/grok-0",
+        "api_model_id": "spacex-ai/grok-1",
+        "has_page_notice": false
+      }
+    },
+    "../../packages/data/catalog/src/data/models/spacex-ai/grok-1.5/model.json": {
+      "hash": "b0cdca9d31e0039826a4b2422e53fae0",
+      "meta": {
+        "model_id": "spacex-ai/grok-1.5",
+        "organisation_id": "spacex-ai",
+        "previous_model_id": "spacex-ai/grok-1",
+        "api_model_id": "spacex-ai/grok-1.5",
+        "has_page_notice": false
+      }
+    },
+    "../../packages/data/catalog/src/data/models/spacex-ai/grok-1.5v/model.json": {
+      "hash": "d296e8433644f737a5a10c0ef65de3de",
+      "meta": {
+        "model_id": "spacex-ai/grok-1.5v",
+        "organisation_id": "spacex-ai",
+        "previous_model_id": null,
+        "api_model_id": "spacex-ai/grok-1.5v",
+        "has_page_notice": false
+      }
+    },
+    "../../packages/data/catalog/src/data/models/spacex-ai/grok-2/model.json": {
+      "hash": "947bb29a87458e68c22a81f0ae3769fd",
+      "meta": {
+        "model_id": "spacex-ai/grok-2",
+        "organisation_id": "spacex-ai",
+        "previous_model_id": "spacex-ai/grok-1-5-2024-03-28",
+        "api_model_id": "spacex-ai/grok-2",
+        "has_page_notice": false
+      }
+    },
+    "../../packages/data/catalog/src/data/models/spacex-ai/grok-2-image-1212/model.json": {
+      "hash": "a646d0c5242e86572d1b99abc73feeef",
+      "meta": {
+        "model_id": "spacex-ai/grok-2-image-1212",
+        "organisation_id": "spacex-ai",
+        "previous_model_id": null,
+        "api_model_id": "spacex-ai/grok-2-image-1212",
+        "has_page_notice": false
+      }
+    },
+    "../../packages/data/catalog/src/data/models/spacex-ai/grok-2-mini/model.json": {
+      "hash": "ca1e6b76d2a2122cd0c8f5c9fce90211",
+      "meta": {
+        "model_id": "spacex-ai/grok-2-mini",
+        "organisation_id": "spacex-ai",
+        "previous_model_id": null,
+        "api_model_id": "spacex-ai/grok-2-mini",
+        "has_page_notice": false
+      }
+    },
+    "../../packages/data/catalog/src/data/models/spacex-ai/grok-2-vision-1212/model.json": {
+      "hash": "55382db6bb8f4404a7af9ea54d0679ae",
+      "meta": {
+        "model_id": "spacex-ai/grok-2-vision-1212",
+        "organisation_id": "spacex-ai",
+        "previous_model_id": null,
+        "api_model_id": "spacex-ai/grok-2-vision-1212",
+        "has_page_notice": false
+      }
+    },
+    "../../packages/data/catalog/src/data/models/spacex-ai/grok-3/model.json": {
+      "hash": "21defaa624a4602293eadde0f35e42bf",
+      "meta": {
+        "model_id": "spacex-ai/grok-3",
+        "organisation_id": "spacex-ai",
+        "previous_model_id": "spacex-ai/grok-3-beta-2025-02-19",
+        "api_model_id": "spacex-ai/grok-3",
+        "has_page_notice": false
+      }
+    },
+    "../../packages/data/catalog/src/data/models/spacex-ai/grok-3-beta/model.json": {
+      "hash": "bf0f01efad40ebf8d57b220e22d53ede",
+      "meta": {
+        "model_id": "spacex-ai/grok-3-beta",
+        "organisation_id": "spacex-ai",
+        "previous_model_id": "spacex-ai/grok-2-2024-08-13",
+        "api_model_id": "spacex-ai/grok-3-beta",
+        "has_page_notice": false
+      }
+    },
+    "../../packages/data/catalog/src/data/models/spacex-ai/grok-3-mini/model.json": {
+      "hash": "27015f8f3fff4cb5f90635082f0242e0",
+      "meta": {
+        "model_id": "spacex-ai/grok-3-mini",
+        "organisation_id": "spacex-ai",
+        "previous_model_id": "spacex-ai/grok-3-mini-beta-2025-02-19",
+        "api_model_id": "spacex-ai/grok-3-mini",
+        "has_page_notice": false
+      }
+    },
+    "../../packages/data/catalog/src/data/models/spacex-ai/grok-3-mini-beta/model.json": {
+      "hash": "1b0a9668c1f2c8fdbee467b0327d9f25",
+      "meta": {
+        "model_id": "spacex-ai/grok-3-mini-beta",
+        "organisation_id": "spacex-ai",
+        "previous_model_id": "spacex-ai/grok-2-mini-2024-08-13",
+        "api_model_id": "spacex-ai/grok-3-mini-beta",
+        "has_page_notice": false
+      }
+    },
+    "../../packages/data/catalog/src/data/models/spacex-ai/grok-4/model.json": {
+      "hash": "3198a1927232203ae67bdd5c890aab71",
+      "meta": {
+        "model_id": "spacex-ai/grok-4",
+        "organisation_id": "spacex-ai",
+        "previous_model_id": "spacex-ai/grok-3-2025-04-18",
+        "api_model_id": "spacex-ai/grok-4",
+        "has_page_notice": false
+      }
+    },
+    "../../packages/data/catalog/src/data/models/spacex-ai/grok-4-fast-non-reasoning/model.json": {
+      "hash": "b35e9a75632fadb932a9a4bd4dc3e9d2",
+      "meta": {
+        "model_id": "spacex-ai/grok-4-fast-non-reasoning",
+        "organisation_id": "spacex-ai",
+        "previous_model_id": null,
+        "api_model_id": "spacex-ai/grok-4-fast-non-reasoning",
+        "has_page_notice": false
+      }
+    },
+    "../../packages/data/catalog/src/data/models/spacex-ai/grok-4-fast-reasoning/model.json": {
+      "hash": "35694add610022faf775cd427fcf28ef",
+      "meta": {
+        "model_id": "spacex-ai/grok-4-fast-reasoning",
+        "organisation_id": "spacex-ai",
+        "previous_model_id": null,
+        "api_model_id": "spacex-ai/grok-4-fast-reasoning",
+        "has_page_notice": false
+      }
+    },
+    "../../packages/data/catalog/src/data/models/spacex-ai/grok-4-heavy/model.json": {
+      "hash": "5350aa2bda9110874e95df84dfa80c32",
+      "meta": {
+        "model_id": "spacex-ai/grok-4-heavy",
+        "organisation_id": "spacex-ai",
+        "previous_model_id": null,
+        "api_model_id": "spacex-ai/grok-4-heavy",
+        "has_page_notice": false
+      }
+    },
+    "../../packages/data/catalog/src/data/models/spacex-ai/grok-4.1-fast/model.json": {
+      "hash": "ceec18540f98a98ca87e5abc0b0a7d93",
+      "meta": {
+        "model_id": "spacex-ai/grok-4.1-fast",
+        "organisation_id": "spacex-ai",
+        "previous_model_id": null,
+        "api_model_id": "spacex-ai/grok-4.1-fast",
+        "has_page_notice": false
+      }
+    },
+    "../../packages/data/catalog/src/data/models/spacex-ai/grok-4.1-non-thinking/model.json": {
+      "hash": "6b7fab5ff583b234420c58a2990a0ced",
+      "meta": {
+        "model_id": "spacex-ai/grok-4.1-non-thinking",
+        "organisation_id": "spacex-ai",
+        "previous_model_id": "spacex-ai/grok-4-fast-non-reasoning-2025-09-20",
+        "api_model_id": "spacex-ai/grok-4.1-non-thinking",
+        "has_page_notice": false
+      }
+    },
+    "../../packages/data/catalog/src/data/models/spacex-ai/grok-4.1-thinking/model.json": {
+      "hash": "2ce85acfbf3b44f23a7b7b834e2e33bf",
+      "meta": {
+        "model_id": "spacex-ai/grok-4.1-thinking",
+        "organisation_id": "spacex-ai",
+        "previous_model_id": "spacex-ai/grok-4-fast-reasoning-2025-09-20",
+        "api_model_id": "spacex-ai/grok-4.1-thinking",
+        "has_page_notice": false
+      }
+    },
+    "../../packages/data/catalog/src/data/models/spacex-ai/grok-4.20/model.json": {
+      "hash": "2d3f7e4418f5b623b1ccf9eb5613a59d",
+      "meta": {
+        "model_id": "spacex-ai/grok-4.20",
+        "organisation_id": "spacex-ai",
+        "previous_model_id": "spacex-ai/grok-4-1-non-thinking-2025-11-17",
+        "api_model_id": "spacex-ai/grok-4.20",
+        "has_page_notice": false
+      }
+    },
+    "../../packages/data/catalog/src/data/models/spacex-ai/grok-4.20-multi-agent-beta/model.json": {
+      "hash": "8a6e15d8a65a8499eb95a75ddeb5a121",
+      "meta": {
+        "model_id": "spacex-ai/grok-4.20-multi-agent-beta",
+        "organisation_id": "spacex-ai",
+        "previous_model_id": "spacex-ai/grok-4-1-non-thinking-2025-11-17",
+        "api_model_id": "spacex-ai/grok-4.20-multi-agent-beta",
+        "has_page_notice": false
+      }
+    },
+    "../../packages/data/catalog/src/data/models/spacex-ai/grok-4.3/model.json": {
+      "hash": "98946bddf63af1221737a633c8a88aba",
+      "meta": {
+        "model_id": "spacex-ai/grok-4.3",
+        "organisation_id": "spacex-ai",
+        "previous_model_id": "spacex-ai/grok-4.20",
+        "api_model_id": "spacex-ai/grok-4.3",
+        "has_page_notice": false
+      }
+    },
+    "../../packages/data/catalog/src/data/models/spacex-ai/grok-4.5/model.json": {
+      "hash": "056d263c3b437a55245bbc085ff11a21",
+      "meta": {
+        "model_id": "spacex-ai/grok-4.5",
+        "organisation_id": "spacex-ai",
+        "previous_model_id": "spacex-ai/grok-4.3",
+        "api_model_id": "spacex-ai/grok-4.5",
+        "has_page_notice": false
+      }
+    },
+    "../../packages/data/catalog/src/data/models/spacex-ai/grok-build-0.1/model.json": {
+      "hash": "ab361abd3b12bb2d30701d668ee0aea3",
+      "meta": {
+        "model_id": "spacex-ai/grok-build-0.1",
+        "organisation_id": "spacex-ai",
+        "previous_model_id": "spacex-ai/grok-code-fast-1",
+        "api_model_id": "spacex-ai/grok-build-0.1",
+        "has_page_notice": false
+      }
+    },
+    "../../packages/data/catalog/src/data/models/spacex-ai/grok-code-fast-1/model.json": {
+      "hash": "b0e0c543c6152d3c42066c08680a7e6d",
+      "meta": {
+        "model_id": "spacex-ai/grok-code-fast-1",
+        "organisation_id": "spacex-ai",
+        "previous_model_id": null,
+        "api_model_id": "spacex-ai/grok-code-fast-1",
+        "has_page_notice": false
+      }
+    },
+    "../../packages/data/catalog/src/data/models/spacex-ai/grok-imagine-image/model.json": {
+      "hash": "466e63de3d90877dd6572059d99ea7a9",
+      "meta": {
+        "model_id": "spacex-ai/grok-imagine-image",
+        "organisation_id": "spacex-ai",
+        "previous_model_id": null,
+        "api_model_id": "spacex-ai/grok-imagine-image",
+        "has_page_notice": false
+      }
+    },
+    "../../packages/data/catalog/src/data/models/spacex-ai/grok-imagine-image-pro/model.json": {
+      "hash": "2034623be6584a417c8d069481cc0fe9",
+      "meta": {
+        "model_id": "spacex-ai/grok-imagine-image-pro",
+        "organisation_id": "spacex-ai",
+        "previous_model_id": null,
+        "api_model_id": "spacex-ai/grok-imagine-image-pro",
+        "has_page_notice": false
+      }
+    },
+    "../../packages/data/catalog/src/data/models/spacex-ai/grok-imagine-image-quality/model.json": {
+      "hash": "2bbfbee2d6060714d0c024a18ebd469b",
+      "meta": {
+        "model_id": "spacex-ai/grok-imagine-image-quality",
+        "organisation_id": "spacex-ai",
+        "previous_model_id": null,
+        "api_model_id": "spacex-ai/grok-imagine-image-quality",
+        "has_page_notice": false
+      }
+    },
+    "../../packages/data/catalog/src/data/models/spacex-ai/grok-imagine-video/model.json": {
+      "hash": "d5b9017f0ca457c36801bc64a9d4db57",
+      "meta": {
+        "model_id": "spacex-ai/grok-imagine-video",
+        "organisation_id": "spacex-ai",
+        "previous_model_id": null,
+        "api_model_id": "spacex-ai/grok-imagine-video",
+        "has_page_notice": false
+      }
+    },
+    "../../packages/data/catalog/src/data/models/spacex-ai/grok-imagine-video-1.5/model.json": {
+      "hash": "61f2eeec9f059dfe7c543f8a84df91fc",
+      "meta": {
+        "model_id": "spacex-ai/grok-imagine-video-1.5",
+        "organisation_id": "spacex-ai",
+        "previous_model_id": "spacex-ai/grok-imagine-video-1.5-preview",
+        "api_model_id": "spacex-ai/grok-imagine-video-1.5",
+        "has_page_notice": false
+      }
+    },
+    "../../packages/data/catalog/src/data/models/spacex-ai/grok-imagine-video-1.5-preview/model.json": {
+      "hash": "e12c5d6f67da6ab860b808ae0b74d257",
+      "meta": {
+        "model_id": "spacex-ai/grok-imagine-video-1.5-preview",
+        "organisation_id": "spacex-ai",
+        "previous_model_id": "spacex-ai/grok-imagine-video",
+        "api_model_id": "spacex-ai/grok-imagine-video-1.5-preview",
+        "has_page_notice": false
+      }
+    },
+    "../../packages/data/catalog/src/data/models/spacex-ai/grok-tts/model.json": {
+      "hash": "51336319eb94d04417a0b8c474e9890b",
+      "meta": {
+        "model_id": "spacex-ai/grok-tts",
+        "organisation_id": "spacex-ai",
+        "previous_model_id": null,
+        "api_model_id": "spacex-ai/grok-tts",
+        "has_page_notice": false
+      }
+    },
+    "../../packages/data/catalog/src/data/models/thinking-machines/inkling/model.json": {
+      "hash": "7739c44507c02a30b06e9dbb48346260",
+      "meta": {
+        "model_id": "thinking-machines/inkling",
+        "organisation_id": "thinking-machines",
+        "previous_model_id": null,
+        "api_model_id": "thinking-machines/inkling",
+        "has_page_notice": false
+      }
+    },
+    "../../packages/data/catalog/src/data/models/thinking-machines/inkling-64k/model.json": {
+      "hash": "0f1b94ef4dc3b78b44e5ec876605e5b3",
+      "meta": {
+        "model_id": "thinking-machines/inkling-64k",
+        "organisation_id": "thinking-machines",
+        "previous_model_id": "thinking-machines/inkling",
+        "api_model_id": "thinking-machines/inkling-64k",
+        "has_page_notice": false
+      }
+    },
+    "../../packages/data/catalog/src/data/models/thinking-machines/inkling-small/model.json": {
+      "hash": "eb64bbd19c857f0a06a03ed500983cc8",
+      "meta": {
+        "model_id": "thinking-machines/inkling-small",
+        "organisation_id": "thinking-machines",
+        "previous_model_id": "thinking-machines/inkling",
+        "api_model_id": "thinking-machines/inkling-small",
+        "has_page_notice": false
+      }
+    },
+    "../../packages/data/catalog/src/data/aliases/anthropic-claude-fable-latest/alias.json": {
+      "hash": "c90b82edb49d9ef3ffdd13706733bb67",
+      "meta": {
+        "alias_slug": "anthropic/claude-fable-latest"
+      }
+    },
+    "../../packages/data/catalog/src/data/aliases/google-gemini-image-latest/alias.json": {
+      "hash": "d60e7f218ae06e16cfde42d6cbc79aae",
+      "meta": {
+        "alias_slug": "google/gemini-image-latest"
+      }
+    },
+    "../../packages/data/catalog/src/data/aliases/google-gemini-image-lite-latest/alias.json": {
+      "hash": "f4960ce6d6f6dbeb4022114499c6dbe1",
+      "meta": {
+        "alias_slug": "google/gemini-image-lite-latest"
+      }
+    },
+    "../../packages/data/catalog/src/data/aliases/google-gemini-image-pro-latest/alias.json": {
+      "hash": "c63040d431ffa411f15adc639968c0cb",
+      "meta": {
+        "alias_slug": "google/gemini-image-pro-latest"
+      }
+    },
+    "../../packages/data/catalog/src/data/aliases/meta-muse-spark-latest/alias.json": {
+      "hash": "ecc64451a94157234159fd0378543955",
+      "meta": {
+        "alias_slug": "meta/muse-spark-latest"
+      }
+    },
+    "../../packages/data/catalog/src/data/aliases/openai-gpt-luna-latest/alias.json": {
+      "hash": "6d58fe3d71cdf7ca262eb6a9c23bf7b4",
+      "meta": {
+        "alias_slug": "openai/gpt-luna-latest"
+      }
+    },
+    "../../packages/data/catalog/src/data/aliases/openai-gpt-sol-latest/alias.json": {
+      "hash": "24ef61cb6af3923f26c1a444705b3559",
+      "meta": {
+        "alias_slug": "openai/gpt-sol-latest"
+      }
+    },
+    "../../packages/data/catalog/src/data/aliases/openai-gpt-terra-latest/alias.json": {
+      "hash": "a516259c089839af383796a47dc129c7",
+      "meta": {
+        "alias_slug": "openai/gpt-terra-latest"
+      }
+    },
+    "../../packages/data/catalog/src/data/aliases/spacex-ai-grok-4.5-latest/alias.json": {
+      "hash": "e6c09b7bc6c193e05ced15586a75e6be",
+      "meta": {
+        "alias_slug": "spacex-ai/grok-4.5-latest"
+      }
+    },
+    "../../packages/data/catalog/src/data/aliases/spacex-ai-grok-build-latest/alias.json": {
+      "hash": "5ba0e192dc321539abd6b3ba7ff0da14",
+      "meta": {
+        "alias_slug": "spacex-ai/grok-build-latest"
+      }
+    },
+    "../../packages/data/catalog/src/data/aliases/spacex-ai-grok-latest/alias.json": {
+      "hash": "1a900db3eb937d2d658718a7905179be",
+      "meta": {
+        "alias_slug": "spacex-ai/grok-latest"
+      }
+    },
+    "../../packages/data/catalog/src/data/pricing/aion-labs/aion-labs-aion-3.0/text.generate/pricing.json": {
+      "hash": "8a4906e01869c25a0d99def29ca9822b",
+      "meta": {
+        "api_provider_id": "aion-labs",
+        "capability_id": "text.generate",
+        "model_id": "aion-labs/aion-3.0",
+        "model_key": "aion-labs:aion-labs/aion-3.0:text.generate"
+      }
+    },
+    "../../packages/data/catalog/src/data/pricing/aion-labs/aion-labs-aion-3.0-mini/text.generate/pricing.json": {
+      "hash": "ceee27142ba7714d0fd02fa7bef0b5d1",
+      "meta": {
+        "api_provider_id": "aion-labs",
+        "capability_id": "text.generate",
+        "model_id": "aion-labs/aion-3.0-mini",
+        "model_key": "aion-labs:aion-labs/aion-3.0-mini:text.generate"
+      }
+    },
+    "../../packages/data/catalog/src/data/pricing/akashml/moonshotai-kimi-k2.7-code/text.generate/pricing.json": {
+      "hash": "faaaa335b752fd76e3bbf69769e97592",
+      "meta": {
+        "api_provider_id": "akashml",
+        "capability_id": "text.generate",
+        "model_id": "moonshotai/kimi-k2.7-code",
+        "model_key": "akashml:moonshotai/kimi-k2.7-code:text.generate"
+      }
+    },
+    "../../packages/data/catalog/src/data/pricing/alibaba-cloud/qwen-qwen3.7-plus/text.generate/pricing.json": {
+      "hash": "9e6a98543557fe329cd78cd4023782f5",
+      "meta": {
+        "api_provider_id": "alibaba-cloud",
+        "capability_id": "text.generate",
+        "model_id": "qwen/qwen3.7-plus",
+        "model_key": "alibaba-cloud:qwen/qwen3.7-plus:text.generate"
+      }
+    },
+    "../../packages/data/catalog/src/data/pricing/alibaba-cloud/qwen-qwen3.7-plus-2026-05-26/text.generate/pricing.json": {
+      "hash": "2beee39d6bd211c93164cac159b7594c",
+      "meta": {
+        "api_provider_id": "alibaba-cloud",
+        "capability_id": "text.generate",
+        "model_id": "qwen/qwen3.7-plus-2026-05-26",
+        "model_key": "alibaba-cloud:qwen/qwen3.7-plus-2026-05-26:text.generate"
+      }
+    },
+    "../../packages/data/catalog/src/data/pricing/amazon-bedrock/anthropic-claude-fable-5/text.generate/pricing.json": {
+      "hash": "495c974ec6474bcfde0ad7f835d3e41c",
+      "meta": {
+        "api_provider_id": "amazon-bedrock",
+        "capability_id": "text.generate",
+        "model_id": "anthropic/claude-fable-5",
+        "model_key": "amazon-bedrock:anthropic/claude-fable-5:text.generate"
+      }
+    },
+    "../../packages/data/catalog/src/data/pricing/amazon-bedrock/anthropic-claude-sonnet-5/text.generate/pricing.json": {
+      "hash": "a4205eb8826f88292db1b952baf329ca",
+      "meta": {
+        "api_provider_id": "amazon-bedrock",
+        "capability_id": "text.generate",
+        "model_id": "anthropic/claude-sonnet-5",
+        "model_key": "amazon-bedrock:anthropic/claude-sonnet-5:text.generate"
+      }
+    },
+    "../../packages/data/catalog/src/data/pricing/amazon-bedrock/openai-gpt-5.6-sol/text.generate/pricing.json": {
+      "hash": "b1511b95a9d23be0a8c1c77a4f950a1c",
+      "meta": {
+        "api_provider_id": "amazon-bedrock",
+        "capability_id": "text.generate",
+        "model_id": "openai/gpt-5.6-sol",
+        "model_key": "amazon-bedrock:openai/gpt-5.6-sol:text.generate"
+      }
+    },
+    "../../packages/data/catalog/src/data/pricing/amazon-bedrock/openai-gpt-5.6-terra/text.generate/pricing.json": {
+      "hash": "1d0712fb6ba3e86d525d09f02f96a2af",
+      "meta": {
+        "api_provider_id": "amazon-bedrock",
+        "capability_id": "text.generate",
+        "model_id": "openai/gpt-5.6-terra",
+        "model_key": "amazon-bedrock:openai/gpt-5.6-terra:text.generate"
+      }
+    },
+    "../../packages/data/catalog/src/data/pricing/amazon-bedrock/spacex-ai-grok-4.3/text.generate/pricing.json": {
+      "hash": "31215926950fbb58bb4d0cb19bdf4a8b",
+      "meta": {
+        "api_provider_id": "amazon-bedrock",
+        "capability_id": "text.generate",
+        "model_id": "spacex-ai/grok-4.3",
+        "model_key": "amazon-bedrock:spacex-ai/grok-4.3:text.generate"
+      }
+    },
+    "../../packages/data/catalog/src/data/pricing/anthropic/anthropic-claude-fable-5/text.generate/pricing.json": {
+      "hash": "a158068057e773fd4a59840814c77b94",
+      "meta": {
+        "api_provider_id": "anthropic",
+        "capability_id": "text.generate",
+        "model_id": "anthropic/claude-fable-5",
+        "model_key": "anthropic:anthropic/claude-fable-5:text.generate"
+      }
+    },
+    "../../packages/data/catalog/src/data/pricing/anthropic/anthropic-claude-sonnet-5/text.generate/pricing.json": {
+      "hash": "7cfffeb4b420b514b46f5c62af14a858",
+      "meta": {
+        "api_provider_id": "anthropic",
+        "capability_id": "text.generate",
+        "model_id": "anthropic/claude-sonnet-5",
+        "model_key": "anthropic:anthropic/claude-sonnet-5:text.generate"
+      }
+    },
+    "../../packages/data/catalog/src/data/pricing/anthropic-aws/anthropic-claude-fable-5/text.generate/pricing.json": {
+      "hash": "476f68dc50b0ec207676f628976f9c6f",
+      "meta": {
+        "api_provider_id": "anthropic-aws",
+        "capability_id": "text.generate",
+        "model_id": "anthropic/claude-fable-5",
+        "model_key": "anthropic-aws:anthropic/claude-fable-5:text.generate"
+      }
+    },
+    "../../packages/data/catalog/src/data/pricing/anthropic-aws/anthropic-claude-sonnet-5/text.generate/pricing.json": {
+      "hash": "b6149c3a83eab939c321e0ff4fea4526",
+      "meta": {
+        "api_provider_id": "anthropic-aws",
+        "capability_id": "text.generate",
+        "model_id": "anthropic/claude-sonnet-5",
+        "model_key": "anthropic-aws:anthropic/claude-sonnet-5:text.generate"
+      }
+    },
+    "../../packages/data/catalog/src/data/pricing/anthropic-aws-us/anthropic-claude-fable-5/text.generate/pricing.json": {
+      "hash": "9a774be77bfdd3bff91c47429cb8d58e",
+      "meta": {
+        "api_provider_id": "anthropic-aws-us",
+        "capability_id": "text.generate",
+        "model_id": "anthropic/claude-fable-5",
+        "model_key": "anthropic-aws-us:anthropic/claude-fable-5:text.generate"
+      }
+    },
+    "../../packages/data/catalog/src/data/pricing/anthropic-aws-us/anthropic-claude-sonnet-5/text.generate/pricing.json": {
+      "hash": "a2e014be5e2c85cade93ffce98c6583c",
+      "meta": {
+        "api_provider_id": "anthropic-aws-us",
+        "capability_id": "text.generate",
+        "model_id": "anthropic/claude-sonnet-5",
+        "model_key": "anthropic-aws-us:anthropic/claude-sonnet-5:text.generate"
+      }
+    },
+    "../../packages/data/catalog/src/data/pricing/anthropic-us/anthropic-claude-fable-5/text.generate/pricing.json": {
+      "hash": "f395c15ab07fec85bebf7bcf792a4f47",
+      "meta": {
+        "api_provider_id": "anthropic-us",
+        "capability_id": "text.generate",
+        "model_id": "anthropic/claude-fable-5",
+        "model_key": "anthropic-us:anthropic/claude-fable-5:text.generate"
+      }
+    },
+    "../../packages/data/catalog/src/data/pricing/anthropic-us/anthropic-claude-sonnet-5/text.generate/pricing.json": {
+      "hash": "3888fcf56cfbfceb1a2a6153dccdd5bd",
+      "meta": {
+        "api_provider_id": "anthropic-us",
+        "capability_id": "text.generate",
+        "model_id": "anthropic/claude-sonnet-5",
+        "model_key": "anthropic-us:anthropic/claude-sonnet-5:text.generate"
+      }
+    },
+    "../../packages/data/catalog/src/data/pricing/atlascloud/kwaipilot-kat-coder-air-v2.5/text.generate/pricing.json": {
+      "hash": "3d469805700b50720e0b2ca50fffdd03",
+      "meta": {
+        "api_provider_id": "atlascloud",
+        "capability_id": "text.generate",
+        "model_id": "kwaipilot/kat-coder-air-v2.5",
+        "model_key": "atlascloud:kwaipilot/kat-coder-air-v2.5:text.generate"
+      }
+    },
+    "../../packages/data/catalog/src/data/pricing/atlascloud/kwaipilot-kat-coder-pro-v2.5/text.generate/pricing.json": {
+      "hash": "d196d4cd2e8cf48e5ebf325402d8555f",
+      "meta": {
+        "api_provider_id": "atlascloud",
+        "capability_id": "text.generate",
+        "model_id": "kwaipilot/kat-coder-pro-v2.5",
+        "model_key": "atlascloud:kwaipilot/kat-coder-pro-v2.5:text.generate"
+      }
+    },
+    "../../packages/data/catalog/src/data/pricing/atlascloud/z-ai-glm-5.2/text.generate/pricing.json": {
+      "hash": "3ac5a1cd94a30a5ce448e26158368f52",
+      "meta": {
+        "api_provider_id": "atlascloud",
+        "capability_id": "text.generate",
+        "model_id": "z-ai/glm-5.2",
+        "model_key": "atlascloud:z-ai/glm-5.2:text.generate"
+      }
+    },
+    "../../packages/data/catalog/src/data/pricing/azure/microsoft-mai-image-2/image.generate/pricing.json": {
+      "hash": "f86f77ca6b0fb026a3a5a50ebe57dec6",
+      "meta": {
+        "api_provider_id": "azure",
+        "capability_id": "image.generate",
+        "model_id": "microsoft/mai-image-2",
+        "model_key": "azure:microsoft/mai-image-2:image.generate"
+      }
+    },
+    "../../packages/data/catalog/src/data/pricing/azure/microsoft-mai-image-2.5/image.edit/pricing.json": {
+      "hash": "1b7a397404171b5ebc77be9af33a8af5",
+      "meta": {
+        "api_provider_id": "azure",
+        "capability_id": "image.edit",
+        "model_id": "microsoft/mai-image-2.5",
+        "model_key": "azure:microsoft/mai-image-2.5:image.edit"
+      }
+    },
+    "../../packages/data/catalog/src/data/pricing/azure/microsoft-mai-image-2.5/image.generate/pricing.json": {
+      "hash": "0e26fea8c8e819102c3c225fe316e277",
+      "meta": {
+        "api_provider_id": "azure",
+        "capability_id": "image.generate",
+        "model_id": "microsoft/mai-image-2.5",
+        "model_key": "azure:microsoft/mai-image-2.5:image.generate"
+      }
+    },
+    "../../packages/data/catalog/src/data/pricing/azure/microsoft-mai-image-2e/image.generate/pricing.json": {
+      "hash": "bc465af857d02b9ca926ba59a62a1b89",
+      "meta": {
+        "api_provider_id": "azure",
+        "capability_id": "image.generate",
+        "model_id": "microsoft/mai-image-2e",
+        "model_key": "azure:microsoft/mai-image-2e:image.generate"
+      }
+    },
+    "../../packages/data/catalog/src/data/pricing/azure/microsoft-mai-transcribe-1/audio.transcription/pricing.json": {
+      "hash": "4077832527a0047c08e9ce42950ac2f7",
+      "meta": {
+        "api_provider_id": "azure",
+        "capability_id": "audio.transcription",
+        "model_id": "microsoft/mai-transcribe-1",
+        "model_key": "azure:microsoft/mai-transcribe-1:audio.transcription"
+      }
+    },
+    "../../packages/data/catalog/src/data/pricing/azure/microsoft-mai-transcribe-1.5/audio.transcription/pricing.json": {
+      "hash": "571269b5f1fddb354c230094dfef0772",
+      "meta": {
+        "api_provider_id": "azure",
+        "capability_id": "audio.transcription",
+        "model_id": "microsoft/mai-transcribe-1.5",
+        "model_key": "azure:microsoft/mai-transcribe-1.5:audio.transcription"
+      }
+    },
+    "../../packages/data/catalog/src/data/pricing/azure/microsoft-mai-voice-1/audio.speech/pricing.json": {
+      "hash": "9acef06785ae66c2862834785906db8b",
+      "meta": {
+        "api_provider_id": "azure",
+        "capability_id": "audio.speech",
+        "model_id": "microsoft/mai-voice-1",
+        "model_key": "azure:microsoft/mai-voice-1:audio.speech"
+      }
+    },
+    "../../packages/data/catalog/src/data/pricing/baseten/moonshotai-kimi-k2.7-code/text.generate/pricing.json": {
+      "hash": "78bda8060e0c3e9fac82f25ff2e26193",
+      "meta": {
+        "api_provider_id": "baseten",
+        "capability_id": "text.generate",
+        "model_id": "moonshotai/kimi-k2.7-code",
+        "model_key": "baseten:moonshotai/kimi-k2.7-code:text.generate"
+      }
+    },
+    "../../packages/data/catalog/src/data/pricing/baseten/thinkingmachines-inkling/text.generate/pricing.json": {
+      "hash": "ee84c9d0dde1067d0b0d363df144877c",
+      "meta": {
+        "api_provider_id": "baseten",
+        "capability_id": "text.generate",
+        "model_id": "thinking-machines/inkling",
+        "model_key": "baseten:thinking-machines/inkling:text.generate"
+      }
+    },
+    "../../packages/data/catalog/src/data/pricing/baseten/z-ai-glm-5.2/text.generate/pricing.json": {
+      "hash": "0002c242cea9658b06511b166ad83b51",
+      "meta": {
+        "api_provider_id": "baseten",
+        "capability_id": "text.generate",
+        "model_id": "z-ai/glm-5.2",
+        "model_key": "baseten:z-ai/glm-5.2:text.generate"
+      }
+    },
+    "../../packages/data/catalog/src/data/pricing/byteplus/bytedance-seedance-2.0-mini-260615/video.generate/pricing.json": {
+      "hash": "da2b4b7ad6b1390b453a3d2fdb999c60",
+      "meta": {
+        "api_provider_id": "byteplus",
+        "capability_id": "video.generate",
+        "model_id": "bytedance/seedance-2.0-mini-260615",
+        "model_key": "byteplus:bytedance/seedance-2.0-mini-260615:video.generate"
+      }
+    },
+    "../../packages/data/catalog/src/data/pricing/cerebras/google-gemma-4-31b/text.generate/pricing.json": {
+      "hash": "d98c025beda2571d92c3b5ddbc5083b8",
+      "meta": {
+        "api_provider_id": "cerebras",
+        "capability_id": "text.generate",
+        "model_id": "google/gemma-4-31b",
+        "model_key": "cerebras:google/gemma-4-31b:text.generate"
+      }
+    },
+    "../../packages/data/catalog/src/data/pricing/cloudflare/deepseek-deepseek-r1-distill-qwen-32b/text.generate/pricing.json": {
+      "hash": "67daa3bf877365dcf9256c616d3dee96",
+      "meta": {
+        "api_provider_id": "cloudflare",
+        "capability_id": "text.generate",
+        "model_id": "deepseek/deepseek-r1-distill-qwen-32b",
+        "model_key": "cloudflare:deepseek/deepseek-r1-distill-qwen-32b:text.generate"
+      }
+    },
+    "../../packages/data/catalog/src/data/pricing/cloudflare/meta-m2m100-1.2b/text.generate/pricing.json": {
+      "hash": "9d11b49b19a3eb2adb7539c24e3d3fe6",
+      "meta": {
+        "api_provider_id": "cloudflare",
+        "capability_id": "text.generate",
+        "model_id": "meta/m2m100-1.2b",
+        "model_key": "cloudflare:meta/m2m100-1.2b:text.generate"
+      }
+    },
+    "../../packages/data/catalog/src/data/pricing/cloudflare/moonshotai-kimi-k2.7-code/text.generate/pricing.json": {
+      "hash": "c207564c8a108061a320a5c468eabd43",
+      "meta": {
+        "api_provider_id": "cloudflare",
+        "capability_id": "text.generate",
+        "model_id": "moonshotai/kimi-k2.7-code",
+        "model_key": "cloudflare:moonshotai/kimi-k2.7-code:text.generate"
+      }
+    },
+    "../../packages/data/catalog/src/data/pricing/cloudflare/openai-whisper-1/audio.transcribe/pricing.json": {
+      "hash": "212462429c3b75fb16ee20554021e4f5",
+      "meta": {
+        "api_provider_id": "cloudflare",
+        "capability_id": "audio.transcribe",
+        "model_id": "openai/whisper-1",
+        "model_key": "cloudflare:openai/whisper-1:audio.transcribe"
+      }
+    },
+    "../../packages/data/catalog/src/data/pricing/cloudflare/openai-whisper-large-v3-turbo/audio.transcribe/pricing.json": {
+      "hash": "8cad472762f07cbfa01303a94282d043",
+      "meta": {
+        "api_provider_id": "cloudflare",
+        "capability_id": "audio.transcribe",
+        "model_id": "openai/whisper-large-v3-turbo",
+        "model_key": "cloudflare:openai/whisper-large-v3-turbo:audio.transcribe"
+      }
+    },
+    "../../packages/data/catalog/src/data/pricing/cloudflare/zai-org-glm-5.2/text.generate/pricing.json": {
+      "hash": "a8314d0fd5b551d6989342660e32c72f",
+      "meta": {
+        "api_provider_id": "cloudflare",
+        "capability_id": "text.generate",
+        "model_id": "zai-org/glm-5.2",
+        "model_key": "cloudflare:zai-org/glm-5.2:text.generate"
+      }
+    },
+    "../../packages/data/catalog/src/data/pricing/cohere/cohere-north-mini-code-1-0-free/text.generate/pricing.json": {
+      "hash": "93f1444476a5737a9f8fabddac23105b",
+      "meta": {
+        "api_provider_id": "cohere",
+        "capability_id": "text.generate",
+        "model_id": "cohere/north-mini-code-1-0:free",
+        "model_key": "cohere:cohere/north-mini-code-1-0:free:text.generate"
+      }
+    },
+    "../../packages/data/catalog/src/data/pricing/crofai/moonshotai-kimi-k2.7-code/text.generate/pricing.json": {
+      "hash": "957b3fe44360b7960a1c35f8a4364334",
+      "meta": {
+        "api_provider_id": "crofai",
+        "capability_id": "text.generate",
+        "model_id": "moonshotai/kimi-k2.7-code",
+        "model_key": "crofai:moonshotai/kimi-k2.7-code:text.generate"
+      }
+    },
+    "../../packages/data/catalog/src/data/pricing/deepinfra/minimax-minimax-m2.7/text.generate/pricing.json": {
+      "hash": "5df9eb93fbf188c5756d72df3e12cf2a",
+      "meta": {
+        "api_provider_id": "deepinfra",
+        "capability_id": "text.generate",
+        "model_id": "minimax/minimax-m2.7",
+        "model_key": "deepinfra:minimax/minimax-m2.7:text.generate"
+      }
+    },
+    "../../packages/data/catalog/src/data/pricing/deepinfra/nvidia-nemotron-3-ultra-550b-a55b/text.generate/pricing.json": {
+      "hash": "e0db45a985c4d89ed32b0f407dd089b6",
+      "meta": {
+        "api_provider_id": "deepinfra",
+        "capability_id": "text.generate",
+        "model_id": "nvidia/nemotron-3-ultra-550b-a55b",
+        "model_key": "deepinfra:nvidia/nemotron-3-ultra-550b-a55b:text.generate"
+      }
+    },
+    "../../packages/data/catalog/src/data/pricing/deepinfra/stepfun-step-3.7-flash/text.generate/pricing.json": {
+      "hash": "03f57612a0b54f96edc95dc284b40f34",
+      "meta": {
+        "api_provider_id": "deepinfra",
+        "capability_id": "text.generate",
+        "model_id": "stepfun/step-3.7-flash",
+        "model_key": "deepinfra:stepfun/step-3.7-flash:text.generate"
+      }
+    },
+    "../../packages/data/catalog/src/data/pricing/deepinfra/z-ai-glm-5.2/text.generate/pricing.json": {
+      "hash": "8ecd6ba4caff328bf4d9bf99cbd5feb0",
+      "meta": {
+        "api_provider_id": "deepinfra",
+        "capability_id": "text.generate",
+        "model_id": "z-ai/glm-5.2",
+        "model_key": "deepinfra:z-ai/glm-5.2:text.generate"
+      }
+    },
+    "../../packages/data/catalog/src/data/pricing/digitalocean/deepseek-deepseek-r1-distill-llama-70b/text.generate/pricing.json": {
+      "hash": "24b87243e6f4ebff7df38a669b3b9662",
+      "meta": {
+        "api_provider_id": "digitalocean",
+        "capability_id": "text.generate",
+        "model_id": "deepseek/deepseek-r1-distill-llama-70b",
+        "model_key": "digitalocean:deepseek/deepseek-r1-distill-llama-70b:text.generate"
+      }
+    },
+    "../../packages/data/catalog/src/data/pricing/digitalocean/deepseek-deepseek-v3.2/text.generate/pricing.json": {
+      "hash": "f4d1696b5463e66a6a072b87ef3bc5a2",
+      "meta": {
+        "api_provider_id": "digitalocean",
+        "capability_id": "text.generate",
+        "model_id": "deepseek/deepseek-v3.2",
+        "model_key": "digitalocean:deepseek/deepseek-v3.2:text.generate"
+      }
+    },
+    "../../packages/data/catalog/src/data/pricing/digitalocean/deepseek-deepseek-v4-flash/text.generate/pricing.json": {
+      "hash": "67ad9ae6046979040dc56e930926e05d",
+      "meta": {
+        "api_provider_id": "digitalocean",
+        "capability_id": "text.generate",
+        "model_id": "deepseek/deepseek-v4-flash",
+        "model_key": "digitalocean:deepseek/deepseek-v4-flash:text.generate"
+      }
+    },
+    "../../packages/data/catalog/src/data/pricing/digitalocean/deepseek-deepseek-v4-pro/text.generate/pricing.json": {
+      "hash": "dd2958a3533779cf7d76812342f4f41c",
+      "meta": {
+        "api_provider_id": "digitalocean",
+        "capability_id": "text.generate",
+        "model_id": "deepseek/deepseek-v4-pro",
+        "model_key": "digitalocean:deepseek/deepseek-v4-pro:text.generate"
+      }
+    },
+    "../../packages/data/catalog/src/data/pricing/digitalocean/google-gemma-4-31b/text.generate/pricing.json": {
+      "hash": "f0fe006bb22c4324709ad0f08d58b18d",
+      "meta": {
+        "api_provider_id": "digitalocean",
+        "capability_id": "text.generate",
+        "model_id": "google/gemma-4-31b",
+        "model_key": "digitalocean:google/gemma-4-31b:text.generate"
+      }
+    },
+    "../../packages/data/catalog/src/data/pricing/digitalocean/meta-llama-3.3-70b/text.generate/pricing.json": {
+      "hash": "0f4b57dc48467ec678b2b56d926b28b7",
+      "meta": {
+        "api_provider_id": "digitalocean",
+        "capability_id": "text.generate",
+        "model_id": "meta/llama-3.3-70b",
+        "model_key": "digitalocean:meta/llama-3.3-70b:text.generate"
+      }
+    },
+    "../../packages/data/catalog/src/data/pricing/digitalocean/meta-llama-4-maverick/text.generate/pricing.json": {
+      "hash": "d04fcd70ff8324d301013577d210ad2c",
+      "meta": {
+        "api_provider_id": "digitalocean",
+        "capability_id": "text.generate",
+        "model_id": "meta/llama-4-maverick",
+        "model_key": "digitalocean:meta/llama-4-maverick:text.generate"
+      }
+    },
+    "../../packages/data/catalog/src/data/pricing/digitalocean/minimax-minimax-m2.5/text.generate/pricing.json": {
+      "hash": "aaf7070619a786615e92fdccf01baff4",
+      "meta": {
+        "api_provider_id": "digitalocean",
+        "capability_id": "text.generate",
+        "model_id": "minimax/minimax-m2.5",
+        "model_key": "digitalocean:minimax/minimax-m2.5:text.generate"
+      }
+    },
+    "../../packages/data/catalog/src/data/pricing/digitalocean/mistral-ministral-3-14b/text.generate/pricing.json": {
+      "hash": "d5e410b6615bfb2e4bd0254b7b694eb6",
+      "meta": {
+        "api_provider_id": "digitalocean",
+        "capability_id": "text.generate",
+        "model_id": "mistral/ministral-3-14b",
+        "model_key": "digitalocean:mistral/ministral-3-14b:text.generate"
+      }
+    },
+    "../../packages/data/catalog/src/data/pricing/digitalocean/moonshotai-kimi-k2.5/text.generate/pricing.json": {
+      "hash": "ffce644c063e52d6d4521fd072322536",
+      "meta": {
+        "api_provider_id": "digitalocean",
+        "capability_id": "text.generate",
+        "model_id": "moonshotai/kimi-k2.5",
+        "model_key": "digitalocean:moonshotai/kimi-k2.5:text.generate"
+      }
+    },
+    "../../packages/data/catalog/src/data/pricing/digitalocean/moonshotai-kimi-k2.6/text.generate/pricing.json": {
+      "hash": "eed6a5601b16757b97d36dc1d6cb8265",
+      "meta": {
+        "api_provider_id": "digitalocean",
+        "capability_id": "text.generate",
+        "model_id": "moonshotai/kimi-k2.6",
+        "model_key": "digitalocean:moonshotai/kimi-k2.6:text.generate"
+      }
+    },
+    "../../packages/data/catalog/src/data/pricing/digitalocean/nvidia-nemotron-3-nano-omni/text.generate/pricing.json": {
+      "hash": "84c436ebf7c4e5c2f9e4991ca7be5097",
+      "meta": {
+        "api_provider_id": "digitalocean",
+        "capability_id": "text.generate",
+        "model_id": "nvidia/nemotron-3-nano-omni",
+        "model_key": "digitalocean:nvidia/nemotron-3-nano-omni:text.generate"
+      }
+    },
+    "../../packages/data/catalog/src/data/pricing/digitalocean/nvidia-nemotron-3-super-120b-a12b/text.generate/pricing.json": {
+      "hash": "cd3b50d6111f9d1015975e2d9f892969",
+      "meta": {
+        "api_provider_id": "digitalocean",
+        "capability_id": "text.generate",
+        "model_id": "nvidia/nemotron-3-super-120b-a12b",
+        "model_key": "digitalocean:nvidia/nemotron-3-super-120b-a12b:text.generate"
+      }
+    },
+    "../../packages/data/catalog/src/data/pricing/digitalocean/nvidia-nemotron-3-ultra-550b-a55b/text.generate/pricing.json": {
+      "hash": "da51d214c9e60c215ed263fc4b6c016d",
+      "meta": {
+        "api_provider_id": "digitalocean",
+        "capability_id": "text.generate",
+        "model_id": "nvidia/nemotron-3-ultra-550b-a55b",
+        "model_key": "digitalocean:nvidia/nemotron-3-ultra-550b-a55b:text.generate"
+      }
+    },
+    "../../packages/data/catalog/src/data/pricing/digitalocean/nvidia-nemotron-nano-12b-v2-vl/text.generate/pricing.json": {
+      "hash": "a030e820a66cf82dd14c492a5eb2b32a",
+      "meta": {
+        "api_provider_id": "digitalocean",
+        "capability_id": "text.generate",
+        "model_id": "nvidia/nemotron-nano-12b-v2-vl",
+        "model_key": "digitalocean:nvidia/nemotron-nano-12b-v2-vl:text.generate"
+      }
+    },
+    "../../packages/data/catalog/src/data/pricing/digitalocean/openai-gpt-oss-120b/text.generate/pricing.json": {
+      "hash": "9fa1a0365b805d4dd544e1ca26bfaeaf",
+      "meta": {
+        "api_provider_id": "digitalocean",
+        "capability_id": "text.generate",
+        "model_id": "openai/gpt-oss-120b",
+        "model_key": "digitalocean:openai/gpt-oss-120b:text.generate"
+      }
+    },
+    "../../packages/data/catalog/src/data/pricing/digitalocean/openai-gpt-oss-20b/text.generate/pricing.json": {
+      "hash": "1d6eb5ec0200bea1a01a6bc087fff1ae",
+      "meta": {
+        "api_provider_id": "digitalocean",
+        "capability_id": "text.generate",
+        "model_id": "openai/gpt-oss-20b",
+        "model_key": "digitalocean:openai/gpt-oss-20b:text.generate"
+      }
+    },
+    "../../packages/data/catalog/src/data/pricing/digitalocean/qwen-qwen3-32b/text.generate/pricing.json": {
+      "hash": "2254ca3023a5ba1db4f6266a019d8e24",
+      "meta": {
+        "api_provider_id": "digitalocean",
+        "capability_id": "text.generate",
+        "model_id": "qwen/qwen3-32b",
+        "model_key": "digitalocean:qwen/qwen3-32b:text.generate"
+      }
+    },
+    "../../packages/data/catalog/src/data/pricing/digitalocean/qwen-qwen3-coder-flash/text.generate/pricing.json": {
+      "hash": "01b33d140acf1c169181240b2abdf222",
+      "meta": {
+        "api_provider_id": "digitalocean",
+        "capability_id": "text.generate",
+        "model_id": "qwen/qwen3-coder-flash",
+        "model_key": "digitalocean:qwen/qwen3-coder-flash:text.generate"
+      }
+    },
+    "../../packages/data/catalog/src/data/pricing/digitalocean/qwen-qwen3-embedding-0.6b/text.embed/pricing.json": {
+      "hash": "f1fd1e8b0d7863405cf2cee9a4fd47a7",
+      "meta": {
+        "api_provider_id": "digitalocean",
+        "capability_id": "text.embed",
+        "model_id": "qwen/qwen3-embedding-0.6b",
+        "model_key": "digitalocean:qwen/qwen3-embedding-0.6b:text.embed"
+      }
+    },
+    "../../packages/data/catalog/src/data/pricing/digitalocean/qwen-qwen3-tts-voicedesign/audio.speech/pricing.json": {
+      "hash": "2952e43092c7d26452b793c1f17c51f9",
+      "meta": {
+        "api_provider_id": "digitalocean",
+        "capability_id": "audio.speech",
+        "model_id": "qwen/qwen3-tts-voicedesign",
+        "model_key": "digitalocean:qwen/qwen3-tts-voicedesign:audio.speech"
+      }
+    },
+    "../../packages/data/catalog/src/data/pricing/digitalocean/qwen-qwen3.5-397b-a17b/text.generate/pricing.json": {
+      "hash": "c42f61747ae3a30b3d2bea1ad39e4636",
+      "meta": {
+        "api_provider_id": "digitalocean",
+        "capability_id": "text.generate",
+        "model_id": "qwen/qwen3.5-397b-a17b",
+        "model_key": "digitalocean:qwen/qwen3.5-397b-a17b:text.generate"
+      }
+    },
+    "../../packages/data/catalog/src/data/pricing/digitalocean/qwen-wan2.2-t2v-a14b/video.generate/pricing.json": {
+      "hash": "87731db4102c8647bbe3ca672270f8e9",
+      "meta": {
+        "api_provider_id": "digitalocean",
+        "capability_id": "video.generate",
+        "model_id": "qwen/wan2.2-t2v-a14b",
+        "model_key": "digitalocean:qwen/wan2.2-t2v-a14b:video.generate"
+      }
+    },
+    "../../packages/data/catalog/src/data/pricing/digitalocean/z-ai-glm-5/text.generate/pricing.json": {
+      "hash": "91a01d22112d1adfac1437eca0a94972",
+      "meta": {
+        "api_provider_id": "digitalocean",
+        "capability_id": "text.generate",
+        "model_id": "z-ai/glm-5",
+        "model_key": "digitalocean:z-ai/glm-5:text.generate"
+      }
+    },
+    "../../packages/data/catalog/src/data/pricing/fireworks/deepseek-deepseek-v4-flash/text.generate/pricing.json": {
+      "hash": "868b7384614b424bda3f1c441f0977fb",
+      "meta": {
+        "api_provider_id": "fireworks",
+        "capability_id": "text.generate",
+        "model_id": "deepseek/deepseek-v4-flash",
+        "model_key": "fireworks:deepseek/deepseek-v4-flash:text.generate"
+      }
+    },
+    "../../packages/data/catalog/src/data/pricing/fireworks/minimax-minimax-m3/text.generate/pricing.json": {
+      "hash": "e3580d11c7397e80e1949046386471ce",
+      "meta": {
+        "api_provider_id": "fireworks",
+        "capability_id": "text.generate",
+        "model_id": "minimax/minimax-m3",
+        "model_key": "fireworks:minimax/minimax-m3:text.generate"
+      }
+    },
+    "../../packages/data/catalog/src/data/pricing/fireworks/moonshotai-kimi-k2.7-code/text.generate/pricing.json": {
+      "hash": "5289b171bb31e0966e08951fddfed6b8",
+      "meta": {
+        "api_provider_id": "fireworks",
+        "capability_id": "text.generate",
+        "model_id": "moonshotai/kimi-k2.7-code",
+        "model_key": "fireworks:moonshotai/kimi-k2.7-code:text.generate"
+      }
+    },
+    "../../packages/data/catalog/src/data/pricing/fireworks/nvidia-nemotron-3-ultra-550b-a55b/text.generate/pricing.json": {
+      "hash": "fd10f40d90f858d032e295aece09ae2f",
+      "meta": {
+        "api_provider_id": "fireworks",
+        "capability_id": "text.generate",
+        "model_id": "nvidia/nemotron-3-ultra-550b-a55b",
+        "model_key": "fireworks:nvidia/nemotron-3-ultra-550b-a55b:text.generate"
+      }
+    },
+    "../../packages/data/catalog/src/data/pricing/fireworks/qwen-qwen3.7-plus/text.generate/pricing.json": {
+      "hash": "a5e6653cd7f79544ee00ad0725212dd8",
+      "meta": {
+        "api_provider_id": "fireworks",
+        "capability_id": "text.generate",
+        "model_id": "qwen/qwen3.7-plus",
+        "model_key": "fireworks:qwen/qwen3.7-plus:text.generate"
+      }
+    },
+    "../../packages/data/catalog/src/data/pricing/fireworks/z-ai-glm-5.2/text.generate/pricing.json": {
+      "hash": "07a33f62302f3d78347bbbef85627035",
+      "meta": {
+        "api_provider_id": "fireworks",
+        "capability_id": "text.generate",
+        "model_id": "z-ai/glm-5.2",
+        "model_key": "fireworks:z-ai/glm-5.2:text.generate"
+      }
+    },
+    "../../packages/data/catalog/src/data/pricing/gmicloud/minimax-minimax-m3/text.generate/pricing.json": {
+      "hash": "7516ec84c7e4db690dd001687560954b",
+      "meta": {
+        "api_provider_id": "gmicloud",
+        "capability_id": "text.generate",
+        "model_id": "minimax/minimax-m3",
+        "model_key": "gmicloud:minimax/minimax-m3:text.generate"
+      }
+    },
+    "../../packages/data/catalog/src/data/pricing/gmicloud/moonshotai-kimi-k2.7-code/text.generate/pricing.json": {
+      "hash": "33b7c54271097c330112b31b426ccb43",
+      "meta": {
+        "api_provider_id": "gmicloud",
+        "capability_id": "text.generate",
+        "model_id": "moonshotai/kimi-k2.7-code",
+        "model_key": "gmicloud:moonshotai/kimi-k2.7-code:text.generate"
+      }
+    },
+    "../../packages/data/catalog/src/data/pricing/google-ai-studio/google-gemini-2.5-pro/text.generate/pricing.json": {
+      "hash": "38c1790ffeb5db745d5b698347f8537f",
+      "meta": {
+        "api_provider_id": "google-ai-studio",
+        "capability_id": "text.generate",
+        "model_id": "google/gemini-2.5-pro",
+        "model_key": "google-ai-studio:google/gemini-2.5-pro:text.generate"
+      }
+    },
+    "../../packages/data/catalog/src/data/pricing/google-ai-studio/google-gemini-3.1-flash-lite-image/images.generations/pricing.json": {
+      "hash": "bca649450b6c3eca67a887600d4c195d",
+      "meta": {
+        "api_provider_id": "google-ai-studio",
+        "capability_id": "images.generations",
+        "model_id": "google/gemini-3.1-flash-lite-image",
+        "model_key": "google-ai-studio:google/gemini-3.1-flash-lite-image:images.generations"
+      }
+    },
+    "../../packages/data/catalog/src/data/pricing/google-ai-studio/google-gemini-3.1-flash-lite-image/text.generate/pricing.json": {
+      "hash": "a34ee39882f09bc7f00473ea93a07d35",
+      "meta": {
+        "api_provider_id": "google-ai-studio",
+        "capability_id": "text.generate",
+        "model_id": "google/gemini-3.1-flash-lite-image",
+        "model_key": "google-ai-studio:google/gemini-3.1-flash-lite-image:text.generate"
+      }
+    },
+    "../../packages/data/catalog/src/data/pricing/google-ai-studio/google-gemini-3.5-live-translate-preview/audio.translations/pricing.json": {
+      "hash": "d61cfe3bb7e573552e748b7517ff9757",
+      "meta": {
+        "api_provider_id": "google-ai-studio",
+        "capability_id": "audio.translations",
+        "model_id": "google/gemini-3.5-live-translate-preview",
+        "model_key": "google-ai-studio:google/gemini-3.5-live-translate-preview:audio.translations"
+      }
+    },
+    "../../packages/data/catalog/src/data/pricing/google-ai-studio/google-gemini-omni-flash-preview/video.generate/pricing.json": {
+      "hash": "482b96ff7b7d83df2fd4ce9f83df3106",
+      "meta": {
+        "api_provider_id": "google-ai-studio",
+        "capability_id": "video.generate",
+        "model_id": "google/gemini-omni-flash-preview",
+        "model_key": "google-ai-studio:google/gemini-omni-flash-preview:video.generate"
+      }
+    },
+    "../../packages/data/catalog/src/data/pricing/google-vertex/anthropic-claude-fable-5/text.generate/pricing.json": {
+      "hash": "3aba03e83989460936c9cd52cf1e9253",
+      "meta": {
+        "api_provider_id": "google-vertex",
+        "capability_id": "text.generate",
+        "model_id": "anthropic/claude-fable-5",
+        "model_key": "google-vertex:anthropic/claude-fable-5:text.generate"
+      }
+    },
+    "../../packages/data/catalog/src/data/pricing/google-vertex/anthropic-claude-sonnet-5/text.generate/pricing.json": {
+      "hash": "10503ef0b34ba00f71914f8b39c4a0cf",
+      "meta": {
+        "api_provider_id": "google-vertex",
+        "capability_id": "text.generate",
+        "model_id": "anthropic/claude-sonnet-5",
+        "model_key": "google-vertex:anthropic/claude-sonnet-5:text.generate"
+      }
+    },
+    "../../packages/data/catalog/src/data/pricing/google-vertex/google-gemini-3.1-flash-lite-image/text.generate/pricing.json": {
+      "hash": "b4a2826025fe9da8836f4dcb327aa96a",
+      "meta": {
+        "api_provider_id": "google-vertex",
+        "capability_id": "text.generate",
+        "model_id": "google/gemini-3.1-flash-lite-image",
+        "model_key": "google-vertex:google/gemini-3.1-flash-lite-image:text.generate"
+      }
+    },
+    "../../packages/data/catalog/src/data/pricing/google-vertex-eu/anthropic-claude-sonnet-5/text.generate/pricing.json": {
+      "hash": "684cb52d4648ca9da65a1b9566511bd4",
+      "meta": {
+        "api_provider_id": "google-vertex-eu",
+        "capability_id": "text.generate",
+        "model_id": "anthropic/claude-sonnet-5",
+        "model_key": "google-vertex-eu:anthropic/claude-sonnet-5:text.generate"
+      }
+    },
+    "../../packages/data/catalog/src/data/pricing/longcat/meituan-longcat-2.0/text.generate/pricing.json": {
+      "hash": "c53f3e23bf2a0fa3fa1d676919918bfb",
+      "meta": {
+        "api_provider_id": "longcat",
+        "capability_id": "text.generate",
+        "model_id": "meituan/longcat-2.0",
+        "model_key": "longcat:meituan/longcat-2.0:text.generate"
+      }
+    },
+    "../../packages/data/catalog/src/data/pricing/longcat/meituan-longcat-2.0-preview/text.generate/pricing.json": {
+      "hash": "d0979892191b5475a91342d3090c5cf5",
+      "meta": {
+        "api_provider_id": "longcat",
+        "capability_id": "text.generate",
+        "model_id": "meituan/longcat-2.0-preview",
+        "model_key": "longcat:meituan/longcat-2.0-preview:text.generate"
+      }
+    },
+    "../../packages/data/catalog/src/data/pricing/meta/meta-muse-spark-1.1/text.generate/pricing.json": {
+      "hash": "564e0e3c458f181a79e0bdc5cb559d4c",
+      "meta": {
+        "api_provider_id": "meta",
+        "capability_id": "text.generate",
+        "model_id": "meta/muse-spark-1.1",
+        "model_key": "meta:meta/muse-spark-1.1:text.generate"
+      }
+    },
+    "../../packages/data/catalog/src/data/pricing/mistral/mistral-leanstral-1.5-free/text.generate/pricing.json": {
+      "hash": "f8fa45aa920bd10dfec4dc0709cc69ef",
+      "meta": {
+        "api_provider_id": "mistral",
+        "capability_id": "text.generate",
+        "model_id": "mistral/leanstral-1.5:free",
+        "model_key": "mistral:mistral/leanstral-1.5:free:text.generate"
+      }
+    },
+    "../../packages/data/catalog/src/data/pricing/mistral/mistral-ocr-4/ocr/pricing.json": {
+      "hash": "426e2adbb1b2b0c54da06883a789ce62",
+      "meta": {
+        "api_provider_id": "mistral",
+        "capability_id": "ocr",
+        "model_id": "mistral/ocr-4",
+        "model_key": "mistral:mistral/ocr-4:ocr"
+      }
+    },
+    "../../packages/data/catalog/src/data/pricing/moonshotai/moonshotai-kimi-k2.7-code/text.generate/pricing.json": {
+      "hash": "dcdb9fd038f4abcd25ad08e1aded6375",
+      "meta": {
+        "api_provider_id": "moonshotai",
+        "capability_id": "text.generate",
+        "model_id": "moonshotai/kimi-k2.7-code",
+        "model_key": "moonshotai:moonshotai/kimi-k2.7-code:text.generate"
+      }
+    },
+    "../../packages/data/catalog/src/data/pricing/nebius-token-factory/moonshotai-kimi-k2.7-code/text.generate/pricing.json": {
+      "hash": "d7bc18031c784f9a77b9f0456a3722a8",
+      "meta": {
+        "api_provider_id": "nebius-token-factory",
+        "capability_id": "text.generate",
+        "model_id": "moonshotai/kimi-k2.7-code",
+        "model_key": "nebius-token-factory:moonshotai/kimi-k2.7-code:text.generate"
+      }
+    },
+    "../../packages/data/catalog/src/data/pricing/nebius-token-factory/z-ai-glm-5.2/text.generate/pricing.json": {
+      "hash": "b23b46b7d818ba15c690f6aefa3579bf",
+      "meta": {
+        "api_provider_id": "nebius-token-factory",
+        "capability_id": "text.generate",
+        "model_id": "z-ai/glm-5.2",
+        "model_key": "nebius-token-factory:z-ai/glm-5.2:text.generate"
+      }
+    },
+    "../../packages/data/catalog/src/data/pricing/novita/moonshotai-kimi-k2.7-code/text.generate/pricing.json": {
+      "hash": "73f15521982e23be5ec5bfa7e1e68c30",
+      "meta": {
+        "api_provider_id": "novita",
+        "capability_id": "text.generate",
+        "model_id": "moonshotai/kimi-k2.7-code",
+        "model_key": "novita:moonshotai/kimi-k2.7-code:text.generate"
+      }
+    },
+    "../../packages/data/catalog/src/data/pricing/novita/nex-agi-nex-n2-pro/text.generate/pricing.json": {
+      "hash": "6237072e664b1ae786cae9a87d91fb1d",
+      "meta": {
+        "api_provider_id": "novita",
+        "capability_id": "text.generate",
+        "model_id": "nex-agi/nex-n2-pro",
+        "model_key": "novita:nex-agi/nex-n2-pro:text.generate"
+      }
+    },
+    "../../packages/data/catalog/src/data/pricing/novita/z-ai-glm-5.2/text.generate/pricing.json": {
+      "hash": "197c2747d8926b739ef4467b6b07a0b4",
+      "meta": {
+        "api_provider_id": "novita",
+        "capability_id": "text.generate",
+        "model_id": "z-ai/glm-5.2",
+        "model_key": "novita:z-ai/glm-5.2:text.generate"
+      }
+    },
+    "../../packages/data/catalog/src/data/pricing/openai/openai-gpt-5.5-cyber/text.generate/pricing.json": {
+      "hash": "77329bcd875f1b99085f38a8e43559bf",
+      "meta": {
+        "api_provider_id": "openai",
+        "capability_id": "text.generate",
+        "model_id": "openai/gpt-5.5-cyber",
+        "model_key": "openai:openai/gpt-5.5-cyber:text.generate"
+      }
+    },
+    "../../packages/data/catalog/src/data/pricing/openai/openai-gpt-5.6-luna-pro/batch/pricing.json": {
+      "hash": "4f559d20565e1c59bf09b5650b6e3210",
+      "meta": {
+        "api_provider_id": "openai",
+        "capability_id": "batch",
+        "model_id": "openai/gpt-5.6-luna-pro",
+        "model_key": "openai:openai/gpt-5.6-luna-pro:batch"
+      }
+    },
+    "../../packages/data/catalog/src/data/pricing/openai/openai-gpt-5.6-luna-pro/text.generate/pricing.json": {
+      "hash": "9f9352fa5bd03349f363a3293a11a2f9",
+      "meta": {
+        "api_provider_id": "openai",
+        "capability_id": "text.generate",
+        "model_id": "openai/gpt-5.6-luna-pro",
+        "model_key": "openai:openai/gpt-5.6-luna-pro:text.generate"
+      }
+    },
+    "../../packages/data/catalog/src/data/pricing/openai/openai-gpt-5.6-sol/batch/pricing.json": {
+      "hash": "5089997eac146d9b129b50e3255db11a",
+      "meta": {
+        "api_provider_id": "openai",
+        "capability_id": "batch",
+        "model_id": "openai/gpt-5.6-sol",
+        "model_key": "openai:openai/gpt-5.6-sol:batch"
+      }
+    },
+    "../../packages/data/catalog/src/data/pricing/openai/openai-gpt-5.6-sol/text.generate/pricing.json": {
+      "hash": "a2f8d5e368100e87b99b5a8855a73ba0",
+      "meta": {
+        "api_provider_id": "openai",
+        "capability_id": "text.generate",
+        "model_id": "openai/gpt-5.6-sol",
+        "model_key": "openai:openai/gpt-5.6-sol:text.generate"
+      }
+    },
+    "../../packages/data/catalog/src/data/pricing/openai/openai-gpt-5.6-sol-pro/batch/pricing.json": {
+      "hash": "c1e169e2adcedc059c333d6a68981b23",
+      "meta": {
+        "api_provider_id": "openai",
+        "capability_id": "batch",
+        "model_id": "openai/gpt-5.6-sol-pro",
+        "model_key": "openai:openai/gpt-5.6-sol-pro:batch"
+      }
+    },
+    "../../packages/data/catalog/src/data/pricing/openai/openai-gpt-5.6-sol-pro/text.generate/pricing.json": {
+      "hash": "42db040807b0b95cd1a1186b17c49695",
+      "meta": {
+        "api_provider_id": "openai",
+        "capability_id": "text.generate",
+        "model_id": "openai/gpt-5.6-sol-pro",
+        "model_key": "openai:openai/gpt-5.6-sol-pro:text.generate"
+      }
+    },
+    "../../packages/data/catalog/src/data/pricing/openai/openai-gpt-5.6-terra/batch/pricing.json": {
+      "hash": "79b0626d54129dd00c78876932062d7c",
+      "meta": {
+        "api_provider_id": "openai",
+        "capability_id": "batch",
+        "model_id": "openai/gpt-5.6-terra",
+        "model_key": "openai:openai/gpt-5.6-terra:batch"
+      }
+    },
+    "../../packages/data/catalog/src/data/pricing/openai/openai-gpt-5.6-terra/text.generate/pricing.json": {
+      "hash": "c7f856dfe641079bd7129750d4bae477",
+      "meta": {
+        "api_provider_id": "openai",
+        "capability_id": "text.generate",
+        "model_id": "openai/gpt-5.6-terra",
+        "model_key": "openai:openai/gpt-5.6-terra:text.generate"
+      }
+    },
+    "../../packages/data/catalog/src/data/pricing/openai/openai-gpt-5.6-terra-pro/batch/pricing.json": {
+      "hash": "b001fe71060aaf3e1468cd467f8dbf03",
+      "meta": {
+        "api_provider_id": "openai",
+        "capability_id": "batch",
+        "model_id": "openai/gpt-5.6-terra-pro",
+        "model_key": "openai:openai/gpt-5.6-terra-pro:batch"
+      }
+    },
+    "../../packages/data/catalog/src/data/pricing/openai/openai-gpt-5.6-terra-pro/text.generate/pricing.json": {
+      "hash": "af9f8c47c9aa18d3518970342c6e0fb4",
+      "meta": {
+        "api_provider_id": "openai",
+        "capability_id": "text.generate",
+        "model_id": "openai/gpt-5.6-terra-pro",
+        "model_key": "openai:openai/gpt-5.6-terra-pro:text.generate"
+      }
+    },
+    "../../packages/data/catalog/src/data/pricing/openai/openai-gpt-realtime-2.1/audio.realtime/pricing.json": {
+      "hash": "aff39cd4bcd814bf097798ef5885a932",
+      "meta": {
+        "api_provider_id": "openai",
+        "capability_id": "audio.realtime",
+        "model_id": "openai/gpt-realtime-2.1",
+        "model_key": "openai:openai/gpt-realtime-2.1:audio.realtime"
+      }
+    },
+    "../../packages/data/catalog/src/data/pricing/openai/openai-gpt-realtime-2.1-mini/audio.realtime/pricing.json": {
+      "hash": "3bb5264407dbb2f5272718fb35b77815",
+      "meta": {
+        "api_provider_id": "openai",
+        "capability_id": "audio.realtime",
+        "model_id": "openai/gpt-realtime-2.1-mini",
+        "model_key": "openai:openai/gpt-realtime-2.1-mini:audio.realtime"
+      }
+    },
+    "../../packages/data/catalog/src/data/pricing/poolside/poolside-laguna-xs-2.1-free/text.generate/pricing.json": {
+      "hash": "4013d4d0e98f3f18be3b5b3ea0d97b0f",
+      "meta": {
+        "api_provider_id": "poolside",
+        "capability_id": "text.generate",
+        "model_id": "poolside/laguna-xs-2.1:free",
+        "model_key": "poolside:poolside/laguna-xs-2.1:free:text.generate"
+      }
+    },
+    "../../packages/data/catalog/src/data/pricing/sakana/sakana-fugu-ultra/text.generate/pricing.json": {
+      "hash": "e0e9c6d1eda9b2ed2ba613349d0c1415",
+      "meta": {
+        "api_provider_id": "sakana",
+        "capability_id": "text.generate",
+        "model_id": "sakana/fugu-ultra",
+        "model_key": "sakana:sakana/fugu-ultra:text.generate"
+      }
+    },
+    "../../packages/data/catalog/src/data/pricing/siliconflow/nex-agi-nex-n2-pro-free/text.generate/pricing.json": {
+      "hash": "6c2a5570643eb5678ea148892311f37a",
+      "meta": {
+        "api_provider_id": "siliconflow",
+        "capability_id": "text.generate",
+        "model_id": "nex-agi/nex-n2-pro:free",
+        "model_key": "siliconflow:nex-agi/nex-n2-pro:free:text.generate"
+      }
+    },
+    "../../packages/data/catalog/src/data/pricing/siliconflow/tencent-hy3-free/text.generate/pricing.json": {
+      "hash": "aed913cf5843e3114ac7ec96d349a36c",
+      "meta": {
+        "api_provider_id": "siliconflow",
+        "capability_id": "text.generate",
+        "model_id": "tencent/hy3:free",
+        "model_key": "siliconflow:tencent/hy3:free:text.generate"
+      }
+    },
+    "../../packages/data/catalog/src/data/pricing/spacex-ai/spacex-ai-grok-2-vision/text.generate/pricing.json": {
+      "hash": "7a5f20bc7e85b6a5e816f0c0f27eb6c2",
+      "meta": {
+        "api_provider_id": "spacex-ai",
+        "capability_id": "text.generate",
+        "model_id": "spacex-ai/grok-2-vision",
+        "model_key": "spacex-ai:spacex-ai/grok-2-vision:text.generate"
+      }
+    },
+    "../../packages/data/catalog/src/data/pricing/spacex-ai/spacex-ai-grok-3/text.generate/pricing.json": {
+      "hash": "c2752beaba04205cea246a811e1057b5",
+      "meta": {
+        "api_provider_id": "spacex-ai",
+        "capability_id": "text.generate",
+        "model_id": "spacex-ai/grok-3",
+        "model_key": "spacex-ai:spacex-ai/grok-3:text.generate"
+      }
+    },
+    "../../packages/data/catalog/src/data/pricing/spacex-ai/spacex-ai-grok-3-mini/text.generate/pricing.json": {
+      "hash": "2a28a365a9984e8a1d84dcd875bf5f0c",
+      "meta": {
+        "api_provider_id": "spacex-ai",
+        "capability_id": "text.generate",
+        "model_id": "spacex-ai/grok-3-mini",
+        "model_key": "spacex-ai:spacex-ai/grok-3-mini:text.generate"
+      }
+    },
+    "../../packages/data/catalog/src/data/pricing/spacex-ai/spacex-ai-grok-4/text.generate/pricing.json": {
+      "hash": "bb663f30d21e818543c881fe02c0f0d7",
+      "meta": {
+        "api_provider_id": "spacex-ai",
+        "capability_id": "text.generate",
+        "model_id": "spacex-ai/grok-4",
+        "model_key": "spacex-ai:spacex-ai/grok-4:text.generate"
+      }
+    },
+    "../../packages/data/catalog/src/data/pricing/spacex-ai/spacex-ai-grok-4.1/text.generate/pricing.json": {
+      "hash": "3ce71cd22f622bf248fd1eefe46081d7",
+      "meta": {
+        "api_provider_id": "spacex-ai",
+        "capability_id": "text.generate",
+        "model_id": "spacex-ai/grok-4.1",
+        "model_key": "spacex-ai:spacex-ai/grok-4.1:text.generate"
+      }
+    },
+    "../../packages/data/catalog/src/data/pricing/spacex-ai/spacex-ai-grok-4.1-thinking/text.generate/pricing.json": {
+      "hash": "c0301ba778d8a850c56692201f5cf1dc",
+      "meta": {
+        "api_provider_id": "spacex-ai",
+        "capability_id": "text.generate",
+        "model_id": "spacex-ai/grok-4.1-thinking",
+        "model_key": "spacex-ai:spacex-ai/grok-4.1-thinking:text.generate"
+      }
+    },
+    "../../packages/data/catalog/src/data/pricing/spacex-ai/spacex-ai-grok-4.20-beta-0309/text.generate/pricing.json": {
+      "hash": "49d70dc919f8dc6f43d07c25991e8404",
+      "meta": {
+        "api_provider_id": "spacex-ai",
+        "capability_id": "text.generate",
+        "model_id": "spacex-ai/grok-4.20-beta-0309",
+        "model_key": "spacex-ai:spacex-ai/grok-4.20-beta-0309:text.generate"
+      }
+    },
+    "../../packages/data/catalog/src/data/pricing/spacex-ai/spacex-ai-grok-4.20-multi-agent-beta-0309/text.generate/pricing.json": {
+      "hash": "fda3b7858e34e6c13c18d996de787722",
+      "meta": {
+        "api_provider_id": "spacex-ai",
+        "capability_id": "text.generate",
+        "model_id": "spacex-ai/grok-4.20-multi-agent-beta-0309",
+        "model_key": "spacex-ai:spacex-ai/grok-4.20-multi-agent-beta-0309:text.generate"
+      }
+    },
+    "../../packages/data/catalog/src/data/pricing/spacex-ai/spacex-ai-grok-4.3/text.generate/pricing.json": {
+      "hash": "f34fff2711164b3ba697790df94afbe0",
+      "meta": {
+        "api_provider_id": "spacex-ai",
+        "capability_id": "text.generate",
+        "model_id": "spacex-ai/grok-4.3",
+        "model_key": "spacex-ai:spacex-ai/grok-4.3:text.generate"
+      }
+    },
+    "../../packages/data/catalog/src/data/pricing/spacex-ai/spacex-ai-grok-4.5/text.generate/pricing.json": {
+      "hash": "460560ed8fa839b94db047215e1428a0",
+      "meta": {
+        "api_provider_id": "spacex-ai",
+        "capability_id": "text.generate",
+        "model_id": "spacex-ai/grok-4.5",
+        "model_key": "spacex-ai:spacex-ai/grok-4.5:text.generate"
+      }
+    },
+    "../../packages/data/catalog/src/data/pricing/spacex-ai/spacex-ai-grok-build-0.1/text.generate/pricing.json": {
+      "hash": "c28faab65577028359357af6be2fc550",
+      "meta": {
+        "api_provider_id": "spacex-ai",
+        "capability_id": "text.generate",
+        "model_id": "spacex-ai/grok-build-0.1",
+        "model_key": "spacex-ai:spacex-ai/grok-build-0.1:text.generate"
+      }
+    },
+    "../../packages/data/catalog/src/data/pricing/spacex-ai/spacex-ai-grok-code-fast-1/text.generate/pricing.json": {
+      "hash": "7b7dec423667b8ebcdbe3163e0f71e4f",
+      "meta": {
+        "api_provider_id": "spacex-ai",
+        "capability_id": "text.generate",
+        "model_id": "spacex-ai/grok-code-fast-1",
+        "model_key": "spacex-ai:spacex-ai/grok-code-fast-1:text.generate"
+      }
+    },
+    "../../packages/data/catalog/src/data/pricing/spacex-ai/spacex-ai-grok-imagine-image/image.edit/pricing.json": {
+      "hash": "ab30eafa5fdfb8f7eb0c719c127a33b7",
+      "meta": {
+        "api_provider_id": "spacex-ai",
+        "capability_id": "image.edit",
+        "model_id": "spacex-ai/grok-imagine-image",
+        "model_key": "spacex-ai:spacex-ai/grok-imagine-image:image.edit"
+      }
+    },
+    "../../packages/data/catalog/src/data/pricing/spacex-ai/spacex-ai-grok-imagine-image/image.generate/pricing.json": {
+      "hash": "1c6779c5171391e7ecc91b2f30bbd75f",
+      "meta": {
+        "api_provider_id": "spacex-ai",
+        "capability_id": "image.generate",
+        "model_id": "spacex-ai/grok-imagine-image",
+        "model_key": "spacex-ai:spacex-ai/grok-imagine-image:image.generate"
+      }
+    },
+    "../../packages/data/catalog/src/data/pricing/spacex-ai/spacex-ai-grok-imagine-image-pro/image.generate/pricing.json": {
+      "hash": "540fc9d841603e33bc32c23ed0df4287",
+      "meta": {
+        "api_provider_id": "spacex-ai",
+        "capability_id": "image.generate",
+        "model_id": "spacex-ai/grok-imagine-image-pro",
+        "model_key": "spacex-ai:spacex-ai/grok-imagine-image-pro:image.generate"
+      }
+    },
+    "../../packages/data/catalog/src/data/pricing/spacex-ai/spacex-ai-grok-imagine-image-quality/image.edit/pricing.json": {
+      "hash": "23fbb3590a41413070fbfe37545e5fa6",
+      "meta": {
+        "api_provider_id": "spacex-ai",
+        "capability_id": "image.edit",
+        "model_id": "spacex-ai/grok-imagine-image-quality",
+        "model_key": "spacex-ai:spacex-ai/grok-imagine-image-quality:image.edit"
+      }
+    },
+    "../../packages/data/catalog/src/data/pricing/spacex-ai/spacex-ai-grok-imagine-image-quality/image.generate/pricing.json": {
+      "hash": "7792da05129d241bc16fc4fe62c69611",
+      "meta": {
+        "api_provider_id": "spacex-ai",
+        "capability_id": "image.generate",
+        "model_id": "spacex-ai/grok-imagine-image-quality",
+        "model_key": "spacex-ai:spacex-ai/grok-imagine-image-quality:image.generate"
+      }
+    },
+    "../../packages/data/catalog/src/data/pricing/spacex-ai/spacex-ai-grok-imagine-video/video.edit/pricing.json": {
+      "hash": "7fe72cd229714f57cc4d87aedfadffe2",
+      "meta": {
+        "api_provider_id": "spacex-ai",
+        "capability_id": "video.edit",
+        "model_id": "spacex-ai/grok-imagine-video",
+        "model_key": "spacex-ai:spacex-ai/grok-imagine-video:video.edit"
+      }
+    },
+    "../../packages/data/catalog/src/data/pricing/spacex-ai/spacex-ai-grok-imagine-video/video.generate/pricing.json": {
+      "hash": "d68db72559a8c07736a66d5109c229b7",
+      "meta": {
+        "api_provider_id": "spacex-ai",
+        "capability_id": "video.generate",
+        "model_id": "spacex-ai/grok-imagine-video",
+        "model_key": "spacex-ai:spacex-ai/grok-imagine-video:video.generate"
+      }
+    },
+    "../../packages/data/catalog/src/data/pricing/spacex-ai/spacex-ai-grok-imagine-video-1.5/video.edit/pricing.json": {
+      "hash": "7b63b9e119f0994ccf47011face9dc3c",
+      "meta": {
+        "api_provider_id": "spacex-ai",
+        "capability_id": "video.edit",
+        "model_id": "spacex-ai/grok-imagine-video-1.5",
+        "model_key": "spacex-ai:spacex-ai/grok-imagine-video-1.5:video.edit"
+      }
+    },
+    "../../packages/data/catalog/src/data/pricing/spacex-ai/spacex-ai-grok-imagine-video-1.5/video.generate/pricing.json": {
+      "hash": "040577723affc6ae1be1ddc71004915a",
+      "meta": {
+        "api_provider_id": "spacex-ai",
+        "capability_id": "video.generate",
+        "model_id": "spacex-ai/grok-imagine-video-1.5",
+        "model_key": "spacex-ai:spacex-ai/grok-imagine-video-1.5:video.generate"
+      }
+    },
+    "../../packages/data/catalog/src/data/pricing/spacex-ai/spacex-ai-grok-imagine-video-1.5-preview/video.edit/pricing.json": {
+      "hash": "1ed4eb2c8f5aad4b73ab55839ae46968",
+      "meta": {
+        "api_provider_id": "spacex-ai",
+        "capability_id": "video.edit",
+        "model_id": "spacex-ai/grok-imagine-video-1.5-preview",
+        "model_key": "spacex-ai:spacex-ai/grok-imagine-video-1.5-preview:video.edit"
+      }
+    },
+    "../../packages/data/catalog/src/data/pricing/spacex-ai/spacex-ai-grok-imagine-video-1.5-preview/video.generate/pricing.json": {
+      "hash": "5d08f14ed2d137422e539093c4a18547",
+      "meta": {
+        "api_provider_id": "spacex-ai",
+        "capability_id": "video.generate",
+        "model_id": "spacex-ai/grok-imagine-video-1.5-preview",
+        "model_key": "spacex-ai:spacex-ai/grok-imagine-video-1.5-preview:video.generate"
+      }
+    },
+    "../../packages/data/catalog/src/data/pricing/spacex-ai/spacex-ai-grok-tts/audio.speech/pricing.json": {
+      "hash": "e37a2aceaafc6f359947e098489331ea",
+      "meta": {
+        "api_provider_id": "spacex-ai",
+        "capability_id": "audio.speech",
+        "model_id": "spacex-ai/grok-tts",
+        "model_key": "spacex-ai:spacex-ai/grok-tts:audio.speech"
+      }
+    },
+    "../../packages/data/catalog/src/data/pricing/thinking-machines/nvidia-nemotron-3-nano-30b-a3b/text.generate/pricing.json": {
+      "hash": "6dbc4ef87918f880ee7e6460ba2fea39",
+      "meta": {
+        "api_provider_id": "thinking-machines",
+        "capability_id": "text.generate",
+        "model_id": "nvidia/nemotron-3-nano-30b-a3b",
+        "model_key": "thinking-machines:nvidia/nemotron-3-nano-30b-a3b:text.generate"
+      }
+    },
+    "../../packages/data/catalog/src/data/pricing/thinking-machines/nvidia-nemotron-3-super-120b-a12b/text.generate/pricing.json": {
+      "hash": "0c2230f3bac6450fbd216285745f12bf",
+      "meta": {
+        "api_provider_id": "thinking-machines",
+        "capability_id": "text.generate",
+        "model_id": "nvidia/nemotron-3-super-120b-a12b",
+        "model_key": "thinking-machines:nvidia/nemotron-3-super-120b-a12b:text.generate"
+      }
+    },
+    "../../packages/data/catalog/src/data/pricing/thinking-machines/nvidia-nemotron-3-ultra-550b-a55b/text.generate/pricing.json": {
+      "hash": "18bff3c75abf314583ce860bd239bf8e",
+      "meta": {
+        "api_provider_id": "thinking-machines",
+        "capability_id": "text.generate",
+        "model_id": "nvidia/nemotron-3-ultra-550b-a55b",
+        "model_key": "thinking-machines:nvidia/nemotron-3-ultra-550b-a55b:text.generate"
+      }
+    },
+    "../../packages/data/catalog/src/data/pricing/thinking-machines/openai-gpt-oss-120b/text.generate/pricing.json": {
+      "hash": "51fac7ae0df9e70628743ba08c84598c",
+      "meta": {
+        "api_provider_id": "thinking-machines",
+        "capability_id": "text.generate",
+        "model_id": "openai/gpt-oss-120b",
+        "model_key": "thinking-machines:openai/gpt-oss-120b:text.generate"
+      }
+    },
+    "../../packages/data/catalog/src/data/pricing/thinking-machines/openai-gpt-oss-20b/text.generate/pricing.json": {
+      "hash": "3e6a1962072ed06a4f430df378a880c3",
+      "meta": {
+        "api_provider_id": "thinking-machines",
+        "capability_id": "text.generate",
+        "model_id": "openai/gpt-oss-20b",
+        "model_key": "thinking-machines:openai/gpt-oss-20b:text.generate"
+      }
+    },
+    "../../packages/data/catalog/src/data/pricing/thinking-machines/qwen-qwen3.5-397b-a17b/text.generate/pricing.json": {
+      "hash": "c5cca14b9d7d12ca28b61e3cead5132c",
+      "meta": {
+        "api_provider_id": "thinking-machines",
+        "capability_id": "text.generate",
+        "model_id": "qwen/qwen3.5-397b-a17b",
+        "model_key": "thinking-machines:qwen/qwen3.5-397b-a17b:text.generate"
+      }
+    },
+    "../../packages/data/catalog/src/data/pricing/thinking-machines/qwen-qwen3.5-4b/text.generate/pricing.json": {
+      "hash": "97a40201a4373226f3a4e953cbcc3188",
+      "meta": {
+        "api_provider_id": "thinking-machines",
+        "capability_id": "text.generate",
+        "model_id": "qwen/qwen3.5-4b",
+        "model_key": "thinking-machines:qwen/qwen3.5-4b:text.generate"
+      }
+    },
+    "../../packages/data/catalog/src/data/pricing/thinking-machines/qwen-qwen3.6-27b/text.generate/pricing.json": {
+      "hash": "4d7dcfa1ecdc51ae8f3964c36cc7eed9",
+      "meta": {
+        "api_provider_id": "thinking-machines",
+        "capability_id": "text.generate",
+        "model_id": "qwen/qwen3.6-27b",
+        "model_key": "thinking-machines:qwen/qwen3.6-27b:text.generate"
+      }
+    },
+    "../../packages/data/catalog/src/data/pricing/thinking-machines/qwen-qwen3.6-35b-a3b/text.generate/pricing.json": {
+      "hash": "de6cdeae9aa26a42c3a5c6c9f11ce793",
+      "meta": {
+        "api_provider_id": "thinking-machines",
+        "capability_id": "text.generate",
+        "model_id": "qwen/qwen3.6-35b-a3b",
+        "model_key": "thinking-machines:qwen/qwen3.6-35b-a3b:text.generate"
+      }
+    },
+    "../../packages/data/catalog/src/data/pricing/thinking-machines/thinkingmachines-inkling/text.generate/pricing.json": {
+      "hash": "94c621441b0a76b109c66124b73a9708",
+      "meta": {
+        "api_provider_id": "thinking-machines",
+        "capability_id": "text.generate",
+        "model_id": "thinking-machines/inkling",
+        "model_key": "thinking-machines:thinking-machines/inkling:text.generate"
+      }
+    },
+    "../../packages/data/catalog/src/data/pricing/thinking-machines/thinkingmachines-inkling-64k/text.generate/pricing.json": {
+      "hash": "22b088377e9b9e26857626010f0b160c",
+      "meta": {
+        "api_provider_id": "thinking-machines",
+        "capability_id": "text.generate",
+        "model_id": "thinking-machines/inkling-64k",
+        "model_key": "thinking-machines:thinking-machines/inkling-64k:text.generate"
+      }
+    },
+    "../../packages/data/catalog/src/data/pricing/together/minimax-minimax-m3/text.generate/pricing.json": {
+      "hash": "4903e639f124bbb31bed16a519f5a41a",
+      "meta": {
+        "api_provider_id": "together",
+        "capability_id": "text.generate",
+        "model_id": "minimax/minimax-m3",
+        "model_key": "together:minimax/minimax-m3:text.generate"
+      }
+    },
+    "../../packages/data/catalog/src/data/pricing/together/moonshotai-kimi-k2.7-code/text.generate/pricing.json": {
+      "hash": "76ce981d3003d590b438a5efaa649ff2",
+      "meta": {
+        "api_provider_id": "together",
+        "capability_id": "text.generate",
+        "model_id": "moonshotai/kimi-k2.7-code",
+        "model_key": "together:moonshotai/kimi-k2.7-code:text.generate"
+      }
+    },
+    "../../packages/data/catalog/src/data/pricing/together/z-ai-glm-5.2/text.generate/pricing.json": {
+      "hash": "754886a9c70768f0cef0de0ed31b4274",
+      "meta": {
+        "api_provider_id": "together",
+        "capability_id": "text.generate",
+        "model_id": "z-ai/glm-5.2",
+        "model_key": "together:z-ai/glm-5.2:text.generate"
+      }
+    },
+    "../../packages/data/catalog/src/data/pricing/venice/anthropic-claude-fable-5/text.generate/pricing.json": {
+      "hash": "193e4bdaa94536a302b59ec61b6ddbda",
+      "meta": {
+        "api_provider_id": "venice",
+        "capability_id": "text.generate",
+        "model_id": "anthropic/claude-fable-5",
+        "model_key": "venice:anthropic/claude-fable-5:text.generate"
+      }
+    },
+    "../../packages/data/catalog/src/data/pricing/venice/anthropic-claude-sonnet-5/text.generate/pricing.json": {
+      "hash": "19268a2b8a99a76341af2c110dea23ef",
+      "meta": {
+        "api_provider_id": "venice",
+        "capability_id": "text.generate",
+        "model_id": "anthropic/claude-sonnet-5",
+        "model_key": "venice:anthropic/claude-sonnet-5:text.generate"
+      }
+    },
+    "../../packages/data/catalog/src/data/pricing/venice/moonshotai-kimi-k2.7-code/text.generate/pricing.json": {
+      "hash": "4af5dae42a4c74e464853c21c00067b7",
+      "meta": {
+        "api_provider_id": "venice",
+        "capability_id": "text.generate",
+        "model_id": "moonshotai/kimi-k2.7-code",
+        "model_key": "venice:moonshotai/kimi-k2.7-code:text.generate"
+      }
+    },
+    "../../packages/data/catalog/src/data/pricing/venice/nvidia-nemotron-3-ultra-550b-a55b/text.generate/pricing.json": {
+      "hash": "45361e295267f33d520b1f44cbe959fa",
+      "meta": {
+        "api_provider_id": "venice",
+        "capability_id": "text.generate",
+        "model_id": "nvidia/nemotron-3-ultra-550b-a55b",
+        "model_key": "venice:nvidia/nemotron-3-ultra-550b-a55b:text.generate"
+      }
+    },
+    "../../packages/data/catalog/src/data/pricing/venice/qwen-qwen3.7-plus/text.generate/pricing.json": {
+      "hash": "8a34016f4765d55fd8793ac501917b6c",
+      "meta": {
+        "api_provider_id": "venice",
+        "capability_id": "text.generate",
+        "model_id": "qwen/qwen3.7-plus",
+        "model_key": "venice:qwen/qwen3.7-plus:text.generate"
+      }
+    },
+    "../../packages/data/catalog/src/data/pricing/venice/spacex-ai-grok-4.1-fast/text.generate/pricing.json": {
+      "hash": "c6d7f2cd5c57bb2ad348f07d766d68e9",
+      "meta": {
+        "api_provider_id": "venice",
+        "capability_id": "text.generate",
+        "model_id": "spacex-ai/grok-4.1-fast",
+        "model_key": "venice:spacex-ai/grok-4.1-fast:text.generate"
+      }
+    },
+    "../../packages/data/catalog/src/data/pricing/venice/spacex-ai-grok-4.20-beta-0309/text.generate/pricing.json": {
+      "hash": "faa8cafae50f1460af8926c84382942a",
+      "meta": {
+        "api_provider_id": "venice",
+        "capability_id": "text.generate",
+        "model_id": "spacex-ai/grok-4.20-beta-0309",
+        "model_key": "venice:spacex-ai/grok-4.20-beta-0309:text.generate"
+      }
+    },
+    "../../packages/data/catalog/src/data/pricing/venice/spacex-ai-grok-4.20-multi-agent-beta-0309/text.generate/pricing.json": {
+      "hash": "36e12d9509f50fde3552101812d2d6e3",
+      "meta": {
+        "api_provider_id": "venice",
+        "capability_id": "text.generate",
+        "model_id": "spacex-ai/grok-4.20-multi-agent-beta-0309",
+        "model_key": "venice:spacex-ai/grok-4.20-multi-agent-beta-0309:text.generate"
+      }
+    },
+    "../../packages/data/catalog/src/data/pricing/venice/spacex-ai-grok-4.3/text.generate/pricing.json": {
+      "hash": "4118f3cface1c28f581e876b5ca30f68",
+      "meta": {
+        "api_provider_id": "venice",
+        "capability_id": "text.generate",
+        "model_id": "spacex-ai/grok-4.3",
+        "model_key": "venice:spacex-ai/grok-4.3:text.generate"
+      }
+    },
+    "../../packages/data/catalog/src/data/pricing/venice/spacex-ai-grok-build-0.1/text.generate/pricing.json": {
+      "hash": "d20d60927d329ab3de40801030279474",
+      "meta": {
+        "api_provider_id": "venice",
+        "capability_id": "text.generate",
+        "model_id": "spacex-ai/grok-build-0.1",
+        "model_key": "venice:spacex-ai/grok-build-0.1:text.generate"
+      }
+    },
+    "../../packages/data/catalog/src/data/pricing/venice/spacex-ai-grok-code-fast-1/text.generate/pricing.json": {
+      "hash": "b31c636ae6f430470598cf600c9bb04f",
+      "meta": {
+        "api_provider_id": "venice",
+        "capability_id": "text.generate",
+        "model_id": "spacex-ai/grok-code-fast-1",
+        "model_key": "venice:spacex-ai/grok-code-fast-1:text.generate"
+      }
+    },
+    "../../packages/data/catalog/src/data/pricing/venice/z-ai-glm-5.2/text.generate/pricing.json": {
+      "hash": "41dad13f865c8918a53c8e5b880157d9",
+      "meta": {
+        "api_provider_id": "venice",
+        "capability_id": "text.generate",
+        "model_id": "z-ai/glm-5.2",
+        "model_key": "venice:z-ai/glm-5.2:text.generate"
+      }
+    },
+    "../../packages/data/catalog/src/data/pricing/venice-e2ee/z-ai-glm-5.2/text.generate/pricing.json": {
+      "hash": "74d3c2bd67e81adffe9b46e6b8de28d1",
+      "meta": {
+        "api_provider_id": "venice-e2ee",
+        "capability_id": "text.generate",
+        "model_id": "z-ai/glm-5.2",
+        "model_key": "venice-e2ee:z-ai/glm-5.2:text.generate"
+      }
+    },
+    "../../packages/data/catalog/src/data/pricing/weights-and-biases/moonshotai-kimi-k2.7-code/text.generate/pricing.json": {
+      "hash": "e73dc938084ef33ef26eddc767e4570a",
+      "meta": {
+        "api_provider_id": "weights-and-biases",
+        "capability_id": "text.generate",
+        "model_id": "moonshotai/kimi-k2.7-code",
+        "model_key": "weights-and-biases:moonshotai/kimi-k2.7-code:text.generate"
+      }
+    },
+    "../../packages/data/catalog/src/data/pricing/weights-and-biases/z-ai-glm-5.2/text.generate/pricing.json": {
+      "hash": "573a2b8674d1eaa44d0cff2f82ed1ccd",
+      "meta": {
+        "api_provider_id": "weights-and-biases",
+        "capability_id": "text.generate",
+        "model_id": "z-ai/glm-5.2",
+        "model_key": "weights-and-biases:z-ai/glm-5.2:text.generate"
+      }
+    },
+    "../../packages/data/catalog/src/data/pricing/z-ai/z-ai-glm-5.2/text.generate/pricing.json": {
+      "hash": "174f40ff7a27552a3f9e59937d55fed6",
+      "meta": {
+        "api_provider_id": "z-ai",
+        "capability_id": "text.generate",
+        "model_id": "z-ai/glm-5.2",
+        "model_key": "z-ai:z-ai/glm-5.2:text.generate"
+      }
+    },
+    "../../packages/data/catalog/src/data/subscription_plans/amazon-q-developer-free/plan.json": {
+      "hash": "0be3e494185fcfddf935d2c2bf90e8c6",
+      "meta": {
+        "plan_id": "amazon-q-developer-free",
+        "organisation_id": "amazon",
+        "model_ids": []
+      }
+    },
+    "../../packages/data/catalog/src/data/subscription_plans/amazon-q-developer-pro/plan.json": {
+      "hash": "b00fde9d738f66af9f37030ca62f0363",
+      "meta": {
+        "plan_id": "amazon-q-developer-pro",
+        "organisation_id": "amazon",
+        "model_ids": []
+      }
+    },
+    "../../packages/data/catalog/src/data/subscription_plans/chatgpt-business/plan.json": {
+      "hash": "5df898d1ee91edc69818ca9969312198",
+      "meta": {
+        "plan_id": "chatgpt-business",
+        "organisation_id": "openai",
+        "model_ids": [
+          "openai/chatgpt-image-latest",
+          "openai/chat-latest",
+          "openai/gpt-5.5",
+          "openai/gpt-5.5-pro",
+          "openai/o3-deep-research",
+          "openai/gpt-5.1-codex-max",
+          "openai/gpt-5.1-codex-mini"
+        ]
+      }
+    },
+    "../../packages/data/catalog/src/data/subscription_plans/chatgpt-business-codex/plan.json": {
+      "hash": "342d04f64258f6e79b2124088827a79d",
+      "meta": {
+        "plan_id": "chatgpt-business-codex",
+        "organisation_id": "openai",
+        "model_ids": [
+          "openai/gpt-5.3-codex",
+          "openai/gpt-5.3-codex-spark",
+          "openai/gpt-5.2-codex",
+          "openai/gpt-5.1-codex-max",
+          "openai/gpt-5.1-codex-mini"
+        ]
+      }
+    },
+    "../../packages/data/catalog/src/data/subscription_plans/chatgpt-enterprise/plan.json": {
+      "hash": "6a0752b7d9052df9aecf7b2be18c834e",
+      "meta": {
+        "plan_id": "chatgpt-enterprise",
+        "organisation_id": "openai",
+        "model_ids": [
+          "openai/chatgpt-image-latest",
+          "openai/chat-latest",
+          "openai/gpt-5.5",
+          "openai/gpt-5.5-pro",
+          "openai/o3-deep-research",
+          "openai/gpt-5.3-codex",
+          "openai/gpt-5.3-codex-spark",
+          "openai/gpt-5.2-codex",
+          "openai/gpt-5.1-codex-max",
+          "openai/gpt-5.1-codex-mini"
+        ]
+      }
+    },
+    "../../packages/data/catalog/src/data/subscription_plans/chatgpt-pro-20x/plan.json": {
+      "hash": "f0f76b9285a13df745ced8089d5bbc9a",
+      "meta": {
+        "plan_id": "chatgpt-pro-20x",
+        "organisation_id": "openai",
+        "model_ids": [
+          "openai/chatgpt-image-latest",
+          "openai/chat-latest",
+          "openai/gpt-5.5",
+          "openai/gpt-5.5-pro",
+          "openai/o3-deep-research",
+          "openai/gpt-5.1-codex-max",
+          "openai/gpt-5.1-codex-mini"
+        ]
+      }
+    },
+    "../../packages/data/catalog/src/data/subscription_plans/claude-enterprise/plan.json": {
+      "hash": "50b9fda5d485a74df323606f027b27a4",
+      "meta": {
+        "plan_id": "claude-enterprise",
+        "organisation_id": "anthropic",
+        "model_ids": [
+          "anthropic/claude-sonnet-4.6",
+          "anthropic/claude-sonnet-4.5",
+          "anthropic/claude-haiku-4.5",
+          "anthropic/claude-opus-4.6",
+          "anthropic/claude-opus-4.5"
+        ]
+      }
+    },
+    "../../packages/data/catalog/src/data/subscription_plans/claude-team-premium/plan.json": {
+      "hash": "3ab604bc7ef31ef7e82454d8cdfeacbf",
+      "meta": {
+        "plan_id": "claude-team-premium",
+        "organisation_id": "anthropic",
+        "model_ids": [
+          "anthropic/claude-sonnet-4.6",
+          "anthropic/claude-sonnet-4.5",
+          "anthropic/claude-haiku-4.5",
+          "anthropic/claude-opus-4.6",
+          "anthropic/claude-opus-4.5"
+        ]
+      }
+    },
+    "../../packages/data/catalog/src/data/subscription_plans/claude-team-standard/plan.json": {
+      "hash": "1edd66f0939e12c6adc1e753d0ae3ff2",
+      "meta": {
+        "plan_id": "claude-team-standard",
+        "organisation_id": "anthropic",
+        "model_ids": [
+          "anthropic/claude-sonnet-4.6",
+          "anthropic/claude-sonnet-4.5",
+          "anthropic/claude-haiku-4.5",
+          "anthropic/claude-opus-4.6",
+          "anthropic/claude-opus-4.5"
+        ]
+      }
+    },
+    "../../packages/data/catalog/src/data/subscription_plans/cursor-enterprise/plan.json": {
+      "hash": "a67fa6828f0aa626f683dcdfe3a09ea2",
+      "meta": {
+        "plan_id": "cursor-enterprise",
+        "organisation_id": "cursor",
+        "model_ids": [
+          "cursor/composer-2.5",
+          "openai/gpt-5.5",
+          "anthropic/claude-sonnet-4.6",
+          "google/gemini-3.5-flash"
+        ]
+      }
+    },
+    "../../packages/data/catalog/src/data/subscription_plans/cursor-hobby/plan.json": {
+      "hash": "5b4a04bdeaefb8dfb3366b1c439455ce",
+      "meta": {
+        "plan_id": "cursor-hobby",
+        "organisation_id": "cursor",
+        "model_ids": [
+          "cursor/composer-2.5"
+        ]
+      }
+    },
+    "../../packages/data/catalog/src/data/subscription_plans/cursor-pro/plan.json": {
+      "hash": "6f3b9d821743bf881d4d2fa42a694398",
+      "meta": {
+        "plan_id": "cursor-pro",
+        "organisation_id": "cursor",
+        "model_ids": [
+          "cursor/composer-2.5",
+          "openai/gpt-5.5",
+          "anthropic/claude-sonnet-4.6",
+          "google/gemini-3.5-flash"
+        ]
+      }
+    },
+    "../../packages/data/catalog/src/data/subscription_plans/cursor-pro-plus/plan.json": {
+      "hash": "d85d235605d36f2d10f663816495661d",
+      "meta": {
+        "plan_id": "cursor-pro-plus",
+        "organisation_id": "cursor",
+        "model_ids": [
+          "cursor/composer-2.5",
+          "openai/gpt-5.5",
+          "anthropic/claude-sonnet-4.6",
+          "google/gemini-3.5-flash"
+        ]
+      }
+    },
+    "../../packages/data/catalog/src/data/subscription_plans/cursor-teams/plan.json": {
+      "hash": "4293f710de84d9b2e675e60989bfccba",
+      "meta": {
+        "plan_id": "cursor-teams",
+        "organisation_id": "cursor",
+        "model_ids": [
+          "cursor/composer-2.5",
+          "openai/gpt-5.5",
+          "anthropic/claude-sonnet-4.6",
+          "google/gemini-3.5-flash"
+        ]
+      }
+    },
+    "../../packages/data/catalog/src/data/subscription_plans/cursor-ultra/plan.json": {
+      "hash": "17c8c1478e35833777b590e9372081cb",
+      "meta": {
+        "plan_id": "cursor-ultra",
+        "organisation_id": "cursor",
+        "model_ids": [
+          "cursor/composer-2.5",
+          "openai/gpt-5.5",
+          "anthropic/claude-sonnet-4.6",
+          "google/gemini-3.5-flash"
+        ]
+      }
+    },
+    "../../packages/data/catalog/src/data/subscription_plans/github-copilot-business/plan.json": {
+      "hash": "ef506075e12f3990aff8cb1159a2e302",
+      "meta": {
+        "plan_id": "github-copilot-business",
+        "organisation_id": "github",
+        "model_ids": [
+          "openai/gpt-5-mini",
+          "openai/gpt-5.2",
+          "openai/gpt-5.3-codex",
+          "openai/gpt-5.5",
+          "anthropic/claude-sonnet-4.6",
+          "anthropic/claude-opus-4.7",
+          "google/gemini-2.5-pro",
+          "google/gemini-3.5-flash",
+          "spacex-ai/grok-code-fast-1"
+        ]
+      }
+    },
+    "../../packages/data/catalog/src/data/subscription_plans/github-copilot-enterprise/plan.json": {
+      "hash": "e0f8588bab41fcd89a87dff54f7964c6",
+      "meta": {
+        "plan_id": "github-copilot-enterprise",
+        "organisation_id": "github",
+        "model_ids": [
+          "openai/gpt-5-mini",
+          "openai/gpt-5.2",
+          "openai/gpt-5.3-codex",
+          "openai/gpt-5.5",
+          "anthropic/claude-sonnet-4.6",
+          "anthropic/claude-opus-4.7",
+          "anthropic/claude-opus-4.8",
+          "google/gemini-2.5-pro",
+          "google/gemini-3.5-flash",
+          "spacex-ai/grok-code-fast-1"
+        ]
+      }
+    },
+    "../../packages/data/catalog/src/data/subscription_plans/github-copilot-free/plan.json": {
+      "hash": "198b26a26f2eb8e968c3f61372cabb8c",
+      "meta": {
+        "plan_id": "github-copilot-free",
+        "organisation_id": "github",
+        "model_ids": [
+          "openai/gpt-5-mini",
+          "openai/gpt-5.2",
+          "openai/gpt-5.2-codex",
+          "openai/gpt-5.3-codex",
+          "openai/gpt-5.4",
+          "openai/gpt-5.4-mini",
+          "openai/gpt-5.5",
+          "anthropic/claude-haiku-4.5",
+          "anthropic/claude-sonnet-4.5",
+          "anthropic/claude-sonnet-4.6",
+          "anthropic/claude-opus-4.5",
+          "anthropic/claude-opus-4.6",
+          "anthropic/claude-opus-4.7",
+          "google/gemini-2.5-pro",
+          "google/gemini-3-flash-preview",
+          "google/gemini-3.1-pro-preview",
+          "google/gemini-3.5-flash",
+          "spacex-ai/grok-code-fast-1"
+        ]
+      }
+    },
+    "../../packages/data/catalog/src/data/subscription_plans/github-copilot-max/plan.json": {
+      "hash": "cbe9c8eb69ecf754d9c90a1c151be681",
+      "meta": {
+        "plan_id": "github-copilot-max",
+        "organisation_id": "github",
+        "model_ids": [
+          "openai/gpt-5-mini",
+          "openai/gpt-5.2",
+          "openai/gpt-5.2-codex",
+          "openai/gpt-5.3-codex",
+          "openai/gpt-5.4",
+          "openai/gpt-5.4-mini",
+          "openai/gpt-5.5",
+          "anthropic/claude-haiku-4.5",
+          "anthropic/claude-sonnet-4.5",
+          "anthropic/claude-sonnet-4.6",
+          "anthropic/claude-opus-4.5",
+          "anthropic/claude-opus-4.6",
+          "anthropic/claude-opus-4.7",
+          "anthropic/claude-opus-4.8",
+          "google/gemini-2.5-pro",
+          "google/gemini-3-flash-preview",
+          "google/gemini-3.1-pro-preview",
+          "google/gemini-3.5-flash",
+          "spacex-ai/grok-code-fast-1"
+        ]
+      }
+    },
+    "../../packages/data/catalog/src/data/subscription_plans/github-copilot-pro/plan.json": {
+      "hash": "ffb3d0682a27b8fb604244eabc63c49f",
+      "meta": {
+        "plan_id": "github-copilot-pro",
+        "organisation_id": "github",
+        "model_ids": [
+          "openai/gpt-5-mini",
+          "openai/gpt-5.2",
+          "openai/gpt-5.2-codex",
+          "openai/gpt-5.3-codex",
+          "openai/gpt-5.4",
+          "openai/gpt-5.4-mini",
+          "openai/gpt-5.5",
+          "anthropic/claude-haiku-4.5",
+          "anthropic/claude-sonnet-4.5",
+          "anthropic/claude-sonnet-4.6",
+          "anthropic/claude-opus-4.5",
+          "anthropic/claude-opus-4.6",
+          "anthropic/claude-opus-4.7",
+          "anthropic/claude-opus-4.8",
+          "google/gemini-2.5-pro",
+          "google/gemini-3-flash-preview",
+          "google/gemini-3.1-pro-preview",
+          "google/gemini-3.5-flash",
+          "spacex-ai/grok-code-fast-1"
+        ]
+      }
+    },
+    "../../packages/data/catalog/src/data/subscription_plans/github-copilot-pro-plus/plan.json": {
+      "hash": "9e1e1e346d931ef16795a36b39d52115",
+      "meta": {
+        "plan_id": "github-copilot-pro-plus",
+        "organisation_id": "github",
+        "model_ids": [
+          "openai/gpt-5-mini",
+          "openai/gpt-5.2",
+          "openai/gpt-5.2-codex",
+          "openai/gpt-5.3-codex",
+          "openai/gpt-5.4",
+          "openai/gpt-5.4-mini",
+          "openai/gpt-5.5",
+          "anthropic/claude-haiku-4.5",
+          "anthropic/claude-sonnet-4.5",
+          "anthropic/claude-sonnet-4.6",
+          "anthropic/claude-opus-4.5",
+          "anthropic/claude-opus-4.6",
+          "anthropic/claude-opus-4.7",
+          "anthropic/claude-opus-4.8",
+          "google/gemini-2.5-pro",
+          "google/gemini-3-flash-preview",
+          "google/gemini-3.1-pro-preview",
+          "google/gemini-3.5-flash",
+          "spacex-ai/grok-code-fast-1"
+        ]
+      }
+    },
+    "../../packages/data/catalog/src/data/subscription_plans/google-ai-ultra-20x/plan.json": {
+      "hash": "d7d5760130ca21058043a6586fc36b71",
+      "meta": {
+        "plan_id": "google-ai-ultra-20x",
+        "organisation_id": "google",
+        "model_ids": [
+          "google/gemini-3-flash-preview",
+          "google/gemini-3.1-pro-preview"
+        ]
+      }
+    },
+    "../../packages/data/catalog/src/data/subscription_plans/google-antigravity-individual/plan.json": {
+      "hash": "534e1c3f38cbe5b73b61b98939a5e6ea",
+      "meta": {
+        "plan_id": "google-antigravity-individual",
+        "organisation_id": "google",
+        "model_ids": [
+          "google/gemini-3.5-flash",
+          "google/gemini-3.1-pro-preview",
+          "google/gemini-3-flash-preview",
+          "anthropic/claude-sonnet-4.6",
+          "anthropic/claude-opus-4.6",
+          "openai/gpt-oss-120b"
+        ]
+      }
+    },
+    "../../packages/data/catalog/src/data/subscription_plans/google-antigravity-organization/plan.json": {
+      "hash": "f21775c687168bcc4b87eea50e765d1a",
+      "meta": {
+        "plan_id": "google-antigravity-organization",
+        "organisation_id": "google",
+        "model_ids": [
+          "google/gemini-3.5-flash",
+          "google/gemini-3.1-pro-preview",
+          "google/gemini-3-flash-preview",
+          "anthropic/claude-sonnet-4.6",
+          "anthropic/claude-opus-4.6",
+          "openai/gpt-oss-120b"
+        ]
+      }
+    },
+    "../../packages/data/catalog/src/data/subscription_plans/google-antigravity-pro/plan.json": {
+      "hash": "101e3553d7f13d09ae9fdca47f7082dd",
+      "meta": {
+        "plan_id": "google-antigravity-pro",
+        "organisation_id": "google",
+        "model_ids": [
+          "google/gemini-3.5-flash",
+          "google/gemini-3.1-pro-preview",
+          "google/gemini-3-flash-preview",
+          "anthropic/claude-sonnet-4.6",
+          "anthropic/claude-opus-4.6",
+          "openai/gpt-oss-120b"
+        ]
+      }
+    },
+    "../../packages/data/catalog/src/data/subscription_plans/google-antigravity-ultra/plan.json": {
+      "hash": "0b4828f0fa43b6b8a7b5d8f7cc2c716b",
+      "meta": {
+        "plan_id": "google-antigravity-ultra",
+        "organisation_id": "google",
+        "model_ids": [
+          "google/gemini-3.5-flash",
+          "google/gemini-3.1-pro-preview",
+          "google/gemini-3-flash-preview",
+          "anthropic/claude-sonnet-4.6",
+          "anthropic/claude-opus-4.6",
+          "openai/gpt-oss-120b"
+        ]
+      }
+    },
+    "../../packages/data/catalog/src/data/subscription_plans/perplexity-enterprise-max/plan.json": {
+      "hash": "39efccbbf7723eec5b801d9573ca11ce",
+      "meta": {
+        "plan_id": "perplexity-enterprise-max",
+        "organisation_id": "perplexity",
+        "model_ids": [
+          "openai/gpt-5.2",
+          "anthropic/claude-sonnet-4.5",
+          "anthropic/claude-opus-4.5",
+          "google/gemini-3.1-pro-preview",
+          "spacex-ai/grok-4.1-fast"
+        ]
+      }
+    },
+    "../../packages/data/catalog/src/data/subscription_plans/perplexity-enterprise-pro/plan.json": {
+      "hash": "f6771552f9433f6203158a159b086955",
+      "meta": {
+        "plan_id": "perplexity-enterprise-pro",
+        "organisation_id": "perplexity",
+        "model_ids": [
+          "openai/gpt-5.2",
+          "anthropic/claude-sonnet-4.5",
+          "google/gemini-3.1-pro-preview",
+          "spacex-ai/grok-4.1-fast"
+        ]
+      }
+    },
+    "../../packages/data/catalog/src/data/subscription_plans/poe-1-65m/plan.json": {
+      "hash": "ebf595b735c040ae886a84fd7dbc8b8e",
+      "meta": {
+        "plan_id": "poe-1-65m",
+        "organisation_id": "poe",
+        "model_ids": [
+          "openai/gpt-5.5",
+          "anthropic/claude-opus-4.7",
+          "google/gemini-3.5-flash",
+          "google/gemini-3-pro-image",
+          "google/veo-3.1-preview"
+        ]
+      }
+    },
+    "../../packages/data/catalog/src/data/subscription_plans/poe-10k-daily/plan.json": {
+      "hash": "9c9d44fd8dbda5d4ff22a5ac71091a96",
+      "meta": {
+        "plan_id": "poe-10k-daily",
+        "organisation_id": "poe",
+        "model_ids": [
+          "openai/gpt-5.5",
+          "anthropic/claude-opus-4.7",
+          "google/gemini-3.5-flash",
+          "google/gemini-3-pro-image",
+          "google/veo-3.1-preview"
+        ]
+      }
+    },
+    "../../packages/data/catalog/src/data/subscription_plans/poe-3-3m/plan.json": {
+      "hash": "8252e151e7ada991a70416540ddf024a",
+      "meta": {
+        "plan_id": "poe-3-3m",
+        "organisation_id": "poe",
+        "model_ids": [
+          "openai/gpt-5.5",
+          "anthropic/claude-opus-4.7",
+          "google/gemini-3.5-flash",
+          "google/gemini-3-pro-image",
+          "google/veo-3.1-preview"
+        ]
+      }
+    },
+    "../../packages/data/catalog/src/data/subscription_plans/poe-660k/plan.json": {
+      "hash": "92d2d46b1f5fa6028facbe49fff9fad8",
+      "meta": {
+        "plan_id": "poe-660k",
+        "organisation_id": "poe",
+        "model_ids": [
+          "openai/gpt-5.5",
+          "anthropic/claude-opus-4.7",
+          "google/gemini-3.5-flash",
+          "google/gemini-3-pro-image",
+          "google/veo-3.1-preview"
+        ]
+      }
+    },
+    "../../packages/data/catalog/src/data/subscription_plans/poe-8-25m/plan.json": {
+      "hash": "afedb60ca6dd54974ae27ebafe4d13ae",
+      "meta": {
+        "plan_id": "poe-8-25m",
+        "organisation_id": "poe",
+        "model_ids": [
+          "openai/gpt-5.5",
+          "anthropic/claude-opus-4.7",
+          "google/gemini-3.5-flash",
+          "google/gemini-3-pro-image",
+          "google/veo-3.1-preview"
+        ]
+      }
+    },
+    "../../packages/data/catalog/src/data/subscription_plans/v0-business/plan.json": {
+      "hash": "9ea4a437ebc0337a378891fd6f91f042",
+      "meta": {
+        "plan_id": "v0-business",
+        "organisation_id": "vercel",
+        "model_ids": [
+          "vercel/v0-1.5-sm",
+          "vercel/v0-1.5-md",
+          "vercel/v0-1.5-lg"
+        ]
+      }
+    },
+    "../../packages/data/catalog/src/data/subscription_plans/v0-enterprise/plan.json": {
+      "hash": "17aec5cf43b4b4615792da68053b4e0e",
+      "meta": {
+        "plan_id": "v0-enterprise",
+        "organisation_id": "vercel",
+        "model_ids": [
+          "vercel/v0-1.5-sm",
+          "vercel/v0-1.5-md",
+          "vercel/v0-1.5-lg"
+        ]
+      }
+    },
+    "../../packages/data/catalog/src/data/subscription_plans/v0-free/plan.json": {
+      "hash": "ebfb60cb0a6f8d9c6a6452e23332d3d1",
+      "meta": {
+        "plan_id": "v0-free",
+        "organisation_id": "vercel",
+        "model_ids": [
+          "vercel/v0-1.5-sm",
+          "vercel/v0-1.5-md",
+          "vercel/v0-1.5-lg"
+        ]
+      }
+    },
+    "../../packages/data/catalog/src/data/subscription_plans/v0-premium-legacy/plan.json": {
+      "hash": "afe4ce8cebc37104bab2214c821417b2",
+      "meta": {
+        "plan_id": "v0-premium-legacy",
+        "organisation_id": "vercel",
+        "model_ids": [
+          "vercel/v0-1.5-sm",
+          "vercel/v0-1.5-md",
+          "vercel/v0-1.5-lg"
+        ]
+      }
+    },
+    "../../packages/data/catalog/src/data/subscription_plans/v0-team/plan.json": {
+      "hash": "cfb71b17f10ddce11ab1877a7736d721",
+      "meta": {
+        "plan_id": "v0-team",
+        "organisation_id": "vercel",
+        "model_ids": [
+          "vercel/v0-1.5-sm",
+          "vercel/v0-1.5-md",
+          "vercel/v0-1.5-lg"
+        ]
+      }
+    },
+    "../../packages/data/catalog/src/data/subscription_plans/windsurf-enterprise/plan.json": {
+      "hash": "7cf119e1c1dadf739a63d95877cf3b24",
+      "meta": {
+        "plan_id": "windsurf-enterprise",
+        "organisation_id": "windsurf",
+        "model_ids": [
+          "windsurf/swe-1.6",
+          "windsurf/swe-1.6-fast",
+          "windsurf/swe-1.5",
+          "windsurf/swe-1-mini",
+          "windsurf/swe-grep"
+        ]
+      }
+    },
+    "../../packages/data/catalog/src/data/subscription_plans/windsurf-free/plan.json": {
+      "hash": "138fd0634916f65b4be5771f748b4d6d",
+      "meta": {
+        "plan_id": "windsurf-free",
+        "organisation_id": "windsurf",
+        "model_ids": [
+          "windsurf/swe-1.6",
+          "windsurf/swe-1.5",
+          "windsurf/swe-1-mini",
+          "windsurf/swe-grep"
+        ]
+      }
+    },
+    "../../packages/data/catalog/src/data/subscription_plans/windsurf-max/plan.json": {
+      "hash": "f03a67f8f910580168ae45fe24d2a435",
+      "meta": {
+        "plan_id": "windsurf-max",
+        "organisation_id": "windsurf",
+        "model_ids": [
+          "windsurf/swe-1.6",
+          "windsurf/swe-1.6-fast",
+          "windsurf/swe-1.5",
+          "windsurf/swe-1-mini",
+          "windsurf/swe-grep"
+        ]
+      }
+    },
+    "../../packages/data/catalog/src/data/subscription_plans/windsurf-pro/plan.json": {
+      "hash": "d7a82260b6898739584dd6809925233e",
+      "meta": {
+        "plan_id": "windsurf-pro",
+        "organisation_id": "windsurf",
+        "model_ids": [
+          "windsurf/swe-1.6",
+          "windsurf/swe-1.6-fast",
+          "windsurf/swe-1.5",
+          "windsurf/swe-1-mini",
+          "windsurf/swe-grep"
+        ]
+      }
+    },
+    "../../packages/data/catalog/src/data/subscription_plans/windsurf-teams/plan.json": {
+      "hash": "e1bf5178a28cc09317bdee5e10e8b1cc",
+      "meta": {
+        "plan_id": "windsurf-teams",
+        "organisation_id": "windsurf",
+        "model_ids": [
+          "windsurf/swe-1.6",
+          "windsurf/swe-1.6-fast",
+          "windsurf/swe-1.5",
+          "windsurf/swe-1-mini",
+          "windsurf/swe-grep"
+        ]
       }
     }
   }

--- a/supabase/migrations/20260716143000_pricing_rule_sku_metadata.sql
+++ b/supabase/migrations/20260716143000_pricing_rule_sku_metadata.sql
@@ -1,0 +1,94 @@
+create table if not exists public.data_api_pricing_skus (
+  model_key text not null,
+  capability_id text not null,
+  sku_id text not null,
+  label text not null,
+  kind text not null,
+  display_order integer not null default 100,
+  unit_label text not null,
+  display_multiplier numeric null,
+  description text null,
+  is_billable boolean not null default true,
+  derived_from_sku_id text null,
+  derived_quantity numeric null,
+  metadata jsonb not null default '{}'::jsonb,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  primary key (model_key, sku_id)
+);
+
+alter table if exists public.data_api_pricing_rules
+  add column if not exists sku_id text,
+  add column if not exists tier_id text,
+  add column if not exists tier_label text,
+  add column if not exists tier_order integer;
+
+update public.data_api_pricing_rules
+set
+  sku_id = coalesce(
+    nullif(btrim(sku_id), ''),
+    trim(both '-' from regexp_replace(lower(meter), '[^a-z0-9]+', '-', 'g')),
+    'usage'
+  ),
+  tier_id = coalesce(nullif(btrim(tier_id), ''), 'default'),
+  tier_label = coalesce(nullif(btrim(tier_label), ''), 'Standard'),
+  tier_order = coalesce(tier_order, 1)
+where
+  sku_id is null or btrim(sku_id) = '' or
+  tier_id is null or btrim(tier_id) = '' or
+  tier_label is null or btrim(tier_label) = '' or
+  tier_order is null;
+
+alter table if exists public.data_api_pricing_rules
+  alter column sku_id set not null,
+  alter column tier_id set not null,
+  alter column tier_label set not null,
+  alter column tier_order set not null;
+
+insert into public.data_api_pricing_skus (
+  model_key,
+  capability_id,
+  sku_id,
+  label,
+  kind,
+  display_order,
+  unit_label,
+  display_multiplier,
+  metadata
+)
+select distinct on (model_key, sku_id)
+  model_key,
+  capability_id,
+  sku_id,
+  initcap(replace(sku_id, '-', ' ')),
+  unit,
+  case
+    when meter like 'input_%' then 10
+    when meter like 'cached_read_%' then 20
+    when meter like 'cached_write_%' then 30
+    when meter like 'output_%' then 40
+    else 100
+  end,
+  case when unit = 'token' then '/M tokens' else '/' || unit end,
+  case when unit = 'token' then 1000000 else null end,
+  jsonb_build_object(
+    'calculator_input',
+    jsonb_build_object('key', meter, 'label', initcap(replace(meter, '_', ' ')), 'type', 'number')
+  )
+from public.data_api_pricing_rules
+on conflict (model_key, sku_id) do nothing;
+
+do $$
+begin
+  if not exists (
+    select 1
+    from pg_constraint
+    where conname = 'data_api_pricing_rules_sku_fk'
+      and conrelid = 'public.data_api_pricing_rules'::regclass
+  ) then
+    alter table public.data_api_pricing_rules
+      add constraint data_api_pricing_rules_sku_fk
+      foreign key (model_key, sku_id)
+      references public.data_api_pricing_skus (model_key, sku_id);
+  end if;
+end $$;


### PR DESCRIPTION
## Summary
- make hash-based incremental imports the default and reserve complete reconciliation for `--full`
- persist importer state between main-branch CI runners and serialize importer jobs
- only retry transient database/network failures and add per-section timing output
- avoid rewriting unchanged provider mappings and prevent targeted model imports from consuming unrelated provider hashes
- support pricing SKU/tier metadata and parent SKU rows required by the production schema
- seed the import-state baseline after a successful production catch-up

## Production rollout
- applied and recorded `20260708110000_add_model_link_titles.sql`
- applied and recorded `20260716143000_pricing_rule_sku_metadata.sql`
- reconciled provider data and imported Kimi K3 as Rumoured

## Validation
- `pnpm --filter @phaseo/web exec jest --runInBand --runTestsByPath scripts/importer/state.test.ts scripts/importer/supa.test.ts scripts/importer/pricingMetadata.test.ts scripts/importer/loaders/providers.test.ts`
- `pnpm --filter @phaseo/web exec next typegen`
- `pnpm --filter @phaseo/web exec tsc --noEmit --pretty false`
- targeted importer ESLint: 0 errors
- `pnpm validate:data`
- CI workflow parsed with `js-yaml`
- production catch-up import: 178 seconds for 368 changed models and 294 changed pricing keys
- production warm no-op import: 5.3 seconds, no catalogue writes
- targeted Gemini, Kimi K3, GPT-5.6 Luna pricing, and full provider imports succeeded

Created with Codex