### PR TITLE
Add GMI Cloud and Novita Kimi K3

### DIFF
--- a/.changeset/prepare-kimi-k3-moonshot.md
+++ b/.changeset/prepare-kimi-k3-moonshot.md
@@ -3,4 +3,4 @@
 "@phaseo/gateway-api": patch
 ---
 
-Prepare Moonshot AI's Kimi K3 catalog entry for its July 16 release with its official 2.8-trillion-parameter architecture, text/image/video input, 1,048,576-token context and output limits, supported API features, and official Moonshot pricing. Update the Moonshot adapter for K3's top-level max reasoning effort, strict structured outputs, video payloads, and reasoning-content continuity.
+Prepare Moonshot AI's Kimi K3 catalog entry for its July 16 release with its official 2.8-trillion-parameter architecture, text/image/video input, 1,048,576-token context and output limits, supported API features, and official Moonshot pricing. Add verified GMI Cloud, Novita, and Venice provider availability, provider-specific limits, and pricing. Update the Moonshot adapter for K3's top-level max reasoning effort, strict structured outputs, video payloads, and reasoning-content continuity.

--- a/apps/api/tests/aimock/cross-provider-models.spec.ts
+++ b/apps/api/tests/aimock/cross-provider-models.spec.ts
@@ -92,9 +92,9 @@ describe("cross-provider model deployment matrix", () => {
         }).toMatchObject({
             models: 355,
             providers: 49,
-            deployments: 796,
+            deployments: 798,
             multiProviderModels: 127,
-            multiProviderDeployments: 565,
+            multiProviderDeployments: 567,
             missing: [],
         });
     });

--- a/packages/data/catalog/src/data/__tests__/validate.test.ts
+++ b/packages/data/catalog/src/data/__tests__/validate.test.ts
@@ -9,6 +9,12 @@ function readPricingJson(relativePath: string) {
     return JSON.parse(fs.readFileSync(path.join(DATA_ROOT, relativePath), 'utf8'));
 }
 
