### PR TITLE
data: add Venice Gemini Flash routes and Cyber catalog

### DIFF
--- a/packages/data/catalog/src/data/api_providers/venice/models.json
+++ b/packages/data/catalog/src/data/api_providers/venice/models.json
@@ -294,6 +294,48 @@
     ]
   },
   {
+    "api_model_id": "google/gemini-3.5-flash-lite",
+    "provider_api_model_id": "venice:google/gemini-3.5-flash-lite",
+    "provider_model_slug": "gemini-3-5-flash-lite",
+    "internal_model_id": "google/gemini-3.5-flash-lite",
+    "is_active_gateway": true,
+    "quantization_scheme": null,
+    "input_modalities": "text,image,audio",
+    "output_modalities": "text",
+    "context_length": 1000000,
+    "max_output_tokens": 65536,
+    "effective_from": "2026-07-21T00:00:00",
+    "effective_to": null,
+    "capabilities": [
+      {
+        "capability_id": "text.generate",
+        "status": "deranked_lvl1",
+        "params": []
+      }
+    ]
+  },
+  {
+    "api_model_id": "google/gemini-3.6-flash",
+    "provider_api_model_id": "venice:google/gemini-3.6-flash",
+    "provider_model_slug": "gemini-3-6-flash",
+    "internal_model_id": "google/gemini-3.6-flash",
+    "is_active_gateway": true,
+    "quantization_scheme": null,
+    "input_modalities": "text,image,audio",
+    "output_modalities": "text",
+    "context_length": 1000000,
+    "max_output_tokens": 65536,
+    "effective_from": "2026-07-21T00:00:00",
+    "effective_to": null,
+    "capabilities": [
+      {
+        "capability_id": "text.generate",
+        "status": "deranked_lvl1",
+        "params": []
+      }
+    ]
+  },
+  {
     "api_model_id": "google/gemma-3-27b",
     "provider_api_model_id": "venice:google/gemma-3-27b",
     "provider_model_slug": "google-gemma-3-27b-it",

--- a/packages/data/catalog/src/data/models/google/gemini-3.5-flash-cyber/model.json
+++ b/packages/data/catalog/src/data/models/google/gemini-3.5-flash-cyber/model.json
@@ -1,0 +1,31 @@
+{
+  "model_id": "google/gemini-3.5-flash-cyber",
+  "organisation_id": "google",
+  "name": "Gemini 3.5 Flash Cyber",
+  "status": "Announced",
+  "previous_model_id": null,
+  "description": "Gemini 3.5 Flash Cyber is Google's specialized cyber-focused model paired with the CodeMender code security agent. It is announced as a research and product combination and is not generally available as a standalone model.",
+  "announced_date": "2026-07-21T00:00:00",
+  "release_date": null,
+  "deprecation_date": null,
+  "retirement_date": null,
+  "license": "Proprietary",
+  "input_types": "text",
+  "output_types": "text",
+  "api_model_id": "google/gemini-3.5-flash-cyber",
+  "family_id": "google/gemini-3.5",
+  "links": [
+    {
+      "title": "Announcement",
+      "kind": "announcement",
+      "url": "https://blog.google/innovation-and-ai/models-and-research/gemini-models/gemini-3-6-flash-3-5-flash-lite-3-5-flash-cyber/"
+    }
+  ],
+  "details": [
+    {
+      "name": "availability",
+      "value": "Google announced Gemini 3.5 Flash Cyber in CodeMender; no standalone public model or API availability was announced."
+    }
+  ],
+  "benchmarks": []
+}

--- a/packages/data/catalog/src/data/pricing/venice/google-gemini-3.5-flash-lite/text.generate/pricing.json
+++ b/packages/data/catalog/src/data/pricing/venice/google-gemini-3.5-flash-lite/text.generate/pricing.json
@@ -1,0 +1,42 @@
+{
+  "key": "venice:google/gemini-3.5-flash-lite:text.generate",
+  "api_provider_id": "venice",
+  "provider_slug": "venice",
+  "api_model_id": "google/gemini-3.5-flash-lite",
+  "capability_id": "text.generate",
+  "rules": [
+    {
+      "meter": "input_text_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 0.375,
+      "currency": "USD",
+      "pricing_plan": "standard",
+      "note": "Venice API model metadata as of 2026-07-21.",
+      "match": [],
+      "priority": 100
+    },
+    {
+      "meter": "cached_read_text_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 0.0375,
+      "currency": "USD",
+      "pricing_plan": "standard",
+      "note": "Venice API model metadata as of 2026-07-21.",
+      "match": [],
+      "priority": 100
+    },
+    {
+      "meter": "output_text_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 3.125,
+      "currency": "USD",
+      "pricing_plan": "standard",
+      "note": "Venice API model metadata as of 2026-07-21.",
+      "match": [],
+      "priority": 100
+    }
+  ]
+}

--- a/packages/data/catalog/src/data/pricing/venice/google-gemini-3.6-flash/text.generate/pricing.json
+++ b/packages/data/catalog/src/data/pricing/venice/google-gemini-3.6-flash/text.generate/pricing.json
@@ -1,0 +1,42 @@
+{
+  "key": "venice:google/gemini-3.6-flash:text.generate",
+  "api_provider_id": "venice",
+  "provider_slug": "venice",
+  "api_model_id": "google/gemini-3.6-flash",
+  "capability_id": "text.generate",
+  "rules": [
+    {
+      "meter": "input_text_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 1.875,
+      "currency": "USD",
+      "pricing_plan": "standard",
+      "note": "Venice API model metadata as of 2026-07-21.",
+      "match": [],
+      "priority": 100
+    },
+    {
+      "meter": "cached_read_text_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 0.1875,
+      "currency": "USD",
+      "pricing_plan": "standard",
+      "note": "Venice API model metadata as of 2026-07-21.",
+      "match": [],
+      "priority": 100
+    },
+    {
+      "meter": "output_text_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 9.375,
+      "currency": "USD",
+      "pricing_plan": "standard",
+      "note": "Venice API model metadata as of 2026-07-21.",
+      "match": [],
+      "priority": 100
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- Add Venice provider coverage for `google/gemini-3.5-flash-lite` and `google/gemini-3.6-flash`.
- Mark both `text.generate` capabilities as `deranked_lvl1` while keeping them active in the catalog.
- Add Venice pricing from the live Venice model metadata endpoint, including cached-read pricing.
- Add `google/gemini-3.5-flash-cyber` as an announced-only catalog model; it has no standalone public provider route or release date.

## Venice metadata

- `gemini-3-5-flash-lite`: 1M context, 65,536 max completion tokens, $0.375/M input, $3.125/M output, $0.0375/M cached read.
- `gemini-3-6-flash`: 1M context, 65,536 max completion tokens, $1.875/M input, $9.375/M output, $0.1875/M cached read.
- Venice reports audio/image input, text output, function calling, and response-schema support for both models.

Sources: https://api.venice.ai/api/v1/models and https://blog.google/innovation-and-ai/models-and-research/gemini-models/gemini-3-6-flash-3-5-flash-lite-3-5-flash-cyber/

## Validation

- `pnpm validate:data`
- `pnpm validate:pricing`
- `pnpm validate:gateway`
- `pnpm exec vitest run tests/aimock/cross-provider-models.spec.ts` — 1,460/1,460 passed.

Created with Codex

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Google Gemini 3.5 Flash Lite and Gemini 3.6 Flash models.
  * Both models support text, image, and audio input with text generation output.
  * Added standard pricing details for input, cached input, and output token usage.
  * Added the announced-only Gemini 3.5 Flash Cyber catalog entry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
