### PR TITLE
fix(web): polish chat mobile settings

### DIFF
--- a/apps/web/src/components/(chat)/ChatHeader.tsx
+++ b/apps/web/src/components/(chat)/ChatHeader.tsx
@@ -1602,12 +1602,12 @@ export function ChatHeader({
 					<TooltipContent>Settings</TooltipContent>
 				</Tooltip>
 				<Dialog open={settingsOpen} onOpenChange={onSettingsOpenChange}>
-					<DialogContent className="overflow-hidden p-0 md:max-h-[520px] md:max-w-[760px] lg:max-w-[820px]">
+					<DialogContent className="max-h-[calc(100dvh-1rem)] w-[calc(100vw-1rem)] max-w-[calc(100vw-1rem)] overflow-hidden p-0 md:max-h-[520px] md:w-auto md:max-w-[760px] lg:max-w-[820px]">
 						<DialogTitle className="sr-only">Settings</DialogTitle>
 						<DialogDescription className="sr-only">
 							Chat settings and diagnostics.
 						</DialogDescription>
-						<div className="flex h-[520px] flex-1 overflow-hidden">
+						<div className="flex h-[calc(100dvh-1rem)] max-h-[520px] flex-1 overflow-hidden">
 							<div className="hidden w-52 shrink-0 flex-col border-r border-border p-2 md:flex">
 								<Button
 									variant={
@@ -1666,7 +1666,7 @@ export function ChatHeader({
 								)}
 							</div>
 							<div className="flex flex-1 flex-col overflow-hidden">
-								<div className="flex items-center gap-2 border-b border-border px-4 py-3 md:hidden">
+								<div className="flex shrink-0 items-center gap-1 overflow-x-auto border-b border-border px-3 py-2 [&>button]:shrink-0 md:hidden">
 									<Button
 										size="sm"
 										variant={
@@ -1721,7 +1721,7 @@ export function ChatHeader({
 										</Button>
 									)}
 								</div>
-								<div className="flex-1 overflow-y-auto p-4">
+								<div className="min-h-0 flex-1 overflow-y-auto p-3 sm:p-4">
 									{settingsTab === "personalization" && (
 										<div className="grid gap-3">
 											<div className="grid gap-1">
@@ -2299,7 +2299,7 @@ export function ChatHeader({
 										</div>
 									)}
 								</div>
-								<div className="border-t border-border px-4 py-3">
+								<div className="border-t border-border px-3 py-3 sm:px-4">
 									<div className="flex justify-end">
 										<Button onClick={onSaveSettings}>
 											Save
@@ -2307,9 +2307,6 @@ export function ChatHeader({
 									</div>
 								</div>
 							</div>
-						</div>
-						<div className="flex justify-end">
-							<Button onClick={onSaveSettings}>Save</Button>
 						</div>
 					</DialogContent>
 				</Dialog>

--- a/apps/web/src/components/(chat)/ChatNewChatDialog.tsx
+++ b/apps/web/src/components/(chat)/ChatNewChatDialog.tsx
@@ -54,7 +54,7 @@ export function ChatNewChatDialog({
                         </ul>
                     </div>
                 ) : null}
-                <DialogFooter className="flex-col-reverse gap-2 sm:flex-row sm:justify-end">
+                <DialogFooter>
                     <Button className="w-full sm:w-auto" variant="ghost" onClick={onUseDefaults}>
                         Use defaults
                     </Button>

--- a/apps/web/src/components/(chat)/ChatNewChatDialog.tsx
+++ b/apps/web/src/components/(chat)/ChatNewChatDialog.tsx
@@ -34,7 +34,7 @@ export function ChatNewChatDialog({
 }: ChatNewChatDialogProps) {
     return (
         <Dialog open={open} onOpenChange={onOpenChange}>
-            <DialogContent className="max-w-md">
+            <DialogContent className="w-[calc(100vw-1rem)] max-w-md">
                 <DialogHeader className="space-y-2 text-left">
                     <DialogTitle>Reuse chat parameters?</DialogTitle>
                     <DialogDescription>
@@ -54,11 +54,11 @@ export function ChatNewChatDialog({
                         </ul>
                     </div>
                 ) : null}
-                <DialogFooter>
-                    <Button variant="ghost" onClick={onUseDefaults}>
+                <DialogFooter className="flex-col-reverse gap-2 sm:flex-row sm:justify-end">
+                    <Button className="w-full sm:w-auto" variant="ghost" onClick={onUseDefaults}>
                         Use defaults
                     </Button>
-                    <Button onClick={onUseCurrent}>Use current</Button>
+                    <Button className="w-full sm:w-auto" onClick={onUseCurrent}>Use current</Button>
                 </DialogFooter>
             </DialogContent>
         </Dialog>

--- a/apps/web/src/components/(chat)/ChatPlayground.tsx
+++ b/apps/web/src/components/(chat)/ChatPlayground.tsx
@@ -887,10 +887,14 @@ function ChatPlaygroundContent({
 						]?.displayName?.trim() ||
 						modelDisplayNameById[comparisonModelId]
 					: undefined;
+			const comparisonProviderLabel = activeThread.settings.providerId
+				? providerNameById.get(activeThread.settings.providerId)
+				: undefined;
 			const changes = getChangedSettings(
 				activeThread.settings,
 				comparisonModelId,
 				comparisonModelDisplayName,
+				comparisonProviderLabel,
 			);
 			if (changes.length > 0) {
 				setPendingNewChat({
@@ -909,6 +913,7 @@ function ChatPlaygroundContent({
 		createThreadWithSettings,
 		modelDisplayNameById,
 		newChatModelPreference,
+		providerNameById,
 	]);
 
 	const handleNewChatDecision = useCallback(

--- a/apps/web/src/components/(chat)/ChatShortcutReference.tsx
+++ b/apps/web/src/components/(chat)/ChatShortcutReference.tsx
@@ -83,7 +83,7 @@ export const CHAT_SHORTCUT_GROUPS = [
 
 function ShortcutKey({ children }: { children: string }) {
 	return (
-		<kbd className="inline-flex h-6 min-w-6 items-center justify-center rounded-md border border-border bg-muted px-1.5 font-mono text-[11px] font-medium text-foreground shadow-xs">
+		<kbd className="inline-flex h-7 min-w-7 items-center justify-center rounded-md border border-border bg-muted px-1.5 font-mono text-[10px] font-medium text-foreground shadow-xs sm:h-6 sm:min-w-6 sm:text-[11px]">
 			{children}
 		</kbd>
 	);
@@ -91,7 +91,7 @@ function ShortcutKey({ children }: { children: string }) {
 
 export function ChatShortcutReference() {
 	return (
-		<div className="grid gap-5">
+		<div className="grid gap-4 sm:gap-5">
 			{CHAT_SHORTCUT_GROUPS.map((group) => (
 				<div key={group.label} className="grid gap-2.5">
 					<div className="px-2 text-xs font-medium text-muted-foreground">
@@ -103,7 +103,7 @@ export function ChatShortcutReference() {
 							return (
 								<div
 									key={item.title}
-									className="grid grid-cols-[minmax(0,1fr)_auto] items-center gap-3 rounded-lg px-2 py-2 hover:bg-muted/70"
+									className="grid grid-cols-1 gap-2 rounded-lg px-2 py-2 hover:bg-muted/70 sm:grid-cols-[minmax(0,1fr)_auto] sm:items-center sm:gap-3"
 								>
 									<div className="flex min-w-0 items-center gap-3">
 										<div className="flex size-8 shrink-0 items-center justify-center rounded-md bg-muted text-muted-foreground">
@@ -113,12 +113,12 @@ export function ChatShortcutReference() {
 											<div className="text-sm font-medium text-foreground">
 												{item.title}
 											</div>
-											<div className="truncate text-xs text-muted-foreground">
+											<div className="text-xs leading-4 text-muted-foreground">
 												{item.description}
 											</div>
 										</div>
 									</div>
-									<div className="flex shrink-0 items-center gap-1">
+									<div className="flex flex-wrap items-center gap-1 pl-11 sm:justify-end sm:pl-0">
 										{item.keys.map((key, keyIndex) => (
 											<Fragment key={`${item.title}-${key}`}>
 												{keyIndex > 0 ? (
@@ -149,7 +149,7 @@ export function ChatShortcutHelpDialog({
 }) {
 	return (
 		<Dialog open={open} onOpenChange={onOpenChange}>
-			<DialogContent className="max-w-[min(92vw,30rem)] gap-0 overflow-hidden p-0">
+			<DialogContent className="max-h-[calc(100dvh-1rem)] w-[calc(100vw-1rem)] max-w-[min(92vw,30rem)] gap-0 overflow-hidden p-0">
 				<DialogHeader className="px-5 pb-3 pt-5">
 					<div className="flex items-start gap-3">
 						<div className="flex size-9 shrink-0 items-center justify-center rounded-lg border border-border bg-muted">
@@ -164,8 +164,8 @@ export function ChatShortcutHelpDialog({
 					</div>
 				</DialogHeader>
 				<Separator />
-				<ScrollArea className="max-h-[min(70vh,26rem)]">
-					<div className="p-5">
+				<ScrollArea className="max-h-[calc(100dvh-8rem)] sm:max-h-[min(70vh,26rem)]">
+					<div className="p-3 sm:p-5">
 						<ChatShortcutReference />
 					</div>
 				</ScrollArea>

--- a/apps/web/src/components/(chat)/ModelSettingsDialog.tsx
+++ b/apps/web/src/components/(chat)/ModelSettingsDialog.tsx
@@ -440,8 +440,8 @@ export function ModelSettingsDialog({
             <DialogContent
                 className={
                     modelPickerOpen
-                        ? "w-[calc(100vw-2rem)] max-w-[720px] sm:max-w-[720px] !top-4 !bottom-4 h-[calc(100vh-2rem)] !max-h-none !translate-y-0 overflow-hidden p-4"
-                        : "w-[calc(100vw-2rem)] max-w-[720px] sm:max-w-[720px] max-h-[85vh] overflow-hidden p-4"
+                        ? "w-[calc(100vw-1rem)] max-w-[calc(100vw-1rem)] sm:w-[calc(100vw-2rem)] sm:max-w-[720px] !top-2 !bottom-2 h-[calc(100dvh-1rem)] !max-h-none !translate-y-0 overflow-hidden p-3 sm:!top-4 sm:!bottom-4 sm:h-[calc(100vh-2rem)] sm:p-4"
+                        : "w-[calc(100vw-1rem)] max-w-[calc(100vw-1rem)] sm:w-[calc(100vw-2rem)] sm:max-w-[720px] max-h-[calc(100dvh-1rem)] sm:max-h-[85vh] overflow-hidden p-3 sm:p-4"
                 }
             >
                 <div
@@ -612,9 +612,9 @@ export function ModelSettingsDialog({
                         Tune how this model responds in this chat.
                     </DialogDescription>
                 </DialogHeader>
-                <div className="grid max-h-[75vh] min-w-0 gap-3 overflow-y-auto overflow-x-hidden pr-1">
+                <div className="grid max-h-[calc(100dvh-7rem)] min-w-0 gap-3 overflow-y-auto overflow-x-hidden pr-1 sm:max-h-[75vh]">
                     <div className="grid gap-2">
-                        <div className="grid grid-cols-[minmax(0,1fr)_auto] items-end gap-2">
+                        <div className="grid gap-3 sm:grid-cols-[minmax(0,1fr)_auto] sm:items-end">
                             <div className="grid flex-1 gap-1.5">
                                 <Label htmlFor="chat-display-name">Chat display name</Label>
                                 <Input
@@ -627,7 +627,7 @@ export function ModelSettingsDialog({
                                     placeholder="Optional model alias for this chat"
                                 />
                             </div>
-                            <div className="flex items-center gap-2 pb-1">
+                            <div className="flex items-center justify-between gap-2 sm:justify-end sm:pb-1">
                                 <Label htmlFor="enable-model" className="text-sm">
                                     Enabled
                                 </Label>

--- a/apps/web/src/components/(chat)/playground/chat-playground-core.test.ts
+++ b/apps/web/src/components/(chat)/playground/chat-playground-core.test.ts
@@ -8,6 +8,19 @@ import {
 	normalizeServerTools,
 } from "./chat-playground-core";
 
+describe("getChangedSettings", () => {
+	it("uses the provider display name instead of the stored provider id", () => {
+		const changes = getChangedSettings(
+			{ ...DEFAULT_SETTINGS, providerId: "openai" },
+			"openai/gpt-5",
+			undefined,
+			"OpenAI",
+		);
+
+		expect(changes).toContainEqual({ label: "Provider", value: "OpenAI" });
+	});
+});
+
 describe("buildDefaultSystemPrompt", () => {
 	it("instructs models to produce valid Streamdown-compatible LaTeX", () => {
 		const prompt = buildDefaultSystemPrompt("openai/gpt-5.6-luna-pro");

--- a/apps/web/src/components/(chat)/playground/chat-playground-core.ts
+++ b/apps/web/src/components/(chat)/playground/chat-playground-core.ts
@@ -115,6 +115,7 @@ export const getChangedSettings = (
 	settings: ChatSettings,
 	modelId: string,
 	modelDisplayName?: string,
+	providerDisplayName?: string,
 ): SettingChange[] => {
 	const defaults: ChatSettings = {
 		...DEFAULT_SETTINGS,
@@ -170,7 +171,18 @@ export const getChangedSettings = (
 		addChange("Streaming", formatSettingValue(settings.stream, "Off"));
 	}
 	if (settings.providerId !== defaults.providerId) {
-		addChange("Provider", formatSettingValue(settings.providerId, "Auto"));
+		const providerId = settings.providerId?.trim();
+		const providerLabel = providerDisplayName?.trim();
+		addChange(
+			"Provider",
+			providerId && providerId !== "auto"
+				? providerLabel ||
+						providerId
+							.split(/[-_\s]+/)
+							.map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+							.join(" ")
+				: "Auto (Gateway)",
+		);
 	}
 	if (settings.reasoningEnabled !== defaults.reasoningEnabled) {
 		addChange(


### PR DESCRIPTION
## Summary
- Remove the duplicate Save action from Chat settings.
- Make Chat model settings, keyboard shortcuts, and New Chat actions responsive on mobile.
- Show provider display names instead of stored provider IDs in the New Chat reuse prompt.

## Root cause
The settings dialog rendered two Save controls, while several mobile layouts kept desktop-sized rows and fixed-height containers. The New Chat summary used the stored provider ID directly instead of the catalog display name.

## Validation
- pnpm --filter @phaseo/web exec eslint --quiet on all changed Chat files
- pnpm --filter @phaseo/web test -- --runTestsByPath 'src/components/(chat)/playground/chat-playground-core.test.ts' (13 passed)
- git diff --check
- Web typecheck reaches unrelated baseline errors in dashboard LayoutProps declarations and uthOrigin.test.ts ProcessEnv typing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved chat settings and model dialogs with responsive sizing, scrolling, spacing, and mobile-friendly layouts.
  * Updated shortcut help displays for clearer responsive presentation and readability.
  * Improved new-chat dialog button layout on smaller screens.
  * Provider changes now display clearer, human-readable labels, including gateway defaults.

* **Tests**
  * Added coverage for provider label display when switching models.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->