+function readProviderModels(providerId: string) {
+    return JSON.parse(
+        fs.readFileSync(path.join(DATA_ROOT, 'api_providers', providerId, 'models.json'), 'utf8')
+    );
+}
+
 describe('pricing safety checks', () => {
     test('active on gateway with no rules -> error flagged', () => {
         const bad = {
@@ -176,6 +182,19 @@ describe('pricing safety checks', () => {
         );
     });
 
+    test.each(['gmicloud', 'novita'])('%s Kimi K3 pricing matches the provider catalog', (providerId) => {
+        const pricing = readPricingJson(
+            `pricing/${providerId}/moonshotai-kimi-k3/text.generate/pricing.json`
+        );
+        expect(pricing.rules).toEqual(
+            expect.arrayContaining([
+                expect.objectContaining({ meter: 'input_text_tokens', price_per_unit: 3 }),
+                expect.objectContaining({ meter: 'cached_read_text_tokens', price_per_unit: 0.3 }),
+                expect.objectContaining({ meter: 'output_text_tokens', price_per_unit: 15 }),
+            ])
+        );
+    });
+
     test('Google Vertex image model does not advertise flex pricing without executor support', () => {
         const pricing = readPricingJson(
             'pricing/google-vertex/google-gemini-3.1-flash-lite-image/text.generate/pricing.json'
@@ -185,6 +204,38 @@ describe('pricing safety checks', () => {
 });
 
 describe('api provider model safety checks', () => {
+    test('Kimi K3 provider rows retain provider-specific limits and support', () => {
+        const gmi = readProviderModels('gmicloud').find(
+            (row: any) => row.provider_api_model_id === 'gmicloud:moonshotai/kimi-k3'
+        );
+        const novita = readProviderModels('novita').find(
+            (row: any) => row.provider_api_model_id === 'novita:moonshotai/kimi-k3'
+        );
+
+        expect(gmi).toMatchObject({
+            is_active_gateway: true,
+            quantization_scheme: 'FP8',
+            input_modalities: 'text,image,video',
+            output_modalities: 'text',
+            context_length: 262144,
+            max_output_tokens: null,
+        });
+        expect(novita).toMatchObject({
+            is_active_gateway: true,
+            input_modalities: 'text,image,video',
+            output_modalities: 'text',
+            context_length: 1048576,
+            max_output_tokens: 1048576,
+        });
+        expect(novita.capabilities[0].params).toEqual(
+            expect.arrayContaining([
+                expect.objectContaining({ param_id: 'tools' }),
+                expect.objectContaining({ param_id: 'structured_outputs' }),
+                expect.objectContaining({ param_id: 'include_reasoning' }),
+            ])
+        );
+    });
+
     test('missing provider_model_slug -> error flagged', () => {
         const bad = {
             api_model_id: 'z-ai/glm-5.1',

--- a/packages/data/catalog/src/data/api_providers/gmicloud/models.json
+++ b/packages/data/catalog/src/data/api_providers/gmicloud/models.json
@@ -336,6 +336,70 @@
     ]
   },
   {
+    "api_model_id": "moonshotai/kimi-k3",
+    "provider_api_model_id": "gmicloud:moonshotai/kimi-k3",
+    "provider_model_slug": "moonshotai/kimi-k3",
+    "internal_model_id": "moonshotai/kimi-k3",
+    "is_active_gateway": true,
+    "quantization_scheme": "FP8",
+    "input_modalities": "text,image,video",
+    "output_modalities": "text",
+    "context_length": 262144,
+    "max_output_tokens": null,
+    "effective_from": "2026-07-16T21:18:04Z",
+    "effective_to": null,
+    "capabilities": [
+      {
+        "capability_id": "text.generate",
+        "status": "active",
+        "params": [
+          {
+            "param_id": "max_tokens",
+            "provider_min": 1,
+            "provider_max": null,
+            "provider_default": null,
+            "notes": "GMI Cloud does not publish a separate maximum completion length for this route."
+          },
+          {
+            "param_id": "response_format",
+            "provider_min": null,
+            "provider_max": null,
+            "provider_default": null,
+            "notes": "Kimi K3 supports strict JSON Schema response formats."
+          },
+          {
+            "param_id": "structured_outputs",
+            "provider_min": null,
+            "provider_max": null,
+            "provider_default": null,
+            "notes": "Kimi K3 supports strict JSON Schema structured output."
+          },
+          {
+            "param_id": "tool_choice",
+            "provider_min": null,
+            "provider_max": null,
+            "provider_default": null,
+            "notes": "Required tool choice was verified against GMI Cloud on 2026-07-17."
+          },
+          {
+            "param_id": "tools",
+            "provider_min": null,
+            "provider_max": null,
+            "provider_default": null,
+            "notes": "Function calling was verified against GMI Cloud on 2026-07-17."
+          },
+          {
+            "param_id": "include_reasoning",
+            "provider_min": null,
+            "provider_max": null,
+            "provider_default": null,
+            "notes": "Kimi K3 always reasons; GMI Cloud returns reasoning_content alongside the answer or tool call."
+          }
+        ]
+      }
+    ]
+  },
+  {
     "api_model_id": "moonshotai/kimi-k2-0905",
     "provider_api_model_id": "gmicloud:moonshotai/kimi-k2-0905",
     "provider_model_slug": "moonshotai/Kimi-K2-Instruct-0905",

--- a/packages/data/catalog/src/data/api_providers/novita/models.json
+++ b/packages/data/catalog/src/data/api_providers/novita/models.json
@@ -4443,6 +4443,70 @@
                          ]
     },
     {
+        "api_model_id":  "moonshotai/kimi-k3",
+        "provider_api_model_id":  "novita:moonshotai/kimi-k3",
+        "provider_model_slug":  "moonshotai/kimi-k3",
+        "internal_model_id":  "moonshotai/kimi-k3",
+        "is_active_gateway":  true,
+        "quantization_scheme":  null,
+        "input_modalities":  "text,image,video",
+        "output_modalities":  "text",
+        "context_length":  1048576,
+        "max_output_tokens":  1048576,
+        "effective_from":  "2026-07-16T02:27:39Z",
+        "effective_to":  null,
+        "capabilities":  [
+                             {
+                                 "capability_id":  "text.generate",
+                                 "status":  "active",
+                                 "params":  [
+                                                {
+                                                    "param_id":  "max_tokens",
+                                                    "provider_min":  1,
+                                                    "provider_max":  1048576,
+                                                    "provider_default":  null,
+                                                    "notes":  "Novita reports a 1,048,576-token maximum output length."
+                                                },
+                                                {
+                                                    "param_id":  "response_format",
+                                                    "provider_min":  null,
+                                                    "provider_max":  null,
+                                                    "provider_default":  null,
+                                                    "notes":  "Novita lists structured-output support for this route."
+                                                },
+                                                {
+                                                    "param_id":  "structured_outputs",
+                                                    "provider_min":  null,
+                                                    "provider_max":  null,
+                                                    "provider_default":  null,
+                                                    "notes":  "Novita lists structured-output support for this route."
+                                                },
+                                                {
+                                                    "param_id":  "tool_choice",
+                                                    "provider_min":  null,
+                                                    "provider_max":  null,
+                                                    "provider_default":  null,
+                                                    "notes":  null
+                                                },
+                                                {
+                                                    "param_id":  "tools",
+                                                    "provider_min":  null,
+                                                    "provider_max":  null,
+                                                    "provider_default":  null,
+                                                    "notes":  "Novita lists function-calling support for this route."
+                                                },
+                                                {
+                                                    "param_id":  "include_reasoning",
+                                                    "provider_min":  null,
+                                                    "provider_max":  null,
+                                                    "provider_default":  null,
+                                                    "notes":  "Kimi K3 always reasons; Novita lists reasoning support for this route."
+                                                }
+                                            ]
+                             }
+                         ]
+    },
+    {
         "api_model_id":  "nex-agi/nex-n2-pro",
         "provider_api_model_id":  "novita:nex-agi/nex-n2-pro",
         "provider_model_slug":  "nex-agi/nex-n2-pro",

--- a/packages/data/catalog/src/data/models/moonshotai/kimi-k3/model.json
+++ b/packages/data/catalog/src/data/models/moonshotai/kimi-k3/model.json
@@ -34,6 +34,21 @@
       "title": "Venice API Pricing",
       "kind": "pricing",
       "url": "https://docs.venice.ai/overview/pricing"
+    },
+    {
+      "title": "GMI Cloud Serverless API",
+      "kind": "docs",
+      "url": "https://docs.gmicloud.ai/inference-engine/marketplace/serverless"
+    },
+    {
+      "title": "GMI Cloud Pricing",
+      "kind": "pricing",
+      "url": "https://docs.gmicloud.ai/inference-engine/billing/price"
+    },
+    {
+      "title": "Novita API and Pricing",
+      "kind": "pricing",
+      "url": "https://novita.ai/models/model-detail/moonshotai-kimi-k3"
     }
   ],
   "details": [
@@ -79,7 +94,7 @@
     },
     {
       "name": "availability_note",
-      "value": "Moonshot AI and Venice provide Kimi K3 API access. Venice currently exposes the standard kimi-k3 route; its live model catalog does not yet expose an E2EE Kimi K3 model ID. Full model weights and the technical report are still forthcoming."
+      "value": "Moonshot AI, GMI Cloud, Novita, and Venice provide Kimi K3 API access. GMI Cloud currently advertises an FP8 route with a 262,144-token context window; Novita advertises text, image, and video input with a 1,048,576-token context and output limit. Venice exposes the standard kimi-k3 route, but its live catalog does not yet expose an E2EE Kimi K3 model ID. Full model weights and the technical report are still forthcoming."
     }
   ],
   "benchmarks": []

--- a/packages/data/catalog/src/data/pricing/gmicloud/moonshotai-kimi-k3/text.generate/pricing.json
+++ b/packages/data/catalog/src/data/pricing/gmicloud/moonshotai-kimi-k3/text.generate/pricing.json
@@ -1,0 +1,45 @@
+{
+  "key": "gmicloud:moonshotai/kimi-k3:text.generate",
+  "api_provider_id": "gmicloud",
+  "provider_slug": "gmicloud",
+  "api_model_id": "moonshotai/kimi-k3",
+  "capability_id": "text.generate",
+  "rules": [
+    {
+      "meter": "input_text_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 3,
+      "currency": "USD",
+      "pricing_plan": "standard",
+      "note": "GMI Cloud model discovery API reports $3.00 per 1M input tokens; observed 2026-07-17.",
+      "match": [],
+      "priority": 100,
+      "effective_from": "2026-07-16T21:18:04Z"
+    },
+    {
+      "meter": "cached_read_text_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 0.3,
+      "currency": "USD",
+      "pricing_plan": "standard",
+      "note": "GMI Cloud model discovery API reports $0.30 per 1M cache-read tokens; observed 2026-07-17.",
+      "match": [],
+      "priority": 100,
+      "effective_from": "2026-07-16T21:18:04Z"
+    },
+    {
+      "meter": "output_text_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 15,
+      "currency": "USD",
+      "pricing_plan": "standard",
+      "note": "GMI Cloud model discovery API reports $15.00 per 1M output tokens; observed 2026-07-17.",
+      "match": [],
+      "priority": 100,
+      "effective_from": "2026-07-16T21:18:04Z"
+    }
+  ]
+}

--- a/packages/data/catalog/src/data/pricing/novita/moonshotai-kimi-k3/text.generate/pricing.json
+++ b/packages/data/catalog/src/data/pricing/novita/moonshotai-kimi-k3/text.generate/pricing.json
@@ -1,0 +1,45 @@
+{
+  "key": "novita:moonshotai/kimi-k3:text.generate",
+  "api_provider_id": "novita",
+  "provider_slug": "novita",
+  "api_model_id": "moonshotai/kimi-k3",
+  "capability_id": "text.generate",
+  "rules": [
+    {
+      "meter": "input_text_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 3,
+      "currency": "USD",
+      "pricing_plan": "standard",
+      "note": "Novita model page and model discovery API report $3.00 per 1M input tokens; observed 2026-07-17.",
+      "match": [],
+      "priority": 100,
+      "effective_from": "2026-07-16T02:27:39Z"
+    },
+    {
+      "meter": "cached_read_text_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 0.3,
+      "currency": "USD",
+      "pricing_plan": "standard",
+      "note": "Novita model page and model discovery API report $0.30 per 1M cache-read tokens; observed 2026-07-17.",
+      "match": [],
+      "priority": 100,
+      "effective_from": "2026-07-16T02:27:39Z"
+    },
+    {
+      "meter": "output_text_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 15,
+      "currency": "USD",
+      "pricing_plan": "standard",
+      "note": "Novita model page and model discovery API report $15.00 per 1M output tokens; observed 2026-07-17.",
+      "match": [],
+      "priority": 100,
+      "effective_from": "2026-07-16T02:27:39Z"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- onboard GMI Cloud and Novita as active Kimi K3 gateway providers
- add verified $3.00/M input, $0.30/M cache-read, and $15.00/M output pricing for both providers
- preserve provider-specific support: GMI Cloud FP8 with a 262,144-token advertised context; Novita text/image/video, reasoning, tools, structured outputs, and 1,048,576-token context/output limits
- update Kimi K3 provider links, availability notes, regression coverage, and release metadata

## Validation

- `pnpm validate:data`
- `pnpm validate:pricing`
- `pnpm validate:gateway`
- Kimi K3 catalog tests: 3 passed
- live GMI Cloud tool-call smoke test using `moonshotai/kimi-k3`
- authenticated GMI Cloud and Novita model-discovery verification

## Notes

- Web typecheck was also attempted; it remains blocked by three existing missing `LayoutProps` globals in dashboard layout files unrelated to this data-only change.
- No auto-merge enabled.

Created with Codex