### PR TITLE
Derank Venice Kimi K3

### DIFF
--- a/apps/api/tests/aimock/cross-provider-models.spec.ts
+++ b/apps/api/tests/aimock/cross-provider-models.spec.ts
@@ -92,9 +92,9 @@ describe("cross-provider model deployment matrix", () => {
         }).toMatchObject({
             models: 355,
             providers: 49,
-            deployments: 799,
+            deployments: 798,
             multiProviderModels: 127,
-            multiProviderDeployments: 568,
+            multiProviderDeployments: 567,
             missing: [],
         });
     });

--- a/packages/data/catalog/src/data/api_providers/venice/models.json
+++ b/packages/data/catalog/src/data/api_providers/venice/models.json
@@ -816,7 +816,7 @@
     "capabilities": [
       {
         "capability_id": "text.generate",
-        "status": "active",
+        "status": "deranked_lvl1",
         "params": [
           {
             "param_id": "max_tokens",


### PR DESCRIPTION
## Summary

- demote Venice Kimi K3 `text.generate` to `deranked_lvl1`
- keep the Venice route active and preserve its pricing metadata

Venice is priced above the SiliconFlow K3 route, so this lowers its routing rank without removing provider support.

## Validation

- `pnpm validate:data`
- `pnpm validate:pricing`
- `pnpm validate:gateway`
- `git diff --check`

Created with Codex


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated model availability status for Moonshot AI’s Kimi K3 text generation model.
  * Corrected deployment coverage counts to reflect the latest active model catalog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->