### PR TITLE
Fix MCP browser OAuth discovery

### DIFF
--- a/apps/mcp/src/index.ts
+++ b/apps/mcp/src/index.ts
@@ -23,6 +23,14 @@ import {
 
 const MAX_RESULTS = 20;
 const MAX_MCP_REQUEST_BODY_BYTES = 1024 * 1024;
+const MCP_CORS_HEADERS = {
+	"Access-Control-Allow-Origin": "*",
+	"Access-Control-Allow-Methods": "GET, POST, DELETE, OPTIONS",
+	"Access-Control-Allow-Headers":
+		"Authorization, Content-Type, Accept, MCP-Protocol-Version, MCP-Session-Id, Last-Event-ID",
+	"Access-Control-Expose-Headers": "WWW-Authenticate, MCP-Session-Id, MCP-Protocol-Version",
+	"Access-Control-Max-Age": "86400",
+} as const;
 
 async function boundedMcpRequest(request: Request): Promise<Request | Response> {
 	const contentLength = Number(request.headers.get("content-length"));
@@ -689,14 +697,19 @@ function secureResponse(response: Response): Response {
 	const headers = new Headers(response.headers);
 	headers.set("X-Content-Type-Options", "nosniff");
 	headers.set("Referrer-Policy", "no-referrer");
+	for (const [name, value] of Object.entries(MCP_CORS_HEADERS)) headers.set(name, value);
 	return new Response(response.body, { status: response.status, statusText: response.statusText, headers });
 }
 
 export default {
 	async fetch(request: Request, env: PhaseoEnv, ctx: ExecutionContext): Promise<Response> {
 		const url = new URL(request.url);
+		if (request.method === "OPTIONS") return secureResponse(new Response(null, { status: 204 }));
 		if (url.pathname === "/health") return secureResponse(Response.json({ status: "ok", service: "phaseo-mcp" }));
-		if (url.pathname === "/.well-known/oauth-protected-resource/mcp") return secureResponse(resourceMetadata(request, env));
+		if (
+			url.pathname === "/.well-known/oauth-protected-resource/mcp" ||
+			url.pathname === "/.well-known/oauth-protected-resource"
+		) return secureResponse(resourceMetadata(request, env));
 		if (url.pathname !== "/mcp") return secureResponse(new Response("Not found", { status: 404 }));
 		if (url.searchParams.has("access_token")) return secureResponse(new Response("Bearer tokens must use the Authorization header.", { status: 400 }));
 		const boundedRequest = await boundedMcpRequest(request);

--- a/apps/mcp/test/server.test.ts
+++ b/apps/mcp/test/server.test.ts
@@ -325,7 +325,9 @@ describe("Phaseo MCP OAuth discovery", () => {
 
 	it("publishes only the scopes required by the enabled MCP tools", async () => {
 		const response = await worker.fetch(
-			new Request("https://mcp.phaseo.app/.well-known/oauth-protected-resource/mcp"),
+			new Request("https://mcp.phaseo.app/.well-known/oauth-protected-resource/mcp", {
+				headers: { Origin: "http://localhost:6284" },
+			}),
 			env,
 			{} as ExecutionContext,
 		);
@@ -350,6 +352,42 @@ describe("Phaseo MCP OAuth discovery", () => {
 			"oauth_clients:read",
 		]);
 		expect(response.headers.get("x-content-type-options")).toBe("nosniff");
+		expect(response.headers.get("access-control-allow-origin")).toBe("*");
+		expect(response.headers.get("access-control-expose-headers")).toContain("WWW-Authenticate");
+	});
+
+	it("supports browser OAuth metadata discovery and preflight requests", async () => {
+		const preflight = await worker.fetch(
+			new Request("https://mcp.phaseo.app/.well-known/oauth-protected-resource/mcp", {
+				method: "OPTIONS",
+				headers: {
+					Origin: "http://localhost:6284",
+					"Access-Control-Request-Method": "GET",
+					"Access-Control-Request-Headers": "authorization",
+				},
+			}),
+			env,
+			{} as ExecutionContext,
+		);
+
+		expect(preflight.status).toBe(204);
+		expect(preflight.headers.get("access-control-allow-origin")).toBe("*");
+		expect(preflight.headers.get("access-control-allow-methods")).toContain("GET");
+		expect(preflight.headers.get("access-control-allow-headers")).toContain("Authorization");
+
+		const fallback = await worker.fetch(
+			new Request("https://mcp.phaseo.app/.well-known/oauth-protected-resource", {
+				headers: { Origin: "http://localhost:6284" },
+			}),
+			env,
+			{} as ExecutionContext,
+		);
+		const metadata = await fallback.json<{ resource: string; authorization_servers: string[] }>();
+
+		expect(fallback.status).toBe(200);
+		expect(fallback.headers.get("access-control-allow-origin")).toBe("*");
+		expect(metadata.resource).toBe("https://mcp.phaseo.app/mcp");
+		expect(metadata.authorization_servers).toEqual(["https://api.phaseo.app/oauth"]);
 	});
 
 	it("publishes write and delete scopes only when their tool classes are enabled", async () => {


### PR DESCRIPTION
## Summary
- add browser-safe CORS headers to MCP responses
- support both RFC 9728 protected-resource metadata paths
- handle browser preflight requests before MCP routing

## Why
MCP Inspector re-discovers OAuth metadata in the browser after the authorization callback. The MCP Worker returned metadata without CORS headers, so the browser blocked discovery and the SDK incorrectly fell back to `https://mcp.phaseo.app/token`.

## Verification
- `pnpm --filter @phaseo/mcp test`
- `pnpm --filter @phaseo/mcp typecheck`
- `pnpm --filter @phaseo/mcp build:production`
- captured the production failure with CDP: `PreflightMissingAllowOriginHeader` on the protected-resource metadata endpoint

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for browser-based cross-origin requests to MCP endpoints.
  * Added handling for preflight `OPTIONS` requests.
  * Added an alternate OAuth protected-resource metadata endpoint.

* **Bug Fixes**
  * Standardized CORS headers across MCP responses, improving compatibility with browser clients.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->