### PR TITLE
fix: unblock Gemini tool calls

### DIFF
--- a/apps/api/src/executors/google-ai-studio/text-generate/__tests__/request-map.test.ts
+++ b/apps/api/src/executors/google-ai-studio/text-generate/__tests__/request-map.test.ts
@@ -2,6 +2,30 @@ import { describe, expect, it } from "vitest";
 import { irToGemini } from "../index";
 
 describe("google-ai-studio irToGemini", () => {
+	it("removes JSON Schema additionalProperties from function declarations", async () => {
+		const request = await irToGemini({
+			model: "gemini-3.5-flash-lite",
+			stream: false,
+			messages: [{ role: "user", content: [{ type: "text", text: "hello" }] }],
+			tools: [{
+				name: "lookup",
+				description: "Look something up",
+				parameters: {
+					type: "object",
+					additionalProperties: false,
+					properties: {
+						query: { type: "string", additionalProperties: false },
+					},
+				},
+			}],
+		} as any);
+
+		expect(request.tools?.[0]?.functionDeclarations?.[0]?.parameters).toEqual({
+			type: "object",
+			properties: { query: { type: "string" } },
+		});
+	});
+
 	it("maps system and developer roles into systemInstruction parts", async () => {
 		const request = await irToGemini({
 			model: "gemini-2.5-flash",

--- a/apps/api/src/executors/google-ai-studio/text-generate/index.ts
+++ b/apps/api/src/executors/google-ai-studio/text-generate/index.ts
@@ -27,6 +27,7 @@ import { googleUsageMetadataToIRUsage } from "@providers/google-ai-studio/usage"
 import { encodeOpenAIChatResponse } from "@protocols/openai-chat/encode";
 import { createSyntheticResponsesStreamFromIR } from "@executors/_shared/text-generate/synthetic-responses-stream";
 import { buildSyntheticServerToolStream } from "@pipeline/surfaces/server-tools.stream";
+import { sanitizeGeminiSchema } from "@executors/google/shared/schema";
 
 const DEFAULT_LYRIA_RETRY_ATTEMPTS = 3;
 const DEFAULT_LYRIA_RETRY_DELAY_MS = 300;
@@ -184,7 +185,7 @@ export async function irToGemini(ir: IRChatRequest, modelOverride?: string | nul
 			generationConfig.responseMimeType = "application/json";
 		} else if (ir.responseFormat.type === "json_schema") {
 			generationConfig.responseMimeType = "application/json";
-			generationConfig.responseSchema = ir.responseFormat.schema;
+			generationConfig.responseSchema = sanitizeGeminiSchema(ir.responseFormat.schema);
 
 			// Reinforce schema adherence for models that treat responseSchema as soft guidance.
 			const schemaText = (() => {
@@ -260,7 +261,7 @@ export async function irToGemini(ir: IRChatRequest, modelOverride?: string | nul
 			functionDeclarations: ir.tools.map(tool => ({
 				name: tool.name,
 				description: tool.description,
-				parameters: tool.parameters,
+				parameters: sanitizeGeminiSchema(tool.parameters),
 			})),
 		}];
 

--- a/apps/api/src/executors/google-vertex/text-generate/__tests__/mapping.test.ts
+++ b/apps/api/src/executors/google-vertex/text-generate/__tests__/mapping.test.ts
@@ -10,6 +10,30 @@ describe("google-vertex route resolution", () => {
 });
 
 describe("google-vertex irToGemini", () => {
+	it("removes JSON Schema additionalProperties from function declarations", async () => {
+		const request = await irToGemini({
+			model: "gemini-3.5-flash-lite",
+			stream: false,
+			messages: [{ role: "user", content: [{ type: "text", text: "hello" }] }],
+			tools: [{
+				name: "lookup",
+				description: "Look something up",
+				parameters: {
+					type: "object",
+					additionalProperties: false,
+					properties: {
+						query: { type: "string", additionalProperties: false },
+					},
+				},
+			}],
+		} as any);
+
+		expect(request.tools?.[0]?.functionDeclarations?.[0]?.parameters).toEqual({
+			type: "object",
+			properties: { query: { type: "string" } },
+		});
+	});
+
 	it("maps system and developer roles into systemInstruction parts", async () => {
 		const request = await irToGemini({
 			model: "gemini-2.5-flash",

--- a/apps/api/src/executors/google-vertex/text-generate/index.ts
+++ b/apps/api/src/executors/google-vertex/text-generate/index.ts
@@ -23,6 +23,7 @@ import {
 	modelSupportsGoogleThinkingLevels,
 	resolveGoogleThinkingLevelForEffort,
 } from "@executors/google/shared/thinking";
+import { sanitizeGeminiSchema } from "@executors/google/shared/schema";
 import type { ProviderExecutor } from "../../types";
 
 type VertexServiceAccount = {
@@ -460,7 +461,7 @@ export async function irToGemini(ir: IRChatRequest, modelOverride?: string | nul
 		generationConfig.responseMimeType = "application/json";
 	} else if (ir.responseFormat?.type === "json_schema") {
 		generationConfig.responseMimeType = "application/json";
-		generationConfig.responseSchema = ir.responseFormat.schema;
+		generationConfig.responseSchema = sanitizeGeminiSchema(ir.responseFormat.schema);
 
 		const schemaText = (() => {
 			try {
@@ -515,7 +516,7 @@ export async function irToGemini(ir: IRChatRequest, modelOverride?: string | nul
 			functionDeclarations: ir.tools.map(tool => ({
 				name: tool.name,
 				description: tool.description,
-				parameters: tool.parameters,
+				parameters: sanitizeGeminiSchema(tool.parameters),
 			})),
 		}];
 		if (ir.toolChoice === "auto") request.toolConfig = { functionCallingConfig: { mode: "AUTO" } };

--- a/apps/api/src/executors/google/shared/schema.ts
+++ b/apps/api/src/executors/google/shared/schema.ts
@@ -1,0 +1,23 @@
+/**
+ * Gemini's native Schema type is an OpenAPI subset and does not accept every
+ * JSON Schema keyword. In particular, additionalProperties is rejected in
+ * function declaration parameters even when it is valid in the caller's
+ * OpenAI-compatible tool schema.
+ */
+export function sanitizeGeminiSchema(schema: unknown): unknown {
+	if (Array.isArray(schema)) {
+		return schema.map(sanitizeGeminiSchema);
+	}
+
+	if (!schema || typeof schema !== "object") {
+		return schema;
+	}
+
+	const sanitized: Record<string, unknown> = {};
+	for (const [key, value] of Object.entries(schema)) {
+		if (key === "additionalProperties") continue;
+		sanitized[key] = sanitizeGeminiSchema(value);
+	}
+
+	return sanitized;
+}

--- a/apps/api/src/executors/google/text-generate/index.ts
+++ b/apps/api/src/executors/google/text-generate/index.ts
@@ -22,6 +22,7 @@ import {
 	modelSupportsGoogleThinkingLevels,
 	resolveGoogleThinkingLevelForEffort,
 } from "../shared/thinking";
+import { sanitizeGeminiSchema } from "../shared/schema";
 import { googleUsageMetadataToIRUsage } from "@providers/google-ai-studio/usage";
 
 /**
@@ -143,7 +144,7 @@ async function irToGemini(ir: IRChatRequest, modelOverride?: string | null): Pro
 			generationConfig.responseMimeType = "application/json";
 		} else if (ir.responseFormat.type === "json_schema") {
 			generationConfig.responseMimeType = "application/json";
-			generationConfig.responseSchema = ir.responseFormat.schema;
+			generationConfig.responseSchema = sanitizeGeminiSchema(ir.responseFormat.schema);
 		}
 	}
 
@@ -195,7 +196,7 @@ async function irToGemini(ir: IRChatRequest, modelOverride?: string | null): Pro
 			functionDeclarations: ir.tools.map(tool => ({
 				name: tool.name,
 				description: tool.description,
-				parameters: tool.parameters,
+				parameters: sanitizeGeminiSchema(tool.parameters),
 			})),
 		}];
 

--- a/apps/api/tests/aimock/provider-tool-contracts.spec.ts
+++ b/apps/api/tests/aimock/provider-tool-contracts.spec.ts
@@ -130,7 +130,16 @@ describe("provider-native tool contract E2E", () => {
         const request = mock.getLastRequest();
         expect(request?.providerId).toBe("google-ai-studio");
         expect(request?.body).toMatchObject({
-            tools: [{ functionDeclarations: [{ name: "lookup_weather", parameters: tool.function.parameters }] }],
+            tools: [{
+                functionDeclarations: [{
+                    name: "lookup_weather",
+                    parameters: {
+                        type: "object",
+                        properties: { city: { type: "string" } },
+                        required: ["city"],
+                    },
+                }],
+            }],
             toolConfig: { functionCallingConfig: { mode: "ANY" } },
         });
         expect(request?.validationIssues).toEqual([]);


### PR DESCRIPTION
## Summary

- Fix Google Gemini tool and structured-output schema translation for AI Studio, Vertex, and the shared Google executor.
- Recursively remove `additionalProperties`, which is accepted in OpenAI-compatible JSON Schema but rejected by Gemini `function_declarations.parameters`.
- Add focused coverage for nested tool schemas on both AI Studio and Vertex request builders.

## Incident

Requests to `google/gemini-3.5-flash-lite` and `google/gemini-3.6-flash` were returning 502 after both Google provider attempts failed. AI Studio returned HTTP 400 with `Unknown name additionalProperties at 'tools[0].function_declarations[0].parameters'`; Vertex returned HTTP 404 during fallback.

## Validation

- `pnpm exec vitest run src/executors/google-ai-studio/text-generate/__tests__/request-map.test.ts src/executors/google-vertex/text-generate/__tests__/mapping.test.ts` — 16/16 passed.
- `pnpm exec tsc --noEmit` in `apps/api` — passed.
- Targeted ESLint — no errors; existing max-lines warning remains on the large AI Studio executor.
- `git diff --cached --check` — passed.

Created with Codex