### PR TITLE
chore(web-api): production rollout checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,7 +110,7 @@ jobs:
         if: github.event_name == 'push' || !startsWith(github.head_ref, 'chore/auto-model-statuses')
         strategy:
             matrix:
-                app: [api, docs, web]
+                app: [api, docs, web, web-api]
         steps:
             - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
 
@@ -149,6 +149,13 @@ jobs:
                   cd apps/web
                   pnpm run lint
                   pnpm run typecheck
+
+            - name: Web API lint, test & build
+              if: matrix.app == 'web-api'
+              run: |
+                  pnpm --filter @phaseo/web-api lint
+                  pnpm --filter @phaseo/web-api test
+                  pnpm --filter @phaseo/web-api build
 
     api-aimock:
         name: API AIMock matrix
@@ -694,6 +701,8 @@ jobs:
                       name: Deploy Web
                     - target: api
                       name: Deploy API
+                    - target: web-api
+                      name: Deploy Web API
                     - target: docs
                       name: Deploy Docs
         steps:
@@ -738,12 +747,12 @@ jobs:
             - name: Restore lockfile (guard setup-node cache mutation)
               run: git checkout -- pnpm-lock.yaml
 
-            - name: Install dependencies (for API)
-              if: matrix.target == 'api'
+            - name: Install dependencies (for Cloudflare Workers)
+              if: matrix.target == 'api' || matrix.target == 'web-api'
               run: corepack pnpm install --frozen-lockfile
 
             - name: Validate Cloudflare API deploy secrets
-              if: matrix.target == 'api'
+              if: matrix.target == 'api' || matrix.target == 'web-api'
               shell: bash
               env:
                   CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
@@ -778,6 +787,15 @@ jobs:
                   apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
                   accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
                   workingDirectory: apps/api
+
+            - name: Deploy Web API Worker to Cloudflare
+              if: matrix.target == 'web-api'
+              uses: cloudflare/wrangler-action@ebbaa1584979971c8614a24965b4405ff95890e0
+              with:
+                  apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+                  accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+                  workingDirectory: apps/web-api
+                  command: deploy
 
             # ---------- DOCS ----------
             - name: Docs (Mintlify deploy is handled by GitHub App)

--- a/apps/web-api/README.md
+++ b/apps/web-api/README.md
@@ -5,45 +5,45 @@ This Worker owns the Cloudflare implementation of the web application's API path
 ## Initial production route
 
 The first production rollout is deliberately limited to
-`phaseo.app/api/public/models*`. This covers the models catalogue and each
-model's section resources, while all other web API paths continue to run on
-Vercel. Expand the Cloudflare route only after each additional endpoint family
-has completed its own rollout.
+`phaseo.app/api/_web/*`. This serves anonymous, cacheable web data such as the
+models catalogue and search index. All account, chat, checkout, Stripe webhook,
+and internal API paths continue to run on Vercel. Expand the Cloudflare route
+only after each endpoint family has completed its own rollout.
 
 ## API boundary
 
 | Path | Intended data | Authentication | Cache policy |
 | --- | --- | --- | --- |
-| `/api/public/*` | Anonymous website data | None | Explicit Cloudflare edge caching only where safe |
-| `/api/account/*` | Current user/workspace data | Supabase bearer JWT | `private, no-store` |
+| `/api/_web/*` | Anonymous website data | None | Explicit Cloudflare edge caching only where safe |
+| Other `/api/*` paths | Authenticated, billing, and internal data | Vercel-owned | Their existing policy |
 
-`public` means the response is identical for every caller. A public endpoint may still be uncacheable when its data is live. `account` means user or workspace data and must never be sent through a shared cache.
-
-Authenticated credit endpoints require a Supabase bearer JWT and a `workspaceId` query parameter. The Worker verifies that the JWT user is a member of that workspace before reading financial data.
+`_web` means the response is identical for every caller. A public endpoint may
+still be uncacheable when its data is live. User, workspace, billing, and
+internal data are explicitly outside this Worker’s production route.
 
 ## Model API cache contract
 
 | Endpoint | Purpose | Cloudflare cache |
 | --- | --- | --- |
