### PR TITLE
Fix OAuth Gateway resource scope bypass

### DIFF
--- a/apps/api/src/lib/oauth/service.security.test.ts
+++ b/apps/api/src/lib/oauth/service.security.test.ts
@@ -310,6 +310,25 @@ describe("OAuth refresh rotation security", () => {
 		expect(state.rpcCalls).toHaveLength(rpcCallCount);
 	});
 
+	it("refuses to mint a Gateway API resource key without gateway access consent", async () => {
+		const { issueOAuthManagedKeyForAuthorizationCode } = await import("./service");
+		const rpcCallCount = state.rpcCalls.length;
+
+		const result = await issueOAuthManagedKeyForAuthorizationCode(
+			"00000000-0000-0000-0000-000000000004",
+			{
+				userId: "user_1",
+				workspaceId: "ws_1",
+				clientId: "third_party",
+				scopes: ["models:read"],
+				resource: "https://api.phaseo.app:443/v1/",
+			},
+		);
+
+		expect(result).toBeNull();
+		expect(state.rpcCalls).toHaveLength(rpcCallCount);
+	});
+
 	it("mints a least-privilege OAuth-managed key for an MCP resource", async () => {
 		state.rotationStatus = "issued";
 		const { issueOAuthManagedKeyForAuthorizationCode } = await import("./service");

--- a/apps/api/src/lib/oauth/service.ts
+++ b/apps/api/src/lib/oauth/service.ts
@@ -96,6 +96,26 @@ export function getApiBaseUrl(): string {
 	return String(bindings.GATEWAY_PUBLIC_BASE_URL ?? DEFAULT_API_BASE_URL).replace(/\/+$/, "");
 }
 
+export function getGatewayOAuthResource(): string {
+	const baseUrl = getApiBaseUrl();
+	return baseUrl.endsWith("/v1") ? baseUrl : `${baseUrl}/v1`;
+}
+
+function normalizeOAuthResource(value: string): string | null {
+	try {
+		const url = new URL(value);
+		url.pathname = url.pathname.replace(/\/+$/, "") || "/";
+		return url.toString();
+	} catch {
+		return null;
+	}
+}
+
+export function isGatewayOAuthResource(resource: string | null | undefined): boolean {
+	if (!resource) return false;
+	return normalizeOAuthResource(resource) === normalizeOAuthResource(getGatewayOAuthResource());
+}
+
 export function getWebBaseUrl(): string {
 	const bindings = getBindings();
 	return String(bindings.PHASEO_WEB_BASE_URL ?? DEFAULT_WEB_BASE_URL).replace(/\/+$/, "");
@@ -634,8 +654,11 @@ export async function issueOAuthManagedKeyForAuthorizationCode(
 	input: TokenIssueInput,
 ) {
 	// Unbound delegated keys can spend workspace credits and require Gateway
-	// consent. Resource-bound keys remain confined to their protected resource.
-	if (!input.resource && !input.scopes.includes(GATEWAY_ACCESS_SCOPE)) return null;
+	// consent. A key bound to the Gateway API is still a Gateway credential and
+	// must carry the same explicit credit-spending permission.
+	if ((!input.resource || isGatewayOAuthResource(input.resource)) && !input.scopes.includes(GATEWAY_ACCESS_SCOPE)) {
+		return null;
+	}
 
 	const pepper = resolveActiveKeyPepper(getBindings());
 	if (!pepper) throw new Error("KEY_PEPPER_ACTIVE is not configured");

--- a/apps/api/src/pipeline/before/auth.cache.test.ts
+++ b/apps/api/src/pipeline/before/auth.cache.test.ts
@@ -11,6 +11,7 @@ type KeyRow = {
 	oauth_client_id?: string | null;
 	oauth_user_id?: string | null;
 	oauth_scopes?: string[] | null;
+	oauth_resource?: string | null;
 };
 
 const runtime = vi.hoisted(() => {
@@ -289,7 +290,7 @@ describe("authenticate hot-path caching", () => {
 		});
 	});
 
-	it("accepts OAuth keys bound to the advertised Gateway API resource", async () => {
+	it("rejects Gateway API resource keys without gateway access consent", async () => {
 		const kid = "KIDOAUTHAPIRES";
 		const secret = "secret_oauth_api_resource";
 		runtime.dbRow.value = {
@@ -311,12 +312,36 @@ describe("authenticate hot-path caching", () => {
 		);
 		await flushBackground();
 
+		expect(result).toEqual({ ok: false, reason: "oauth_gateway_scope_required" });
+	});
+
+	it("accepts Gateway API resource keys with gateway access consent", async () => {
+		const kid = "KIDOAUTHAPIYES";
+		const secret = "secret_oauth_api_resource_allowed";
+		runtime.dbRow.value = {
+			id: "key_oauth_api_resource_allowed",
+			workspace_id: "team_oauth",
+			status: "active",
+			hash: hashSecret(secret),
+			key_kind: "oauth_delegated",
+			oauth_user_id: "user_oauth",
+			oauth_client_id: "client_oauth",
+			oauth_scopes: ["gateway:access", "models:read"],
+			oauth_resource: "https://api.phaseo.app:443/v1/",
+		};
+
+		const { authenticateManagement } = await import("./auth");
+		const result = await authenticateManagement(
+			buildRequest(`phaseo_v1_sk_${kid}_${secret}`),
+			{ useKvCache: false },
+		);
+		await flushBackground();
+
 		expect(result).toMatchObject({
 			ok: true,
 			authMethod: "oauth",
-			oauthScopes: ["models:read"],
-			oauthResource: "https://api.phaseo.app/v1",
-			scopes: ["models:read"],
+			oauthScopes: ["gateway:access", "models:read"],
+			scopes: ["gateway:access", "models:read"],
 		});
 	});
 

--- a/apps/api/src/pipeline/before/auth.ts
+++ b/apps/api/src/pipeline/before/auth.ts
@@ -17,21 +17,6 @@ const KEY_CACHE_TTL_SECONDS = 60;
 const KEY_VERSION_L1_TTL_MS = 1_000;
 const KEY_LOOKUP_L1_TTL_MS = 1_000;
 const KEY_LOOKUP_L1_MAX_ENTRIES = 2_000;
-const DEFAULT_GATEWAY_PUBLIC_BASE_URL = "https://api.phaseo.app";
-
-function removeTrailingSlashes(value: string): string {
-	let end = value.length;
-	while (end > 0 && value.charCodeAt(end - 1) === 47) end -= 1;
-	return value.slice(0, end);
-}
-
-function gatewayOAuthResource(bindings: ReturnType<typeof getBindings>): string {
-	const configured = removeTrailingSlashes(
-		String(bindings.GATEWAY_PUBLIC_BASE_URL ?? DEFAULT_GATEWAY_PUBLIC_BASE_URL).trim(),
-	);
-	return configured.endsWith("/v1") ? configured : `${configured}/v1`;
-}
-
 /* -------------------- Web Crypto HMAC helpers -------------------- */
 
 /**
@@ -540,17 +525,17 @@ export async function authenticate(req: Request, options: AuthenticateOptions = 
 			if (!userId || !clientId || oauthScopes.length === 0) {
 				return { ok: false, reason: "oauth_managed_key_invalid" };
 			}
-			const { getActiveOAuthWorkspaceScopes } = await import("@/lib/oauth/service");
+			const { getActiveOAuthWorkspaceScopes, isGatewayOAuthResource } = await import("@/lib/oauth/service");
 			const activeAuthorizationScopes = await getActiveOAuthWorkspaceScopes({ userId, workspaceId, clientId });
 			if (activeAuthorizationScopes === null) {
 				return { ok: false, reason: "oauth_authorization_revoked" };
 			}
 			const effectiveScopes = oauthScopes.filter((scope) => activeAuthorizationScopes.includes(scope));
 			const oauthResource = String(keyRow.oauth_resource ?? "").trim() || null;
-			if (!oauthResource && !effectiveScopes.includes(GATEWAY_ACCESS_SCOPE)) {
+			const isGatewayApiResource = isGatewayOAuthResource(oauthResource);
+			if ((!oauthResource || isGatewayApiResource) && !effectiveScopes.includes(GATEWAY_ACCESS_SCOPE)) {
 				return { ok: false, reason: "oauth_gateway_scope_required" };
 			}
-			const isGatewayApiResource = oauthResource === gatewayOAuthResource(bindings);
 			if (oauthResource && !isGatewayApiResource && !options.allowResourceBoundOAuthKey) {
 				return { ok: false, reason: "oauth_resource_token_not_valid_for_api" };
 			}

--- a/apps/api/src/routes/oauth.security.test.ts
+++ b/apps/api/src/routes/oauth.security.test.ts
@@ -155,6 +155,12 @@ vi.mock("@/lib/oauth/service", () => ({
 		return { access_token: "phaseo_v1_sk_test", token_type: "Bearer" };
 	}),
 	issueMcpUpstreamToken: vi.fn(async () => ({ access_token: "upstream-jwt", token_type: "Bearer", expires_in: 300 })),
+	isGatewayOAuthResource: vi.fn((resource: string | null | undefined) => {
+		if (!resource) return false;
+		const candidate = new URL(resource);
+		candidate.pathname = candidate.pathname.replace(/\/+$/, "") || "/";
+		return candidate.toString() === "https://api.example.com/v1";
+	}),
 	isValidPkceChallenge: vi.fn((value: string) => /^[A-Za-z0-9_-]{43}$/.test(value)),
 	isFirstPartyCliClient: vi.fn((clientId: string) => clientId === "phaseo_cli" || clientId === "aistats_cli"),
 	isThirdPartyOAuthEnabled: vi.fn(() => true),
@@ -506,6 +512,84 @@ describe("OAuth route security", () => {
 			clientId: "third_party",
 			scopes: ["gateway:access", "models:read"],
 		});
+	});
+
+	it("rejects Gateway API resource authorization without gateway access consent", async () => {
+		state.client = { id: "third_party", name: "Third Party", client_type: "public" };
+		const challenge = "a".repeat(43);
+		const { oauthRouter } = await import("./oauth");
+		const response = await oauthRouter.request(
+			`https://example.com/authorize?client_id=third_party&redirect_uri=${encodeURIComponent("https://example.com/callback")}&response_type=code&scope=models%3Aread&code_challenge=${challenge}&code_challenge_method=S256&resource=${encodeURIComponent("https://api.example.com/v1/")}`,
+		);
+
+		expect(response.status).toBe(400);
+		expect(await response.json()).toMatchObject({
+			error: "invalid_scope",
+			error_description: "gateway:access is required for third-party OAuth",
+		});
+	});
+
+	it("rejects Gateway API resource approval without gateway access consent", async () => {
+		state.client = { id: "third_party", name: "Third Party", client_type: "public" };
+		const { oauthRouter } = await import("./oauth");
+		const response = await oauthRouter.request("https://example.com/authorize/approve", {
+			method: "POST",
+			headers: { "content-type": "application/json" },
+			body: JSON.stringify({
+				client_id: "third_party",
+				redirect_uri: "https://example.com/callback",
+				primary_workspace_id: "ws_1",
+				scopes: ["models:read"],
+				code_challenge: "a".repeat(43),
+				code_challenge_method: "S256",
+				resource: "https://api.example.com/v1",
+			}),
+		});
+
+		expect(response.status).toBe(400);
+		expect(await response.json()).toMatchObject({
+			error: "invalid_scope",
+			error_description: "gateway:access is required for third-party OAuth",
+		});
+	});
+
+	it("does not exchange a Gateway API resource grant without gateway access consent", async () => {
+		state.client = { id: "third_party", name: "Third Party", client_type: "confidential" };
+		state.authorizationCodeRow = {
+			id: "authorization_code_gateway_resource",
+			client_id: "third_party",
+			user_id: "user_1",
+			workspace_id: "ws_1",
+			redirect_uri: "https://example.com/callback",
+			scopes: ["models:read"],
+			resource: "https://api.example.com/v1/",
+			code_challenge: "challenge",
+			code_challenge_method: "S256",
+			expires_at: FUTURE_EXPIRES_AT,
+			used_at: null,
+		};
+		state.authorizationRow = { id: "auth_1", revoked_at: null };
+
+		const { oauthRouter } = await import("./oauth");
+		const response = await oauthRouter.request("https://example.com/token", {
+			method: "POST",
+			headers: { "content-type": "application/json" },
+			body: JSON.stringify({
+				grant_type: "authorization_code",
+				client_id: "third_party",
+				code: "authorization-code",
+				redirect_uri: "https://example.com/callback",
+				code_verifier: "verifier",
+				resource: "https://api.example.com/v1/",
+			}),
+		});
+
+		expect(response.status).toBe(400);
+		expect(await response.json()).toMatchObject({
+			error: "invalid_scope",
+			error_description: "gateway:access consent is required for a delegated key",
+		});
+		expect(state.issuedManagedKeys).toEqual([]);
 	});
 
 	it("does not issue a delegated key from identity-only consent", async () => {

--- a/apps/api/src/routes/oauth.ts
+++ b/apps/api/src/routes/oauth.ts
@@ -40,6 +40,7 @@ import {
 	issueTokenPairForGrant,
 	issueOAuthManagedKeyForAuthorizationCode,
 	issueMcpUpstreamToken,
+	isGatewayOAuthResource,
 	isValidPkceChallenge,
 	isFirstPartyCliClient,
 	isThirdPartyOAuthEnabled,
@@ -275,6 +276,12 @@ function isProtectedResourceAllowed(value: string): boolean {
 	} catch {
 		return false;
 	}
+}
+
+function requiresGatewayAccessScope(clientId: string, resource: string, scopes: string[]): boolean {
+	return !isFirstPartyCliClient(clientId)
+		&& (!resource || isGatewayOAuthResource(resource))
+		&& !scopes.includes(GATEWAY_ACCESS_SCOPE);
 }
 
 export function oauthAuthorizationServerMetadata() {
@@ -766,7 +773,7 @@ oauthRouter.get(
 		if (scopes.length !== requestedScopes.length) {
 			return oauthError("invalid_scope", "One or more requested scopes are not allowed for this client");
 		}
-		if (!isFirstPartyCliClient(client.id) && !resource && !scopes.includes(GATEWAY_ACCESS_SCOPE)) {
+		if (requiresGatewayAccessScope(client.id, resource, scopes)) {
 			return oauthError("invalid_scope", `${GATEWAY_ACCESS_SCOPE} is required for third-party OAuth`);
 		}
 
@@ -829,7 +836,7 @@ oauthRouter.post(
 		if (scopes.length !== requestedScopes.length) {
 			return oauthError("invalid_scope", "One or more requested scopes are not allowed for this client");
 		}
-		if (!isFirstPartyCliClient(client.id) && !resource && !scopes.includes(GATEWAY_ACCESS_SCOPE)) {
+		if (requiresGatewayAccessScope(client.id, resource, scopes)) {
 			return oauthError("invalid_scope", `${GATEWAY_ACCESS_SCOPE} is required for third-party OAuth`);
 		}
 		const selectedWorkspaceIds = Array.from(new Set([...workspaceIds, workspaceId]));
@@ -1117,11 +1124,7 @@ oauthRouter.post(
 				scopes: Array.isArray(data.scopes) ? data.scopes.map(String) : [],
 				...(grantedResource ? { resource: grantedResource } : {}),
 			};
-			if (
-				!isFirstPartyCliClient(client.id) &&
-				!grantedResource &&
-				!tokenInput.scopes.includes(GATEWAY_ACCESS_SCOPE)
-			) {
+			if (requiresGatewayAccessScope(client.id, grantedResource, tokenInput.scopes)) {
 				return oauthError("invalid_scope", `${GATEWAY_ACCESS_SCOPE} consent is required for a delegated key`);
 			}
 			// The CLI retains refreshable sessions for `login`, logout, and token

--- a/supabase/migrations/20260718010000_require_gateway_scope_for_gateway_resource.sql
+++ b/supabase/migrations/20260718010000_require_gateway_scope_for_gateway_resource.sql
@@ -1,0 +1,137 @@
+-- A delegated credential bound to the Phaseo Gateway API is still capable of
+-- billable inference. Require the explicit gateway:access grant at the storage
+-- boundary as well as in the API authorization checks.
+
+-- Revoke any credential minted during the vulnerable deployment window before
+-- tightening the constraint. Runtime authorization also rejects these keys.
+update public.keys
+set status = 'revoked'
+where key_kind = 'oauth_delegated'
+  and status = 'active'
+  and coalesce(btrim(oauth_resource) ~* '^https://api\.phaseo\.app(?::443)?/v1/*$', false)
+  and not (coalesce(oauth_scopes, array[]::text[]) @> array['gateway:access']::text[]);
+
+alter table public.keys
+  drop constraint if exists keys_active_oauth_delegated_gateway_scope_check;
+
+alter table public.keys
+  add constraint keys_active_oauth_delegated_gateway_scope_check
+  check (
+    key_kind <> 'oauth_delegated'
+    or status <> 'active'
+    or (
+      nullif(btrim(oauth_resource), '') is not null
+      and not coalesce(btrim(oauth_resource) ~* '^https://api\.phaseo\.app(?::443)?/v1/*$', false)
+    )
+    or coalesce(oauth_scopes, array[]::text[]) @> array['gateway:access']::text[]
+  ) not valid;
+
+alter table public.keys
+  validate constraint keys_active_oauth_delegated_gateway_scope_check;
+
+create or replace function public.consume_oauth_code_and_issue_managed_key(
+  p_code_id uuid,
+  p_key_hash text,
+  p_key_kid text,
+  p_key_prefix text,
+  p_key_name text,
+  p_user_id uuid,
+  p_workspace_id uuid,
+  p_client_id text,
+  p_scopes text[],
+  p_resource text
+)
+returns text
+language plpgsql
+security definer
+set search_path = ''
+as $$
+declare
+  granted_scopes text[];
+  granted_resource text;
+  resource_is_gateway boolean;
+begin
+  resource_is_gateway := coalesce(
+    btrim(p_resource) ~* '^https://api\.phaseo\.app(?::443)?/v1/*$',
+    false
+  );
+
+  -- Unbound and Gateway-bound credentials both authorize billable API use.
+  if (nullif(btrim(p_resource), '') is null or resource_is_gateway)
+    and not (coalesce(p_scopes, array[]::text[]) @> array['gateway:access']::text[])
+  then
+    return 'invalid';
+  end if;
+
+  perform 1
+  from public.workspace_members member
+  where member.user_id = p_user_id
+    and member.workspace_id = p_workspace_id
+  for key share;
+
+  if not found then
+    return 'invalid';
+  end if;
+
+  perform 1
+  from public.oauth_authorizations authorization_row
+  where authorization_row.user_id = p_user_id
+    and authorization_row.workspace_id = p_workspace_id
+    and authorization_row.client_id = p_client_id
+    and authorization_row.revoked_at is null
+    and coalesce(authorization_row.scopes, array[]::text[]) @> coalesce(p_scopes, array[]::text[])
+    and (
+      (nullif(btrim(p_resource), '') is not null and not resource_is_gateway)
+      or coalesce(authorization_row.scopes, array[]::text[]) @> array['gateway:access']::text[]
+    )
+  for update;
+
+  if not found then
+    return 'invalid';
+  end if;
+
+  update public.oauth_authorization_codes authorization_code
+  set used_at = now()
+  where authorization_code.id = p_code_id
+    and authorization_code.used_at is null
+    and authorization_code.expires_at > now()
+    and authorization_code.user_id = p_user_id
+    and authorization_code.workspace_id = p_workspace_id
+    and authorization_code.client_id = p_client_id
+    and authorization_code.resource is not distinct from nullif(btrim(p_resource), '')
+    and (
+      (authorization_code.resource is not null and not resource_is_gateway)
+      or coalesce(authorization_code.scopes, array[]::text[]) @> array['gateway:access']::text[]
+    )
+    and coalesce(authorization_code.scopes, array[]::text[]) <@ coalesce(p_scopes, array[]::text[])
+    and coalesce(p_scopes, array[]::text[]) <@ coalesce(authorization_code.scopes, array[]::text[])
+  returning authorization_code.scopes, authorization_code.resource
+    into granted_scopes, granted_resource;
+
+  if not found then
+    return 'invalid';
+  end if;
+
+  update public.keys
+  set status = 'revoked'
+  where key_kind = 'oauth_delegated'
+    and oauth_user_id = p_user_id
+    and workspace_id = p_workspace_id
+    and oauth_client_id = p_client_id
+    and oauth_resource is not distinct from granted_resource
+    and status = 'active';
+
+  insert into public.keys (
+    workspace_id, name, hash, prefix, status, scopes, created_by, kid,
+    key_kind, oauth_client_id, oauth_user_id, oauth_scopes, oauth_resource, issued_via, expires_at
+  ) values (
+    p_workspace_id, p_key_name, p_key_hash, p_key_prefix, 'active', '[]', p_user_id, p_key_kid,
+    'oauth_delegated', p_client_id, p_user_id, granted_scopes, granted_resource, 'oauth_pkce', now() + interval '7 days'
+  );
+
+  return 'issued';
+end;
+$$;
+
+revoke all on function public.consume_oauth_code_and_issue_managed_key(uuid, text, text, text, text, uuid, uuid, text, text[], text) from public, anon, authenticated;
+grant execute on function public.consume_oauth_code_and_issue_managed_key(uuid, text, text, text, text, uuid, uuid, text, text[], text) to service_role;


### PR DESCRIPTION
## Summary
- require `gateway:access` whenever a delegated OAuth key is unbound or bound to the Gateway API resource
- enforce the rule at authorization, approval, token exchange, managed-key issuance, and runtime authentication
- add a forward-only migration that revokes vulnerable active keys and hardens the database constraint/RPC
- preserve least-privilege MCP resource tokens and first-party CLI behavior

## Security impact
Closes the path where a third-party client could request a read-only scope with `resource=https://api.phaseo.app/v1`, receive a delegated key without Gateway consent, and use it for billable `/v1` requests.

## Rollout order
1. Deploy the API Worker so runtime authentication immediately rejects vulnerable credentials.
2. Apply `20260718010000_require_gateway_scope_for_gateway_resource.sql` to revoke existing affected keys and harden future issuance.

## Validation
- `pnpm --filter @phaseo/gateway-api test -- src/routes/oauth.security.test.ts src/lib/oauth/service.security.test.ts src/pipeline/before/auth.cache.test.ts` (52 passed)
- `pnpm --filter @phaseo/gateway-api lint` (passes; existing max-lines warnings only)
- `pnpm --filter @phaseo/gateway-api exec wrangler deploy --dry-run --strict`
- `supabase db push --dry-run --linked`