### PR TITLE
Add SiliconFlow Kimi K3 mapping

### DIFF
--- a/packages/data/catalog/src/data/api_providers/siliconflow/models.json
+++ b/packages/data/catalog/src/data/api_providers/siliconflow/models.json
@@ -1281,6 +1281,27 @@
     ]
   },
   {
+    "api_model_id": "moonshotai/kimi-k3",
+    "provider_api_model_id": "siliconflow:moonshotai/kimi-k3",
+    "provider_model_slug": "moonshotai/Kimi-K3",
+    "internal_model_id": "moonshotai/kimi-k3",
+    "is_active_gateway": false,
+    "quantization_scheme": null,
+    "input_modalities": "text,image",
+    "output_modalities": "text",
+    "context_length": 1048576,
+    "max_output_tokens": 1048576,
+    "effective_from": "2026-07-18T00:00:00Z",
+    "effective_to": null,
+    "capabilities": [
+      {
+        "capability_id": "text.generate",
+        "status": "active",
+        "params": []
+      }
+    ]
+  },
+  {
     "api_model_id": "z-ai/glm-5.2",
     "provider_api_model_id": "siliconflow:z-ai/glm-5.2",
     "provider_model_slug": "zai-org/GLM-5.2",


### PR DESCRIPTION
## Summary

- map SiliconFlow's newly discovered `moonshotai/Kimi-K3` slug to the canonical Kimi K3 model
- stage the route as gateway-disabled until SiliconFlow pricing and route behavior are verified
- retain the verified Kimi K3 context and text/image input metadata without speculating about provider quantization

## Validation

- `pnpm validate:data`
- focused JSON check confirms exactly one SiliconFlow `moonshotai/Kimi-K3` mapping
- `git diff --check`

Created with Codex