-| `GET /api/public/models` | Main catalogue, pagination, and name search | 1 hour + 24-hour stale window |
-| `GET /api/public/models/:modelId` | Stable model overview/about facts | 1 day + 7-day stale window |
-| `GET /api/public/models/:modelId/benchmarks` | Benchmark results | 1 day + 7-day stale window |
-| `GET /api/public/models/:modelId/performance` | Gateway performance rollup | 15 minutes + 15-minute stale window |
-| `GET /api/public/models/:modelId/timeline` | Stable lifecycle/version timeline | 1 day + 7-day stale window |
-| `GET /api/public/models/:modelId/subscription-plans` | Model subscription-plan coverage | 1 day + 7-day stale window |
-| `GET /api/public/models/:modelId/pricing` | Active provider pricing rules | 1 hour + 24-hour stale window |
+| `GET /api/_web/models` | Main catalogue, pagination, and name search | 5 minutes + 5-minute stale window |
+| `GET /api/_web/models/:modelId` | Stable model overview/about facts | 1 day + 7-day stale window |
+| `GET /api/_web/models/:modelId/benchmarks` | Benchmark results | 1 day + 7-day stale window |
+| `GET /api/_web/models/:modelId/performance` | Gateway performance rollup | 15 minutes + 15-minute stale window |
+| `GET /api/_web/models/:modelId/timeline` | Stable lifecycle/version timeline | 1 day + 7-day stale window |
+| `GET /api/_web/models/:modelId/subscription-plans` | Model subscription-plan coverage | 1 day + 7-day stale window |
+| `GET /api/_web/models/:modelId/pricing` | Active provider pricing rules | 1 hour + 24-hour stale window |
 
 ## Other public reference APIs
 
 | Endpoint | Purpose | Cloudflare cache |
 | --- | --- | --- |
-| `GET /api/public/organisations` | Organisation identities | 1 day + 7-day stale window |
-| `GET /api/public/benchmarks?sort=coverage` | Benchmark reference list | 1 day + 7-day stale window |
-| `GET /api/public/api-providers` | Stable provider identity metadata | 1 day + 7-day stale window |
-| `GET /api/public/families` and `/:familyId` | Model family reference data | 1 day + 7-day stale window |
-| `GET /api/public/subscription-plans` and `/:planId` | Public subscription-plan data | 1 day + 7-day stale window |
-| `GET /api/public/countries` and `/:iso` | Country and public model summaries | 1 day + 7-day stale window |
-| `GET /api/public/collections` | Derived public model collections | 1 hour + 24-hour stale window |
+| `GET /api/_web/organisations` | Organisation identities | 1 day + 7-day stale window |
+| `GET /api/_web/benchmarks?sort=coverage` | Benchmark reference list | 1 day + 7-day stale window |
+| `GET /api/_web/api-providers` | Stable provider identity metadata | 1 day + 7-day stale window |
+| `GET /api/_web/families` and `/:familyId` | Model family reference data | 1 day + 7-day stale window |
+| `GET /api/_web/subscription-plans` and `/:planId` | Public subscription-plan data | 1 day + 7-day stale window |
+| `GET /api/_web/countries` and `/:iso` | Country and public model summaries | 1 day + 7-day stale window |
+| `GET /api/_web/collections` | Derived public model collections | 1 hour + 24-hour stale window |
 
 Each model page section will be added as an independent resource rather than extending the overview response. The table migration follows the same principle: a stable catalogue/facet resource is kept separate from frequently changing gateway telemetry.
 
@@ -58,7 +58,7 @@ Each model page section will be added as an independent resource rather than ext
 ## Deployment prerequisites
 
 - Add the production `SUPABASE_URL`, `SUPABASE_ANON_KEY`, and `SUPABASE_SERVICE_ROLE_KEY` as Worker environment values/secrets. The service-role key is only available inside Cloudflare and is used to read public catalogue data consistently regardless of Supabase RLS.
