### PR TITLE
fix(web): reindex model catalog

### DIFF
--- a/apps/web/src/app/(dashboard)/models/[organisationId]/[modelId]/layout.tsx
+++ b/apps/web/src/app/(dashboard)/models/[organisationId]/[modelId]/layout.tsx
@@ -1,7 +1,17 @@
 import type { ReactNode } from "react";
+import type { Metadata } from "next";
 import ShowFooterStyle from "@/components/layout/ShowFooterStyle";
 import type { ModelRouteParams } from "@/components/(data)/model/model-route-helpers";
 import ScrollToTopOnModelChange from "./ScrollToTopOnModelChange";
+
+// Model overview pages override this with indexable metadata. Secondary tabs
+// remain noindex to consolidate search signals on the canonical overview URL.
+export const metadata: Metadata = {
+	robots: {
+		index: false,
+		follow: true,
+	},
+};
 
 export default async function ModelDetailLayout({
 	children,

--- a/apps/web/src/app/(dashboard)/models/[organisationId]/[modelId]/layout.tsx
+++ b/apps/web/src/app/(dashboard)/models/[organisationId]/[modelId]/layout.tsx
@@ -1,17 +1,7 @@
 import type { ReactNode } from "react";
-import type { Metadata } from "next";
 import ShowFooterStyle from "@/components/layout/ShowFooterStyle";
 import type { ModelRouteParams } from "@/components/(data)/model/model-route-helpers";
 import ScrollToTopOnModelChange from "./ScrollToTopOnModelChange";
-
-// Model detail routes remain available for product navigation, but the public
-// models directory is the single search landing page for this content.
-export const metadata: Metadata = {
-	robots: {
-		index: false,
-		follow: true,
-	},
-};
 
 export default async function ModelDetailLayout({
 	children,

--- a/apps/web/src/app/(dashboard)/models/[organisationId]/[modelId]/page.tsx
+++ b/apps/web/src/app/(dashboard)/models/[organisationId]/[modelId]/page.tsx
@@ -130,7 +130,7 @@ export async function generateMetadata(props: {
 		].filter(Boolean) as string[],
 		imagePath,
 		robots: {
-			index: false,
+			index: true,
 			follow: true,
 		},
 	});

--- a/apps/web/src/app/sitemap.ts
+++ b/apps/web/src/app/sitemap.ts
@@ -9,6 +9,7 @@ import {
 	fetchFrontendBenchmarks,
 	fetchFrontendCountrySummaries,
 	fetchFrontendMarketplacePresets,
+	fetchFrontendModels,
 	fetchFrontendOrganisations,
 	fetchFrontendSubscriptionPlans,
 } from "@/lib/fetchers/frontend/fetchPublicCatalog";
@@ -109,7 +110,11 @@ const COUNTRY_SUFFIXES: RouteSuffix[] = [
 ];
 
 const MARKETPLACE_PRESET_SUFFIXES: RouteSuffix[] = [
-    { suffix: "", changeFrequency: "weekly", priority: 0.55 },
+	{ suffix: "", changeFrequency: "weekly", priority: 0.55 },
+];
+
+const MODEL_SUFFIXES: RouteSuffix[] = [
+	{ suffix: "", changeFrequency: "weekly", priority: 0.85 },
 ];
 
 function buildRouteUrl(route: string): string {
@@ -158,6 +163,32 @@ function normalizeSingleSegmentSlugs(list?: string[], label?: string): string[] 
 				label ?? "single segment"
 			} slug(s)`,
 		);
+	}
+
+	return [...normalized].sort();
+}
+
+function normalizeModelIds(list?: string[]): string[] {
+	const normalized = new Set<string>();
+	let dropped = 0;
+
+	for (const modelId of list ?? []) {
+		const segments = String(modelId ?? "")
+			.trim()
+			.replace(/^\/+|\/+$/g, "")
+			.split("/")
+			.filter(Boolean);
+
+		if (segments.length !== 2) {
+			dropped += 1;
+			continue;
+		}
+
+		normalized.add(segments.join("/"));
+	}
+
+	if (dropped > 0) {
+		console.warn(`[sitemap] dropped ${dropped} malformed model id(s)`);
 	}
 
 	return [...normalized].sort();
@@ -258,6 +289,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
 		plansResult,
 		countriesResult,
 		marketplacePresetsResult,
+		modelsResult,
 		helpCategoryResult,
 		helpArticleResult,
 	] = await Promise.allSettled([
@@ -267,6 +299,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
 		fetchFrontendSubscriptionPlans(),
 		fetchFrontendCountrySummaries(),
 		fetchFrontendMarketplacePresets(),
+		fetchFrontendModels(),
 		getHelpCategoryParams(),
 		getHelpArticleParams(),
 	]);
@@ -323,7 +356,19 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
 		).map((preset) => String(preset.id ?? "").trim()),
 		"marketplace preset",
 	);
+	const modelsForSitemap = fromSettled(modelsResult, "models for sitemap", []);
+	const modelIds = normalizeModelIds(
+		modelsForSitemap.map((model) => model.model_id),
+	);
+	const modelEntries = modelIds.map((slug) => {
+		const source = modelsForSitemap.find((model) => model.model_id === slug);
+		return {
+			slug,
+			lastModified: resolveLastModified(source?.updated_at),
+		};
+	});
 	const dynamicItems = [
+		...applySuffixesWithEntries("/models", modelEntries, MODEL_SUFFIXES),
 		...applySuffixesWithEntries(
 			"/api-providers",
 			providerEntries,

--- a/apps/web/src/app/sitemap.ts
+++ b/apps/web/src/app/sitemap.ts
@@ -168,23 +168,28 @@ function normalizeSingleSegmentSlugs(list?: string[], label?: string): string[] 
 	return [...normalized].sort();
 }
 
+function normalizeModelId(modelId: unknown): string | null {
+	const segments = String(modelId ?? "")
+		.trim()
+		.replace(/^\/+|\/+$/g, "")
+		.split("/")
+		.filter(Boolean);
+
+	return segments.length === 2 ? segments.join("/") : null;
+}
+
 function normalizeModelIds(list?: string[]): string[] {
 	const normalized = new Set<string>();
 	let dropped = 0;
 
 	for (const modelId of list ?? []) {
-		const segments = String(modelId ?? "")
-			.trim()
-			.replace(/^\/+|\/+$/g, "")
-			.split("/")
-			.filter(Boolean);
-
-		if (segments.length !== 2) {
+		const normalizedModelId = normalizeModelId(modelId);
+		if (!normalizedModelId) {
 			dropped += 1;
 			continue;
 		}
 
-		normalized.add(segments.join("/"));
+		normalized.add(normalizedModelId);
 	}
 
 	if (dropped > 0) {
@@ -360,11 +365,22 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
 	const modelIds = normalizeModelIds(
 		modelsForSitemap.map((model) => model.model_id),
 	);
+	const modelLastModifiedById = new Map<string, string | null>();
+	for (const model of modelsForSitemap) {
+		const modelId = normalizeModelId(model.model_id);
+		if (!modelId) continue;
+		modelLastModifiedById.set(
+			modelId,
+			resolveLastModified(
+				modelLastModifiedById.get(modelId),
+				model.updated_at,
+			),
+		);
+	}
 	const modelEntries = modelIds.map((slug) => {
-		const source = modelsForSitemap.find((model) => model.model_id === slug);
 		return {
 			slug,
-			lastModified: resolveLastModified(source?.updated_at),
+			lastModified: modelLastModifiedById.get(slug) ?? null,
 		};
 	});
 	const dynamicItems = [


### PR DESCRIPTION
## Summary

- removes the inherited `noindex` directive from model-detail routes
- adds every valid canonical model overview URL to the public sitemap
- adds model update timestamps as sitemap `lastmod` values when available

## SEO impact

- re-enables indexing for the model catalog and its model-detail routes
- makes the canonical ~1,200 model overview pages directly discoverable through `sitemap.xml`

## Validation

- `git diff --check`
- CI will run the full web build and typecheck


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added model detail pages to the sitemap.
  * Model sitemap entries now include update dates, change frequency, and priority.

* **Bug Fixes**
  * Improved sitemap model ID handling by validating, normalizing, sorting, and removing duplicates.

* **SEO**
  * Updated model page indexing metadata to support accurate search engine crawling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->