### PR TITLE
Add Together provider for Inkling

### DIFF
--- a/apps/api/tests/aimock/cross-provider-models.spec.ts
+++ b/apps/api/tests/aimock/cross-provider-models.spec.ts
@@ -92,9 +92,9 @@ describe("cross-provider model deployment matrix", () => {
         }).toMatchObject({
             models: 355,
             providers: 49,
-            deployments: 798,
+            deployments: 799,
             multiProviderModels: 127,
-            multiProviderDeployments: 567,
+            multiProviderDeployments: 568,
             missing: [],
         });
     });

--- a/packages/data/catalog/src/data/api_providers/together/models.json
+++ b/packages/data/catalog/src/data/api_providers/together/models.json
@@ -525,6 +525,27 @@
     ]
   },
   {
+    "api_model_id": "thinking-machines/inkling",
+    "provider_api_model_id": "together:thinking-machines/inkling",
+    "provider_model_slug": "thinkingmachines/Inkling",
+    "internal_model_id": "thinking-machines/inkling",
+    "is_active_gateway": true,
+    "quantization_scheme": "NVFP4",
+    "input_modalities": "text,image,audio",
+    "output_modalities": "text",
+    "context_length": 524288,
+    "max_output_tokens": null,
+    "effective_from": "2026-07-15T00:00:00",
+    "effective_to": null,
+    "capabilities": [
+      {
+        "capability_id": "text.generate",
+        "status": "active",
+        "params": []
+      }
+    ]
+  },
+  {
     "api_model_id": "z-ai/glm-5",
     "provider_api_model_id": "together:z-ai/glm-5",
     "provider_model_slug": "zai-org/GLM-5",

--- a/packages/data/catalog/src/data/models/thinking-machines/inkling/model.json
+++ b/packages/data/catalog/src/data/models/thinking-machines/inkling/model.json
@@ -28,6 +28,11 @@
       "title": "Inkling on Hugging Face",
       "kind": "model",
       "url": "https://huggingface.co/thinkingmachines/inkling"
+    },
+    {
+      "title": "Inkling on Together AI",
+      "kind": "model",
+      "url": "https://www.together.ai/models/inkling"
     }
   ],
   "details": [
@@ -49,15 +54,15 @@
     },
     {
       "name": "availability_note",
-      "value": "Full weights are available on Hugging Face. Tinker currently exposes Inkling for sampling and fine-tuning, but its provider is not yet active in the gateway."
+      "value": "Full weights are available on Hugging Face. Tinker exposes Inkling for sampling and fine-tuning, Together AI offers serverless inference, and Baseten offers Model API inference."
     },
     {
       "name": "confirmed_api_providers",
-      "value": "Tinker (beta sampling and fine-tuning API)"
+      "value": "Tinker (beta sampling and fine-tuning API); Together AI (serverless); Baseten (Model API)"
     },
     {
       "name": "weights_distribution",
-      "value": "Hugging Face (weights distribution; no hosted inference provider currently listed)"
+      "value": "Hugging Face (weights distribution)"
     }
   ],
   "benchmarks": []

--- a/packages/data/catalog/src/data/pricing/together/thinking-machines-inkling/text.generate/pricing.json
+++ b/packages/data/catalog/src/data/pricing/together/thinking-machines-inkling/text.generate/pricing.json
@@ -1,0 +1,45 @@
+{
+  "key": "together:thinking-machines/inkling:text.generate",
+  "api_provider_id": "together",
+  "provider_slug": "together",
+  "api_model_id": "thinking-machines/inkling",
+  "capability_id": "text.generate",
+  "rules": [
+    {
+      "meter": "input_text_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 1,
+      "currency": "USD",
+      "pricing_plan": "standard",
+      "note": "Mapped from Together AI's serverless model catalog.",
+      "match": [],
+      "priority": 100,
+      "effective_from": "2026-07-15T00:00:00Z"
+    },
+    {
+      "meter": "cached_read_text_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 0.17,
+      "currency": "USD",
+      "pricing_plan": "standard",
+      "note": "Mapped from Together AI's serverless model catalog.",
+      "match": [],
+      "priority": 100,
+      "effective_from": "2026-07-15T00:00:00Z"
+    },
+    {
+      "meter": "output_text_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 4.05,
+      "currency": "USD",
+      "pricing_plan": "standard",
+      "note": "Mapped from Together AI's serverless model catalog.",
+      "match": [],
+      "priority": 100,
+      "effective_from": "2026-07-15T00:00:00Z"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- add Together AI's serverless Inkling mapping using `thinkingmachines/Inkling`
- record the 524,288-token NVFP4 provider configuration and multimodal inputs
- add Together's input, cached-input, and output token pricing
- refresh Inkling availability metadata to include Together and the existing Baseten Model API

Fireworks is intentionally not added as a provider in this change.

## Validation

- `pnpm validate:data`
- `pnpm validate:pricing`
- `pnpm validate:gateway`
- `git diff --check`

Created with Codex


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Together AI support for the Thinking Machines Inkling model.
  * Inkling now supports text, image, and audio inputs with text generation output.
  * Added pricing information for input, cached, and output tokens.
  * Updated model availability details, including Together AI, Tinker, Baseten, and Hugging Face.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->