### PR TITLE
Add Venice support for Kimi K3

### DIFF
--- a/apps/api/tests/aimock/cross-provider-models.spec.ts
+++ b/apps/api/tests/aimock/cross-provider-models.spec.ts
@@ -92,9 +92,9 @@ describe("cross-provider model deployment matrix", () => {
         }).toMatchObject({
             models: 355,
             providers: 49,
-            deployments: 795,
-            multiProviderModels: 126,
-            multiProviderDeployments: 563,
+            deployments: 796,
+            multiProviderModels: 127,
+            multiProviderDeployments: 565,
             missing: [],
         });
     });

--- a/packages/data/catalog/src/data/api_providers/venice-e2ee/models.json
+++ b/packages/data/catalog/src/data/api_providers/venice-e2ee/models.json
@@ -271,5 +271,69 @@
         "params": []
       }
     ]
+  },
+  {
+    "api_model_id": "moonshotai/kimi-k3",
+    "provider_api_model_id": "venice/e2ee:moonshotai/kimi-k3",
+    "provider_model_slug": "e2ee-kimi-k3",
+    "internal_model_id": "moonshotai/kimi-k3",
+    "is_active_gateway": false,
+    "quantization_scheme": null,
+    "input_modalities": "text,image",
+    "output_modalities": "text",
+    "context_length": 1000000,
+    "max_output_tokens": 131072,
+    "effective_from": "2026-07-16T00:00:00",
+    "effective_to": null,
+    "capabilities": [
+      {
+        "capability_id": "text.generate",
+        "status": "active",
+        "params": [
+          {
+            "param_id": "max_tokens",
+            "provider_min": 1,
+            "provider_max": 131072,
+            "provider_default": null,
+            "notes": "Prepared for Venice's E2EE Kimi K3 route; enable after the upstream model ID is published and responds successfully."
+          },
+          {
+            "param_id": "reasoning.effort",
+            "provider_min": null,
+            "provider_max": null,
+            "provider_default": "max",
+            "notes": "Kimi K3 supports max reasoning effort."
+          },
+          {
+            "param_id": "response_format",
+            "provider_min": null,
+            "provider_max": null,
+            "provider_default": null,
+            "notes": null
+          },
+          {
+            "param_id": "structured_outputs",
+            "provider_min": null,
+            "provider_max": null,
+            "provider_default": null,
+            "notes": null
+          },
+          {
+            "param_id": "tool_choice",
+            "provider_min": null,
+            "provider_max": null,
+            "provider_default": null,
+            "notes": null
+          },
+          {
+            "param_id": "tools",
+            "provider_min": null,
+            "provider_max": null,
+            "provider_default": null,
+            "notes": null
+          }
+        ]
+      }
+    ]
   }
 ]

--- a/packages/data/catalog/src/data/api_providers/venice-e2ee/models.json
+++ b/packages/data/catalog/src/data/api_providers/venice-e2ee/models.json
@@ -283,7 +283,7 @@
     "output_modalities": "text",
     "context_length": 1000000,
     "max_output_tokens": 131072,
