### PR TITLE
Derive benchmark ranks via RPC

### DIFF
--- a/apps/web/scripts/importer/loaders/models.ts
+++ b/apps/web/scripts/importer/loaders/models.ts
@@ -499,7 +499,6 @@ export async function loadModels(
                     is_self_reported: !!b.is_self_reported,
                     other_info: b.other_info ?? null,
                     source_link: b.source_link ?? null,
-                    rank: b.rank ?? null,
                     occur_idx,
                     variant: null,       // keep null for now; add if you later encode run config
                     result_key,

--- a/apps/web/src/app/(dashboard)/internal/audit/actions-advanced.ts
+++ b/apps/web/src/app/(dashboard)/internal/audit/actions-advanced.ts
@@ -333,7 +333,6 @@ export interface CreateBenchmarkResultInput {
 	isSelfReported: boolean;
 	otherInfo?: string;
 	sourceLink?: string;
-	rank?: number;
 }
 
 export async function createBenchmarkResult(input: CreateBenchmarkResultInput) {
@@ -349,7 +348,6 @@ export async function createBenchmarkResult(input: CreateBenchmarkResultInput) {
 		is_self_reported: input.isSelfReported,
 		other_info: input.otherInfo || null,
 		source_link: input.sourceLink || null,
-		rank: input.rank || null,
 	});
 
 	if (error) {
@@ -374,7 +372,6 @@ export interface UpdateBenchmarkResultInput {
 	isSelfReported?: boolean;
 	otherInfo?: string;
 	sourceLink?: string;
-	rank?: number;
 }
 
 export async function updateBenchmarkResult(input: UpdateBenchmarkResultInput) {
@@ -389,7 +386,6 @@ export async function updateBenchmarkResult(input: UpdateBenchmarkResultInput) {
 		updateData.is_self_reported = input.isSelfReported;
 	if (input.otherInfo !== undefined) updateData.other_info = input.otherInfo || null;
 	if (input.sourceLink !== undefined) updateData.source_link = input.sourceLink || null;
-	if (input.rank !== undefined) updateData.rank = input.rank || null;
 
 	const { error } = await supabase
 		.from("data_benchmark_results")

--- a/apps/web/src/app/(dashboard)/models/actions.ts
+++ b/apps/web/src/app/(dashboard)/models/actions.ts
@@ -141,7 +141,6 @@ export interface ModelUpdatePayload {
     other_info?: string | null
     source_link?: string | null
     variant?: string | null
-    rank?: number | null
   }>
   pricing_rules?: Array<{
     id?: string
@@ -541,7 +540,6 @@ export async function updateModel(payload: ModelUpdatePayload) {
         other_info: result.other_info?.trim() || null,
         source_link: result.source_link?.trim() || null,
         variant: result.variant?.trim() || null,
-        rank: result.rank ?? null,
         created_at: nowIso,
         updated_at: nowIso,
       }))

--- a/apps/web/src/components/(data)/model/benchmarks/BenchmarkDialog.tsx
+++ b/apps/web/src/components/(data)/model/benchmarks/BenchmarkDialog.tsx
@@ -32,8 +32,6 @@ interface BenchmarkDialogProps {
 	benchmarkName: string;
 	models: BenchmarkComparisonModel[];
 	isLowerBetter: boolean;
-	currentRank: number | null;
-	totalModels: number | null;
 	currentScoreDisplay: string | null;
 }
 
@@ -203,8 +201,6 @@ export function BenchmarkDialog({
 	benchmarkName,
 	models,
 	isLowerBetter,
-	currentRank,
-	totalModels,
 	currentScoreDisplay,
 }: BenchmarkDialogProps) {
 	const isMobile = useIsMobile();
@@ -255,12 +251,6 @@ export function BenchmarkDialog({
 						{currentScoreDisplay && (
 							<Badge variant="secondary">
 								{currentScoreDisplay}
-							</Badge>
-						)}
-						{currentRank != null && (
-							<Badge variant="outline">
-								Rank #{currentRank}
-								{totalModels != null ? `/${totalModels}` : ""}
 							</Badge>
 						)}
 						{isLowerBetter && (

--- a/apps/web/src/components/(data)/model/benchmarks/ModelBenchmarksComparisonGrid.tsx
+++ b/apps/web/src/components/(data)/model/benchmarks/ModelBenchmarksComparisonGrid.tsx
@@ -406,8 +406,6 @@ export function ModelBenchmarksComparisonGrid({
 		currentModel?.topScoreDisplay ??
 		selectedComparison.current.scoreDisplay ??
 		null;
-	const currentRank =
-		currentModel?.rank ?? selectedComparison.current.rank ?? null;
 	const totalModels = selectedComparison.totalModels ?? null;
 
 	return (
@@ -469,12 +467,6 @@ export function ModelBenchmarksComparisonGrid({
 				<div className="flex flex-wrap items-center gap-2">
 					{currentScoreDisplay ? (
 						<Badge variant="secondary">{currentScoreDisplay}</Badge>
-					) : null}
-					{currentRank != null ? (
-						<Badge variant="outline">
-							Rank #{currentRank}
-							{totalModels != null ? `/${totalModels}` : ""}
-						</Badge>
 					) : null}
 					{totalModels != null ? (
 						<Badge variant="secondary">{totalModels} models</Badge>
@@ -608,8 +600,6 @@ export function ModelBenchmarksComparisonGrid({
 				benchmarkName={selectedComparison.benchmarkName}
 				models={allModels}
 				isLowerBetter={isLowerBetter}
-				currentRank={currentRank}
-				totalModels={totalModels}
 				currentScoreDisplay={currentScoreDisplay}
 			/>
 		</div>

--- a/apps/web/src/components/monitor/ComprehensiveModelEditor.tsx
+++ b/apps/web/src/components/monitor/ComprehensiveModelEditor.tsx
@@ -205,7 +205,6 @@ export function ComprehensiveModelEditor({
 		isSelfReported: boolean;
 		sourceLink: string;
 		otherInfo: string;
-		rank: string;
 	} | null>(null);
 
 	// Fetch ALL data when dialog opens
@@ -565,7 +564,6 @@ export function ComprehensiveModelEditor({
 			isSelfReported: benchmark.is_self_reported,
 			sourceLink: benchmark.source_link || "",
 			otherInfo: benchmark.other_info || "",
-			rank: benchmark.rank ? String(benchmark.rank) : "",
 		});
 	};
 
@@ -580,7 +578,6 @@ export function ComprehensiveModelEditor({
 				isSelfReported: editBenchmarkForm.isSelfReported,
 				sourceLink: editBenchmarkForm.sourceLink || undefined,
 				otherInfo: editBenchmarkForm.otherInfo || undefined,
-				rank: editBenchmarkForm.rank ? parseInt(editBenchmarkForm.rank) : undefined,
 			});
 
 			if (result.success) {

--- a/apps/web/src/lib/fetchers/benchmarks/getBenchmark.ts
+++ b/apps/web/src/lib/fetchers/benchmarks/getBenchmark.ts
@@ -1,6 +1,7 @@
 // lib/fetchers/benchmarks/getBenchmark.ts
 import { createAdminClient } from "@/utils/supabase/admin";
 import { cacheLife, cacheTag } from "next/cache";
+import { getBenchmarkResultRankings } from "@/lib/fetchers/benchmarks/getBenchmarkResultRankings";
 
 // BenchmarkPage (with results) is defined later in this file.
 export interface Organisation {
@@ -100,12 +101,42 @@ export default async function getBenchmark(
     const row = benchmarks as any | undefined;
     if (!row) return null;
 
+    let derivedRankByResultId = new Map<
+        string,
+        { rank: number | null; totalRankedModels: number | null }
+    >();
+    try {
+        const derivedRankings = await getBenchmarkResultRankings({
+            benchmarkIds: [benchmark_id],
+            includeHidden,
+        });
+        derivedRankByResultId = new Map(
+            derivedRankings.map((ranking) => [
+                ranking.resultId,
+                {
+                    rank: ranking.rank,
+                    totalRankedModels: ranking.totalRankedModels,
+                },
+            ])
+        );
+    } catch (rankingError) {
+        // Keep rolling deployments functional until the RPC migration is live.
+        console.warn("[benchmarks] Falling back to persisted benchmark ranks", {
+            benchmarkId: benchmark_id,
+            error:
+                rankingError instanceof Error
+                    ? rankingError.message
+                    : String(rankingError),
+        });
+    }
+
     const results: BenchmarkResult[] = (row.data_benchmark_results ?? [])
         .filter((r: any) => {
             if (includeHidden) return true;
             return !r?.data_models?.hidden;
         })
         .map((r: any) => {
+        const derivedRanking = derivedRankByResultId.get(String(r.id));
         const modelRow = r.data_models ?? null;
         const orgRow = modelRow?.data_organisations ?? null;
 
@@ -140,10 +171,14 @@ export default async function getBenchmark(
             source_link: r.source_link ?? null,
             created_at: r.created_at ?? null,
             updated_at: r.updated_at ?? null,
-            rank: r.rank ?? null,
+            rank: derivedRanking ? derivedRanking.rank : (r.rank ?? null),
             model,
         } as BenchmarkResult;
     });
+
+    const derivedTotalModels = Array.from(derivedRankByResultId.values()).find(
+        (ranking) => ranking.totalRankedModels != null
+    )?.totalRankedModels;
 
     const formatted: BenchmarkPage = {
         id: row.id,
@@ -151,7 +186,7 @@ export default async function getBenchmark(
         category: row.category ?? null,
         ascending_order:
             typeof row.ascending_order === "boolean" ? row.ascending_order : null,
-        total_models: row.total_models ?? null,
+        total_models: derivedTotalModels ?? row.total_models ?? null,
         link: row.link ?? null,
         results,
         type: row.type ?? null,

--- a/apps/web/src/lib/fetchers/benchmarks/getBenchmarkResultRankings.test.ts
+++ b/apps/web/src/lib/fetchers/benchmarks/getBenchmarkResultRankings.test.ts
@@ -1,0 +1,53 @@
+import { mapDerivedBenchmarkRankingRow } from "./getBenchmarkResultRankings";
+
+const BASE_ROW = {
+	result_id: "7e4f01e2-1ae2-48db-811b-72ca0351b2b5",
+	model_id: "moonshotai/kimi-k3",
+	benchmark_id: "deepswe",
+	score: "67.5",
+	score_numeric: "67.5",
+	is_self_reported: true,
+	other_info: "KimiCode harness",
+	source_link: "https://www.kimi.com/blog/kimi-k3",
+	created_at: "2026-07-17T00:00:00.000Z",
+	updated_at: "2026-07-17T00:00:00.000Z",
+	occur_idx: 1,
+	variant: null,
+	result_key: "moonshotai/kimi-k3|deepswe|hash|1",
+	benchmark_rank: "2",
+	total_ranked_models: "17",
+	is_primary_result: true,
+	model_name: "Kimi K3",
+	release_date: "2026-07-16T00:00:00.000Z",
+	announcement_date: "2026-07-16T00:00:00.000Z",
+	organisation_id: "moonshotai",
+	organisation_name: "Moonshot AI",
+	organisation_colour: "#000000",
+};
+
+describe("mapDerivedBenchmarkRankingRow", () => {
+	it("normalizes Postgres numeric and bigint strings", () => {
+		expect(mapDerivedBenchmarkRankingRow(BASE_ROW)).toMatchObject({
+			resultId: BASE_ROW.result_id,
+			modelId: "moonshotai/kimi-k3",
+			benchmarkId: "deepswe",
+			scoreNumeric: 67.5,
+			rank: 2,
+			totalRankedModels: 17,
+			isPrimaryResult: true,
+		});
+	});
+
+	it("treats invalid and non-positive ranking values as unavailable", () => {
+		const mapped = mapDerivedBenchmarkRankingRow({
+			...BASE_ROW,
+			score_numeric: "not-a-number",
+			benchmark_rank: "0",
+			total_ranked_models: null,
+		});
+
+		expect(mapped.scoreNumeric).toBeNull();
+		expect(mapped.rank).toBeNull();
+		expect(mapped.totalRankedModels).toBeNull();
+	});
+});

--- a/apps/web/src/lib/fetchers/benchmarks/getBenchmarkResultRankings.ts
+++ b/apps/web/src/lib/fetchers/benchmarks/getBenchmarkResultRankings.ts
@@ -1,0 +1,120 @@
+import { createAdminClient } from "@/utils/supabase/admin";
+
+export interface DerivedBenchmarkRankingRow {
+	resultId: string;
+	modelId: string;
+	benchmarkId: string;
+	score: string | number | null;
+	scoreNumeric: number | null;
+	isSelfReported: boolean;
+	otherInfo: string | null;
+	sourceLink: string | null;
+	createdAt: string | null;
+	updatedAt: string | null;
+	occurIndex: number | null;
+	variant: string | null;
+	resultKey: string | null;
+	rank: number | null;
+	totalRankedModels: number | null;
+	isPrimaryResult: boolean;
+	modelName: string;
+	releaseDate: string | null;
+	announcementDate: string | null;
+	organisationId: string;
+	organisationName: string | null;
+	organisationColour: string | null;
+}
+
+interface RawDerivedBenchmarkRankingRow {
+	result_id: string;
+	model_id: string;
+	benchmark_id: string;
+	score: string | number | null;
+	score_numeric: string | number | null;
+	is_self_reported: boolean | null;
+	other_info: string | null;
+	source_link: string | null;
+	created_at: string | null;
+	updated_at: string | null;
+	occur_idx: number | null;
+	variant: string | null;
+	result_key: string | null;
+	benchmark_rank: string | number | null;
+	total_ranked_models: string | number | null;
+	is_primary_result: boolean | null;
+	model_name: string | null;
+	release_date: string | null;
+	announcement_date: string | null;
+	organisation_id: string | null;
+	organisation_name: string | null;
+	organisation_colour: string | null;
+}
+
+function finiteNumber(value: string | number | null): number | null {
+	if (value == null) return null;
+	const parsed = typeof value === "number" ? value : Number(value);
+	return Number.isFinite(parsed) ? parsed : null;
+}
+
+function positiveInteger(value: string | number | null): number | null {
+	const parsed = finiteNumber(value);
+	if (parsed == null || parsed < 1) return null;
+	return Math.trunc(parsed);
+}
+
+export function mapDerivedBenchmarkRankingRow(
+	row: RawDerivedBenchmarkRankingRow
+): DerivedBenchmarkRankingRow {
+	return {
+		resultId: row.result_id,
+		modelId: row.model_id,
+		benchmarkId: row.benchmark_id,
+		score: row.score,
+		scoreNumeric: finiteNumber(row.score_numeric),
+		isSelfReported: Boolean(row.is_self_reported),
+		otherInfo: row.other_info ?? null,
+		sourceLink: row.source_link ?? null,
+		createdAt: row.created_at ?? null,
+		updatedAt: row.updated_at ?? null,
+		occurIndex: row.occur_idx ?? null,
+		variant: row.variant ?? null,
+		resultKey: row.result_key ?? null,
+		rank: positiveInteger(row.benchmark_rank),
+		totalRankedModels: positiveInteger(row.total_ranked_models),
+		isPrimaryResult: Boolean(row.is_primary_result),
+		modelName: row.model_name ?? row.model_id,
+		releaseDate: row.release_date ?? null,
+		announcementDate: row.announcement_date ?? null,
+		organisationId: row.organisation_id ?? "",
+		organisationName: row.organisation_name ?? null,
+		organisationColour: row.organisation_colour ?? null,
+	};
+}
+
+export async function getBenchmarkResultRankings(args: {
+	benchmarkIds: string[];
+	modelId?: string | null;
+	includeHidden: boolean;
+	limitPerBenchmark?: number | null;
+}): Promise<DerivedBenchmarkRankingRow[]> {
+	const benchmarkIds = Array.from(
+		new Set(args.benchmarkIds.map((id) => id.trim()).filter(Boolean))
+	);
+	if (!benchmarkIds.length) return [];
+
+	const supabase = createAdminClient();
+	const { data, error } = await supabase.rpc("get_benchmark_result_rankings", {
+		p_benchmark_ids: benchmarkIds,
+		p_model_id: args.modelId ?? null,
+		p_include_hidden: args.includeHidden,
+		p_limit_per_benchmark: args.limitPerBenchmark ?? null,
+	});
+
+	if (error) {
+		throw new Error(error.message || "Failed to derive benchmark rankings");
+	}
+
+	return ((data ?? []) as RawDerivedBenchmarkRankingRow[]).map(
+		mapDerivedBenchmarkRankingRow
+	);
+}

--- a/apps/web/src/lib/fetchers/models/getModelBenchmarkData.ts
+++ b/apps/web/src/lib/fetchers/models/getModelBenchmarkData.ts
@@ -11,6 +11,10 @@ import {
 	parseBenchmarkScore,
 	resolveBenchmarkIsPercentage,
 } from "@/lib/benchmarks/scoreFormat";
+import {
+	getBenchmarkResultRankings,
+	type DerivedBenchmarkRankingRow,
+} from "@/lib/fetchers/benchmarks/getBenchmarkResultRankings";
 
 export interface ModelBenchmarkOrganisation {
 	organisation_id: string;
@@ -257,7 +261,45 @@ async function loadBenchmarkResults(
 ): Promise<RawBenchmarkPayload> {
 	// Rely on Next.js cache tags/lifetimes instead of process-local memoization.
 	// This avoids stale benchmark data persisting after importer updates.
-	return fetchBenchmarkResultsRaw(modelId, includeHidden);
+	const payload = await fetchBenchmarkResultsRaw(modelId, includeHidden);
+	if (!payload.results.length) return payload;
+
+	try {
+		const rankings = await getBenchmarkResultRankings({
+			benchmarkIds: payload.results.map((result) => result.benchmark_id),
+			modelId,
+			includeHidden,
+		});
+		const rankingByResultId = new Map(
+			rankings.map((ranking) => [ranking.resultId, ranking])
+		);
+
+		return {
+			...payload,
+			results: payload.results.map((result) => {
+				const ranking = rankingByResultId.get(result.id);
+				if (!ranking) return result;
+
+				return {
+					...result,
+					rank: ranking.rank,
+					benchmark: {
+						...result.benchmark,
+						total_models:
+							ranking.totalRankedModels ?? result.benchmark.total_models,
+					},
+				};
+			}),
+		};
+	} catch (error) {
+		// Keep previews and rolling deployments functional until the migration is
+		// applied. Persisted ranks are a temporary compatibility fallback only.
+		console.warn("[benchmarks] Falling back to persisted model ranks", {
+			modelId,
+			error: error instanceof Error ? error.message : String(error),
+		});
+		return payload;
+	}
 }
 
 function selectHighlightResults(
@@ -373,6 +415,31 @@ type ComparisonRow = {
 	rank: number | null;
 	model: ComparisonRowModel | ComparisonRowModel[];
 };
+
+function derivedRankingToComparisonRow(
+	ranking: DerivedBenchmarkRankingRow
+): ComparisonRow {
+	return {
+		model_id: ranking.modelId,
+		score: ranking.score,
+		is_self_reported: ranking.isSelfReported,
+		other_info: ranking.otherInfo,
+		source_link: ranking.sourceLink,
+		rank: ranking.rank,
+		model: {
+			model_id: ranking.modelId,
+			name: ranking.modelName,
+			organisation: ranking.organisationId
+				? {
+						organisation_id: ranking.organisationId,
+						name:
+							ranking.organisationName ?? ranking.organisationId,
+						colour: ranking.organisationColour,
+					}
+				: null,
+		},
+	};
+}
 
 function determineIsLowerBetter(
 	models: BenchmarkComparisonModel[],
@@ -558,16 +625,43 @@ async function fetchBenchmarkComparisonCharts(
 	const supabase = createAdminClient();
 	const charts: BenchmarkComparisonChart[] = [];
 	const processedBenchmarks = new Set<string>();
+	const benchmarkIds = Array.from(
+		new Set(results.map((result) => result.benchmark_id).filter(Boolean))
+	);
+	let derivedRowsByBenchmark: Map<string, ComparisonRow[]> | null = null;
+
+	try {
+		const rankings = await getBenchmarkResultRankings({
+			benchmarkIds,
+			includeHidden,
+			limitPerBenchmark: 100,
+		});
+		derivedRowsByBenchmark = new Map<string, ComparisonRow[]>();
+		for (const ranking of rankings) {
+			const rows = derivedRowsByBenchmark.get(ranking.benchmarkId) ?? [];
+			rows.push(derivedRankingToComparisonRow(ranking));
+			derivedRowsByBenchmark.set(ranking.benchmarkId, rows);
+		}
+	} catch (error) {
+		console.warn("[benchmarks] Falling back to persisted comparison ranks", {
+			modelId,
+			error: error instanceof Error ? error.message : String(error),
+		});
+	}
 
 	for (const result of results) {
 		if (!result.benchmark_id) continue;
 		if (processedBenchmarks.has(result.benchmark_id)) continue;
 		processedBenchmarks.add(result.benchmark_id);
 
-		const { data, error } = await supabase
-			.from("data_benchmark_results")
-			.select(
-				`
+		let rows: ComparisonRow[];
+		if (derivedRowsByBenchmark) {
+			rows = derivedRowsByBenchmark.get(result.benchmark_id) ?? [];
+		} else {
+			const { data, error } = await supabase
+				.from("data_benchmark_results")
+				.select(
+					`
 					model_id,
 					score,
 					is_self_reported,
@@ -588,24 +682,25 @@ async function fetchBenchmarkComparisonCharts(
 							colour
 						)
 					)
-				`
-			)
-			.eq("benchmark_id", result.benchmark_id)
-			.order("rank", { ascending: true, nullsFirst: false })
-			.limit(100);
+					`
+				)
+				.eq("benchmark_id", result.benchmark_id)
+				.order("rank", { ascending: true, nullsFirst: false })
+				.limit(100);
 
-		if (error) {
-			throw new Error(
-				error.message ||
-				`Failed to fetch benchmark comparison for ${result.benchmark_id}`
-			);
+			if (error) {
+				throw new Error(
+					error.message ||
+						`Failed to fetch benchmark comparison for ${result.benchmark_id}`
+				);
+			}
+
+			rows = (data ?? []).filter((row: any) => {
+				if (includeHidden) return true;
+				const modelEntry = normalizeMaybeArray(row?.model);
+				return !modelEntry?.hidden;
+			});
 		}
-
-		const rows: ComparisonRow[] = (data ?? []).filter((row: any) => {
-			if (includeHidden) return true;
-			const modelEntry = normalizeMaybeArray(row?.model);
-			return !modelEntry?.hidden;
-		});
 		if (!rows.length) continue;
 		const benchmarkType = result.benchmark.type;
 		const lowerIsBetterHint = getLowerIsBetter(

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
 		"data:update-statuses": "tsx scripts/update-model-statuses.ts",
 		"data:recompute-benchmark-ranks": "pnpm --filter @phaseo/web run catalog:recompute-benchmark-ranks",
 		"data:recompute-benchmark-ranks:db": "pnpm --filter @phaseo/web run db:recompute-benchmark-ranks",
-		"data:prep-pr": "pnpm run data:recompute-benchmark-ranks && pnpm run openapi:gen && pnpm run validate:data && pnpm run validate:pricing && pnpm run validate:gateway && pnpm run validate:docs",
+		"data:prep-pr": "pnpm run openapi:gen && pnpm run validate:data && pnpm run validate:pricing && pnpm run validate:gateway && pnpm run validate:docs",
 		"data:precommit": "pnpm run data:prep-pr",
 		"data:reconcile-api-model-links": "pnpm --filter @phaseo/web run db:reconcile-api-model-links",
 		"data:check-new-models": "tsx scripts/model-discovery/run.ts",

--- a/supabase/migrations/20260717090000_add_derived_benchmark_rankings_rpc.sql
+++ b/supabase/migrations/20260717090000_add_derived_benchmark_rankings_rpc.sql
@@ -1,0 +1,191 @@
+-- Derive benchmark ranks from source results instead of persisting catalogue-wide
+-- rank updates. A model occupies one position per benchmark even when multiple
+-- source or harness variants are stored for it.
+
+alter table public.data_benchmark_results
+  add column if not exists score_numeric numeric
+  generated always as (
+    substring(score from '[-+]?[0-9]*\.?[0-9]+')::numeric
+  ) stored;
+
+create index if not exists data_benchmark_results_benchmark_model_score_idx
+  on public.data_benchmark_results (benchmark_id, model_id, score_numeric)
+  where score_numeric is not null;
+
+create index if not exists data_benchmark_results_model_benchmark_idx
+  on public.data_benchmark_results (model_id, benchmark_id);
+
+create or replace function public.get_benchmark_result_rankings(
+  p_benchmark_ids text[] default null,
+  p_model_id text default null,
+  p_include_hidden boolean default false,
+  p_limit_per_benchmark integer default null
+)
+returns table (
+  result_id uuid,
+  model_id text,
+  benchmark_id text,
+  score text,
+  score_numeric numeric,
+  is_self_reported boolean,
+  other_info text,
+  source_link text,
+  created_at timestamptz,
+  updated_at timestamptz,
+  occur_idx integer,
+  variant text,
+  result_key text,
+  benchmark_rank bigint,
+  total_ranked_models bigint,
+  is_primary_result boolean,
+  model_name text,
+  release_date timestamptz,
+  announcement_date timestamptz,
+  organisation_id text,
+  organisation_name text,
+  organisation_colour text
+)
+language sql
+stable
+security invoker
+set search_path = ''
+as $function$
+  with target_benchmarks as (
+    select
+      b.id,
+      b.ascending_order,
+      b.type
+    from public.data_benchmarks b
+    where
+      (p_benchmark_ids is null or b.id = any (p_benchmark_ids))
+      and (
+        p_model_id is null
+        or exists (
+          select 1
+          from public.data_benchmark_results requested_result
+          where requested_result.benchmark_id = b.id
+            and requested_result.model_id = p_model_id
+        )
+      )
+  ),
+  scoped_results as (
+    select
+      result.*,
+      model.name as model_name,
+      model.release_date,
+      model.announcement_date,
+      model.organisation_id,
+      organisation.name as organisation_name,
+      organisation.colour as organisation_colour,
+      target.ascending_order,
+      case
+        when target.type = 'percentage'
+          and abs(result.score_numeric) > 0
+          and abs(result.score_numeric) <= 1
+          then result.score_numeric * 100
+        else result.score_numeric
+      end as comparable_score
+    from target_benchmarks target
+    join public.data_benchmark_results result
+      on result.benchmark_id = target.id
+    join public.data_models model
+      on model.model_id = result.model_id
+    left join public.data_organisations organisation
+      on organisation.organisation_id = model.organisation_id
+    where p_include_hidden or not coalesce(model.hidden, false)
+  ),
+  model_scores as (
+    select
+      scoped.benchmark_id,
+      scoped.model_id,
+      bool_or(scoped.ascending_order is false) as lower_is_better,
+      case
+        when bool_or(scoped.ascending_order is false)
+          then min(scoped.comparable_score)
+        else max(scoped.comparable_score)
+      end as primary_score
+    from scoped_results scoped
+    where scoped.comparable_score is not null
+    group by scoped.benchmark_id, scoped.model_id
+  ),
+  ranked_models as (
+    select
+      scores.benchmark_id,
+      scores.model_id,
+      scores.primary_score,
+      rank() over (
+        partition by scores.benchmark_id
+        order by
+          case when scores.lower_is_better then scores.primary_score end asc nulls last,
+          case when not scores.lower_is_better then scores.primary_score end desc nulls last
+      ) as benchmark_rank,
+      count(*) over (
+        partition by scores.benchmark_id
+      ) as total_ranked_models
+    from model_scores scores
+  ),
+  selected_models as (
+    select
+      roster.benchmark_id,
+      roster.model_id,
+      ranked.primary_score,
+      ranked.benchmark_rank,
+      ranked.total_ranked_models
+    from (
+      select distinct scoped.benchmark_id, scoped.model_id
+      from scoped_results scoped
+    ) roster
+    left join ranked_models ranked
+      on ranked.benchmark_id = roster.benchmark_id
+     and ranked.model_id = roster.model_id
+    where
+      (p_model_id is null or roster.model_id = p_model_id)
+      and (
+        p_limit_per_benchmark is null
+        or ranked.benchmark_rank <= greatest(p_limit_per_benchmark, 1)
+      )
+  )
+  select
+    scoped.id as result_id,
+    scoped.model_id,
+    scoped.benchmark_id,
+    scoped.score,
+    scoped.score_numeric,
+    scoped.is_self_reported,
+    scoped.other_info,
+    scoped.source_link,
+    scoped.created_at,
+    scoped.updated_at,
+    scoped.occur_idx,
+    scoped.variant,
+    scoped.result_key,
+    ranked.benchmark_rank,
+    ranked.total_ranked_models,
+    ranked.primary_score is not null
+      and scoped.comparable_score is not distinct from ranked.primary_score
+      as is_primary_result,
+    scoped.model_name,
+    scoped.release_date,
+    scoped.announcement_date,
+    scoped.organisation_id,
+    scoped.organisation_name,
+    scoped.organisation_colour
+  from scoped_results scoped
+  join selected_models ranked
+    on ranked.benchmark_id = scoped.benchmark_id
+   and ranked.model_id = scoped.model_id
+  order by
+    scoped.benchmark_id,
+    ranked.benchmark_rank,
+    scoped.model_id,
+    scoped.occur_idx,
+    scoped.id;
+$function$;
+
+comment on function public.get_benchmark_result_rankings(text[], text, boolean, integer)
+  is 'Returns tie-aware model-level benchmark ranks derived from numeric result scores, while preserving every source-result variant for display.';
+
+revoke execute on function public.get_benchmark_result_rankings(text[], text, boolean, integer)
+  from public, anon, authenticated;
+grant execute on function public.get_benchmark_result_rankings(text[], text, boolean, integer)
+  to service_role;


### PR DESCRIPTION
## Summary

- add an indexed `get_benchmark_result_rankings` RPC that derives tie-aware model ranks from benchmark scores
- rank one best score per model and benchmark, so multiple harness/source variants no longer consume multiple positions
- normalize percentage fractions during comparison and exclude hidden models from public ranking totals
- use a generated numeric score column so every write path remains synchronized automatically
- switch model highlights, comparison charts, and benchmark pages to RPC-derived ranks with a rolling-deployment fallback
- keep rank badges hidden on `/models/[id]` while retaining rank data for sorting and future presentation
- stop importing manual rank values and remove rank recomputation from the normal data PR workflow

## Rollout

The `20260717090000_add_derived_benchmark_rankings_rpc.sql` migration has been applied to production and recorded in the migration ledger. Production verification confirmed that `service_role` can execute the RPC, public roles cannot, and a live ranking query returns data.

## Validation

- production migration execution and live RPC verification
- ephemeral PostgreSQL execution of the complete migration and RPC, covering duplicate variants, ties, percentage normalization, hidden models, and lower-is-better ordering
- `pnpm --filter @phaseo/web test` — 87 suites, 374 tests passed
- `pnpm --filter @phaseo/web typecheck`
- targeted ESLint — no errors
- `pnpm validate:data`
- `git diff --check`
- `pnpm --filter @phaseo/web build` compiled and type-checked successfully; prerendering could not complete because this isolated worktree has no Supabase environment variables

Created with Codex