### PR TITLE
Fix public model catalogue cache invalidation

### DIFF
--- a/apps/web/src/lib/cache/revalidateDataTags.ts
+++ b/apps/web/src/lib/cache/revalidateDataTags.ts
@@ -73,6 +73,8 @@ const MODEL_API_GLOBAL_TAGS = [
 	"data:data_api_provider_models",
 	"data:data_api_models",
 	"data:data_api_pricing_rules",
+	"web-api-models",
+	"web-api-models-v2",
 	"data:gateway_requests",
 	"data:gateway_usage_rollups",
 	"data:gateway_provider_health_states",


### PR DESCRIPTION
## Summary
- Include the public web API model cache tags in global model API invalidation.
- Ensure public catalogue refreshes clear both the v1 and v2 `/models` data paths.

## Validation
- `pnpm --filter @phaseo/web-api test -- src/cache/scopes.test.ts` (4 passed)
- `pnpm --filter @phaseo/web typecheck` (blocked by four pre-existing errors in unrelated layout/test files)
- Production `/api/_web/models?limit=2000&offset=0&shape=page&projection=5` now returns both new Gemini IDs after the main importer refresh.

Created with Codex