### PR TITLE
Fix browser OAuth metadata discovery

### DIFF
--- a/apps/api/src/routes/oauth.security.test.ts
+++ b/apps/api/src/routes/oauth.security.test.ts
@@ -210,6 +210,39 @@ describe("OAuth route security", () => {
 		expect(response.headers.get("access-control-allow-origin")).toBe("*");
 		expect(response.headers.get("access-control-allow-methods")).toContain("POST");
 		expect(response.headers.get("access-control-allow-headers")).toContain("Content-Type");
+		expect(response.headers.get("access-control-allow-headers")).toContain("MCP-Protocol-Version");
+	});
+
+	it("allows browser-based MCP clients to discover root OAuth metadata", async () => {
+		const { rootRouter } = await import("./root");
+		const preflight = await rootRouter.request(
+			"https://example.com/.well-known/oauth-authorization-server/oauth",
+			{
+				method: "OPTIONS",
+				headers: {
+					origin: "http://localhost:6284",
+					"access-control-request-method": "GET",
+					"access-control-request-headers": "mcp-protocol-version",
+				},
+			},
+		);
+
+		expect(preflight.status).toBe(204);
+		expect(preflight.headers.get("access-control-allow-origin")).toBe("*");
+		expect(preflight.headers.get("access-control-allow-headers")).toContain("MCP-Protocol-Version");
+
+		const metadata = await rootRouter.request(
+			"https://example.com/.well-known/oauth-authorization-server/oauth",
+			{ headers: { origin: "http://localhost:6284" } },
+		);
+
+		expect(metadata.status).toBe(200);
+		expect(metadata.headers.get("access-control-allow-origin")).toBe("*");
+		expect(await metadata.json()).toMatchObject({
+			issuer: "https://api.example.com/oauth",
+			authorization_endpoint: "https://api.example.com/oauth/authorize",
+			token_endpoint: "https://api.example.com/oauth/token",
+		});
 	});
 
 	it("does not let device-code denial overwrite a code that is no longer pending", async () => {

--- a/apps/api/src/routes/oauth.ts
+++ b/apps/api/src/routes/oauth.ts
@@ -60,10 +60,10 @@ import {
 
 export const oauthRouter = new Hono<Env>();
 const MAX_OAUTH_REQUEST_BODY_BYTES = 16 * 1024;
-const OAUTH_CORS_HEADERS: Record<string, string> = {
+export const OAUTH_CORS_HEADERS: Record<string, string> = {
 	"Access-Control-Allow-Origin": "*",
 	"Access-Control-Allow-Methods": "GET, POST, OPTIONS",
-	"Access-Control-Allow-Headers": "Authorization, Content-Type",
+	"Access-Control-Allow-Headers": "Authorization, Content-Type, Accept, MCP-Protocol-Version",
 	"Access-Control-Max-Age": "86400",
 };
 const DYNAMIC_MCP_SCOPES = [

--- a/apps/api/src/routes/root.ts
+++ b/apps/api/src/routes/root.ts
@@ -7,9 +7,23 @@ import { Hono } from "hono";
 import type { Env } from "@/runtime/types";
 import { json, withRuntime } from "./utils";
 import { getLocalJwks } from "@/lib/oauth/service";
-import { oauthAuthorizationServerMetadata } from "./oauth";
+import { OAUTH_CORS_HEADERS, oauthAuthorizationServerMetadata } from "./oauth";
 
 export const rootRouter = new Hono<Env>();
+
+rootRouter.use("/.well-known/*", async (c, next) => {
+    if (c.req.method === "OPTIONS") {
+        return new Response(null, { status: 204, headers: OAUTH_CORS_HEADERS });
+    }
+    await next();
+    const headers = new Headers(c.res.headers);
+    for (const [key, value] of Object.entries(OAUTH_CORS_HEADERS)) headers.set(key, value);
+    c.res = new Response(c.res.body, {
+        status: c.res.status,
+        statusText: c.res.statusText,
+        headers,
+    });
+});
 
 rootRouter.get(
     "/",


### PR DESCRIPTION
## Summary
- add CORS and preflight handling to the root OAuth/OIDC discovery aliases
- allow the `MCP-Protocol-Version` request header across OAuth discovery endpoints
- cover browser discovery of the RFC 8414 issuer-specific metadata URL

## Why
After MCP resource discovery was fixed, MCP Inspector correctly followed the Phaseo authorization server issuer to `/.well-known/oauth-authorization-server/oauth`. That root alias did not include CORS headers, so the browser fell through to the OIDC alias and rejected the OAuth-shaped response with a schema validation error.

## Verification
- `pnpm --filter @phaseo/gateway-api test -- src/routes/oauth.security.test.ts` (24 passed)
- `pnpm --filter @phaseo/gateway-api typecheck`
- `pnpm --filter @phaseo/gateway-api exec wrangler deploy --dry-run --env production`
- live MCP Inspector/CDP trace isolated the failing RFC 8414 discovery request