### PR TITLE
Correct Poolside data policy metadata

### DIFF
--- a/.changeset/bright-poolside-logs.md
+++ b/.changeset/bright-poolside-logs.md
@@ -1,0 +1,5 @@
+---
+"@phaseo/data-catalog": patch
+---
+
+Correct Poolside's data-policy metadata to reflect opt-out training terms and log retention.

--- a/packages/data/catalog/src/data/api_providers/poolside/api_provider.json
+++ b/packages/data/catalog/src/data/api_providers/poolside/api_provider.json
@@ -6,9 +6,13 @@
   "country_code": "US",
   "status": "Active",
   "colour": "#111111",
-  "privacy_policy_url": "https://poolside.ai/legal",
-  "terms_of_service_url": "https://poolside.ai/legal",
-  "prompt_training_policy": "no_train",
-  "prompt_training_notes": "Poolside documents that its platform runs inside the customer environment so code, prompts, and data do not leave the customer control boundary.",
-  "prompt_training_source_url": "https://docs.poolside.ai/legal-and-safety/data-processing-agreement"
+  "privacy_policy_url": "https://poolside.ai/legal/privacy",
+  "terms_of_service_url": "https://poolside.ai/legal/eula",
+  "prompt_training_policy": "opt_out_available",
+  "prompt_training_notes": "Poolside's Terms say it may use Content for training unless the user opts out. The Terms also state that third-party platform opt-out settings may govern. For the opted-out route, classify provider handling as logs rather than private/no-storage; safety-review and feedback exceptions still apply.",
+  "prompt_training_source_url": "https://poolside.ai/legal/eula",
+  "data_policy_tier": "logs",
+  "data_policy_confidence": "maybe",
+  "data_policy_contract_mode": "none",
+  "data_policy_contract_notes": "The public Terms establish an opt-out mechanism but do not provide a general zero-retention guarantee. This route is classified as logs based on the opted-out account configuration; verify the account or upstream platform setting if it changes."
 }


### PR DESCRIPTION
## Summary

- Correct Poolside's training policy from `no_train` to `opt_out_available` based on the current Terms of Use.
- Classify the opted-out route as `logs` rather than private/no-storage.
- Link the canonical Privacy Policy and Terms pages and document the remaining safety-review and feedback exceptions.

## Validation

- `pnpm validate:data`
- `pnpm validate:gateway`
- `git diff --check`

## Sources

- https://poolside.ai/legal/eula
- https://poolside.ai/legal/privacy
- https://poolside.ai/legal/dpa
