### PR TITLE
ci: persist importer state in pull request

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -219,6 +219,9 @@ jobs:
     importer:
         name: Run importer on main
         runs-on: ubuntu-latest
+        permissions:
+            contents: write
+            pull-requests: write
         concurrency:
             group: importer-main
             cancel-in-progress: false
@@ -231,6 +234,8 @@ jobs:
             NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.NEXT_PUBLIC_SUPABASE_URL }}
         steps:
             - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+              with:
+                  fetch-depth: 0
 
             - name: Setup pnpm
               uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320
@@ -295,6 +300,42 @@ jobs:
               with:
                   path: packages/data/catalog/src/data/.import-state.json
                   key: ${{ steps.importer-state-cache.outputs.cache-primary-key }}
+
+            - name: Prepare importer state update
+              id: importer-state-update
+              if: success() && env.SUPABASE_SERVICE_ROLE_KEY != '' && env.NEXT_PUBLIC_SUPABASE_URL != ''
+              shell: bash
+              run: |
+                  set -euo pipefail
+                  state_file="packages/data/catalog/src/data/.import-state.json"
+                  if git diff --quiet -- "${state_file}"; then
+                    echo "changed=false" >> "${GITHUB_OUTPUT}"
+                    echo "Importer state is already committed."
+                    exit 0
+                  fi
+
+                  branch="automation/importer-state-${GITHUB_RUN_ID}"
+                  git config user.name "github-actions[bot]"
+                  git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+                  git switch --create "${branch}"
+                  git add "${state_file}"
+                  git commit -m "chore(data): persist importer state"
+                  git push --set-upstream origin "${branch}"
+                  echo "changed=true" >> "${GITHUB_OUTPUT}"
+                  echo "branch=${branch}" >> "${GITHUB_OUTPUT}"
+
+            - name: Open importer state update PR
+              if: steps.importer-state-update.outputs.changed == 'true'
+              env:
+                  GH_TOKEN: ${{ github.token }}
+              shell: bash
+              run: |
+                  set -euo pipefail
+                  gh pr create \
+                    --base main \
+                    --head "${{ steps.importer-state-update.outputs.branch }}" \
+                    --title "chore(data): persist importer state" \
+                    --body "Automated update of the committed importer hash state after a successful main import."
 
     sdk-gen:
         name: Generate SDKs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -219,9 +219,6 @@ jobs:
     importer:
         name: Run importer on main
         runs-on: ubuntu-latest
-        permissions:
-            contents: write
-            pull-requests: write
         concurrency:
             group: importer-main
             cancel-in-progress: false
@@ -243,6 +240,7 @@ jobs:
             - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
               with:
                   fetch-depth: 0
+                  persist-credentials: false
                   token: ${{ steps.importer-app-token.outputs.token }}
 
             - name: Setup pnpm
@@ -312,6 +310,8 @@ jobs:
             - name: Prepare importer state update
               id: importer-state-update
               if: success() && env.SUPABASE_SERVICE_ROLE_KEY != '' && env.NEXT_PUBLIC_SUPABASE_URL != ''
+              env:
+                  GH_TOKEN: ${{ steps.importer-app-token.outputs.token }}
               shell: bash
               run: |
                   set -euo pipefail
@@ -322,13 +322,13 @@ jobs:
                     exit 0
                   fi
 
-                  branch="automation/importer-state-${GITHUB_RUN_ID}"
+                  branch="automation/importer-state-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
                   git config user.name "github-actions[bot]"
                   git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
                   git switch --create "${branch}"
                   git add "${state_file}"
                   git commit -m "chore(data): persist importer state"
-                  git push --set-upstream origin "${branch}"
+                  git push --set-upstream "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" "${branch}"
                   echo "changed=true" >> "${GITHUB_OUTPUT}"
                   echo "branch=${branch}" >> "${GITHUB_OUTPUT}"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -233,9 +233,17 @@ jobs:
             SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
             NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.NEXT_PUBLIC_SUPABASE_URL }}
         steps:
+            - name: Create GitHub App token (Phaseo Bot)
+              id: importer-app-token
+              uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1
+              with:
+                  client-id: ${{ secrets.PHASEO_APP_CLIENT_ID }}
+                  private-key: ${{ secrets.PHASEO_APP_PRIVATE_KEY }}
+
             - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
               with:
                   fetch-depth: 0
+                  token: ${{ steps.importer-app-token.outputs.token }}
 
             - name: Setup pnpm
               uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320
@@ -327,7 +335,7 @@ jobs:
             - name: Open importer state update PR
               if: steps.importer-state-update.outputs.changed == 'true'
               env:
-                  GH_TOKEN: ${{ github.token }}
+                  GH_TOKEN: ${{ steps.importer-app-token.outputs.token }}
               shell: bash
               run: |
                   set -euo pipefail


### PR DESCRIPTION
## Summary

- persist the generated importer hash state through a normal automation PR
- grant only the importer job write permissions and use a unique automation branch
- keep the committed `.import-state.json` as the durable fallback when Actions cache entries are evicted

## Why

The importer state cache can be evicted when repository Actions cache storage reaches its limit. When that happens, the importer falls back to a stale committed state file and reprocesses a large portion of the catalogue. After a successful main import, this workflow now opens a PR containing the generated state file instead of pushing directly to `main`.

## Validation

- Ruby YAML parse of `.github/workflows/ci.yml`
- `git diff --check`

Created with Codex


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Importer runs can now automatically save updated state changes in a dedicated branch and open a pull request for review.
  * Importer workflows can push changes and create pull requests when updates are detected.

* **Bug Fixes**
  * Improved importer workflow permissions and repository access to support reliable state persistence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->