### PR TITLE
Add blog table of contents

### DIFF
--- a/apps/web/src/app/(dashboard)/blog/[slug]/page.tsx
+++ b/apps/web/src/app/(dashboard)/blog/[slug]/page.tsx
@@ -4,9 +4,10 @@ import { notFound, redirect } from "next/navigation";
 import { compileMDX } from "next-mdx-remote/rsc";
 import { ArrowLeft } from "lucide-react";
 import remarkGfm from "remark-gfm";
+import { BlogTableOfContents } from "@/components/announcements/BlogTableOfContents";
 import { announcementMdxComponents } from "@/components/announcements/announcementMdxComponents";
 import { Badge } from "@/components/ui/badge";
-import { Button } from "@/components/ui/button";
+import { buttonVariants } from "@/components/ui/button";
 import {
 	formatAnnouncementDate,
 	formatAnnouncementReadingTime,
@@ -14,8 +15,13 @@ import {
 	getAnnouncementPost,
 	isAnnouncementPublished,
 } from "@/lib/content/announcements";
+import {
+	createBlogHeadingsPlugin,
+	type BlogTocItem,
+} from "@/lib/content/blogToc";
 import { canPreviewFutureBlogPosts } from "@/lib/flags/blogPreview";
 import { buildMetadata } from "@/lib/seo";
+import { cn } from "@/lib/utils";
 
 type AnnouncementPageProps = {
 	params: Promise<{ slug: string }>;
@@ -95,12 +101,13 @@ export default async function AnnouncementPostPage({
 		formatAnnouncementReadingTime(post.readingTimeMinutes),
 	].filter(Boolean);
 
+	const tocItems: BlogTocItem[] = [];
 	const { content } = await compileMDX({
 		source: post.content,
 		options: {
 			parseFrontmatter: false,
 			mdxOptions: {
-				remarkPlugins: [remarkGfm],
+				remarkPlugins: [remarkGfm, createBlogHeadingsPlugin(tocItems)],
 			},
 		},
 		components: announcementMdxComponents,
@@ -108,57 +115,65 @@ export default async function AnnouncementPostPage({
 
 	return (
 		<div className="container mx-auto mt-8 mb-20 max-w-7xl px-4 sm:px-6 lg:px-8">
-			<article className="mx-auto w-full max-w-4xl space-y-8">
-				<Button asChild variant="ghost" size="sm" className="-ml-2 w-fit">
-					<Link href="/blog">
+			<div className="mx-auto flex max-w-6xl flex-col gap-8 lg:flex-row lg:items-start">
+				{tocItems.length ? <BlogTableOfContents items={tocItems} /> : null}
+
+				<article className="w-full max-w-4xl space-y-8 lg:flex-1">
+					<Link
+						href="/blog"
+						className={cn(
+							buttonVariants({ variant: "ghost", size: "sm" }),
+							"-ml-2 w-fit",
+						)}
+					>
 						<ArrowLeft className="h-4 w-4" />
 						Back to blog
 					</Link>
-				</Button>
 
-				<header className="mx-auto max-w-3xl space-y-4 text-center">
-					{isPreview ? (
-						<div className="flex justify-center">
-							<Badge className="rounded-full border-amber-300 bg-amber-100 text-xs font-semibold text-amber-900 hover:bg-amber-100 dark:border-amber-500/40 dark:bg-amber-500/15 dark:text-amber-200">
-								Preview
-							</Badge>
+					<header className="mx-auto max-w-3xl space-y-4 text-center">
+						{isPreview ? (
+							<div className="flex justify-center">
+								<Badge className="rounded-full border-amber-300 bg-amber-100 text-xs font-semibold text-amber-900 hover:bg-amber-100 dark:border-amber-500/40 dark:bg-amber-500/15 dark:text-amber-200">
+									Preview
+								</Badge>
+							</div>
+						) : null}
+						<p className="flex flex-wrap items-center justify-center gap-x-1.5 gap-y-1 text-sm font-medium text-zinc-500 dark:text-zinc-400">
+							{metaParts.map((part, index) => (
+								<span key={part} className="inline-flex items-center gap-x-1.5">
+									{index > 0 ? (
+										<span
+											className="inline-block h-[5px] w-[5px] rounded-full bg-zinc-400 align-middle dark:bg-zinc-500"
+											aria-hidden="true"
+										/>
+									) : null}
+									<span>{part}</span>
+								</span>
+							))}
+						</p>
+						<h1 className="text-3xl font-semibold tracking-tight text-zinc-950 dark:text-zinc-50 md:text-5xl">
+							{post.title}
+						</h1>
+						<p className="mx-auto max-w-2xl text-base leading-7 text-zinc-600 dark:text-zinc-300 md:text-lg">
+							{post.description}
+						</p>
+					</header>
+
+					{post.coverImage ? (
+						<div className="mx-auto flex max-w-2xl justify-center">
+							<img
+								src={post.coverImage}
+								alt={`${post.title} cover image`}
+								className="h-auto max-h-[320px] max-w-full rounded-lg object-contain"
+							/>
 						</div>
 					) : null}
-					<p className="flex flex-wrap items-center justify-center gap-x-1.5 gap-y-1 text-sm font-medium text-zinc-500 dark:text-zinc-400">
-						{metaParts.map((part, index) => (
-							<span key={part} className="inline-flex items-center gap-x-1.5">
-								{index > 0 ? (
-									<span
-										className="inline-block h-[5px] w-[5px] rounded-full bg-zinc-400 align-middle dark:bg-zinc-500"
-										aria-hidden="true"
-									/>
-								) : null}
-								<span>{part}</span>
-							</span>
-						))}
-					</p>
-					<h1 className="text-3xl font-semibold tracking-tight text-zinc-950 dark:text-zinc-50 md:text-5xl">
-						{post.title}
-					</h1>
-					<p className="mx-auto max-w-2xl text-base leading-7 text-zinc-600 dark:text-zinc-300 md:text-lg">
-						{post.description}
-					</p>
-				</header>
 
-				{post.coverImage ? (
-					<div className="mx-auto flex max-w-2xl justify-center">
-						<img
-							src={post.coverImage}
-							alt={`${post.title} cover image`}
-							className="h-auto max-h-[320px] max-w-full rounded-lg object-contain"
-						/>
-					</div>
-				) : null}
+					<hr className="border-zinc-200 dark:border-zinc-800" />
 
-				<hr className="border-zinc-200 dark:border-zinc-800" />
-
-				<div>{content}</div>
-			</article>
+					<div>{content}</div>
+				</article>
+			</div>
 		</div>
 	);
 }

--- a/apps/web/src/components/announcements/BlogTableOfContents.tsx
+++ b/apps/web/src/components/announcements/BlogTableOfContents.tsx
@@ -1,0 +1,125 @@
+import Link from "next/link";
+import { ChevronDown } from "lucide-react";
+import { cn } from "@/lib/utils";
+import type { BlogTocItem } from "@/lib/content/blogToc";
+
+type BlogTableOfContentsProps = {
+	items: BlogTocItem[];
+};
+
+function getTocScript(items: BlogTocItem[]) {
+	const itemIds = JSON.stringify(items.map((item) => item.id)).replace(
+		/</g,
+		"\\u003c",
+	);
+
+	return `(() => {
+  const itemIds = new Set(${itemIds});
+  let frame = 0;
+
+  const updateActiveSection = () => {
+    frame = 0;
+    const headings = [...itemIds]
+      .map((id) => document.getElementById(id))
+      .filter(Boolean);
+    if (!headings.length) return;
+
+    let activeId = headings[0].id;
+    for (const heading of headings) {
+      if (heading.getBoundingClientRect().top <= 160) activeId = heading.id;
+      else break;
+    }
+
+    document.querySelectorAll("[data-blog-toc-id]").forEach((link) => {
+      const isActive = link.dataset.blogTocId === activeId;
+      link.dataset.active = String(isActive);
+      if (isActive) link.setAttribute("aria-current", "location");
+      else link.removeAttribute("aria-current");
+    });
+
+    document.querySelectorAll("[data-blog-toc-list]").forEach((list) => {
+      const activeLink = list.querySelector("[data-blog-toc-id][data-active=true]");
+      const indicator = list.querySelector("[data-blog-toc-indicator]");
+      if (!activeLink || !indicator) return;
+      indicator.style.height = activeLink.offsetHeight + "px";
+      indicator.style.transform = "translateY(" + activeLink.offsetTop + "px)";
+    });
+  };
+
+  const requestUpdate = () => {
+    if (frame) return;
+    frame = requestAnimationFrame(updateActiveSection);
+  };
+
+  window.addEventListener("scroll", requestUpdate, { passive: true });
+  document.addEventListener("scroll", requestUpdate, { capture: true, passive: true });
+  window.addEventListener("resize", requestUpdate);
+  window.addEventListener("hashchange", requestUpdate);
+  new MutationObserver(requestUpdate).observe(document.body, { childList: true, subtree: true });
+  requestUpdate();
+})();`;
+}
+
+function TableOfContentsLinks({ items }: { items: BlogTocItem[] }) {
+	return (
+		<nav aria-label="Table of contents">
+			<ul className="space-y-1">
+				{items.map((item) => {
+					return (
+						<li key={item.id}>
+							<Link
+								href={`#${item.id}`}
+								aria-current={item.id === items[0]?.id ? "location" : undefined}
+								data-active={item.id === items[0]?.id ? "true" : "false"}
+								data-blog-toc-id={item.id}
+								className={cn(
+                  "block border-l-2 border-transparent py-1.5 text-sm leading-5 text-zinc-500 transition-colors data-[active=true]:font-medium data-[active=true]:text-zinc-950 dark:text-zinc-400 dark:data-[active=true]:text-zinc-50",
+									item.level === 3 ? "pl-5 text-xs" : "pl-3",
+									"hover:border-zinc-300 hover:text-zinc-950 dark:hover:border-zinc-700 dark:hover:text-zinc-50",
+								)}
+							>
+								{item.label}
+							</Link>
+						</li>
+					);
+				})}
+			</ul>
+		</nav>
+	);
+}
+
+export function BlogTableOfContents({ items }: BlogTableOfContentsProps) {
+	return (
+		<>
+			<div className="lg:hidden">
+				<details className="group border-y border-zinc-200 py-4 dark:border-zinc-800">
+					<summary className="flex cursor-pointer list-none items-center justify-between text-sm font-semibold text-zinc-950 marker:hidden dark:text-zinc-50 [&::-webkit-details-marker]:hidden">
+						<span>On this page</span>
+						<ChevronDown
+							aria-hidden="true"
+							className="size-4 text-zinc-500 transition-transform duration-200 group-open:rotate-180 dark:text-zinc-400"
+						/>
+					</summary>
+					<div className="mt-4">
+						<TableOfContentsLinks items={items} />
+					</div>
+				</details>
+			</div>
+
+			<aside className="sticky top-[calc(var(--site-header-height,3.75rem)+1rem)] hidden max-h-[calc(100vh-5rem)] w-56 shrink-0 overflow-y-auto lg:block">
+				<p className="mb-3 text-xs font-semibold text-zinc-500 dark:text-zinc-400">
+					On this page
+				</p>
+				<div data-blog-toc-list className="relative">
+					<span
+						data-blog-toc-indicator
+						aria-hidden="true"
+						className="pointer-events-none absolute left-0 top-0 z-10 h-6 w-0.5 rounded-full bg-sky-500 transition-[height,transform] duration-300 ease-[cubic-bezier(0.22,1,0.36,1)] motion-reduce:transition-none"
+					/>
+					<TableOfContentsLinks items={items} />
+				</div>
+			</aside>
+			<script dangerouslySetInnerHTML={{ __html: getTocScript(items) }} />
+		</>
+	);
+}

--- a/apps/web/src/components/announcements/announcementMdxComponents.tsx
+++ b/apps/web/src/components/announcements/announcementMdxComponents.tsx
@@ -254,13 +254,13 @@ export const announcementMdxComponents = {
 	),
 	h2: (props: ComponentPropsWithoutRef<"h2">) => (
 		<h2
-			className="mt-10 text-2xl font-semibold tracking-tight text-zinc-950 dark:text-zinc-50"
+			className="mt-10 scroll-mt-24 text-2xl font-semibold tracking-tight text-zinc-950 dark:text-zinc-50"
 			{...props}
 		/>
 	),
 	h3: (props: ComponentPropsWithoutRef<"h3">) => (
 		<h3
-			className="mt-8 text-xl font-semibold tracking-tight text-zinc-950 dark:text-zinc-50"
+			className="mt-8 scroll-mt-24 text-xl font-semibold tracking-tight text-zinc-950 dark:text-zinc-50"
 			{...props}
 		/>
 	),

--- a/apps/web/src/lib/content/blogToc.ts
+++ b/apps/web/src/lib/content/blogToc.ts
@@ -1,0 +1,67 @@
+export type BlogTocItem = {
+	id: string;
+	label: string;
+	level: 2 | 3;
+};
+
+type BlogMdastNode = {
+	children?: BlogMdastNode[];
+	data?: {
+		hProperties?: Record<string, unknown>;
+	};
+	depth?: number;
+	type?: string;
+	value?: string;
+};
+
+function getHeadingText(node: BlogMdastNode): string {
+	if (node.type === "text" || node.type === "inlineCode") {
+		return node.value ?? "";
+	}
+
+	return node.children?.map(getHeadingText).join("") ?? "";
+}
+
+function slugifyHeading(label: string, counts: Map<string, number>): string {
+	const base =
+		label
+			.normalize("NFKD")
+			.replace(/[\u0300-\u036f]/g, "")
+			.toLowerCase()
+			.replace(/[^a-z0-9]+/g, "-")
+			.replace(/^-+|-+$/g, "") || "section";
+	const count = (counts.get(base) ?? 0) + 1;
+	counts.set(base, count);
+
+	return count === 1 ? base : `${base}-${count}`;
+}
+
+export function createBlogHeadingsPlugin(tocItems: BlogTocItem[]) {
+	return function blogHeadingsRemarkPlugin() {
+		return (tree: BlogMdastNode) => {
+			const counts = new Map<string, number>();
+
+			const visit = (node: BlogMdastNode) => {
+				if (node.type === "heading" && (node.depth === 2 || node.depth === 3)) {
+					const label = getHeadingText(node).replace(/\s+/g, " ").trim();
+
+					if (label) {
+						const id = slugifyHeading(label, counts);
+						node.data = {
+							...node.data,
+							hProperties: {
+								...node.data?.hProperties,
+								id,
+							},
+						};
+						tocItems.push({ id, label, level: node.depth });
+					}
+				}
+
+				node.children?.forEach(visit);
+			};
+
+			visit(tree);
+		};
+	};
+}


### PR DESCRIPTION
## What changed

- Add a generated table of contents for blog posts from H2 and H3 headings.
- Add scroll-linked active-section tracking with an animated blue indicator on desktop.
- Add a mobile disclosure with a Lucide chevron that rotates when expanded.
- Preserve heading scroll offsets and the working blog back link.

## Validation

- `pnpm --filter @phaseo/web typecheck`
- `git diff --check`

Created with Codex

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an automatically generated table of contents to blog posts.
  * Added clickable navigation to article headings with active-section highlighting.
  * Added responsive table-of-contents layouts for mobile and desktop.
* **Enhancements**
  * Improved heading anchor scrolling so linked sections display with appropriate spacing.
  * Updated the “Back to blog” control for a more consistent navigation experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->