### PR TITLE
Allow browser OAuth token exchange

### DIFF
--- a/apps/api/src/routes/oauth.security.test.ts
+++ b/apps/api/src/routes/oauth.security.test.ts
@@ -195,6 +195,23 @@ describe("OAuth route security", () => {
 		vi.resetModules();
 	});
 
+	it("allows browser-based OAuth clients to preflight token requests", async () => {
+		const { oauthRouter } = await import("./oauth");
+		const response = await oauthRouter.request("https://example.com/token", {
+			method: "OPTIONS",
+			headers: {
+				origin: "http://localhost:6274",
+				"access-control-request-method": "POST",
+				"access-control-request-headers": "content-type",
+			},
+		});
+
+		expect(response.status).toBe(204);
+		expect(response.headers.get("access-control-allow-origin")).toBe("*");
+		expect(response.headers.get("access-control-allow-methods")).toContain("POST");
+		expect(response.headers.get("access-control-allow-headers")).toContain("Content-Type");
+	});
+
 	it("does not let device-code denial overwrite a code that is no longer pending", async () => {
 		state.deviceRow = {
 			id: "device_1",
@@ -233,6 +250,7 @@ describe("OAuth route security", () => {
 		});
 
 		expect(response.status).toBe(413);
+		expect(response.headers.get("access-control-allow-origin")).toBe("*");
 		await expect(response.json()).resolves.toMatchObject({ error: "invalid_request" });
 	});
 

--- a/apps/api/src/routes/oauth.ts
+++ b/apps/api/src/routes/oauth.ts
@@ -60,6 +60,12 @@ import {
 
 export const oauthRouter = new Hono<Env>();
 const MAX_OAUTH_REQUEST_BODY_BYTES = 16 * 1024;
+const OAUTH_CORS_HEADERS: Record<string, string> = {
+	"Access-Control-Allow-Origin": "*",
+	"Access-Control-Allow-Methods": "GET, POST, OPTIONS",
+	"Access-Control-Allow-Headers": "Authorization, Content-Type",
+	"Access-Control-Max-Age": "86400",
+};
 const DYNAMIC_MCP_SCOPES = [
 	"openid",
 	"profile",
@@ -101,6 +107,20 @@ const DYNAMIC_MCP_SCOPE_SET = new Set<string>(DYNAMIC_MCP_SCOPES);
 const MCP_RESOURCE_SERVER_CLIENT_ID = "phaseo_mcp_resource_server";
 
 class OAuthRequestBodyTooLarge extends Error {}
+
+oauthRouter.use("*", async (c, next) => {
+	if (c.req.method === "OPTIONS") {
+		return new Response(null, { status: 204, headers: OAUTH_CORS_HEADERS });
+	}
+	await next();
+	const headers = new Headers(c.res.headers);
+	for (const [key, value] of Object.entries(OAUTH_CORS_HEADERS)) headers.set(key, value);
+	c.res = new Response(c.res.body, {
+		status: c.res.status,
+		statusText: c.res.statusText,
+		headers,
+	});
+});
 
 function noStore(status = 200) {
 	return { status, headers: { "Cache-Control": "no-store" } };


### PR DESCRIPTION
## Summary

- handle OAuth `OPTIONS` preflights for browser-based public clients
- attach CORS headers to OAuth success and error responses
- allow `Authorization` and `Content-Type` without enabling credentialed cookies
- cover token preflight and error-response CORS in security tests

## Live launch finding

After the dynamic MCP consent fix reached production, MCP Inspector completed authorization and returned to its localhost callback, but its PKCE token exchange failed in-browser with `TypeError: Failed to fetch`. A production preflight to `https://api.phaseo.app/oauth/token` returned `404` with no CORS headers. This change supplies the OAuth endpoint CORS contract needed by localhost/native browser clients.

## Verification

- `pnpm --filter @phaseo/gateway-api test -- src/routes/oauth.security.test.ts` (21 passed)
- `pnpm --filter @phaseo/gateway-api typecheck`
- `pnpm --filter @phaseo/gateway-api exec wrangler deploy --dry-run --strict`
- `git diff --check`