### PR TITLE
Add SiliconFlow Kimi K3 pricing

### DIFF
--- a/packages/data/catalog/src/data/models/moonshotai/kimi-k3/model.json
+++ b/packages/data/catalog/src/data/models/moonshotai/kimi-k3/model.json
@@ -19,6 +19,11 @@
       "title": "API Reference",
       "kind": "api_reference",
       "url": "https://platform.kimi.ai/docs/guide/kimi-k3-quickstart"
+    },
+    {
+      "title": "SiliconFlow pricing",
+      "kind": "pricing",
+      "url": "https://siliconflow.cn/pricing"
     }
   ],
   "details": [
@@ -64,7 +69,7 @@
     },
     {
       "name": "availability_note",
-      "value": "Moonshot AI, GMI Cloud, Novita, and Venice provide Kimi K3 API access. GMI Cloud currently advertises an FP8 route with a 262,144-token context window; Novita advertises text, image, and video input with a 1,048,576-token context and output limit. Venice exposes the standard kimi-k3 route at $3.75 per million input tokens, $0.375 per million cached input tokens, and $18.75 per million output tokens. Venice's live catalog does not expose an E2EE Kimi K3 model ID, so no E2EE route or pricing is listed. Full model weights and the technical report are still forthcoming."
+      "value": "Moonshot AI, GMI Cloud, Novita, SiliconFlow, and Venice provide Kimi K3 API access. GMI Cloud currently advertises an FP8 route with a 262,144-token context window; Novita advertises text, image, and video input with a 1,048,576-token context and output limit; SiliconFlow advertises text and image input with a 1,048,576-token context and online pricing of $0.30 per million cached input tokens, $3.00 per million input tokens, and $15.00 per million output tokens. Venice exposes the standard kimi-k3 route at $3.75 per million input tokens, $0.375 per million cached input tokens, and $18.75 per million output tokens. Venice's live catalog does not expose an E2EE Kimi K3 model ID, so no E2EE route or pricing is listed. Full model weights and the technical report are still forthcoming."
     }
   ],
   "benchmarks": []

--- a/packages/data/catalog/src/data/pricing/siliconflow/moonshotai-kimi-k3/text.generate/pricing.json
+++ b/packages/data/catalog/src/data/pricing/siliconflow/moonshotai-kimi-k3/text.generate/pricing.json
@@ -1,0 +1,45 @@
+{
+  "key": "siliconflow:moonshotai/kimi-k3:text.generate",
+  "api_provider_id": "siliconflow",
+  "provider_slug": "siliconflow",
+  "api_model_id": "moonshotai/kimi-k3",
+  "capability_id": "text.generate",
+  "rules": [
+    {
+      "meter": "cached_read_text_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 0.3,
+      "currency": "USD",
+      "pricing_plan": "standard",
+      "note": "SiliconFlow online pricing for moonshotai/kimi-k3.",
+      "match": [],
+      "priority": 100,
+      "effective_from": "2026-07-18T00:00:00Z"
+    },
+    {
+      "meter": "input_text_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 3,
+      "currency": "USD",
+      "pricing_plan": "standard",
+      "note": "SiliconFlow online pricing for moonshotai/kimi-k3.",
+      "match": [],
+      "priority": 100,
+      "effective_from": "2026-07-18T00:00:00Z"
+    },
+    {
+      "meter": "output_text_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 15,
+      "currency": "USD",
+      "pricing_plan": "standard",
+      "note": "SiliconFlow online pricing for moonshotai/kimi-k3.",
+      "match": [],
+      "priority": 100,
+      "effective_from": "2026-07-18T00:00:00Z"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- add SiliconFlow online pricing for its existing Kimi K3 provider mapping
- record cached input at $0.30/M tokens, input at $3.00/M, and output at $15.00/M
- link SiliconFlow pricing and include the provider in Kimi K3 availability metadata

This closes the pricing gap introduced when SiliconFlow Kimi K3 support landed in PR #1129.

## Validation

- `pnpm validate:data`
- `pnpm validate:pricing`
- `pnpm validate:gateway`
- `git diff --check`

Created with Codex


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added SiliconFlow as a pricing provider for the MoonshotAI Kimi K3 text generation model.
  - Added pricing details for cached input, input, and output tokens.
  - Updated model availability information to include SiliconFlow’s advertised rates.
  - SiliconFlow pricing takes effect July 18, 2026.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->