-- Deploy this Worker after confirming that `phaseo.app` is an active proxied Cloudflare zone. Its initial route only matches `phaseo.app/api/public/models*`; the rest of the hostname and web API continue to Vercel.
+- Deploy this Worker after confirming that `phaseo.app` is an active proxied Cloudflare zone. Its initial route only matches `phaseo.app/api/_web/*`; the rest of the hostname and web API continue to Vercel.
 - Keep `api.phaseo.app` deployed from `apps/api`; it remains the external gateway API.
 
 ## Staging and promotion
@@ -66,4 +66,6 @@ Each model page section will be added as an independent resource rather than ext
 - `pnpm exec wrangler deploy --env staging` creates `phaseo-web-api-staging` on the account's `workers.dev` subdomain. It has no `phaseo.app` route, so it is safe for PR validation.
 - The PR workflow deploys that staging Worker and points its Vercel preview at it with `WEB_API_ORIGIN`; it supplies the origin at both build and runtime without changing Vercel's shared preview environment.
 - Before the first staging deployment, provision its `SUPABASE_URL`, `SUPABASE_ANON_KEY`, and `SUPABASE_SERVICE_ROLE_KEY` values in Cloudflare.
-- Promote the default environment explicitly with `pnpm exec wrangler deploy --env=""` after the PR is reviewed. `phaseo-web-api` is the only Worker allowed to own `phaseo.app/api/public/models*` during the initial rollout.
+- Merges to `main` deploy the production Worker from `apps/web-api`. The Worker is the only service allowed to own `phaseo.app/api/_web/*` during the initial rollout.
+- After deployment, run `INCLUDE_LEGACY_API_SMOKES=1 pnpm --filter @phaseo/web-api smoke:production` (macOS/Linux), or `$env:INCLUDE_LEGACY_API_SMOKES='1'; pnpm --filter @phaseo/web-api smoke:production` (PowerShell). It verifies the Cloudflare models cache contract, then safely verifies that unauthenticated checkout and an unsigned Stripe webhook are rejected by Vercel. It cannot create a payment or credit a workspace.
+- In an isolated Stripe test environment, add `SIGNED_STRIPE_WEBHOOK_SMOKE=1` and that environment's `STRIPE_WEBHOOK_SECRET` to verify signature validation with a signed `customer.created` event. The handler ignores that event type, so it does not create a payment, credit a workspace, or call Stripe's API.

--- a/apps/web-api/package.json
+++ b/apps/web-api/package.json
@@ -7,6 +7,7 @@
     "dev": "wrangler dev --port 8788",
     "build": "wrangler deploy --dry-run --env=\"\"",
     "lint": "eslint src && pnpm run typecheck",
+    "smoke:production": "node scripts/smoke-production.mjs",
     "typecheck": "tsc --noEmit",
     "test": "vitest run"
   },