-    "effective_from": "2026-07-16T00:00:00",
+    "effective_from": "2026-07-16T00:00:00Z",
     "effective_to": null,
     "capabilities": [
       {

--- a/packages/data/catalog/src/data/api_providers/venice/models.json
+++ b/packages/data/catalog/src/data/api_providers/venice/models.json
@@ -811,7 +811,7 @@
     "output_modalities": "text",
     "context_length": 1000000,
     "max_output_tokens": 131072,
-    "effective_from": "2026-07-16T00:00:00",
+    "effective_from": "2026-07-16T00:00:00Z",
     "effective_to": null,
     "capabilities": [
       {

--- a/packages/data/catalog/src/data/api_providers/venice/models.json
+++ b/packages/data/catalog/src/data/api_providers/venice/models.json
@@ -801,6 +801,70 @@
     ]
   },
   {
+    "api_model_id": "moonshotai/kimi-k3",
+    "provider_api_model_id": "venice:moonshotai/kimi-k3",
+    "provider_model_slug": "kimi-k3",
+    "internal_model_id": "moonshotai/kimi-k3",
+    "is_active_gateway": true,
+    "quantization_scheme": null,
+    "input_modalities": "text,image",
+    "output_modalities": "text",
+    "context_length": 1000000,
+    "max_output_tokens": 131072,
+    "effective_from": "2026-07-16T00:00:00",
+    "effective_to": null,
+    "capabilities": [
+      {
+        "capability_id": "text.generate",
+        "status": "active",
+        "params": [
+          {
+            "param_id": "max_tokens",
+            "provider_min": 1,
+            "provider_max": 131072,
+            "provider_default": null,
+            "notes": "Venice reports a 131,072-token maximum completion length."
+          },
+          {
+            "param_id": "reasoning.effort",
+            "provider_min": null,
+            "provider_max": null,
+            "provider_default": "max",
+            "notes": "Venice currently supports only max reasoning effort for Kimi K3."
+          },
+          {
+            "param_id": "response_format",
+            "provider_min": null,
+            "provider_max": null,
+            "provider_default": null,
+            "notes": "Venice reports response-schema support for Kimi K3."
+          },
+          {
+            "param_id": "structured_outputs",
+            "provider_min": null,
+            "provider_max": null,
+            "provider_default": null,
+            "notes": "Venice reports response-schema support for Kimi K3."
+          },
+          {
+            "param_id": "tool_choice",
+            "provider_min": null,
+            "provider_max": null,
+            "provider_default": null,
+            "notes": null
+          },
+          {
+            "param_id": "tools",
+            "provider_min": null,
+            "provider_max": null,
+            "provider_default": null,
+            "notes": null
+          }
+        ]
+      }
+    ]
+  },
+  {
     "api_model_id": "moonshotai/kimi-k2-thinking",
     "provider_api_model_id": "venice:moonshotai/kimi-k2-thinking",
     "provider_model_slug": "kimi-k2-thinking",

--- a/packages/data/catalog/src/data/models/moonshotai/kimi-k3/model.json
+++ b/packages/data/catalog/src/data/models/moonshotai/kimi-k3/model.json
@@ -24,6 +24,16 @@
       "title": "Pricing",
       "kind": "pricing",
       "url": "https://platform.kimi.ai/docs/pricing/chat-k3"
+    },
+    {
+      "title": "Venice API Models",
+      "kind": "docs",
+      "url": "https://docs.venice.ai/models/overview"
+    },
+    {
+      "title": "Venice API Pricing",
+      "kind": "pricing",
+      "url": "https://docs.venice.ai/overview/pricing"
     }
   ],
   "details": [
@@ -69,7 +79,7 @@
     },
     {
       "name": "availability_note",
-      "value": "Moonshot AI has published Kimi K3 API documentation and pricing. Moonshot AI is the only confirmed API provider currently listed; full model weights and the technical report are still forthcoming."
+      "value": "Moonshot AI and Venice provide Kimi K3 API access. Venice currently exposes the standard kimi-k3 route; its live model catalog does not yet expose an E2EE Kimi K3 model ID. Full model weights and the technical report are still forthcoming."
     }
   ],
   "benchmarks": []

--- a/packages/data/catalog/src/data/pricing/venice/moonshotai-kimi-k3/text.generate/pricing.json
+++ b/packages/data/catalog/src/data/pricing/venice/moonshotai-kimi-k3/text.generate/pricing.json
@@ -1,0 +1,45 @@
+{
+  "key": "venice:moonshotai/kimi-k3:text.generate",
+  "api_provider_id": "venice",
+  "provider_slug": "venice",
+  "api_model_id": "moonshotai/kimi-k3",
+  "capability_id": "text.generate",
+  "rules": [
+    {
+      "meter": "input_text_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 3.75,
+      "currency": "USD",
+      "pricing_plan": "standard",
+      "note": null,
+      "match": [],
+      "priority": 100,
+      "effective_from": "2026-07-16T00:00:00Z"
+    },
+    {
+      "meter": "cached_read_text_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 0.375,
+      "currency": "USD",
+      "pricing_plan": "standard",
+      "note": null,
+      "match": [],
+      "priority": 100,
+      "effective_from": "2026-07-16T00:00:00Z"
+    },
+    {
+      "meter": "output_text_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 18.75,
+      "currency": "USD",
+      "pricing_plan": "standard",
+      "note": null,
+      "match": [],
+      "priority": 100,
+      "effective_from": "2026-07-16T00:00:00Z"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- add Kimi K3 as an active Venice gateway deployment using the live `kimi-k3` upstream model
- add Venice pricing from the live models API: $3.75/M input, $0.375/M cached input, and $18.75/M output
- record Venice's 1,000,000-token context, 131,072-token output limit, vision, reasoning, tool, and structured-output support
- prepare the Venice E2EE deployment as inactive until Venice publishes a working E2EE K3 model ID and pricing
- update AIMock deployment coverage

## Verification

- live Venice `GET /api/v1/models` lookup
- live Venice K3 chat-completions request returned HTTP 200 with usage
- tested `e2ee-kimi-k3` and `e2ee-kimi-k3-p`; both currently return HTTP 404
- `pnpm validate:data`
- `pnpm validate:pricing`
- `pnpm validate:gateway`
- `pnpm --filter @phaseo/gateway-api test:aimock` (1,871 tests passed)

Created with Codex

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added Venice catalog entries for the Moonshot AI **Kimi K3** model, including extended text generation parameters and long-context support.
  - Enabled support metadata for **text/image inputs** and **text outputs** (E2EE variant).
  - Added **standard token-based pricing** for input, cached input, and output.
- **Documentation**
  - Updated model availability notes and added Venice API **Models/Pricing** links, clarifying exposed routes vs. E2EE model ID availability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->