### PR TITLE
fix(web): polish responsive Chat settings dialogs

### DIFF
--- a/apps/web/src/components/(chat)/ChatHeader.tsx
+++ b/apps/web/src/components/(chat)/ChatHeader.tsx
@@ -21,6 +21,7 @@ import {
 } from "@/components/ai-elements/model-selector";
 import {
 	Dialog,
+	DialogClose,
 	DialogContent,
 	DialogDescription,
 	DialogTitle,
@@ -163,6 +164,32 @@ const CUSTOM_ACCENT_SELECT_VALUE = "custom";
 const DEFAULT_CUSTOM_ACCENT_COLOR = "#2563eb";
 const HEX_COLOR_PATTERN = /^#[0-9a-fA-F]{6}$/;
 const CUSTOM_API_SELECT_VALUE = "custom";
+
+type ChatSettingsTab =
+	| "personalization"
+	| "data-controls"
+	| "shortcuts"
+	| "admin";
+
+const CHAT_SETTINGS_TAB_LABELS: Record<ChatSettingsTab, string> = {
+	personalization: "Personalization",
+	"data-controls": "Data Controls",
+	shortcuts: "Shortcuts",
+	admin: "Admin",
+};
+
+function ChatSettingsTabIcon({ tab }: { tab: ChatSettingsTab }) {
+	const Icon =
+		tab === "personalization"
+			? Paintbrush
+			: tab === "data-controls"
+				? Database
+				: tab === "shortcuts"
+					? Keyboard
+					: Shield;
+
+	return <Icon className="h-4 w-4 shrink-0 text-muted-foreground" />;
+}
 
 function normalizeHexColor(value: string) {
 	const trimmedValue = value.trim();
@@ -341,9 +368,9 @@ export function ChatHeader({
 	requireAudioInput = false,
 }: ChatHeaderProps) {
 	const { toggleSidebar, state: sidebarState } = useSidebar();
-	const [settingsTab, setSettingsTab] = useState<
-		"personalization" | "data-controls" | "shortcuts" | "admin"
-	>("personalization");
+	const [settingsTab, setSettingsTab] = useState<ChatSettingsTab>(
+		"personalization",
+	);
 	const [modelSearchValue, setModelSearchValue] = useState("");
 	const [activeBrowseModelId, setActiveBrowseModelId] = useState<string | null>(
 		null,
@@ -1602,13 +1629,76 @@ export function ChatHeader({
 					<TooltipContent>Settings</TooltipContent>
 				</Tooltip>
 				<Dialog open={settingsOpen} onOpenChange={onSettingsOpenChange}>
-					<DialogContent className="max-h-[calc(100dvh-1rem)] w-[calc(100vw-1rem)] max-w-[calc(100vw-1rem)] overflow-hidden p-0 md:max-h-[520px] md:w-auto md:max-w-[760px] lg:max-w-[820px]">
+					<DialogContent
+						showCloseButton={false}
+						className="max-h-[calc(100dvh-1rem)] w-[calc(100vw-1rem)] max-w-[calc(100vw-1rem)] overflow-hidden p-0 md:max-h-[520px] md:w-auto md:max-w-[760px] lg:max-w-[820px]"
+					>
 						<DialogTitle className="sr-only">Settings</DialogTitle>
 						<DialogDescription className="sr-only">
 							Chat settings and diagnostics.
 						</DialogDescription>
-						<div className="flex h-[calc(100dvh-1rem)] max-h-[520px] flex-1 overflow-hidden">
-							<div className="hidden w-52 shrink-0 flex-col border-r border-border p-2 md:flex">
+						<div className="flex h-[calc(100dvh-1rem)] max-h-[520px] flex-1 flex-col overflow-hidden">
+							<div className="flex h-12 shrink-0 items-center justify-between border-b border-border px-3 sm:px-4">
+								<div className="min-w-0 flex-1 lg:hidden">
+									<Select
+										value={settingsTab}
+										onValueChange={(value) => {
+											const nextTab = value as ChatSettingsTab;
+											setSettingsTab(nextTab);
+											if (nextTab === "data-controls") {
+												setImportResult(null);
+											}
+										}}
+									>
+										<SelectTrigger
+											size="sm"
+											className="w-full max-w-xs rounded-lg border-border/70 bg-background/60"
+										>
+											<SelectValue>
+												<span className="flex min-w-0 items-center gap-2">
+													<ChatSettingsTabIcon tab={settingsTab} />
+													<span className="truncate">
+														{CHAT_SETTINGS_TAB_LABELS[settingsTab]}
+													</span>
+												</span>
+											</SelectValue>
+										</SelectTrigger>
+										<SelectContent align="start">
+											<SelectItem value="personalization">
+												<ChatSettingsTabIcon tab="personalization" />
+												<span>Personalization</span>
+											</SelectItem>
+											<SelectItem value="data-controls">
+												<ChatSettingsTabIcon tab="data-controls" />
+												<span>Data Controls</span>
+											</SelectItem>
+											<SelectItem value="shortcuts">
+												<ChatSettingsTabIcon tab="shortcuts" />
+												<span>Shortcuts</span>
+											</SelectItem>
+											{isAdmin ? (
+												<SelectItem value="admin">
+													<ChatSettingsTabIcon tab="admin" />
+													<span>Admin</span>
+												</SelectItem>
+											) : null}
+										</SelectContent>
+									</Select>
+								</div>
+								<p className="hidden text-sm font-semibold lg:block">Settings</p>
+								<DialogClose asChild>
+									<Button
+										variant="ghost"
+										size="icon-sm"
+										aria-label="Close settings"
+										className="shrink-0"
+									>
+										<X className="h-4 w-4" />
+									</Button>
+								</DialogClose>
+							</div>
+							<div className="flex min-h-0 flex-1 overflow-hidden">
+							<div className="hidden w-52 shrink-0 flex-col border-r border-border p-2 lg:flex">
 								<Button
 									variant={
 										settingsTab === "personalization"
@@ -1666,62 +1756,10 @@ export function ChatHeader({
 								)}
 							</div>
 							<div className="flex flex-1 flex-col overflow-hidden">
-								<div className="flex shrink-0 items-center gap-1 overflow-x-auto border-b border-border px-3 py-2 [&>button]:shrink-0 md:hidden">
-									<Button
-										size="sm"
-										variant={
-											settingsTab === "personalization"
-												? "secondary"
-												: "ghost"
-										}
-										onClick={() =>
-											setSettingsTab("personalization")
-										}
-									>
-										Personalization
-									</Button>
-									<Button
-										size="sm"
-										variant={
-											settingsTab === "data-controls"
-												? "secondary"
-												: "ghost"
-										}
-										onClick={() => {
-											setSettingsTab("data-controls");
-											setImportResult(null);
-										}}
-									>
-										Data Controls
-									</Button>
-									<Button
-										size="sm"
-										variant={
-											settingsTab === "shortcuts"
-												? "secondary"
-												: "ghost"
-										}
-										onClick={() => setSettingsTab("shortcuts")}
-									>
-										Shortcuts
-									</Button>
-									{isAdmin && (
-										<Button
-											size="sm"
-											variant={
-												settingsTab === "admin"
-													? "secondary"
-													: "ghost"
-											}
-											onClick={() =>
-												setSettingsTab("admin")
-											}
-										>
-											Admin
-										</Button>
-									)}
-								</div>
-								<div className="min-h-0 flex-1 overflow-y-auto p-3 sm:p-4">
+								<ScrollArea
+									className="min-h-0 flex-1"
+									viewportClassName="p-3 sm:p-4"
+								>
 									{settingsTab === "personalization" && (
 										<div className="grid gap-3">
 											<div className="grid gap-1">
@@ -2298,7 +2336,7 @@ export function ChatHeader({
 											</div>
 										</div>
 									)}
-								</div>
+								</ScrollArea>
 								<div className="border-t border-border px-3 py-3 sm:px-4">
 									<div className="flex justify-end">
 										<Button onClick={onSaveSettings}>
@@ -2308,6 +2346,7 @@ export function ChatHeader({
 								</div>
 							</div>
 						</div>
+					</div>
 					</DialogContent>
 				</Dialog>
 			</div>

--- a/apps/web/src/components/(chat)/ChatRequestErrorNotice.tsx
+++ b/apps/web/src/components/(chat)/ChatRequestErrorNotice.tsx
@@ -20,6 +20,7 @@ import {
 	DialogHeader,
 	DialogTitle,
 } from "@/components/ui/dialog";
+import { ScrollArea } from "@/components/ui/scroll-area";
 import {
 	Popover,
 	PopoverContent,
@@ -266,7 +267,10 @@ export function ChatRequestErrorNotice({
 							Inspect the gateway failure and create a GitHub issue from this dialog.
 						</DialogDescription>
 					</DialogHeader>
-					<div className="grid gap-3 overflow-y-auto">
+					<ScrollArea
+						className="min-h-0 max-h-[calc(85vh-8rem)]"
+						viewportClassName="grid gap-3 pr-1"
+					>
 						<div className="grid gap-2 rounded-lg border border-border p-3 text-sm">
 							<div className="grid gap-1 sm:grid-cols-2">
 								<p>
@@ -319,9 +323,14 @@ export function ChatRequestErrorNotice({
 						{error.routingDiagnostics ? (
 							<div className="grid gap-2 rounded-lg border border-border p-3 text-sm">
 								<p className="font-medium">Routing diagnostics</p>
-								<pre className="max-h-56 overflow-auto rounded bg-muted p-3 text-xs">
-									{JSON.stringify(error.routingDiagnostics, null, 2)}
-								</pre>
+								<ScrollArea
+									className="max-h-56 rounded bg-muted"
+									viewportClassName="p-3"
+								>
+									<pre className="text-xs">
+										{JSON.stringify(error.routingDiagnostics, null, 2)}
+									</pre>
+								</ScrollArea>
 							</div>
 						) : null}
 						<div className="grid gap-2">
@@ -333,7 +342,7 @@ export function ChatRequestErrorNotice({
 								placeholder="What were you trying to do? How can we reproduce it?"
 							/>
 						</div>
-					</div>
+					</ScrollArea>
 					<DialogFooter>
 						<Button type="button" variant="outline" onClick={copyDiagnostics}>
 							Copy diagnostics

--- a/apps/web/src/components/(chat)/ChatShortcutReference.tsx
+++ b/apps/web/src/components/(chat)/ChatShortcutReference.tsx
@@ -103,22 +103,20 @@ export function ChatShortcutReference() {
 							return (
 								<div
 									key={item.title}
-									className="grid grid-cols-1 gap-2 rounded-lg px-2 py-2 hover:bg-muted/70 sm:grid-cols-[minmax(0,1fr)_auto] sm:items-center sm:gap-3"
+									className="grid grid-cols-[auto_minmax(0,1fr)] items-start gap-x-3 gap-y-1 rounded-lg px-2 py-2 hover:bg-muted/70"
 								>
-									<div className="flex min-w-0 items-center gap-3">
-										<div className="flex size-8 shrink-0 items-center justify-center rounded-md bg-muted text-muted-foreground">
+									<div className="row-span-2 flex size-8 shrink-0 items-center justify-center rounded-md bg-muted text-muted-foreground">
 											<Icon className="h-4 w-4" />
+									</div>
+									<div className="min-w-0">
+										<div className="text-sm font-medium text-foreground">
+											{item.title}
 										</div>
-										<div className="min-w-0">
-											<div className="text-sm font-medium text-foreground">
-												{item.title}
-											</div>
-											<div className="text-xs leading-4 text-muted-foreground">
-												{item.description}
-											</div>
+										<div className="text-xs leading-4 text-muted-foreground">
+											{item.description}
 										</div>
 									</div>
-									<div className="flex flex-wrap items-center gap-1 pl-11 sm:justify-end sm:pl-0">
+									<div className="hidden flex-wrap items-center gap-1 sm:flex">
 										{item.keys.map((key, keyIndex) => (
 											<Fragment key={`${item.title}-${key}`}>
 												{keyIndex > 0 ? (

--- a/apps/web/src/components/(chat)/ChatTagsDialog.tsx
+++ b/apps/web/src/components/(chat)/ChatTagsDialog.tsx
@@ -13,6 +13,7 @@ import {
 } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { ScrollArea } from "@/components/ui/scroll-area";
 import type { ChatTag, ChatThread } from "@/lib/indexeddb/chats";
 import { cn } from "@/lib/utils";
 
@@ -138,7 +139,10 @@ export function ChatTagsDialog({
 									{selectedTags.length} selected
 								</span>
 							</div>
-							<div className="flex max-h-36 flex-wrap gap-2 overflow-y-auto rounded-xl border border-border bg-muted/20 p-2">
+							<ScrollArea
+								className="max-h-36 rounded-xl border border-border bg-muted/20"
+								viewportClassName="flex flex-wrap gap-2 p-2"
+							>
 								{availableTags.map((tag) => {
 									const selected = selectedTagIds.has(tag.id);
 									return (
@@ -162,7 +166,7 @@ export function ChatTagsDialog({
 										</button>
 									);
 								})}
-							</div>
+							</ScrollArea>
 						</div>
 					) : null}
 					<div className="grid gap-2">

--- a/apps/web/src/components/(chat)/ModelSettingsDialog.tsx
+++ b/apps/web/src/components/(chat)/ModelSettingsDialog.tsx
@@ -612,7 +612,10 @@ export function ModelSettingsDialog({
                         Tune how this model responds in this chat.
                     </DialogDescription>
                 </DialogHeader>
-                <div className="grid max-h-[calc(100dvh-7rem)] min-w-0 gap-3 overflow-y-auto overflow-x-hidden pr-1 sm:max-h-[75vh]">
+                <ScrollArea
+                    className="min-w-0 max-h-[calc(100dvh-7rem)] sm:max-h-[75vh]"
+                    viewportClassName="grid gap-3 pr-1"
+                >
                     <div className="grid gap-2">
                         <div className="grid gap-3 sm:grid-cols-[minmax(0,1fr)_auto] sm:items-end">
                             <div className="grid flex-1 gap-1.5">
@@ -1318,7 +1321,7 @@ export function ModelSettingsDialog({
                             Apply to all
                         </Button>
                     </div>
-                </div>
+                    </ScrollArea>
                     </motion.div>
                 )}
                 </AnimatePresence>

--- a/apps/web/src/components/(chat)/rooms/MediaStudioRoom.tsx
+++ b/apps/web/src/components/(chat)/rooms/MediaStudioRoom.tsx
@@ -52,6 +52,7 @@ import {
 	MediaPlayerVolumeIndicator,
 } from "@/components/ui/media-player";
 import { Skeleton } from "@/components/ui/skeleton";
+import { ScrollArea } from "@/components/ui/scroll-area";
 import { Textarea } from "@/components/ui/textarea";
 import { RoomModelSelector } from "@/components/(chat)/RoomModelSelector";
 import { useSidebar } from "@/components/ui/sidebar";
@@ -2290,7 +2291,8 @@ export function MediaStudioRoom({ roomId, models }: MediaStudioRoomProps) {
 					if (!open) setPreviewEntryId(null);
 				}}
 			>
-				<DialogContent className="max-h-[90vh] max-w-5xl overflow-auto p-0">
+				<DialogContent className="max-h-[90vh] max-w-5xl overflow-hidden p-0">
+					<ScrollArea className="max-h-[90vh]" viewportClassName="p-0">
 					{previewEntry ? (
 						roomId === "image" ? (
 							<div className="flex flex-col">
@@ -2546,6 +2548,7 @@ export function MediaStudioRoom({ roomId, models }: MediaStudioRoomProps) {
 							</div>
 						)
 					) : null}
+					</ScrollArea>
 				</DialogContent>
 			</Dialog>
 			{roomId === "image" && dialogProfile ? (

--- a/apps/web/src/components/(chat)/rooms/settings/RoomModelSettingsShell.tsx
+++ b/apps/web/src/components/(chat)/rooms/settings/RoomModelSettingsShell.tsx
@@ -41,6 +41,7 @@ import {
 import { Switch } from "@/components/ui/switch";
 import { Separator } from "@/components/ui/separator";
 import { Button } from "@/components/ui/button";
+import { ScrollArea } from "@/components/ui/scroll-area";
 import {
 	Popover,
 	PopoverContent,
@@ -201,7 +202,10 @@ export function RoomModelSettingsShell({
 						<DialogTitle>{title}</DialogTitle>
 						<DialogDescription>{description}</DialogDescription>
 					</DialogHeader>
-					<div className="grid max-h-[72vh] gap-3 overflow-y-auto pr-1">
+					<ScrollArea
+						className="max-h-[72vh]"
+						viewportClassName="grid gap-3 pr-1"
+					>
 						<div className="grid gap-3">
 							<div className="grid gap-1.5">
 								<Label>Model</Label>
@@ -438,7 +442,7 @@ export function RoomModelSettingsShell({
 								</AlertDialogContent>
 							</AlertDialog>
 						</div>
-					</div>
+					</ScrollArea>
 				</DialogContent>
 			</Dialog>
 		</>


### PR DESCRIPTION
## Summary

- Replace dialog-native scrolling with shared `ScrollArea` components across Chat settings, model settings, diagnostics, tags, and media preview dialogs.
- Replace the mobile/medium settings tab strip with a top-level section selector and a dedicated close control.
- Keep section icons in both the selector menu and its selected value.
- Make keyboard shortcut rows responsive at all widths, hiding keycaps on small screens and preventing text/key overlap on larger layouts.
- Remove the extra bordered shortcut card.

## Validation

- Focused ESLint passed for the seven changed Chat UI files.
- `pnpm --filter @phaseo/web test -- --runTestsByPath 'src/components/(chat)/playground/chat-playground-core.test.ts'` passed (13 tests).
- `git diff --check` passed.

## Scope

This PR is based on `origin/main` and contains only the seven intended Chat UI files.