--- a/apps/web-api/scripts/smoke-production.mjs
+++ b/apps/web-api/scripts/smoke-production.mjs
@@ -1,0 +1,104 @@
+import { createHmac, randomUUID } from "node:crypto";
+
+const origin = (process.env.PHASEO_WEB_ORIGIN ?? "https://phaseo.app").replace(/\/$/, "");
+const includeLegacyApiSmokes = process.env.INCLUDE_LEGACY_API_SMOKES === "1";
+const includeSignedStripeWebhookSmoke = process.env.SIGNED_STRIPE_WEBHOOK_SMOKE === "1";
+
+function assert(condition, message) {
+	if (!condition) throw new Error(message);
+}
+
+async function request(name, path, options = {}) {
+	const response = await fetch(`${origin}${path}`, {
+		redirect: "manual",
+		...options,
+	});
+
+	return { name, response };
+}
+
+function requireVercel(response, name) {
+	assert(response.headers.has("x-vercel-id"), `${name} was not served by Vercel.`);
+}
+
+async function main() {
+	const { response: models } = await request("models", "/api/_web/models?limit=1");
+	assert(models.status === 200, `Models endpoint returned ${models.status}, expected 200.`);
+	assert(!models.headers.has("x-vercel-id"), "Models endpoint unexpectedly reached Vercel.");
+	assert(
+		models.headers.get("server")?.toLowerCase().includes("cloudflare"),
+		"Models endpoint did not report a Cloudflare response.",
+	);
+
+	const cacheControl = models.headers.get("cache-control") ?? "";
+	assert(cacheControl.includes("s-maxage=300"), "Models response is missing s-maxage=300.");
+	assert(
+		cacheControl.includes("stale-while-revalidate=300"),
+		"Models response is missing stale-while-revalidate=300.",
+	);
+	console.log("PASS models: Cloudflare route and cache contract");
+
+	const { response: search } = await request("search", "/api/_web/search");
+	assert(search.status === 200, `Search endpoint returned ${search.status}, expected 200.`);
+	assert(!search.headers.has("x-vercel-id"), "Search endpoint unexpectedly reached Vercel.");
+	const searchCacheControl = search.headers.get("cache-control") ?? "";
+	assert(searchCacheControl.includes("s-maxage=900"), "Search response is missing s-maxage=900.");
+	assert(
+		searchCacheControl.includes("stale-while-revalidate=3600"),
+		"Search response is missing stale-while-revalidate=3600.",
+	);
+	console.log("PASS search: Cloudflare route and cache contract");
+
+	if (!includeLegacyApiSmokes) {
+		console.log("SKIP legacy API checks (set INCLUDE_LEGACY_API_SMOKES=1 to verify checkout and Stripe routing).");
+		return;
+	}
+
+	const jsonHeaders = { "content-type": "application/json" };
+	const { response: checkout } = await request("checkout", "/api/checkout/create", {
+		method: "POST",
+		headers: jsonHeaders,
+		body: "{}",
+	});
+	assert(checkout.status === 401, `Checkout returned ${checkout.status}, expected 401 without a session.`);
+	requireVercel(checkout, "Checkout");
+	console.log("PASS checkout: Vercel route rejects an unauthenticated request");
+
+	const { response: webhook } = await request("Stripe webhook", "/api/webhooks/stripe-checkout", {
+		method: "POST",
+		headers: jsonHeaders,
+		body: "{}",
+	});
+	assert(webhook.status === 400, `Stripe webhook returned ${webhook.status}, expected 400 for an unsigned event.`);
+	requireVercel(webhook, "Stripe webhook");
+	console.log("PASS Stripe webhook: Vercel route rejects an unsigned event");
+
+	if (!includeSignedStripeWebhookSmoke) return;
+
+	const webhookSecret = process.env.STRIPE_WEBHOOK_SECRET?.trim();
+	assert(webhookSecret, "SIGNED_STRIPE_WEBHOOK_SMOKE=1 requires STRIPE_WEBHOOK_SECRET.");
+	const timestamp = Math.floor(Date.now() / 1_000);
+	const payload = JSON.stringify({
+		id: `evt_phaseo_smoke_${randomUUID().replaceAll("-", "")}`,
+		object: "event",
+		api_version: "2025-09-30.clover",
+		created: timestamp,
+		livemode: false,
+		type: "customer.created",
+		data: { object: { id: `cus_phaseo_smoke_${randomUUID().replaceAll("-", "")}`, object: "customer" } },
+	});
+	const signature = createHmac("sha256", webhookSecret).update(`${timestamp}.${payload}`).digest("hex");
+	const { response: signedWebhook } = await request("signed Stripe webhook", "/api/webhooks/stripe-checkout", {
+		method: "POST",
+		headers: { ...jsonHeaders, "stripe-signature": `t=${timestamp},v1=${signature}` },
+		body: payload,
+	});
+	assert(signedWebhook.status === 200, `Signed Stripe webhook returned ${signedWebhook.status}, expected 200.`);
+	requireVercel(signedWebhook, "Signed Stripe webhook");
+	console.log("PASS Stripe webhook: Vercel accepts a signed no-op event");
+}
+
+main().catch((error) => {
+	console.error(`FAIL ${error instanceof Error ? error.message : String(error)}`);
+	process.exitCode = 1;
+});

--- a/apps/web-api/wrangler.toml
+++ b/apps/web-api/wrangler.toml
@@ -1,6 +1,7 @@
 name = "phaseo-web-api"
 main = "src/index.ts"
-compatibility_date = "2026-05-28"
+compatibility_date = "2026-07-20"
+compatibility_flags = ["nodejs_compat"]
 workers_dev = false
 preview_urls = false
 

