### PR TITLE
Fix MCP OAuth migration syntax

### DIFF
--- a/supabase/migrations/20260717180000_restrict_dynamic_oauth_clients_to_read_only.sql
+++ b/supabase/migrations/20260717180000_restrict_dynamic_oauth_clients_to_read_only.sql
@@ -22,12 +22,12 @@ with dynamic_clients as (
   where client.id in (select id from dynamic_clients)
   returning client.id
 )
-update public.oauth_authorizations authorization
-set revoked_at = coalesce(authorization.revoked_at, now())
-where authorization.client_id in (select id from restricted_clients)
+update public.oauth_authorizations authz
+set revoked_at = coalesce(authz.revoked_at, now())
+where authz.client_id in (select id from restricted_clients)
   and exists (
     select 1
-    from unnest(coalesce(authorization.scopes, array[]::text[])) scope
+    from unnest(coalesce(authz.scopes, array[]::text[])) scope
     where scope = 'gateway:access' or scope ~ ':(write|delete)$'
   );
 


### PR DESCRIPTION
## Summary

- replace the reserved PostgreSQL alias `authorization` in the MCP OAuth restriction migration
- preserve the exact migration behavior; the failed production attempt was rejected before any statement was applied

## Verification

- reviewed the remaining aliases and statements for PostgreSQL reserved-word conflicts
- production migration history still shows all three MCP migrations as pending