### PR TITLE
Fix dynamic MCP client consent approval

### DIFF
--- a/apps/web/src/app/(auth)/oauth/consent/actions.ts
+++ b/apps/web/src/app/(auth)/oauth/consent/actions.ts
@@ -33,6 +33,33 @@ interface ConsentResult {
 	error?: string;
 }
 
+interface RegisteredOAuthClient {
+	client_id: string;
+	redirect_uris: string[];
+}
+
+async function loadRegisteredOAuthClient(
+	accessToken: string,
+	clientId: string,
+): Promise<RegisteredOAuthClient | null> {
+	const response = await fetch(
+		`${apiBaseUrl()}/oauth/client-metadata?client_id=${encodeURIComponent(clientId)}`,
+		{
+			headers: { Authorization: `Bearer ${accessToken}` },
+			cache: "no-store",
+		},
+	);
+	if (!response.ok) return null;
+	const payload = await response.json().catch(() => null) as Record<string, unknown> | null;
+	if (!payload || String(payload.client_id ?? "") !== clientId) return null;
+	return {
+		client_id: clientId,
+		redirect_uris: Array.isArray(payload.redirect_uris)
+			? payload.redirect_uris.filter((value): value is string => typeof value === "string")
+			: [],
+	};
+}
+
 /**
  * Approve OAuth authorization request
  *
@@ -153,31 +180,6 @@ export async function approveAuthorizationAction(
 			};
 		}
 
-		// User-owned applications live in oauth_app_metadata. First-party and
-		// dynamically registered MCP clients live in oauth_clients. The API-owned
-		// authorization server accepts both stores, so consent must do the same.
-		const { data: oauthApp } = await supabase
-			.from("oauth_app_metadata")
-			.select("client_id")
-			.eq("client_id", resolvedClientId)
-			.eq("status", "active")
-			.maybeSingle();
-		let registeredClient = null;
-		if (!oauthApp) {
-			const result = await supabase
-				.from("oauth_clients")
-				.select("id")
-				.eq("id", resolvedClientId)
-				.eq("status", "active")
-				.maybeSingle();
-			registeredClient = result.data;
-		}
-		const isFirstPartyCli =
-			resolvedClientId === "phaseo_cli" || resolvedClientId === "aistats_cli";
-		if (!oauthApp && !registeredClient && !isFirstPartyCli) {
-			return { error: "OAuth application not found or inactive" };
-		}
-
 		const resolvedRedirectUri = input.redirect_uri?.trim() || null;
 		if (!resolvedRedirectUri) {
 			return {
@@ -191,6 +193,9 @@ export async function approveAuthorizationAction(
 		} = await supabase.auth.getSession();
 		if (!session?.access_token) {
 			return { error: "Unauthorized" };
+		}
+		if (!(await loadRegisteredOAuthClient(session.access_token, resolvedClientId))) {
+			return { error: "OAuth application not found or inactive" };
 		}
 
 		const response = await fetch(`${apiBaseUrl()}/oauth/authorize/approve`, {
@@ -229,12 +234,13 @@ export async function approveAuthorizationAction(
 				redirect_url: payload.redirect_url,
 			},
 		};
-	} catch (error: any) {
+	} catch {
+		const requestId = crypto.randomUUID();
 		console.error("oauth_consent_approve_authorization_failed", {
 			operation: "approveAuthorizationAction",
-			error,
+			request_id: requestId,
 		});
-		return { error: error.message || "Failed to approve authorization" };
+		return { error: `Failed to approve authorization. Reference: ${requestId}` };
 	}
 }
 
@@ -295,21 +301,10 @@ export async function denyAuthorizationAction(input: {
 				return [];
 			}
 		};
-		const metadata = await supabase
-			.from("oauth_app_metadata")
-			.select("redirect_uris")
-			.eq("client_id", clientId)
-			.eq("status", "active")
-			.maybeSingle();
-		const client = metadata.data
-			? null
-			: await supabase
-				.from("oauth_clients")
-				.select("redirect_uris")
-				.eq("id", clientId)
-				.eq("status", "active")
-				.maybeSingle();
-		const registeredRedirectUris = readRedirectUris(metadata.data?.redirect_uris ?? client?.data?.redirect_uris);
+		const { data: { session } } = await supabase.auth.getSession();
+		if (!session?.access_token) return { error: "Unauthorized" };
+		const registeredClient = await loadRegisteredOAuthClient(session.access_token, clientId);
+		const registeredRedirectUris = readRedirectUris(registeredClient?.redirect_uris);
 		let isCliLoopback = false;
 		if (clientId === "phaseo_cli" || clientId === "aistats_cli") {
 			try {
@@ -342,12 +337,13 @@ export async function denyAuthorizationAction(input: {
 				redirect_url: redirectUrl.toString(),
 			},
 		};
-	} catch (error: any) {
+	} catch {
+		const requestId = crypto.randomUUID();
 		console.error("oauth_consent_deny_authorization_failed", {
 			operation: "denyAuthorizationAction",
-			error,
+			request_id: requestId,
 		});
-		return { error: error.message || "Failed to deny authorization" };
+		return { error: `Failed to deny authorization. Reference: ${requestId}` };
 	}
 }
 
@@ -382,16 +378,17 @@ export async function revokeAuthorizationAction(
 
 		if (revokeError) {
 			return {
-				error: `Failed to revoke authorization: ${revokeError.message}`,
+				error: "Failed to revoke authorization",
 			};
 		}
 
 		return { data: {} };
-	} catch (error: any) {
+	} catch {
+		const requestId = crypto.randomUUID();
 		console.error("oauth_consent_revoke_authorization_failed", {
 			operation: "revokeAuthorizationAction",
-			error,
+			request_id: requestId,
 		});
-		return { error: error.message || "Failed to revoke authorization" };
+		return { error: `Failed to revoke authorization. Reference: ${requestId}` };
 	}
 }

--- a/apps/web/src/app/(auth)/oauth/consent/actions.ts
+++ b/apps/web/src/app/(auth)/oauth/consent/actions.ts
@@ -291,20 +291,10 @@ export async function denyAuthorizationAction(input: {
 			};
 		}
 
-		const readRedirectUris = (value: unknown): string[] => {
-			if (Array.isArray(value)) return value.filter((entry): entry is string => typeof entry === "string");
-			if (typeof value !== "string") return [];
-			try {
-				const parsed = JSON.parse(value);
-				return Array.isArray(parsed) ? parsed.filter((entry): entry is string => typeof entry === "string") : [];
-			} catch {
-				return [];
-			}
-		};
 		const { data: { session } } = await supabase.auth.getSession();
 		if (!session?.access_token) return { error: "Unauthorized" };
 		const registeredClient = await loadRegisteredOAuthClient(session.access_token, clientId);
-		const registeredRedirectUris = readRedirectUris(registeredClient?.redirect_uris);
+		const registeredRedirectUris = registeredClient?.redirect_uris ?? [];
 		let isCliLoopback = false;
 		if (clientId === "phaseo_cli" || clientId === "aistats_cli") {
 			try {
@@ -376,11 +366,7 @@ export async function revokeAuthorizationAction(
 			.eq("id", authorizationId)
 			.eq("user_id", user.id); // Ensure user owns this authorization
 
-		if (revokeError) {
-			return {
-				error: "Failed to revoke authorization",
-			};
-		}
+		if (revokeError) throw revokeError;
 
 		return { data: {} };
 	} catch {


### PR DESCRIPTION
## Summary

- validate consent clients through the authenticated OAuth metadata API
- support dynamically registered MCP clients despite service-role-only storage policies
- reuse authoritative redirect URI metadata for denial redirects
- avoid returning or logging raw exception/storage details from consent actions

## Launch blocker fixed

MCP Inspector could dynamically register and display consent, but approval failed with `OAuth application not found or inactive` because the server action queried `oauth_clients` through the user-scoped browser client. The API already owns an authenticated, admin-backed metadata lookup; consent now uses that path for both approval and denial.

## Verification

- `pnpm --filter @phaseo/web typecheck`
- `pnpm --filter @phaseo/web test -- --runInBand src/lib/oauth/thirdPartyOAuth.test.ts src/lib/security/safeUrls.test.ts`
- `pnpm --filter @phaseo/web exec eslint src/app/(auth)/oauth/consent/actions.ts` (0 errors; 3 existing server logging warnings)
- `pnpm --filter @phaseo/web build`
- `git diff --check`

Repository-wide web lint remains blocked by the existing lint backlog (1,144 findings) unrelated to this change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security & Reliability**
  * OAuth consent and authorization flows now validate registered application details through the API.
  * Invalid or inactive OAuth applications are rejected.
  * Redirect URIs are validated from registered application metadata.

* **Bug Fixes**
  * Improved error handling during approval, denial, and revocation.
  * Sensitive internal error details are replaced with generic messages and a request reference for troubleshooting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->