--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -116,12 +116,8 @@ const nextConfig = {
 		...(webApiOrigin
 			? [
 					{
-						source: "/api/public/:path*",
-						destination: `${webApiOrigin}/api/public/:path*`,
-					},
-					{
-						source: "/api/account/:path*",
-						destination: `${webApiOrigin}/api/account/:path*`,
+						source: "/api/_web/:path*",
+						destination: `${webApiOrigin}/api/_web/:path*`,
 					},
 				]
 			: []),

--- a/apps/web/src/components/ai-elements/message.tsx
+++ b/apps/web/src/components/ai-elements/message.tsx
@@ -211,7 +211,7 @@ export const MessageBranchContent = ({
   ));
 };
 
-export type MessageBranchSelectorProps = HTMLAttributes<HTMLDivElement> & {
+export type MessageBranchSelectorProps = ComponentProps<typeof ButtonGroup> & {
   from: UIMessage["role"];
 };
 

--- a/apps/web/src/lib/auth/authOrigin.test.ts
+++ b/apps/web/src/lib/auth/authOrigin.test.ts
@@ -2,6 +2,7 @@ import {
 	buildAuthCallbackUrl,
 	configuredAuthOriginsFromEnv,
 	resolveLocalDevAuthOrigin,
+	resolveVercelPreviewAuthOrigin,
 } from "./authOrigin";
 
 describe("auth origin helpers", () => {
@@ -30,6 +31,25 @@ describe("auth origin helpers", () => {
 				hostHeader: "127.0.0.1:3100",
 			}),
 		).toBe("http://127.0.0.1:3100");
+	});
+
+	it("uses the canonical Vercel preview deployment for preview auth callbacks", () => {
+		expect(
+			resolveVercelPreviewAuthOrigin({
+				NODE_ENV: "production",
+				VERCEL_ENV: "preview",
+				VERCEL_URL: "ai-stats-ywe0ybx3k-ai-stats.vercel.app",
+			} as NodeJS.ProcessEnv),
+		).toBe("https://ai-stats-ywe0ybx3k-ai-stats.vercel.app");
+	});
+
+	it("never uses an arbitrary URL for preview auth callbacks", () => {
+		expect(
+			resolveVercelPreviewAuthOrigin({
+				VERCEL_ENV: "preview",
+				VERCEL_URL: "https://example.com",
+			} as NodeJS.ProcessEnv),
+		).toBeNull();
 	});
 
 	it("builds callback URLs and preserves valid returnUrl", () => {

--- a/apps/web/src/lib/auth/authOrigin.ts
+++ b/apps/web/src/lib/auth/authOrigin.ts
@@ -17,6 +17,31 @@ export function configuredAuthOriginsFromEnv(
 	return [...new Set(candidates)];
 }
 
+export function resolveVercelPreviewAuthOrigin(
+	env: NodeJS.ProcessEnv = process.env,
+): string | null {
+	if (env.VERCEL_ENV !== "preview") return null;
+
+	const deploymentUrl = String(
+		env.NEXT_PUBLIC_VERCEL_URL ?? env.VERCEL_URL ?? "",
+	).trim();
+	if (!deploymentUrl) return null;
+
+	try {
+		const url = new URL(
+			deploymentUrl.startsWith("http")
+				? deploymentUrl
+				: `https://${deploymentUrl}`,
+		);
+		if (url.protocol !== "https:" || !url.hostname.endsWith(".vercel.app")) {
+			return null;
+		}
+		return stripTrailingSlash(url.origin);
+	} catch {
+		return null;
+	}
+}
+
 export function resolveLocalDevAuthOrigin(input: {
 	originHeader?: string | null;
 	hostHeader?: string | null;
@@ -47,6 +72,9 @@ export async function resolveAuthOrigin(
 ): Promise<string> {
 	const configuredOrigins = configuredAuthOriginsFromEnv(env);
 	const isDev = env.NODE_ENV !== "production";
+	const vercelPreviewOrigin = resolveVercelPreviewAuthOrigin(env);
+
+	if (vercelPreviewOrigin) return vercelPreviewOrigin;
 
 	if (!isDev) {
 		if (configuredOrigins.length > 0) return configuredOrigins[0]!;

--- a/packages/devtools/raycast-extension/package.json
+++ b/packages/devtools/raycast-extension/package.json
@@ -49,7 +49,7 @@
   },
   "devDependencies": {
     "@types/node": "22.19.17",
-    "@types/react": "19.0.10",
+    "@types/react": "19.2.17",
     "eslint": "^10.0.3",
     "prettier": "^3.8.3",
     "typescript": "^6.0.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -635,10 +635,10 @@ importers:
     dependencies:
       '@raycast/api':
         specifier: ^1.104.21
-        version: 1.104.21(@types/node@22.19.17)(@types/react@19.0.10)
+        version: 1.104.21(@types/node@22.19.17)(@types/react@19.2.17)
       '@raycast/utils':
         specifier: ^2.2.7
-        version: 2.2.7(@raycast/api@1.104.21(@types/node@22.19.17)(@types/react@19.0.10))(react@19.2.7)
+        version: 2.2.7(@raycast/api@1.104.21(@types/node@22.19.17)(@types/react@19.2.17))(react@19.2.7)
     devDependencies:
       '@raycast/eslint-config':
         specifier: ^2.1.1
@@ -647,8 +647,8 @@ importers:
         specifier: 22.19.17
         version: 22.19.17
       '@types/react':
-        specifier: 19.0.10
-        version: 19.0.10
+        specifier: 19.2.17
+        version: 19.2.17
       eslint:
         specifier: ^10.0.3
         version: 10.1.0(jiti@2.7.0)
@@ -15758,7 +15758,7 @@ snapshots:
 
   '@radix-ui/rect@1.1.1': {}
 
-  '@raycast/api@1.104.21(@types/node@22.19.17)(@types/react@19.0.10)':
+  '@raycast/api@1.104.21(@types/node@22.19.17)(@types/react@19.2.17)':
     dependencies:
       '@oclif/core': 4.10.0
       '@oclif/plugin-autocomplete': 3.2.41
@@ -15768,7 +15768,7 @@ snapshots:
       react: 19.0.0
     optionalDependencies:
       '@types/node': 22.19.17
-      '@types/react': 19.0.10
+      '@types/react': 19.2.17
     transitivePeerDependencies:
       - supports-color
 
@@ -15793,9 +15793,9 @@ snapshots:
       - supports-color
       - typescript
 
-  '@raycast/utils@2.2.7(@raycast/api@1.104.21(@types/node@22.19.17)(@types/react@19.0.10))(react@19.2.7)':
+  '@raycast/utils@2.2.7(@raycast/api@1.104.21(@types/node@22.19.17)(@types/react@19.2.17))(react@19.2.7)':
     dependencies:
-      '@raycast/api': 1.104.21(@types/node@22.19.17)(@types/react@19.0.10)
+      '@raycast/api': 1.104.21(@types/node@22.19.17)(@types/react@19.2.17)
       dequal: 2.0.3
     optionalDependencies:
       react: 19.2.7


### PR DESCRIPTION
## Summary

- keep Cloudflare limited to the cacheable `/api/_web/*` boundary and make local/preview rewrites match it
- validate, test, and deploy `apps/web-api` from CI when changes reach `main`
- add safe production smoke checks for models, search, checkout, and Stripe webhook routing
- document the production rollout and signed no-op Stripe verification

## Validation

- `pnpm --filter @phaseo/web-api lint`
- `pnpm --filter @phaseo/web-api test` (5 files, 8 tests)
- `pnpm --filter @phaseo/web-api build`
- `pnpm --filter @phaseo/web typecheck`
- `pnpm --filter @phaseo/web build`
- production smoke: models and search served by Cloudflare; checkout rejects unauthenticated requests on Vercel; Stripe webhook rejects unsigned requests on Vercel
- CI YAML parsed successfully

## Remaining staging check

Run the signed no-op Stripe webhook smoke using the staging Vercel environment's `STRIPE_WEBHOOK_SECRET`. It sends a `customer.created` event which the handler ignores, so it cannot create a charge or mutate a wallet.

Created with Codex