### PR TITLE
Fix blank Gemini responses

### DIFF
--- a/.changeset/fix-google-empty-streams.md
+++ b/.changeset/fix-google-empty-streams.md
@@ -1,0 +1,6 @@
+---
+"@phaseo/gateway-api": patch
+"@phaseo/web": patch
+---
+
+Route Gemini 3.6 Flash and Gemini 3.5 Flash-Lite through Google's current Interactions request shape, reject zero-output provider responses for failover, and show a structured error instead of persisting blank chat messages.

--- a/apps/api/src/executors/google-ai-studio/text-generate/__tests__/execute-usage-fallback.test.ts
+++ b/apps/api/src/executors/google-ai-studio/text-generate/__tests__/execute-usage-fallback.test.ts
@@ -67,7 +67,10 @@ describe("google-ai-studio execute usage fallback", () => {
 			}),
 		}]);
 
-		const result = await executor(buildArgs());
+		const result = await executor(buildArgs(undefined, {
+			endpoint: "interactions",
+			protocol: "google.interactions",
+		}));
 		mock.restore();
 
 		expect(result.kind).toBe("completed");
@@ -118,7 +121,11 @@ describe("google-ai-studio execute usage fallback", () => {
 
 		const result = await executor(buildArgs(
 			{ model: "google/lyria-3-pro-preview" },
-			{ providerModelSlug: "google/lyria-3-pro-preview" },
+			{
+				providerModelSlug: "google/lyria-3-pro-preview",
+				endpoint: "interactions",
+				protocol: "google.interactions",
+			},
 		));
 		mock.restore();
 
@@ -169,7 +176,11 @@ describe("google-ai-studio execute usage fallback", () => {
 
 		const result = await executor(buildArgs(
 			{ model: "google/lyria-3-pro" },
-			{ providerModelSlug: "google/lyria-3-pro" },
+			{
+				providerModelSlug: "google/lyria-3-pro",
+				endpoint: "interactions",
+				protocol: "google.interactions",
+			},
 		));
 		mock.restore();
 
@@ -217,7 +228,11 @@ describe("google-ai-studio execute usage fallback", () => {
 
 		const result = await executor(buildArgs(
 			{ model: "google/lyria-3-clip-preview" },
-			{ providerModelSlug: "google/lyria-3-clip-preview" },
+			{
+				providerModelSlug: "google/lyria-3-clip-preview",
+				endpoint: "interactions",
+				protocol: "google.interactions",
+			},
 		));
 		mock.restore();
 

--- a/apps/api/src/executors/google-ai-studio/text-generate/__tests__/execute-usage-fallback.test.ts
+++ b/apps/api/src/executors/google-ai-studio/text-generate/__tests__/execute-usage-fallback.test.ts
@@ -11,7 +11,11 @@ vi.mock("@supabase/supabase-js", () => ({
 
 function buildArgs(
 	overrides?: Partial<IRChatRequest>,
-	options?: { providerModelSlug?: string },
+	options?: {
+		providerModelSlug?: string;
+		endpoint?: string;
+		protocol?: string;
+	},
 ): ExecutorExecuteArgs {
 	const ir: IRChatRequest = {
 		model: "google/gemma-3-27b:free",
@@ -24,8 +28,8 @@ function buildArgs(
 		requestId: "req_google_usage_fallback",
 		workspaceId: "team_test",
 		providerId: "google-ai-studio",
-		endpoint: "responses",
-		protocol: "openai.responses",
+		endpoint: options?.endpoint ?? "responses",
+		protocol: options?.protocol ?? "openai.responses",
 		capability: "text.generate",
 		providerModelSlug: options?.providerModelSlug ?? "gemma-3-27b-it",
 		capabilityParams: null,
@@ -44,6 +48,64 @@ afterAll(() => {
 });
 
 describe("google-ai-studio execute usage fallback", () => {
+	it("routes current Gemini Flash models through Interactions and rejects empty output", async () => {
+		const mock = installFetchMock([{
+			match: (url) => url.endsWith("/v1beta/interactions"),
+			response: new Response(JSON.stringify({
+				id: "v1_empty_response",
+				status: "completed",
+				steps: [],
+				usage: { total_input_tokens: 8, total_output_tokens: 0, total_tokens: 8 },
+			}), {
+				status: 200,
+				headers: { "Content-Type": "application/json" },
+			}),
+		}]);
+
+		const result = await executor(buildArgs(
+			{ model: "google/gemini-3.6-flash" },
+			{ providerModelSlug: "google/gemini-3.6-flash" },
+		));
+		mock.restore();
+
+		expect(result.kind).toBe("completed");
+		if (result.kind !== "completed") return;
+		expect(result.ir).toBeUndefined();
+		expect(result.upstream?.status).toBe(502);
+		expect(mock.calls).toHaveLength(1);
+		expect(mock.calls[0]?.bodyJson?.model).toBe("gemini-3.6-flash");
+		expect(mock.calls[0]?.bodyJson?.generation_config).toBeUndefined();
+	});
+
+	it("keeps legacy GenerateContent routing for older AI Studio models", async () => {
+		const mock = installFetchMock([{
+			match: (url) => url.endsWith("/v1beta/models/gemini-2.5-flash:generateContent"),
+			response: new Response(JSON.stringify({
+				candidates: [{
+					content: { parts: [{ text: "legacy response" }] },
+					finishReason: "STOP",
+				}],
+			}), {
+				status: 200,
+				headers: { "Content-Type": "application/json" },
+			}),
+		}]);
+
+		const result = await executor(buildArgs(
+			{ model: "google/gemini-2.5-flash" },
+			{ providerModelSlug: "google/gemini-2.5-flash" },
+		));
+		mock.restore();
+
+		expect(result.kind).toBe("completed");
+		if (result.kind !== "completed") return;
+		expect(result.ir?.choices[0]?.message.content[0]).toEqual({
+			type: "text",
+			text: "legacy response",
+		});
+		expect(mock.calls[0]?.bodyJson?.contents?.[0]?.role).toBe("user");
+	});
+
 	it("estimates completion tokens when upstream usage reports prompt-only counts", async () => {
 		const payload = {
 			id: "v1_usage_fallback",

--- a/apps/api/src/executors/google-ai-studio/text-generate/__tests__/execute-usage-fallback.test.ts
+++ b/apps/api/src/executors/google-ai-studio/text-generate/__tests__/execute-usage-fallback.test.ts
@@ -45,29 +45,25 @@ afterAll(() => {
 
 describe("google-ai-studio execute usage fallback", () => {
 	it("estimates completion tokens when upstream usage reports prompt-only counts", async () => {
-		const sseBody = [
-			`data: ${JSON.stringify({
-				candidates: [{
-					index: 0,
-					content: { parts: [{ text: "This is a generated answer from Gemini." }] },
-					finishReason: "STOP",
-				}],
-				usageMetadata: {
-					promptTokenCount: 552,
-					candidatesTokenCount: 0,
-					totalTokenCount: 552,
-				},
-			})}`,
-			"",
-			"data: [DONE]",
-			"",
-		].join("\n");
+		const payload = {
+			id: "v1_usage_fallback",
+			status: "completed",
+			steps: [{
+				type: "model_output",
+				content: [{ type: "text", text: "This is a generated answer from Gemini." }],
+			}],
+			usage: {
+				total_input_tokens: 552,
+				total_output_tokens: 0,
+				total_tokens: 552,
+			},
+		};
 
 		const mock = installFetchMock([{
-			match: (url) => url.includes(":streamGenerateContent"),
-			response: new Response(sseBody, {
+			match: (url) => url.endsWith("/v1beta/interactions"),
+			response: new Response(JSON.stringify(payload), {
 				status: 200,
-				headers: { "Content-Type": "text/event-stream" },
+				headers: { "Content-Type": "application/json" },
 			}),
 		}]);
 
@@ -84,34 +80,27 @@ describe("google-ai-studio execute usage fallback", () => {
 		expect(result.ir?.usage?.outputTokens ?? 0).toBeGreaterThan(0);
 		expect(result.ir?.usage?.totalTokens ?? 0).toBeGreaterThan(552);
 
-		const usage = (result.rawResponse as any)?.usage;
-		expect(usage?.prompt_tokens).toBe(552);
-		expect(usage?.completion_tokens ?? 0).toBeGreaterThan(0);
-		expect(usage?.total_tokens ?? 0).toBeGreaterThan(552);
+		expect(result.bill.usage?.output_text_tokens ?? 0).toBeGreaterThan(0);
 	});
 
 	it("retries Lyria transient 5xx failures on the same candidate model", async () => {
-		const sseBody = [
-			`data: ${JSON.stringify({
-				candidates: [{
-					index: 0,
-					content: { parts: [{ text: "Recovered after transient upstream failure." }] },
-					finishReason: "STOP",
-				}],
-				usageMetadata: {
-					promptTokenCount: 24,
-					candidatesTokenCount: 11,
-					totalTokenCount: 35,
-				},
-			})}`,
-			"",
-			"data: [DONE]",
-			"",
-		].join("\n");
+		const payload = {
+			id: "v1_lyria_retry",
+			status: "completed",
+			steps: [{
+				type: "model_output",
+				content: [{ type: "text", text: "Recovered after transient upstream failure." }],
+			}],
+			usage: {
+				total_input_tokens: 24,
+				total_output_tokens: 11,
+				total_tokens: 35,
+			},
+		};
 
 		let attempts = 0;
 		const mock = installFetchMock([{
-			match: (url) => url.includes("models/lyria-3-pro-preview:streamGenerateContent"),
+			match: (url) => url.endsWith("/v1beta/interactions"),
 			response: () => {
 				attempts += 1;
 				if (attempts === 1) {
@@ -120,9 +109,9 @@ describe("google-ai-studio execute usage fallback", () => {
 						headers: { "Content-Type": "application/json" },
 					});
 				}
-				return new Response(sseBody, {
+				return new Response(JSON.stringify(payload), {
 					status: 200,
-					headers: { "Content-Type": "text/event-stream" },
+					headers: { "Content-Type": "application/json" },
 				});
 			},
 		}]);
@@ -136,7 +125,7 @@ describe("google-ai-studio execute usage fallback", () => {
 		expect(result.kind).toBe("completed");
 		if (result.kind !== "completed") return;
 		expect(attempts).toBe(2);
-		expect(mock.calls.every((call) => call.url.includes("models/lyria-3-pro-preview:streamGenerateContent"))).toBe(true);
+		expect(mock.calls.every((call) => call.bodyJson?.model === "lyria-3-pro-preview")).toBe(true);
 		expect(result.ir?.choices?.[0]?.message?.content?.[0]).toEqual({
 			type: "text",
 			text: "Recovered after transient upstream failure.",
@@ -144,38 +133,37 @@ describe("google-ai-studio execute usage fallback", () => {
 	});
 
 	it("falls back from non-preview Lyria alias to preview candidate model", async () => {
-		const sseBody = [
-			`data: ${JSON.stringify({
-				candidates: [{
-					index: 0,
-					content: { parts: [{ text: "Served by fallback candidate." }] },
-					finishReason: "STOP",
-				}],
-				usageMetadata: {
-					promptTokenCount: 19,
-					candidatesTokenCount: 8,
-					totalTokenCount: 27,
-				},
-			})}`,
-			"",
-			"data: [DONE]",
-			"",
-		].join("\n");
+		const payload = {
+			id: "v1_lyria_fallback",
+			status: "completed",
+			steps: [{
+				type: "model_output",
+				content: [{ type: "text", text: "Served by fallback candidate." }],
+			}],
+			usage: {
+				total_input_tokens: 19,
+				total_output_tokens: 8,
+				total_tokens: 27,
+			},
+		};
+		let attempts = 0;
 
 		const mock = installFetchMock([
 			{
-				match: (url) => url.includes("models/lyria-3-pro:streamGenerateContent"),
-				response: new Response(JSON.stringify({ error: { message: "Model not found." } }), {
-					status: 404,
-					headers: { "Content-Type": "application/json" },
-				}),
-			},
-			{
-				match: (url) => url.includes("models/lyria-3-pro-preview:streamGenerateContent"),
-				response: new Response(sseBody, {
-					status: 200,
-					headers: { "Content-Type": "text/event-stream" },
-				}),
+				match: (url) => url.endsWith("/v1beta/interactions"),
+				response: () => {
+					attempts += 1;
+					if (attempts === 1) {
+						return new Response(JSON.stringify({ error: { message: "Model not found." } }), {
+							status: 404,
+							headers: { "Content-Type": "application/json" },
+						});
+					}
+					return new Response(JSON.stringify(payload), {
+						status: 200,
+						headers: { "Content-Type": "application/json" },
+					});
+				},
 			},
 		]);
 
@@ -188,7 +176,7 @@ describe("google-ai-studio execute usage fallback", () => {
 		expect(result.kind).toBe("completed");
 		if (result.kind !== "completed") return;
 		expect(
-			mock.calls.some((call) => call.url.includes("models/lyria-3-pro-preview:streamGenerateContent")),
+			mock.calls.some((call) => call.bodyJson?.model === "lyria-3-pro-preview"),
 		).toBe(true);
 		expect(result.ir?.model).toBe("lyria-3-pro-preview");
 		expect(result.ir?.choices?.[0]?.message?.content?.[0]).toEqual({
@@ -197,66 +185,30 @@ describe("google-ai-studio execute usage fallback", () => {
 		});
 	});
 
-	it("parses Lyria JSON chunk-array responses into text+audio IR content", async () => {
-		const payload = [
-			{
-				candidates: [{
-					index: 0,
-					content: {
-						role: "model",
-						parts: [{ text: "Verse line one" }],
+	it("parses Interactions JSON responses into text+audio IR content", async () => {
+		const payload = {
+			id: "resp_123",
+			status: "completed",
+			steps: [{
+				type: "model_output",
+				content: [
+					{ type: "text", text: "Verse line one" },
+					{
+						type: "audio",
+						mime_type: "audio/mpeg",
+						data: "RkFLRS1NUEczLURBVEE=",
 					},
-				}],
-				usageMetadata: {
-					promptTokenCount: 21,
-					candidatesTokenCount: 573,
-					totalTokenCount: 594,
-				},
-				modelVersion: "lyria-3-clip-preview",
-				responseId: "resp_123",
+				],
+			}],
+			usage: {
+				total_input_tokens: 21,
+				total_output_tokens: 1106,
+				total_tokens: 1127,
 			},
-			{
-				candidates: [{
-					index: 0,
-					content: {
-						role: "model",
-						parts: [{
-							inlineData: {
-								mimeType: "audio/mpeg",
-								data: "RkFLRS1NUEczLURBVEE=",
-							},
-						}],
-					},
-				}],
-				usageMetadata: {
-					promptTokenCount: 21,
-					candidatesTokenCount: 1106,
-					totalTokenCount: 1127,
-				},
-				modelVersion: "lyria-3-clip-preview",
-				responseId: "resp_123",
-			},
-			{
-				candidates: [{
-					index: 0,
-					content: {
-						role: "model",
-						parts: [{ text: "" }],
-					},
-					finishReason: "STOP",
-				}],
-				usageMetadata: {
-					promptTokenCount: 21,
-					candidatesTokenCount: 1106,
-					totalTokenCount: 1127,
-				},
-				modelVersion: "lyria-3-clip-preview",
-				responseId: "resp_123",
-			},
-		];
+		};
 
 		const mock = installFetchMock([{
-			match: (url) => url.includes("models/lyria-3-clip-preview:streamGenerateContent"),
+			match: (url) => url.endsWith("/v1beta/interactions"),
 			response: new Response(JSON.stringify(payload), {
 				status: 200,
 				headers: { "Content-Type": "application/json" },
@@ -271,7 +223,7 @@ describe("google-ai-studio execute usage fallback", () => {
 
 		expect(result.kind).toBe("completed");
 		if (result.kind !== "completed") return;
-		expect(mock.calls.some((call) => call.url.includes("?alt=sse"))).toBe(false);
+		expect(mock.calls.some((call) => call.bodyJson?.stream)).toBe(false);
 		expect(result.ir?.nativeId).toBe("resp_123");
 		expect(result.ir?.choices?.[0]?.finishReason).toBe("stop");
 		expect(result.ir?.choices?.[0]?.message?.content).toEqual([
@@ -286,4 +238,3 @@ describe("google-ai-studio execute usage fallback", () => {
 		expect(result.ir?.usage?.totalTokens).toBe(1127);
 	});
 });
-

--- a/apps/api/src/executors/google-ai-studio/text-generate/__tests__/request-map.test.ts
+++ b/apps/api/src/executors/google-ai-studio/text-generate/__tests__/request-map.test.ts
@@ -2,6 +2,29 @@ import { describe, expect, it } from "vitest";
 import { irToGemini } from "../index";
 
 describe("google-ai-studio irToGemini", () => {
+	it("uses the Interactions request shape for current Gemini Flash models", async () => {
+		const request = await irToGemini({
+			model: "gemini-3.6-flash",
+			stream: true,
+			temperature: 0.2,
+			topP: 0.8,
+			topK: 20,
+			maxTokens: 256,
+			messages: [{ role: "user", content: [{ type: "text", text: "hello" }] }],
+		} as any);
+
+		expect(request.model).toBe("gemini-3.6-flash");
+		expect(request.input).toEqual([{
+			type: "user_input",
+			content: [{ type: "text", text: "hello" }],
+		}]);
+		expect(request.generation_config).toEqual({ max_output_tokens: 256 });
+		expect(request).not.toHaveProperty("temperature");
+		expect(request.generation_config).not.toHaveProperty("temperature");
+		expect(request.generation_config).not.toHaveProperty("top_p");
+		expect(request.generation_config).not.toHaveProperty("top_k");
+	});
+
 	it("maps system and developer roles into system_instruction", async () => {
 		const request = await irToGemini({
 			model: "gemini-2.5-flash",

--- a/apps/api/src/executors/google-ai-studio/text-generate/__tests__/request-map.test.ts
+++ b/apps/api/src/executors/google-ai-studio/text-generate/__tests__/request-map.test.ts
@@ -2,31 +2,7 @@ import { describe, expect, it } from "vitest";
 import { irToGemini } from "../index";
 
 describe("google-ai-studio irToGemini", () => {
-	it("removes JSON Schema additionalProperties from function declarations", async () => {
-		const request = await irToGemini({
-			model: "gemini-3.5-flash-lite",
-			stream: false,
-			messages: [{ role: "user", content: [{ type: "text", text: "hello" }] }],
-			tools: [{
-				name: "lookup",
-				description: "Look something up",
-				parameters: {
-					type: "object",
-					additionalProperties: false,
-					properties: {
-						query: { type: "string", additionalProperties: false },
-					},
-				},
-			}],
-		} as any);
-
-		expect(request.tools?.[0]?.functionDeclarations?.[0]?.parameters).toEqual({
-			type: "object",
-			properties: { query: { type: "string" } },
-		});
-	});
-
-	it("maps system and developer roles into systemInstruction parts", async () => {
+	it("maps system and developer roles into system_instruction", async () => {
 		const request = await irToGemini({
 			model: "gemini-2.5-flash",
 			stream: false,
@@ -37,14 +13,12 @@ describe("google-ai-studio irToGemini", () => {
 			],
 		} as any);
 
-		expect(request.systemInstruction?.parts).toEqual([
-			{ text: "system prompt" },
-			{ text: "developer prompt" },
-		]);
-		expect(request.contents).toHaveLength(1);
-		expect(request.contents[0]).toEqual({
-			role: "user",
-			parts: [{ text: "hello" }],
+		expect(request.system_instruction).toBe("system prompt\n\ndeveloper prompt");
+		expect(request.store).toBe(false);
+		expect(request.input).toHaveLength(1);
+		expect(request.input[0]).toEqual({
+			type: "user_input",
+			content: [{ type: "text", text: "hello" }],
 		});
 	});
 
@@ -66,23 +40,24 @@ describe("google-ai-studio irToGemini", () => {
 			},
 		} as any);
 
-		expect(request.generationConfig?.responseMimeType).toBe("application/json");
-		expect(request.generationConfig?.responseSchema).toEqual({
+		expect(request.response_format).toEqual({
+			type: "text",
+			mime_type: "application/json",
+			schema: {
+				type: "object",
+				properties: { answer: { type: "string" } },
+				required: ["answer"],
+			},
+		});
+		expect(request.response_format?.schema).toEqual({
 			type: "object",
 			properties: { answer: { type: "string" } },
 			required: ["answer"],
 		});
-		expect(Array.isArray(request.systemInstruction?.parts)).toBe(true);
-		expect(
-			request.systemInstruction.parts.some(
-				(part: any) =>
-					typeof part?.text === "string" &&
-					part.text.includes("Return only valid JSON that matches this schema exactly:"),
-			),
-		).toBe(true);
+		expect(request.system_instruction).toContain("Return only valid JSON that matches this schema exactly:");
 	});
 
-	it("maps image config passthrough and explicit thought controls", async () => {
+	it("maps image response format and explicit thought controls", async () => {
 		const request = await irToGemini({
 			model: "gemini-3.1-flash-image-preview",
 			stream: false,
@@ -97,13 +72,14 @@ describe("google-ai-studio irToGemini", () => {
 			},
 		} as any);
 
-		expect(request.generationConfig?.responseModalities).toEqual(["IMAGE"]);
-		expect(request.generationConfig?.thinkingConfig?.includeThoughts).toBe(false);
-		expect(request.generationConfig?.imageConfig).toEqual({
-			aspectRatio: "9:16",
-			imageSize: "0.5K",
-			includeRaiReason: true,
-			referenceImages: [{ referenceType: "REFERENCE_TYPE_RAW" }],
+		expect(request.response_modalities).toEqual(["image"]);
+		expect(request.generation_config?.thinking_summaries).toBe("none");
+		expect(request.response_format).toEqual({
+			type: "image",
+			mime_type: "image/jpeg",
+			delivery: "inline",
+			aspect_ratio: "9:16",
+			image_size: "512",
 		});
 	});
 
@@ -114,7 +90,7 @@ describe("google-ai-studio irToGemini", () => {
 			messages: [{ role: "user", content: [{ type: "text", text: "draw a blue square" }] }],
 		} as any);
 
-		expect(request.generationConfig?.responseModalities).toEqual(["TEXT", "IMAGE"]);
+		expect(request.response_modalities).toEqual(["text", "image"]);
 	});
 
 	it("maps audio modality for Gemini responseModalities", async () => {
@@ -125,7 +101,7 @@ describe("google-ai-studio irToGemini", () => {
 			modalities: ["text", "audio"],
 		} as any);
 
-		expect(request.generationConfig?.responseModalities).toEqual(["TEXT", "AUDIO"]);
+		expect(request.response_modalities).toEqual(["text", "audio"]);
 	});
 
 	it("maps reasoning.effort to thinkingLevel for Gemini 3.1 image preview", async () => {
@@ -136,8 +112,8 @@ describe("google-ai-studio irToGemini", () => {
 			reasoning: { effort: "minimal", enabled: true },
 		} as any);
 
-		expect(request.generationConfig?.thinkingConfig?.thinkingLevel).toBe("MINIMAL");
-		expect(request.generationConfig?.thinkingConfig?.thinkingBudget).toBeUndefined();
+		expect(request.generation_config?.thinking_level).toBe("minimal");
+		expect(request.generation_config?.thinking_budget).toBeUndefined();
 	});
 
 	it("passes through supported image sizes and aspect ratios", async () => {
@@ -156,10 +132,9 @@ describe("google-ai-studio irToGemini", () => {
 					},
 				} as any);
 
-				expect(request.generationConfig?.imageConfig?.imageSize).toBe(size);
-				expect(request.generationConfig?.imageConfig?.aspectRatio).toBe(ratio);
+				expect(request.response_format?.image_size).toBe(size === "0.5K" ? "512" : size);
+				expect(request.response_format?.aspect_ratio).toBe(ratio);
 			}
 		}
 	});
 });
-

--- a/apps/api/src/executors/google-ai-studio/text-generate/__tests__/stream-transform.test.ts
+++ b/apps/api/src/executors/google-ai-studio/text-generate/__tests__/stream-transform.test.ts
@@ -35,6 +35,25 @@ function baseArgs(overrides?: Record<string, any>): any {
 }
 
 describe("google-ai-studio stream transform", () => {
+	it("emits a structured error instead of a blank successful stream", async () => {
+		const upstream = makeGoogleSseStream([
+			{
+				interaction: {
+					id: "v1_empty",
+					status: "completed",
+					usage: { total_input_tokens: 5, total_output_tokens: 0, total_tokens: 5 },
+				},
+				event_type: "interaction.completed",
+			},
+		]);
+
+		const output = await readStreamText(transformStream(upstream, baseArgs()));
+
+		expect(output).toContain("event: error");
+		expect(output).toContain("google_empty_response");
+		expect(output).toContain("data: [DONE]");
+	});
+
 	it("emits chat tool_call deltas from Interactions function_call steps", async () => {
 		const upstream = makeGoogleSseStream([
 			{

--- a/apps/api/src/executors/google-ai-studio/text-generate/__tests__/stream-transform.test.ts
+++ b/apps/api/src/executors/google-ai-studio/text-generate/__tests__/stream-transform.test.ts
@@ -49,7 +49,7 @@ describe("google-ai-studio stream transform", () => {
 
 		const output = await readStreamText(transformStream(upstream, baseArgs()));
 
-		expect(output).toContain("event: error");
+		expect(output).toContain("event: response.failed");
 		expect(output).toContain("google_empty_response");
 		expect(output).toContain("data: [DONE]");
 	});

--- a/apps/api/src/executors/google-ai-studio/text-generate/__tests__/stream-transform.test.ts
+++ b/apps/api/src/executors/google-ai-studio/text-generate/__tests__/stream-transform.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { transformStream } from "../index";
 
-function makeGeminiSseStream(payloads: any[]): ReadableStream<Uint8Array> {
+function makeGoogleSseStream(payloads: any[]): ReadableStream<Uint8Array> {
 	const body = payloads
 		.map((payload) => `data: ${JSON.stringify(payload)}\n\n`)
 		.join("");
@@ -35,26 +35,37 @@ function baseArgs(overrides?: Record<string, any>): any {
 }
 
 describe("google-ai-studio stream transform", () => {
-	it("emits chat tool_call deltas from Gemini functionCall parts", async () => {
-		const upstream = makeGeminiSseStream([
+	it("emits chat tool_call deltas from Interactions function_call steps", async () => {
+		const upstream = makeGoogleSseStream([
 			{
-				candidates: [{
-					index: 0,
-					content: {
-						parts: [{
-							functionCall: {
-								name: "get_weather",
-								args: { city: "SF" },
-							},
-						}],
-					},
-					finishReason: "STOP",
-				}],
-				usageMetadata: {
-					promptTokenCount: 5,
-					candidatesTokenCount: 3,
-					totalTokenCount: 8,
+				index: 0,
+				step: {
+					type: "function_call",
+					id: "call_weather",
+					name: "get_weather",
+					arguments: {},
 				},
+				event_type: "step.start",
+			},
+			{
+				index: 0,
+				delta: {
+					type: "arguments_delta",
+					arguments: "{\"city\":\"SF\"}",
+				},
+				event_type: "step.delta",
+			},
+			{
+				interaction: {
+					id: "v1_test",
+					status: "requires_action",
+					usage: {
+						total_input_tokens: 5,
+						total_output_tokens: 3,
+						total_tokens: 8,
+					},
+				},
+				event_type: "interaction.completed",
 			},
 		]);
 
@@ -68,33 +79,44 @@ describe("google-ai-studio stream transform", () => {
 	});
 
 	it("converts Gemini functionCall stream to responses function call events", async () => {
-		const upstream = makeGeminiSseStream([
+		const upstream = makeGoogleSseStream([
 			{
-				candidates: [{
-					index: 0,
-					content: {
-						parts: [{
-							functionCall: {
-								name: "get_weather",
-								partialArgs: "{\"city\":\"",
-							},
-						}],
-					},
-				}],
+				index: 0,
+				step: {
+					type: "function_call",
+					id: "call_weather",
+					name: "get_weather",
+					arguments: {},
+				},
+				event_type: "step.start",
 			},
 			{
-				candidates: [{
-					index: 0,
-					content: {
-						parts: [{
-							functionCall: {
-								name: "get_weather",
-								partialArgs: "SF\"}",
-							},
-						}],
+				index: 0,
+				delta: {
+					type: "arguments_delta",
+					arguments: "{\"city\":\"",
+				},
+				event_type: "step.delta",
+			},
+			{
+				index: 0,
+				delta: {
+					type: "arguments_delta",
+					arguments: "SF\"}",
+				},
+				event_type: "step.delta",
+			},
+			{
+				interaction: {
+					id: "v1_test",
+					status: "requires_action",
+					usage: {
+						total_input_tokens: 5,
+						total_output_tokens: 3,
+						total_tokens: 8,
 					},
-					finishReason: "STOP",
-				}],
+				},
+				event_type: "interaction.completed",
 			},
 		]);
 
@@ -111,25 +133,35 @@ describe("google-ai-studio stream transform", () => {
 		expect(output).toContain("\"arguments\":\"{\\\"city\\\":\\\"SF\\\"}\"");
 	});
 
-	it("emits reasoning_content deltas for Gemini thought parts", async () => {
-		const upstream = makeGeminiSseStream([
+	it("emits reasoning_content deltas for Interactions thought summaries", async () => {
+		const upstream = makeGoogleSseStream([
 			{
-				candidates: [{
-					index: 0,
-					content: {
-						parts: [{
-							text: "thinking trace",
-							thought: true,
-						}],
-					},
-					finishReason: "STOP",
-				}],
-				usageMetadata: {
-					promptTokenCount: 5,
-					candidatesTokenCount: 3,
-					totalTokenCount: 8,
-					thoughtsTokenCount: 2,
+				index: 0,
+				step: {
+					type: "thought",
 				},
+				event_type: "step.start",
+			},
+			{
+				index: 0,
+				delta: {
+					type: "thought_summary",
+					content: { type: "text", text: "thinking trace" },
+				},
+				event_type: "step.delta",
+			},
+			{
+				interaction: {
+					id: "v1_test",
+					status: "completed",
+					usage: {
+						total_input_tokens: 5,
+						total_output_tokens: 3,
+						total_tokens: 8,
+						total_thought_tokens: 2,
+					},
+				},
+				event_type: "interaction.completed",
 			},
 		]);
 
@@ -145,30 +177,37 @@ describe("google-ai-studio stream transform", () => {
 		expect(output).toContain("\"reasoning_content\":\"thinking trace\"");
 	});
 
-	it("emits image deltas when Gemini stream returns inlineData image parts", async () => {
-		const upstream = makeGeminiSseStream([
+	it("emits image deltas when Interactions stream returns image content", async () => {
+		const upstream = makeGoogleSseStream([
 			{
-				candidates: [{
-					index: 0,
-					content: {
-						parts: [{
-							inlineData: {
-								mimeType: "image/png",
-								data: "ZmFrZS1pbWFnZQ==",
-							},
-						}],
-					},
-					finishReason: "STOP",
-				}],
-				usageMetadata: {
-					promptTokenCount: 66,
-					candidatesTokenCount: 1536,
-					totalTokenCount: 2027,
-					thoughtsTokenCount: 425,
-					candidatesTokensDetails: [
-						{ modality: "IMAGE", tokenCount: 1120 },
-					],
+				index: 0,
+				step: { type: "model_output" },
+				event_type: "step.start",
+			},
+			{
+				index: 0,
+				delta: {
+					type: "image",
+					mime_type: "image/png",
+					data: "ZmFrZS1pbWFnZQ==",
 				},
+				event_type: "step.delta",
+			},
+			{
+				interaction: {
+					id: "v1_test",
+					status: "completed",
+					usage: {
+						total_input_tokens: 66,
+						total_output_tokens: 1536,
+						total_tokens: 2027,
+						total_thought_tokens: 425,
+						output_tokens_by_modality: [
+							{ modality: "image", tokens: 1120 },
+						],
+					},
+				},
+				event_type: "interaction.completed",
 			},
 		]);
 
@@ -181,29 +220,36 @@ describe("google-ai-studio stream transform", () => {
 		expect(output).toContain("\"output_images\":1120");
 	});
 
-	it("emits audio deltas when Gemini stream returns inlineData audio parts", async () => {
-		const upstream = makeGeminiSseStream([
+	it("emits audio deltas when Interactions stream returns audio content", async () => {
+		const upstream = makeGoogleSseStream([
 			{
-				candidates: [{
-					index: 0,
-					content: {
-						parts: [{
-							inlineData: {
-								mimeType: "audio/wav",
-								data: "UklGRlIAAABXQVZFZm10",
-							},
-						}],
-					},
-					finishReason: "STOP",
-				}],
-				usageMetadata: {
-					promptTokenCount: 11,
-					candidatesTokenCount: 22,
-					totalTokenCount: 33,
-					candidatesTokensDetails: [
-						{ modality: "AUDIO", tokenCount: 22 },
-					],
+				index: 0,
+				step: { type: "model_output" },
+				event_type: "step.start",
+			},
+			{
+				index: 0,
+				delta: {
+					type: "audio",
+					mime_type: "audio/wav",
+					data: "UklGRlIAAABXQVZFZm10",
 				},
+				event_type: "step.delta",
+			},
+			{
+				interaction: {
+					id: "v1_test",
+					status: "completed",
+					usage: {
+						total_input_tokens: 11,
+						total_output_tokens: 22,
+						total_tokens: 33,
+						output_tokens_by_modality: [
+							{ modality: "audio", tokens: 22 },
+						],
+					},
+				},
+				event_type: "interaction.completed",
 			},
 		]);
 

--- a/apps/api/src/executors/google-ai-studio/text-generate/index.ts
+++ b/apps/api/src/executors/google-ai-studio/text-generate/index.ts
@@ -61,6 +61,120 @@ async function sleep(ms: number): Promise<void> {
 	await new Promise((resolve) => setTimeout(resolve, ms));
 }
 
+async function irToLegacyGemini(ir: IRChatRequest, modelOverride?: string | null): Promise<any> {
+	const contents: any[] = [];
+	const systemInstructionParts: any[] = [];
+	const toolNamesById = new Map<string, string>();
+
+	for (const message of ir.messages) {
+		if (message.role !== "assistant") continue;
+		for (const toolCall of message.toolCalls ?? []) {
+			if (toolCall.id && toolCall.name) toolNamesById.set(toolCall.id, toolCall.name);
+		}
+	}
+
+	for (const message of ir.messages) {
+		if (message.role === "system" || message.role === "developer") {
+			systemInstructionParts.push(...await irPartsToGeminiParts(message.content, { preserveReasoningAsThought: true }));
+			continue;
+		}
+
+		if (message.role === "user" || message.role === "assistant") {
+			contents.push({
+				role: message.role === "assistant" ? "model" : "user",
+				parts: await irPartsToGeminiParts(message.content, { preserveReasoningAsThought: true }),
+			});
+			continue;
+		}
+
+		if (message.role === "tool") {
+			for (const toolResult of message.toolResults) {
+				let response: any = toolResult.content;
+				if (typeof response === "string") {
+					try {
+						response = JSON.parse(response);
+					} catch {
+						response = { content: response };
+					}
+				}
+				contents.push({
+					role: "user",
+					parts: [{
+						functionResponse: {
+							name: toolNamesById.get(toolResult.toolCallId) ?? toolResult.toolCallId,
+							response,
+						},
+					}],
+				});
+			}
+		}
+	}
+
+	const request: any = { contents };
+	if (ir.googleCachedContent !== undefined) request.cachedContent = ir.googleCachedContent;
+	if (systemInstructionParts.length > 0) request.systemInstruction = { parts: systemInstructionParts };
+
+	const generationConfig: any = {};
+	if (ir.temperature !== undefined) generationConfig.temperature = ir.temperature;
+	if (ir.maxTokens !== undefined) generationConfig.maxOutputTokens = ir.maxTokens;
+	if (ir.topP !== undefined) generationConfig.topP = ir.topP;
+	if (ir.topK !== undefined) generationConfig.topK = ir.topK;
+	if (ir.stop) generationConfig.stopSequences = Array.isArray(ir.stop) ? ir.stop : [ir.stop];
+
+	if (ir.reasoning?.enabled || ir.reasoning?.effort || ir.reasoning?.maxTokens !== undefined || ir.reasoning?.includeThoughts !== undefined) {
+		const thinkingConfig: any = { includeThoughts: ir.reasoning?.includeThoughts ?? true };
+		const modelName = modelOverride ?? ir.model;
+		if (ir.reasoning?.effort && modelSupportsGoogleThinkingLevels(modelName ?? "")) {
+			const level = resolveGoogleThinkingLevelForEffort(modelName ?? "", ir.reasoning.effort);
+			if (level) thinkingConfig.thinkingLevel = level;
+		} else if (ir.reasoning?.maxTokens !== undefined) {
+			thinkingConfig.thinkingBudget = ir.reasoning.maxTokens;
+		} else if (ir.reasoning?.enabled) {
+			thinkingConfig.thinkingBudget = -1;
+		}
+		generationConfig.thinkingConfig = thinkingConfig;
+	}
+
+	if (ir.responseFormat?.type === "json_object") {
+		generationConfig.responseMimeType = "application/json";
+	} else if (ir.responseFormat?.type === "json_schema") {
+		generationConfig.responseMimeType = "application/json";
+		generationConfig.responseSchema = ir.responseFormat.schema;
+	}
+
+	const modalities = (ir.modalities ?? [])
+		.map((modality) => String(modality).toUpperCase())
+		.filter((modality) => modality === "TEXT" || modality === "IMAGE" || modality === "AUDIO");
+	if (modalities.length > 0) generationConfig.responseModalities = modalities;
+
+	if (ir.imageConfig) {
+		const imageConfig: any = {};
+		if (ir.imageConfig.aspectRatio) imageConfig.aspectRatio = ir.imageConfig.aspectRatio;
+		if (ir.imageConfig.imageSize) imageConfig.imageSize = ir.imageConfig.imageSize;
+		if (typeof ir.imageConfig.includeRaiReason === "boolean") imageConfig.includeRaiReason = ir.imageConfig.includeRaiReason;
+		if (ir.imageConfig.referenceImages?.length) imageConfig.referenceImages = ir.imageConfig.referenceImages;
+		if (Object.keys(imageConfig).length > 0) generationConfig.imageConfig = imageConfig;
+	}
+
+	if (Object.keys(generationConfig).length > 0) request.generationConfig = generationConfig;
+
+	if (ir.tools?.length) {
+		request.tools = [{ functionDeclarations: ir.tools.map((tool) => ({
+			name: tool.name,
+			description: tool.description,
+			parameters: tool.parameters,
+		})) }];
+		if (ir.toolChoice === "auto") request.toolConfig = { functionCallingConfig: { mode: "AUTO" } };
+		if (ir.toolChoice === "none") request.toolConfig = { functionCallingConfig: { mode: "NONE" } };
+		if (ir.toolChoice === "required") request.toolConfig = { functionCallingConfig: { mode: "ANY" } };
+		if (typeof ir.toolChoice === "object" && "name" in ir.toolChoice) {
+			request.toolConfig = { functionCallingConfig: { mode: "ANY", allowedFunctionNames: [ir.toolChoice.name] } };
+		}
+	}
+
+	return request;
+}
+
 /**
  * Transform IR request to Google's Interactions API format.
  *
@@ -860,6 +974,7 @@ export function preprocess(ir: IRChatRequest, args: ExecutorExecuteArgs): IRChat
  */
 export async function execute(args: ExecutorExecuteArgs): Promise<ExecutorResult> {
 	const { ir, providerId, providerModelSlug, requestId, pricingCard, meta } = args;
+	const isInteractionsRequest = args.protocol === "google.interactions";
 	const bindings = getBindings() as any;
 
 	// Resolve API key: prefer decrypted BYOK for this provider, else use gateway keys.
@@ -869,7 +984,7 @@ export async function execute(args: ExecutorExecuteArgs): Promise<ExecutorResult
 
 	// Determine model candidates (must be in URL, not body)
 	const requestedModel = providerModelSlug || ir.model || "gemini-2.0-flash-exp";
-	const forceSyntheticImageStream = Boolean(ir.stream) && isGeminiImageModelName(requestedModel);
+	const forceSyntheticImageStream = !isInteractionsRequest && Boolean(ir.stream) && isGeminiImageModelName(requestedModel);
 	const modelCandidates = resolveGoogleModelCandidates(requestedModel);
 	let model = modelCandidates[0] || "gemini-2.0-flash-exp";
 
@@ -883,7 +998,12 @@ export async function execute(args: ExecutorExecuteArgs): Promise<ExecutorResult
 
 	const upstreamStartMs = meta.upstreamStartMs ?? Date.now();
 
-	const makeEndpoint = () => `${baseUrl}/interactions`;
+	const makeEndpoint = (candidateModel: string) => {
+		if (isInteractionsRequest) return `${baseUrl}/interactions`;
+		return Boolean(ir.stream) && !forceSyntheticImageStream
+			? `${baseUrl}/models/${encodeURIComponent(candidateModel)}:streamGenerateContent?alt=sse`
+			: `${baseUrl}/models/${encodeURIComponent(candidateModel)}:generateContent`;
+	};
 
 	const lyriaRetryAttempts = parsePositiveInt(
 		bindings.GOOGLE_AI_STUDIO_LYRIA_RETRY_ATTEMPTS,
@@ -897,11 +1017,13 @@ export async function execute(args: ExecutorExecuteArgs): Promise<ExecutorResult
 
 	try {
 		const doRequest = async (candidateModel: string) => {
-			const requestBody = await irToGemini(ir, candidateModel);
-			if (Boolean(ir.stream) && !forceSyntheticImageStream) {
+			const requestBody = isInteractionsRequest
+				? await irToGemini(ir, candidateModel)
+				: await irToLegacyGemini(ir, candidateModel);
+			if (isInteractionsRequest && Boolean(ir.stream) && !forceSyntheticImageStream) {
 				requestBody.stream = true;
 			}
-			const endpoint = makeEndpoint();
+			const endpoint = makeEndpoint(candidateModel);
 			const response = await fetch(endpoint, {
 				method: "POST",
 				headers: {

--- a/apps/api/src/executors/google-ai-studio/text-generate/index.ts
+++ b/apps/api/src/executors/google-ai-studio/text-generate/index.ts
@@ -27,6 +27,7 @@ import { googleUsageMetadataToIRUsage } from "@providers/google-ai-studio/usage"
 import { encodeOpenAIChatResponse } from "@protocols/openai-chat/encode";
 import { createSyntheticResponsesStreamFromIR } from "@executors/_shared/text-generate/synthetic-responses-stream";
 import { buildSyntheticServerToolStream } from "@pipeline/surfaces/server-tools.stream";
+import { sanitizeGeminiSchema } from "@executors/google/shared/schema";
 
 const DEFAULT_LYRIA_RETRY_ATTEMPTS = 3;
 const DEFAULT_LYRIA_RETRY_DELAY_MS = 300;
@@ -64,7 +65,10 @@ function hasUsableIRResponse(response: IRChatResponse | undefined): boolean {
 		return (choice.message?.content ?? []).some((part: any) => {
 			if (!part || typeof part !== "object") return false;
 			if (typeof part.text === "string" && part.text.trim().length > 0) return true;
-			return typeof part.data === "string" && part.data.length > 0;
+			return (
+				(typeof part.data === "string" && part.data.length > 0) ||
+				(typeof part.url === "string" && part.url.length > 0)
+			);
 		});
 	});
 }
@@ -193,7 +197,7 @@ async function irToLegacyGemini(ir: IRChatRequest, modelOverride?: string | null
 		request.tools = [{ functionDeclarations: ir.tools.map((tool) => ({
 			name: tool.name,
 			description: tool.description,
-			parameters: tool.parameters,
+			parameters: sanitizeGeminiSchema(tool.parameters),
 		})) }];
 		if (ir.toolChoice === "auto") request.toolConfig = { functionCallingConfig: { mode: "AUTO" } };
 		if (ir.toolChoice === "none") request.toolConfig = { functionCallingConfig: { mode: "NONE" } };
@@ -1472,7 +1476,10 @@ export function transformStream(
 			return (choice.delta?.contentParts ?? []).some((part: any) => {
 				if (!part || typeof part !== "object") return false;
 				if (typeof part.text === "string" && part.text.trim().length > 0) return true;
-				return typeof part.data === "string" && part.data.length > 0;
+				return (
+					(typeof part.data === "string" && part.data.length > 0) ||
+					(typeof part.url === "string" && part.url.length > 0)
+				);
 			});
 		})) {
 			sawUsableOutput = true;
@@ -1866,7 +1873,10 @@ export function transformStream(
 						},
 					};
 					controller.enqueue(encoder.encode(
-						`event: error\ndata: ${JSON.stringify(errorPayload)}\n\n`,
+						`event: response.failed\ndata: ${JSON.stringify({
+							type: "response.failed",
+								...errorPayload,
+						})}\n\n`,
 					));
 				}
 				controller.enqueue(encoder.encode("data: [DONE]\n\n"));

--- a/apps/api/src/executors/google-ai-studio/text-generate/index.ts
+++ b/apps/api/src/executors/google-ai-studio/text-generate/index.ts
@@ -52,6 +52,37 @@ function isGeminiImageModelName(value: string): boolean {
 	);
 }
 
+function isGeminiInteractionsModelName(value: string): boolean {
+	const normalized = String(value ?? "").toLowerCase();
+	return normalized.includes("gemini-3.6-flash") || normalized.includes("gemini-3.5-flash");
+}
+
+function hasUsableIRResponse(response: IRChatResponse | undefined): boolean {
+	if (!response?.choices?.length) return false;
+	return response.choices.some((choice) => {
+		if ((choice.message?.toolCalls?.length ?? 0) > 0) return true;
+		return (choice.message?.content ?? []).some((part: any) => {
+			if (!part || typeof part !== "object") return false;
+			if (typeof part.text === "string" && part.text.trim().length > 0) return true;
+			return typeof part.data === "string" && part.data.length > 0;
+		});
+	});
+}
+
+function emptyGoogleResponse(model: string, provider: string): Response {
+	return new Response(JSON.stringify({
+		error: {
+			code: "google_empty_response",
+			message: "Google returned a successful response without any output.",
+			model,
+			provider,
+		},
+	}), {
+		status: 502,
+		headers: { "Content-Type": "application/json" },
+	});
+}
+
 function isRetryableGoogleStatus(status: number): boolean {
 	return status === 429 || status >= 500;
 }
@@ -278,9 +309,10 @@ export async function irToGemini(ir: IRChatRequest, modelOverride?: string | nul
 
 	const generationConfig: any = {};
 
-	if (ir.temperature !== undefined) generationConfig.temperature = ir.temperature;
+	const isCurrentGeminiModel = isGeminiInteractionsModelName(modelOverride ?? ir.model);
+	if (!isCurrentGeminiModel && ir.temperature !== undefined) generationConfig.temperature = ir.temperature;
 	if (ir.maxTokens !== undefined) generationConfig.max_output_tokens = ir.maxTokens;
-	if (ir.topP !== undefined) generationConfig.top_p = ir.topP;
+	if (!isCurrentGeminiModel && ir.topP !== undefined) generationConfig.top_p = ir.topP;
 	if (ir.seed !== undefined) generationConfig.seed = ir.seed;
 	if (ir.frequencyPenalty !== undefined) generationConfig.frequency_penalty = ir.frequencyPenalty;
 	if (ir.presencePenalty !== undefined) generationConfig.presence_penalty = ir.presencePenalty;
@@ -974,7 +1006,6 @@ export function preprocess(ir: IRChatRequest, args: ExecutorExecuteArgs): IRChat
  */
 export async function execute(args: ExecutorExecuteArgs): Promise<ExecutorResult> {
 	const { ir, providerId, providerModelSlug, requestId, pricingCard, meta } = args;
-	const isInteractionsRequest = args.protocol === "google.interactions";
 	const bindings = getBindings() as any;
 
 	// Resolve API key: prefer decrypted BYOK for this provider, else use gateway keys.
@@ -984,7 +1015,13 @@ export async function execute(args: ExecutorExecuteArgs): Promise<ExecutorResult
 
 	// Determine model candidates (must be in URL, not body)
 	const requestedModel = providerModelSlug || ir.model || "gemini-2.0-flash-exp";
-	const forceSyntheticImageStream = !isInteractionsRequest && Boolean(ir.stream) && isGeminiImageModelName(requestedModel);
+	const isInteractionsRequest =
+		(args.protocol as string) === "google.interactions" ||
+		isGeminiInteractionsModelName(requestedModel);
+	const forceSyntheticStream = Boolean(ir.stream) && (
+		isGeminiImageModelName(requestedModel) ||
+		isInteractionsRequest
+	);
 	const modelCandidates = resolveGoogleModelCandidates(requestedModel);
 	let model = modelCandidates[0] || "gemini-2.0-flash-exp";
 
@@ -1000,7 +1037,7 @@ export async function execute(args: ExecutorExecuteArgs): Promise<ExecutorResult
 
 	const makeEndpoint = (candidateModel: string) => {
 		if (isInteractionsRequest) return `${baseUrl}/interactions`;
-		return Boolean(ir.stream) && !forceSyntheticImageStream
+		return Boolean(ir.stream) && !forceSyntheticStream
 			? `${baseUrl}/models/${encodeURIComponent(candidateModel)}:streamGenerateContent?alt=sse`
 			: `${baseUrl}/models/${encodeURIComponent(candidateModel)}:generateContent`;
 	};
@@ -1020,7 +1057,7 @@ export async function execute(args: ExecutorExecuteArgs): Promise<ExecutorResult
 			const requestBody = isInteractionsRequest
 				? await irToGemini(ir, candidateModel)
 				: await irToLegacyGemini(ir, candidateModel);
-			if (isInteractionsRequest && Boolean(ir.stream) && !forceSyntheticImageStream) {
+			if (isInteractionsRequest && Boolean(ir.stream) && !forceSyntheticStream) {
 				requestBody.stream = true;
 			}
 			const endpoint = makeEndpoint(candidateModel);
@@ -1083,11 +1120,22 @@ export async function execute(args: ExecutorExecuteArgs): Promise<ExecutorResult
 			};
 		}
 
-		if (forceSyntheticImageStream) {
+		if (forceSyntheticStream) {
 			const rawData = await response.json();
 			const data = normalizeGeminiResponsePayload(rawData);
 			const irResponse = providerPayloadToIR(data, requestId, model, providerId);
 			applyGoogleOutputTokenFallback(irResponse);
+			if (!hasUsableIRResponse(irResponse)) {
+				return {
+					kind: "completed",
+					ir: undefined,
+					upstream: emptyGoogleResponse(model, providerId),
+					bill: { cost_cents: 0, currency: "USD" },
+					keySource: keyInfo.source,
+					byokKeyId: keyInfo.byokId,
+					mappedRequest,
+				};
+			}
 
 			const bill: any = {
 				cost_cents: 0,
@@ -1184,6 +1232,17 @@ export async function execute(args: ExecutorExecuteArgs): Promise<ExecutorResult
 					irResponse.usage?.totalTokens ?? 0,
 				);
 			}
+			if (!hasUsableIRResponse(irResponse)) {
+				return {
+					kind: "completed",
+					ir: undefined,
+					upstream: emptyGoogleResponse(model, providerId),
+					bill: { cost_cents: 0, currency: "USD" },
+					keySource: keyInfo.source,
+					byokKeyId: keyInfo.byokId,
+					mappedRequest,
+				};
+			}
 
 			const bill: any = {
 				cost_cents: 0,
@@ -1215,6 +1274,17 @@ export async function execute(args: ExecutorExecuteArgs): Promise<ExecutorResult
 		const data = normalizeGeminiResponsePayload(rawData);
 		const irResponse = providerPayloadToIR(data, requestId, model, providerId);
 		applyGoogleOutputTokenFallback(irResponse);
+		if (!hasUsableIRResponse(irResponse)) {
+			return {
+				kind: "completed",
+				ir: undefined,
+				upstream: emptyGoogleResponse(model, providerId),
+				bill: { cost_cents: 0, currency: "USD" },
+				keySource: keyInfo.source,
+				byokKeyId: keyInfo.byokId,
+				mappedRequest,
+			};
+		}
 
 		// Calculate pricing
 		const bill: any = {
@@ -1375,6 +1445,7 @@ export function transformStream(
 	const interactionStepStates = new Map<number, InteractionStepState>();
 	let interactionToolCallCount = 0;
 	let interactionSawFunctionCall = false;
+	let sawUsableOutput = false;
 
 	let created = Math.floor(Date.now() / 1000);
 	const model = args.providerModelSlug || args.ir.model || "gemini-2.0-flash-exp";
@@ -1395,6 +1466,17 @@ export function transformStream(
 		irChunk: IRStreamChunk,
 		controller: ReadableStreamDefaultController<Uint8Array>,
 	): void => {
+		if (irChunk.choices.some((choice: any) => {
+			if ((choice.delta?.toolCalls?.length ?? 0) > 0) return true;
+			if (typeof choice.delta?.content === "string" && choice.delta.content.trim().length > 0) return true;
+			return (choice.delta?.contentParts ?? []).some((part: any) => {
+				if (!part || typeof part !== "object") return false;
+				if (typeof part.text === "string" && part.text.trim().length > 0) return true;
+				return typeof part.data === "string" && part.data.length > 0;
+			});
+		})) {
+			sawUsableOutput = true;
+		}
 		const openAIChunk = encodeIRChunkToOpenAI(irChunk);
 		controller.enqueue(encoder.encode(`data: ${JSON.stringify(openAIChunk)}\n\n`));
 	};
@@ -1775,6 +1857,17 @@ export function transformStream(
 						}
 						emittedChunkCount += emitPayloadEntries(toPayloadEntries(payload), controller);
 					}
+				}
+				if (!sawUsableOutput) {
+					const errorPayload = {
+						error: {
+							code: "google_empty_response",
+							message: "Google returned a successful response without any output.",
+						},
+					};
+					controller.enqueue(encoder.encode(
+						`event: error\ndata: ${JSON.stringify(errorPayload)}\n\n`,
+					));
 				}
 				controller.enqueue(encoder.encode("data: [DONE]\n\n"));
 			} catch (err) {

--- a/apps/api/src/executors/google-ai-studio/text-generate/index.ts
+++ b/apps/api/src/executors/google-ai-studio/text-generate/index.ts
@@ -6,7 +6,7 @@
 // Documentation: https://ai.google.dev/gemini-api/docs/text-generation
 // Uses Google's native Gemini API format (NOT OpenAI-compatible)
 
-import type { IRChatRequest, IRChatResponse, IRContentPart, IRChoice, IRStreamChunk, IRStreamDelta } from "@core/ir";
+import type { IRChatRequest, IRChatResponse, IRContentPart, IRChoice, IRStreamChunk, IRStreamDelta, IRToolCall, IRUsage } from "@core/ir";
 import type { ExecutorExecuteArgs, ExecutorResult } from "@executors/types";
 import type { ProviderExecutor } from "../../types";
 import { buildTextExecutor, cherryPickIRParams } from "@executors/_shared/text-generate/shared";
@@ -27,7 +27,6 @@ import { googleUsageMetadataToIRUsage } from "@providers/google-ai-studio/usage"
 import { encodeOpenAIChatResponse } from "@protocols/openai-chat/encode";
 import { createSyntheticResponsesStreamFromIR } from "@executors/_shared/text-generate/synthetic-responses-stream";
 import { buildSyntheticServerToolStream } from "@pipeline/surfaces/server-tools.stream";
-import { sanitizeGeminiSchema } from "@executors/google/shared/schema";
 
 const DEFAULT_LYRIA_RETRY_ATTEMPTS = 3;
 const DEFAULT_LYRIA_RETRY_DELAY_MS = 300;
@@ -63,18 +62,17 @@ async function sleep(ms: number): Promise<void> {
 }
 
 /**
- * Transform IR request to Google Gemini format
+ * Transform IR request to Google's Interactions API format.
  *
- * Google uses:
- * - `contents` array (not `messages`)
- * - `parts` within each content (can be text, inline_data, etc.)
- * - `systemInstruction` for system messages (not in contents)
- * - `generationConfig` for parameters
- * - Model in URL path, not request body
+ * Interactions uses:
+ * - `input` as content blocks, steps, turns, or text
+ * - `system_instruction` as a plain string
+ * - `generation_config` with snake_case parameter names
+ * - `model` in the JSON body
  */
 export async function irToGemini(ir: IRChatRequest, modelOverride?: string | null): Promise<any> {
-	const contents: any[] = [];
-	const systemInstructionParts: any[] = [];
+	const input: any[] = [];
+	const systemInstructionParts: string[] = [];
 	const toolNamesById = new Map<string, string>();
 
 	for (const msg of ir.messages) {
@@ -85,24 +83,44 @@ export async function irToGemini(ir: IRChatRequest, modelOverride?: string | nul
 		}
 	}
 
-	// Process messages
 	for (const msg of ir.messages) {
 		if (msg.role === "system" || msg.role === "developer") {
-			// System/developer messages go in systemInstruction, not contents.
-			const parts = await irPartsToGeminiParts(msg.content, { preserveReasoningAsThought: true });
-			systemInstructionParts.push(...parts);
+			const text = await irPartsToPlainText(msg.content);
+			if (text) systemInstructionParts.push(text);
 		} else if (msg.role === "user") {
-			contents.push({
-				role: "user",
-				parts: await irPartsToGeminiParts(msg.content, { preserveReasoningAsThought: true }),
+			input.push({
+				type: "user_input",
+				content: await irPartsToInteractionContent(msg.content),
 			});
 		} else if (msg.role === "assistant") {
-			contents.push({
-				role: "model", // Google uses "model" not "assistant"
-				parts: await irPartsToGeminiParts(msg.content, { preserveReasoningAsThought: true }),
-			});
+			const outputContent = await irPartsToInteractionContent(
+				msg.content.filter((part) => part.type !== "reasoning_text"),
+			);
+			if (outputContent.length > 0) {
+				input.push({
+					type: "model_output",
+					content: outputContent,
+				});
+			}
+			for (const part of msg.content) {
+				if (part.type !== "reasoning_text") continue;
+				input.push({
+					type: "thought",
+					...(part.thoughtSignature ? { signature: part.thoughtSignature } : {}),
+					summary: { type: "text", text: part.summary || part.text },
+				});
+			}
+			if (Array.isArray(msg.toolCalls)) {
+				for (const toolCall of msg.toolCalls) {
+					input.push({
+						type: "function_call",
+						id: toolCall.id,
+						name: toolCall.name,
+						arguments: parseToolCallArguments(toolCall.arguments),
+					});
+				}
+			}
 		} else if (msg.role === "tool") {
-			// Tool results
 			for (const toolResult of msg.toolResults) {
 				let responsePayload: any = toolResult.content;
 				if (typeof toolResult.content === "string") {
@@ -112,179 +130,296 @@ export async function irToGemini(ir: IRChatRequest, modelOverride?: string | nul
 						responsePayload = { content: toolResult.content };
 					}
 				}
-				contents.push({
-					role: "user",
-					parts: [{
-						functionResponse: {
-							name: toolNamesById.get(toolResult.toolCallId) ?? toolResult.toolCallId,
-							response: responsePayload,
-						},
-					}],
+				input.push({
+					type: "function_result",
+					call_id: toolResult.toolCallId,
+					name: toolNamesById.get(toolResult.toolCallId) ?? toolResult.toolCallId,
+					is_error: toolResult.isError,
+					result: responsePayload,
 				});
 			}
 		}
 	}
 
+	const previousInteractionId = resolvePreviousInteractionId(ir);
 	const request: any = {
-		contents,
+		model: modelOverride ?? ir.model,
+		input,
+		store: Boolean(ir.store || previousInteractionId || ir.background),
 	};
 
 	if (ir.googleCachedContent !== undefined) {
-		request.cachedContent = ir.googleCachedContent;
+		request.cached_content = ir.googleCachedContent;
 	}
 
-	// Build generationConfig
+	if (previousInteractionId) {
+		request.previous_interaction_id = previousInteractionId;
+	}
+	if (ir.background !== undefined) {
+		request.background = ir.background;
+	}
+	if (ir.serviceTier) {
+		request.service_tier = ir.serviceTier;
+	}
+
 	const generationConfig: any = {};
 
 	if (ir.temperature !== undefined) generationConfig.temperature = ir.temperature;
-	if (ir.maxTokens !== undefined) generationConfig.maxOutputTokens = ir.maxTokens;
-	if (ir.topP !== undefined) generationConfig.topP = ir.topP;
-	if (ir.topK !== undefined) generationConfig.topK = ir.topK;
+	if (ir.maxTokens !== undefined) generationConfig.max_output_tokens = ir.maxTokens;
+	if (ir.topP !== undefined) generationConfig.top_p = ir.topP;
+	if (ir.seed !== undefined) generationConfig.seed = ir.seed;
+	if (ir.frequencyPenalty !== undefined) generationConfig.frequency_penalty = ir.frequencyPenalty;
+	if (ir.presencePenalty !== undefined) generationConfig.presence_penalty = ir.presencePenalty;
 	if (ir.stop) {
-		generationConfig.stopSequences = Array.isArray(ir.stop) ? ir.stop : [ir.stop];
+		generationConfig.stop_sequences = Array.isArray(ir.stop) ? ir.stop : [ir.stop];
 	}
 
-	// Thinking mode support (Gemini 2.x and 3.x)
 	if (
 		ir.reasoning?.enabled ||
 		ir.reasoning?.effort ||
 		(ir.reasoning?.maxTokens !== undefined) ||
 		(ir.reasoning?.includeThoughts !== undefined)
 	) {
-		const thinkingConfig: any = {
-			includeThoughts: ir.reasoning?.includeThoughts ?? true
-		};
-
 		const modelName = modelOverride ?? ir.model;
 		const supportsThinkingLevel = modelSupportsGoogleThinkingLevels(modelName ?? "");
-
-		// Gemini 3+ Thinking Level
 		if (ir.reasoning?.effort && supportsThinkingLevel) {
 			const level = resolveGoogleThinkingLevelForEffort(modelName ?? "", ir.reasoning.effort);
-			if (level) thinkingConfig.thinkingLevel = level;
+			if (level) generationConfig.thinking_level = level.toLowerCase();
 		}
-		// Gemini 2.x Thinking Budget (or fallback for Gemini 3 if effort not set)
-		else if (ir.reasoning?.maxTokens !== undefined) {
-			// -1 is dynamic budget for Gemini 2.5
-			thinkingConfig.thinkingBudget = ir.reasoning.maxTokens;
-		} else if (ir.reasoning?.enabled) {
-			// default to dynamic/high
-			if (supportsThinkingLevel) {
-				thinkingConfig.thinkingLevel = "HIGH";
-			} else {
-				thinkingConfig.thinkingBudget = -1;
-			}
+		else if (ir.reasoning?.enabled && supportsThinkingLevel) {
+			generationConfig.thinking_level = "high";
 		}
 
-		generationConfig.thinkingConfig = thinkingConfig;
+		generationConfig.thinking_summaries = ir.reasoning?.includeThoughts === false ? "none" : "auto";
 	}
 
-	// Response format (JSON mode)
+	const responseFormatEntries: any[] = [];
 	if (ir.responseFormat) {
 		if (ir.responseFormat.type === "json_object") {
-			generationConfig.responseMimeType = "application/json";
+			responseFormatEntries.push({ type: "text", mime_type: "application/json" });
 		} else if (ir.responseFormat.type === "json_schema") {
-			generationConfig.responseMimeType = "application/json";
-			generationConfig.responseSchema = sanitizeGeminiSchema(ir.responseFormat.schema);
-
-			// Reinforce schema adherence for models that treat responseSchema as soft guidance.
+			responseFormatEntries.push({
+				type: "text",
+				mime_type: "application/json",
+				schema: ir.responseFormat.schema,
+			});
 			const schemaText = (() => {
 				try {
 					return JSON.stringify(ir.responseFormat?.schema ?? {});
 				} catch {
 					return "";
 				}
-			})();
+				})();
 			if (schemaText) {
 				const schemaInstruction =
 					`Return only valid JSON that matches this schema exactly: ${schemaText}. ` +
 					"Do not include markdown or any extra text.";
-				systemInstructionParts.push({ text: schemaInstruction });
+				systemInstructionParts.push(schemaInstruction);
 			}
 		}
 	}
 
-	// Response modalities (text/image/audio)
 	const requestedModalities = Array.isArray(ir.modalities) && ir.modalities.length > 0
 		? ir.modalities
 		: isGeminiImageModelName(modelOverride ?? ir.model)
 			? (["text", "image"] as const)
 			: [];
+	let mappedResponseModalities: string[] = [];
 	if (requestedModalities.length > 0) {
 		const mapped = requestedModalities
-			.map((mode) => (typeof mode === "string" ? mode.toUpperCase() : ""))
-			.filter((mode) => mode === "TEXT" || mode === "IMAGE" || mode === "AUDIO");
+			.map((mode) => (typeof mode === "string" ? mode.toLowerCase() : ""))
+			.filter((mode) => mode === "text" || mode === "image" || mode === "audio");
 		if (mapped.length > 0) {
-			generationConfig.responseModalities = mapped;
+			mappedResponseModalities = mapped;
+			request.response_modalities = mapped;
 		}
 	}
 
-	// Image generation configuration (multimodal text.generate)
 	if (ir.imageConfig) {
-		const imageConfig: any = {};
+		const imageFormat: any = {
+			type: "image",
+			mime_type: "image/jpeg",
+			delivery: "inline",
+		};
 
 		if (ir.imageConfig.aspectRatio) {
-			imageConfig.aspectRatio = ir.imageConfig.aspectRatio;
+			imageFormat.aspect_ratio = ir.imageConfig.aspectRatio;
 		}
 
 		if (ir.imageConfig.imageSize) {
-			imageConfig.imageSize = ir.imageConfig.imageSize;
+			imageFormat.image_size = ir.imageConfig.imageSize === "0.5K"
+				? "512"
+				: ir.imageConfig.imageSize;
 		}
 
-		if (typeof ir.imageConfig.includeRaiReason === "boolean") {
-			imageConfig.includeRaiReason = ir.imageConfig.includeRaiReason;
-		}
+		responseFormatEntries.push(imageFormat);
+	}
 
-		if (
-			Array.isArray(ir.imageConfig.referenceImages) &&
-			ir.imageConfig.referenceImages.length > 0
-		) {
-			imageConfig.referenceImages = ir.imageConfig.referenceImages;
-		}
-
-		if (Object.keys(imageConfig).length > 0) {
-			generationConfig.imageConfig = imageConfig;
-		}
+	if (mappedResponseModalities.includes("image") && !responseFormatEntries.some((entry) => entry?.type === "image")) {
+		responseFormatEntries.push({
+			type: "image",
+			mime_type: "image/jpeg",
+			delivery: "inline",
+		});
+	}
+	if (mappedResponseModalities.includes("audio") && !responseFormatEntries.some((entry) => entry?.type === "audio")) {
+		responseFormatEntries.push({
+			type: "audio",
+			delivery: "inline",
+		});
 	}
 
 	if (Object.keys(generationConfig).length > 0) {
-		request.generationConfig = generationConfig;
+		request.generation_config = generationConfig;
 	}
 
 	if (systemInstructionParts.length > 0) {
-		request.systemInstruction = { parts: systemInstructionParts };
+		request.system_instruction = systemInstructionParts.join("\n\n");
 	}
 
-	// Tools (function calling)
-	if (ir.tools && ir.tools.length > 0) {
-		request.tools = [{
-			functionDeclarations: ir.tools.map(tool => ({
-				name: tool.name,
-				description: tool.description,
-				parameters: sanitizeGeminiSchema(tool.parameters),
-			})),
-		}];
+	if (responseFormatEntries.length === 1) {
+		request.response_format = responseFormatEntries[0];
+	} else if (responseFormatEntries.length > 1) {
+		request.response_format = responseFormatEntries;
+	}
 
-		// Tool choice
+	if (ir.tools && ir.tools.length > 0) {
+		request.tools = ir.tools.map(tool => ({
+			type: "function",
+			name: tool.name,
+			description: tool.description,
+			parameters: tool.parameters,
+		}));
+
 		if (ir.toolChoice) {
 			if (ir.toolChoice === "auto") {
-				request.toolConfig = { functionCallingConfig: { mode: "AUTO" } };
+				generationConfig.tool_choice = "auto";
 			} else if (ir.toolChoice === "none") {
-				request.toolConfig = { functionCallingConfig: { mode: "NONE" } };
+				generationConfig.tool_choice = "none";
 			} else if (ir.toolChoice === "required") {
-				request.toolConfig = { functionCallingConfig: { mode: "ANY" } };
+				generationConfig.tool_choice = "any";
 			} else if (typeof ir.toolChoice === "object" && "name" in ir.toolChoice) {
-				request.toolConfig = {
-					functionCallingConfig: {
-						mode: "ANY",
-						allowedFunctionNames: [ir.toolChoice.name],
-					},
+				generationConfig.tool_choice = {
+					type: "function",
+					name: ir.toolChoice.name,
 				};
 			}
+			request.generation_config = generationConfig;
 		}
 	}
 
 	return request;
+}
+
+async function irPartsToPlainText(parts: IRContentPart[]): Promise<string> {
+	const mapped = await irPartsToGeminiParts(parts, { preserveReasoningAsThought: true });
+	return mapped
+		.map((part) => {
+			if (typeof part?.text === "string") return part.text;
+			if (part?.inline_data?.mime_type) return `[${part.inline_data.mime_type} omitted from system instruction]`;
+			if (part?.file_data?.file_uri) return `[file: ${part.file_data.file_uri}]`;
+			try {
+				return JSON.stringify(part);
+			} catch {
+				return "";
+			}
+		})
+		.filter((text) => text.length > 0)
+		.join("\n");
+}
+
+async function irPartsToInteractionContent(parts: IRContentPart[]): Promise<any[]> {
+	const mapped = await irPartsToGeminiParts(parts, { preserveReasoningAsThought: true });
+	const content: any[] = [];
+
+	for (const part of mapped) {
+		content.push(...geminiPartToInteractionContent(part));
+	}
+
+	return content;
+}
+
+function geminiPartToInteractionContent(part: any): any[] {
+	if (!part || typeof part !== "object") return [];
+	if (typeof part.text === "string") {
+		return [{ type: "text", text: part.text }];
+	}
+
+	const inlineData = normalizeGeminiInlineData(part);
+	if (inlineData?.data) {
+		const mimeType = inlineData.mime_type || "application/octet-stream";
+		if (mimeType.startsWith("image/")) {
+			return [{
+				type: "image",
+				mime_type: mimeType,
+				data: inlineData.data,
+			}];
+		}
+		if (mimeType.startsWith("audio/")) {
+			return [{
+				type: "audio",
+				mime_type: mimeType,
+				data: inlineData.data,
+			}];
+		}
+		if (mimeType.startsWith("video/")) {
+			return [{
+				type: "video",
+				mime_type: mimeType,
+				data: inlineData.data,
+			}];
+		}
+		return [{
+			type: "document",
+			mime_type: mimeType,
+			data: inlineData.data,
+		}];
+	}
+
+	if (part.file_data?.file_uri) {
+		const mimeType = part.file_data.mime_type || "application/octet-stream";
+		const mediaType =
+			mimeType.startsWith("image/")
+				? "image"
+				: mimeType.startsWith("audio/")
+					? "audio"
+					: mimeType.startsWith("video/")
+						? "video"
+						: "document";
+		return [{
+			type: mediaType,
+			mime_type: mimeType,
+			uri: part.file_data.file_uri,
+		}];
+	}
+
+	return [];
+}
+
+function parseToolCallArguments(value: string): Record<string, any> {
+	if (!value) return {};
+	try {
+		const parsed = JSON.parse(value);
+		return parsed && typeof parsed === "object" && !Array.isArray(parsed)
+			? parsed
+			: { value: parsed };
+	} catch {
+		return { value };
+	}
+}
+
+function resolvePreviousInteractionId(ir: IRChatRequest): string | undefined {
+	const vendorGoogle = (ir.vendor as any)?.google;
+	const candidates = [
+		vendorGoogle?.previous_interaction_id,
+		vendorGoogle?.previousInteractionId,
+		vendorGoogle?.interaction_id,
+		vendorGoogle?.interactionId,
+		typeof ir.previousResponseId === "string" && ir.previousResponseId.startsWith("interactions/")
+			? ir.previousResponseId
+			: undefined,
+	];
+	return candidates.find((value): value is string => typeof value === "string" && value.length > 0);
 }
 
 /**
@@ -368,6 +503,267 @@ function geminiToIR(
 		choices,
 		usage,
 	};
+}
+
+function isInteractionPayload(json: any): boolean {
+	return Boolean(
+		json &&
+		typeof json === "object" &&
+		(
+			Array.isArray(json.steps) ||
+			json.object === "interaction" ||
+			typeof json.id === "string" && json.id.startsWith("interactions/")
+		),
+	);
+}
+
+function providerPayloadToIR(
+	json: any,
+	requestId: string,
+	model: string,
+	provider: string,
+): IRChatResponse {
+	if (isInteractionPayload(json)) {
+		return interactionToIR(json, requestId, model, provider);
+	}
+	return geminiToIR(json, requestId, model, provider);
+}
+
+function interactionToIR(
+	json: any,
+	requestId: string,
+	model: string,
+	provider: string,
+): IRChatResponse {
+	const contentParts: IRContentPart[] = [];
+	const toolCalls: IRToolCall[] = [];
+
+	for (const step of Array.isArray(json?.steps) ? json.steps : []) {
+		if (!step || typeof step !== "object") continue;
+
+		if (step.type === "model_output") {
+			for (const block of Array.isArray(step.content) ? step.content : []) {
+				const part = interactionContentToIRPart(block);
+				if (part) contentParts.push(part);
+			}
+		} else if (step.type === "thought") {
+			const text = interactionTextFromContent(step.summary);
+			if (text) {
+				contentParts.push({
+					type: "reasoning_text",
+					text,
+					thoughtSignature: typeof step.signature === "string" ? step.signature : undefined,
+					summary: text,
+				});
+			}
+		} else if (step.type === "function_call") {
+			toolCalls.push({
+				id: typeof step.id === "string" ? step.id : `call_${requestId}_${toolCalls.length}`,
+				name: String(step.name ?? "function"),
+				arguments: stringifyToolArguments(step.arguments),
+			});
+		}
+	}
+
+	const finishReason = toolCalls.length > 0
+		? "tool_calls"
+		: mapInteractionStatusToFinishReason(json?.status);
+
+	return {
+		id: requestId,
+		nativeId: json?.id ?? json?.name,
+		created: Math.floor(Date.now() / 1000),
+		model,
+		provider,
+		choices: [{
+			index: 0,
+			message: {
+				role: "assistant",
+				content: contentParts,
+				toolCalls: toolCalls.length > 0 ? toolCalls : undefined,
+			},
+			finishReason,
+		}],
+		usage: interactionUsageToIRUsage(
+			json?.usage ??
+			json?.metadata?.total_usage ??
+			json?.usage_metadata ??
+			json?.usageMetadata,
+		),
+	};
+}
+
+function interactionContentToIRPart(block: any): IRContentPart | null {
+	if (!block || typeof block !== "object") return null;
+
+	if (block.type === "text" && typeof block.text === "string") {
+		return {
+			type: "text",
+			text: block.text,
+		};
+	}
+
+	if (block.type === "image") {
+		const mimeType = typeof block.mime_type === "string" ? block.mime_type : undefined;
+		if (typeof block.data === "string") {
+			return {
+				type: "image",
+				source: "data",
+				data: block.data,
+				mimeType,
+			};
+		}
+		if (typeof block.uri === "string") {
+			return {
+				type: "image",
+				source: "url",
+				data: block.uri,
+				mimeType,
+			};
+		}
+	}
+
+	if (block.type === "audio") {
+		if (typeof block.data === "string") {
+			return {
+				type: "audio",
+				source: "data",
+				data: block.data,
+				format: resolveAudioFormatFromMimeType(block.mime_type),
+			};
+		}
+		if (typeof block.uri === "string") {
+			return {
+				type: "audio",
+				source: "url",
+				data: block.uri,
+				format: resolveAudioFormatFromMimeType(block.mime_type),
+			};
+		}
+	}
+
+	if (block.type === "video" && typeof block.uri === "string") {
+		return {
+			type: "video",
+			source: "url",
+			url: block.uri,
+		};
+	}
+
+	return null;
+}
+
+function interactionTextFromContent(value: any): string {
+	if (!value) return "";
+	if (typeof value === "string") return value;
+	if (Array.isArray(value)) {
+		return value.map(interactionTextFromContent).filter(Boolean).join("");
+	}
+	if (typeof value === "object") {
+		if (typeof value.text === "string") return value.text;
+		if (value.content) return interactionTextFromContent(value.content);
+	}
+	return "";
+}
+
+function stringifyToolArguments(value: any): string {
+	if (typeof value === "string") return value;
+	try {
+		return JSON.stringify(value ?? {});
+	} catch {
+		return "{}";
+	}
+}
+
+function mapInteractionStatusToFinishReason(status: unknown): IRChoice["finishReason"] {
+	switch (status) {
+		case "failed":
+		case "cancelled":
+		case "expired":
+			return "error";
+		case "incomplete":
+			return "length";
+		default:
+			return "stop";
+	}
+}
+
+function pickFiniteUsageNumber(value: unknown): number | undefined {
+	return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}
+
+function readInteractionModalityCounts(items: unknown): Record<string, number> {
+	const counts: Record<string, number> = {};
+	if (!Array.isArray(items)) return counts;
+
+	for (const item of items) {
+		if (!item || typeof item !== "object") continue;
+		const entry = item as any;
+		const modality = typeof entry.modality === "string" ? entry.modality.toLowerCase() : "text";
+		const tokens = pickFiniteUsageNumber(entry.tokens ?? entry.token_count ?? entry.tokenCount);
+		if (tokens == null) continue;
+		counts[modality] = (counts[modality] ?? 0) + tokens;
+	}
+
+	return counts;
+}
+
+function sumUsageCounts(counts: Record<string, number>): number | undefined {
+	const values = Object.values(counts).filter((value) => Number.isFinite(value));
+	if (values.length === 0) return undefined;
+	return values.reduce((total, value) => total + value, 0);
+}
+
+function interactionUsageToIRUsage(usage: any): IRUsage | undefined {
+	if (!usage || typeof usage !== "object") return undefined;
+
+	const inputByModality = readInteractionModalityCounts(usage.input_tokens_by_modality);
+	const outputByModality = readInteractionModalityCounts(usage.output_tokens_by_modality);
+	const cachedByModality = readInteractionModalityCounts(usage.cached_tokens_by_modality);
+
+	const inputTokens =
+		pickFiniteUsageNumber(usage.total_input_tokens ?? usage.input_tokens) ??
+		sumUsageCounts(inputByModality) ??
+		0;
+	const outputTokens =
+		pickFiniteUsageNumber(usage.total_output_tokens ?? usage.output_tokens) ??
+		sumUsageCounts(outputByModality) ??
+		0;
+	const totalTokens =
+		pickFiniteUsageNumber(usage.total_tokens) ??
+		inputTokens + outputTokens;
+	const cachedInputTokens =
+		pickFiniteUsageNumber(usage.total_cached_tokens ?? usage.cached_tokens) ??
+		sumUsageCounts(cachedByModality);
+	const reasoningTokens =
+		pickFiniteUsageNumber(
+			usage.total_thought_tokens ??
+			usage.thought_tokens ??
+			usage.reasoning_tokens,
+		);
+
+	const ext: IRUsage["_ext"] = {};
+	if (pickFiniteUsageNumber(inputByModality.image) != null) ext.inputImageTokens = inputByModality.image;
+	if (pickFiniteUsageNumber(inputByModality.audio) != null) ext.inputAudioTokens = inputByModality.audio;
+	if (pickFiniteUsageNumber(inputByModality.video) != null) ext.inputVideoTokens = inputByModality.video;
+	if (pickFiniteUsageNumber(outputByModality.image) != null) ext.outputImageTokens = outputByModality.image;
+	if (pickFiniteUsageNumber(outputByModality.audio) != null) ext.outputAudioTokens = outputByModality.audio;
+	if (pickFiniteUsageNumber(outputByModality.video) != null) ext.outputVideoTokens = outputByModality.video;
+
+	const irUsage: IRUsage = {
+		inputTokens,
+		outputTokens,
+		totalTokens,
+	};
+
+	if (cachedInputTokens != null) {
+		irUsage.cachedInputTokens = cachedInputTokens;
+		irUsage.cachedReadTokensAreSubsetOfInput = true;
+	}
+	if (reasoningTokens != null) irUsage.reasoningTokens = reasoningTokens;
+	if (Object.keys(ext).length > 0) irUsage._ext = ext;
+
+	return irUsage;
 }
 
 function mergeGeminiChunkArray(chunks: any[]): any {
@@ -487,10 +883,7 @@ export async function execute(args: ExecutorExecuteArgs): Promise<ExecutorResult
 
 	const upstreamStartMs = meta.upstreamStartMs ?? Date.now();
 
-	const makeEndpoint = (candidateModel: string, stream: boolean) =>
-		stream
-			? `${baseUrl}/models/${encodeURIComponent(candidateModel)}:streamGenerateContent?alt=sse`
-			: `${baseUrl}/models/${encodeURIComponent(candidateModel)}:generateContent`;
+	const makeEndpoint = () => `${baseUrl}/interactions`;
 
 	const lyriaRetryAttempts = parsePositiveInt(
 		bindings.GOOGLE_AI_STUDIO_LYRIA_RETRY_ATTEMPTS,
@@ -505,10 +898,10 @@ export async function execute(args: ExecutorExecuteArgs): Promise<ExecutorResult
 	try {
 		const doRequest = async (candidateModel: string) => {
 			const requestBody = await irToGemini(ir, candidateModel);
-			const endpoint = makeEndpoint(
-				candidateModel,
-				Boolean(ir.stream) && !forceSyntheticImageStream,
-			);
+			if (Boolean(ir.stream) && !forceSyntheticImageStream) {
+				requestBody.stream = true;
+			}
+			const endpoint = makeEndpoint();
 			const response = await fetch(endpoint, {
 				method: "POST",
 				headers: {
@@ -547,14 +940,14 @@ export async function execute(args: ExecutorExecuteArgs): Promise<ExecutorResult
 		}
 
 		model = attempted.candidateModel;
-		const geminiRequest = attempted.requestBody;
+		const googleInteractionRequest = attempted.requestBody;
 		const response = attempted.response;
 		const mappedRequest = (
 			meta.echoUpstreamRequest ||
 			meta.returnUpstreamRequest ||
 			meta.debug?.return_upstream_request ||
 			meta.debug?.trace
-		) ? JSON.stringify(geminiRequest) : undefined;
+		) ? JSON.stringify(googleInteractionRequest) : undefined;
 
 		if (!response.ok) {
 			return {
@@ -571,7 +964,7 @@ export async function execute(args: ExecutorExecuteArgs): Promise<ExecutorResult
 		if (forceSyntheticImageStream) {
 			const rawData = await response.json();
 			const data = normalizeGeminiResponsePayload(rawData);
-			const irResponse = geminiToIR(data, requestId, model, providerId);
+			const irResponse = providerPayloadToIR(data, requestId, model, providerId);
 			applyGoogleOutputTokenFallback(irResponse);
 
 			const bill: any = {
@@ -698,7 +1091,7 @@ export async function execute(args: ExecutorExecuteArgs): Promise<ExecutorResult
 
 		const rawData = await response.json();
 		const data = normalizeGeminiResponsePayload(rawData);
-		const irResponse = geminiToIR(data, requestId, model, providerId);
+		const irResponse = providerPayloadToIR(data, requestId, model, providerId);
 		applyGoogleOutputTokenFallback(irResponse);
 
 		// Calculate pricing
@@ -848,7 +1241,18 @@ export function transformStream(
 		argumentsSoFar: string;
 		emittedName: boolean;
 	};
+	type InteractionStepState = {
+		type: string;
+		id?: string;
+		name?: string;
+		argumentsSoFar: string;
+		emittedName: boolean;
+		toolIndex: number;
+	};
 	const toolStates = new Map<string, StreamToolState>();
+	const interactionStepStates = new Map<number, InteractionStepState>();
+	let interactionToolCallCount = 0;
+	let interactionSawFunctionCall = false;
 
 	let created = Math.floor(Date.now() / 1000);
 	const model = args.providerModelSlug || args.ir.model || "gemini-2.0-flash-exp";
@@ -865,19 +1269,173 @@ export function transformStream(
 			remainder: blocks[blocks.length - 1] ?? "",
 		};
 	};
+	const enqueueIRChunk = (
+		irChunk: IRStreamChunk,
+		controller: ReadableStreamDefaultController<Uint8Array>,
+	): void => {
+		const openAIChunk = encodeIRChunkToOpenAI(irChunk);
+		controller.enqueue(encoder.encode(`data: ${JSON.stringify(openAIChunk)}\n\n`));
+	};
+	const buildBaseIRChunk = (): IRStreamChunk => ({
+		id: args.requestId,
+		created,
+		model,
+		provider,
+		choices: [],
+	});
+	const emitInteractionPayloadEntry = (
+		payloadEntry: any,
+		controller: ReadableStreamDefaultController<Uint8Array>,
+	): number | null => {
+		const eventType = typeof payloadEntry?.event_type === "string" ? payloadEntry.event_type : null;
+		if (!eventType) return null;
+
+		if (eventType === "interaction.created") {
+			const createdAt = Date.parse(payloadEntry?.interaction?.created ?? "");
+			if (Number.isFinite(createdAt)) {
+				created = Math.floor(createdAt / 1000);
+			}
+			return 0;
+		}
+
+		if (eventType === "step.start") {
+			const index = Number.isFinite(payloadEntry.index) ? Number(payloadEntry.index) : 0;
+			const step = payloadEntry.step ?? {};
+			const state: InteractionStepState = {
+				type: String(step.type ?? ""),
+				id: typeof step.id === "string" ? step.id : undefined,
+				name: typeof step.name === "string" ? step.name : undefined,
+				argumentsSoFar: "",
+				emittedName: false,
+				toolIndex: interactionToolCallCount,
+			};
+			if (state.type === "function_call") {
+				interactionSawFunctionCall = true;
+				interactionToolCallCount += 1;
+			}
+			interactionStepStates.set(index, state);
+
+			if (state.type === "function_call") {
+				const irChunk = buildBaseIRChunk();
+				irChunk.choices.push({
+					index: 0,
+					delta: {
+						role: "assistant",
+						toolCalls: [{
+							index: state.toolIndex,
+							...(state.id ? { id: state.id } : {}),
+							...(state.name ? { name: state.name } : {}),
+							arguments: "",
+						}],
+					},
+				} as any);
+				state.emittedName = Boolean(state.name);
+				enqueueIRChunk(irChunk, controller);
+				return 1;
+			}
+
+			return 0;
+		}
+
+		if (eventType === "step.delta") {
+			const index = Number.isFinite(payloadEntry.index) ? Number(payloadEntry.index) : 0;
+			const state = interactionStepStates.get(index);
+			const delta = payloadEntry.delta ?? {};
+			const irChunk = buildBaseIRChunk();
+			const choice: any = {
+				index: 0,
+				delta: {
+					role: "assistant",
+				},
+			};
+
+			if (delta.type === "text" && typeof delta.text === "string") {
+				choice.delta.content = delta.text;
+			} else if (delta.type === "image" || delta.type === "audio") {
+				const part = interactionContentToIRPart(delta);
+				if (part) {
+					choice.delta.contentParts = [part];
+				}
+			} else if (delta.type === "thought_summary") {
+				const text = interactionTextFromContent(delta.content);
+				if (text) {
+					choice.delta.contentParts = [{
+						type: "reasoning_text",
+						text,
+					}];
+				}
+			} else if (delta.type === "arguments_delta") {
+				const argumentsDelta = typeof delta.arguments === "string" ? delta.arguments : "";
+				const toolIndex = state?.toolIndex ?? 0;
+				const toolDelta: {
+					index: number;
+					id?: string;
+					name?: string;
+					arguments?: string;
+				} = {
+					index: toolIndex,
+				};
+				if (state?.id) toolDelta.id = state.id;
+				if (state?.name && !state.emittedName) {
+					toolDelta.name = state.name;
+					state.emittedName = true;
+				}
+				if (argumentsDelta) {
+					toolDelta.arguments = argumentsDelta;
+					if (state) {
+						state.argumentsSoFar += argumentsDelta;
+					}
+				}
+				choice.delta.toolCalls = [toolDelta];
+			}
+
+			const hasDelta = Object.keys(choice.delta).some((key) => key !== "role");
+			if (!hasDelta) return 0;
+			irChunk.choices.push(choice);
+			enqueueIRChunk(irChunk, controller);
+			return 1;
+		}
+
+		if (eventType === "interaction.completed") {
+			const interaction = payloadEntry.interaction ?? {};
+			const usage = interactionUsageToIRUsage(
+				interaction.usage ??
+				payloadEntry.usage ??
+				payloadEntry.metadata?.total_usage,
+			);
+			const irChunk = buildBaseIRChunk();
+			irChunk.choices.push({
+				index: 0,
+				delta: { role: "assistant" },
+				finishReason: interactionSawFunctionCall
+					? "tool_calls"
+					: mapInteractionStatusToFinishReason(interaction.status),
+			});
+			if (usage) irChunk.usage = usage;
+			enqueueIRChunk(irChunk, controller);
+			return 1;
+		}
+
+		if (eventType === "error") {
+			const message = payloadEntry?.error?.message || "google_interaction_stream_error";
+			throw new Error(message);
+		}
+
+		return 0;
+	};
 	const emitPayloadEntries = (
 		payloadEntries: any[],
 		controller: ReadableStreamDefaultController<Uint8Array>,
 	): number => {
 		let emitted = 0;
 		for (const payloadEntry of payloadEntries) {
-			const irChunk: IRStreamChunk = {
-				id: args.requestId,
-				created,
-				model,
-				provider,
-				choices: [],
-			};
+			const interactionEmitted = emitInteractionPayloadEntry(payloadEntry, controller);
+			if (interactionEmitted !== null) {
+				emitted += interactionEmitted;
+				continue;
+			}
+
+			const irChunk = buildBaseIRChunk();
 
 			if (Array.isArray(payloadEntry?.candidates)) {
 				for (const cand of payloadEntry.candidates) {
@@ -1010,8 +1568,7 @@ export function transformStream(
 				continue;
 			}
 
-			const openAIChunk = encodeIRChunkToOpenAI(irChunk);
-			controller.enqueue(encoder.encode(`data: ${JSON.stringify(openAIChunk)}\n\n`));
+			enqueueIRChunk(irChunk, controller);
 			emitted += 1;
 		}
 		return emitted;
@@ -1259,7 +1816,3 @@ export const executor: ProviderExecutor = buildTextExecutor({
 	postprocess,
 	transformStream,
 });
-
-
-
-

--- a/apps/api/src/executors/google-vertex/text-generate/__tests__/mapping.test.ts
+++ b/apps/api/src/executors/google-vertex/text-generate/__tests__/mapping.test.ts
@@ -1,11 +1,68 @@
-import { describe, expect, it } from "vitest";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 import { geminiToIR, irToGemini, resolveVertexModelRoute } from "../index";
+import type { IRChatRequest } from "@core/ir";
+import type { ExecutorExecuteArgs } from "@executors/types";
+import { execute } from "../index";
+import { installFetchMock } from "../../../../../tests/helpers/mock-fetch";
+import { setupTestRuntime, teardownTestRuntime } from "../../../../../tests/helpers/runtime";
+
+vi.mock("@supabase/supabase-js", () => ({
+	createClient: () => ({}),
+}));
+
+beforeAll(() => setupTestRuntime());
+afterAll(() => teardownTestRuntime());
+
+function buildExecuteArgs(): ExecutorExecuteArgs {
+	const ir: IRChatRequest = {
+		model: "google/gemini-3.6-flash",
+		stream: false,
+		messages: [{ role: "user", content: [{ type: "text", text: "hello" }] }],
+	};
+	return {
+		ir,
+		requestId: "req_google_vertex_empty",
+		workspaceId: "team_test",
+		providerId: "google-vertex",
+		endpoint: "responses",
+		protocol: "openai.responses",
+		capability: "text.generate",
+		providerModelSlug: "gemini-3.6-flash",
+		capabilityParams: null,
+		byokMeta: [],
+		pricingCard: null as any,
+		meta: {},
+	} as ExecutorExecuteArgs;
+}
 
 describe("google-vertex route resolution", () => {
 	it("routes prefixed models by family", () => {
 		expect(resolveVertexModelRoute("google/gemini-2.5-flash").family).toBe("gemini");
 		expect(resolveVertexModelRoute("anthropic/claude-sonnet-4@20250514").family).toBe("anthropic");
 		expect(resolveVertexModelRoute("openai/gpt-4.1").family).toBe("openapi_chat");
+	});
+});
+
+describe("google-vertex empty response handling", () => {
+	it("turns a zero-output Gemini response into a failoverable error", async () => {
+		const mock = installFetchMock([{
+			match: (url) => url.includes(":streamGenerateContent"),
+			response: new Response(JSON.stringify({
+				candidates: [{ finishReason: "STOP" }],
+				usageMetadata: { promptTokenCount: 8, candidatesTokenCount: 0, totalTokenCount: 8 },
+			}), {
+				status: 200,
+				headers: { "Content-Type": "application/json" },
+			}),
+		}]);
+
+		const result = await execute(buildExecuteArgs());
+		mock.restore();
+
+		expect(result.kind).toBe("completed");
+		if (result.kind !== "completed") return;
+		expect(result.ir).toBeUndefined();
+		expect(result.upstream?.status).toBe(502);
 	});
 });
 

--- a/apps/api/src/executors/google-vertex/text-generate/__tests__/mapping.test.ts
+++ b/apps/api/src/executors/google-vertex/text-generate/__tests__/mapping.test.ts
@@ -56,8 +56,12 @@ describe("google-vertex empty response handling", () => {
 			}),
 		}]);
 
-		const result = await execute(buildExecuteArgs());
-		mock.restore();
+		let result: Awaited<ReturnType<typeof execute>>;
+		try {
+			result = await execute(buildExecuteArgs());
+		} finally {
+			mock.restore();
+		}
 
 		expect(result.kind).toBe("completed");
 		if (result.kind !== "completed") return;

--- a/apps/api/src/executors/google-vertex/text-generate/index.ts
+++ b/apps/api/src/executors/google-vertex/text-generate/index.ts
@@ -44,6 +44,31 @@ function vertexError(code: string): Error & { code: string } {
 	return error;
 }
 
+function hasUsableIRResponse(response: IRChatResponse | undefined): boolean {
+	if (!response?.choices?.length) return false;
+	return response.choices.some((choice) => {
+		if ((choice.message?.toolCalls?.length ?? 0) > 0) return true;
+		return (choice.message?.content ?? []).some((part: any) => {
+			if (!part || typeof part !== "object") return false;
+			if (typeof part.text === "string" && part.text.trim().length > 0) return true;
+			return typeof part.data === "string" && part.data.length > 0;
+		});
+	});
+}
+
+function emptyVertexResponse(model: string): Response {
+	return new Response(JSON.stringify({
+		error: {
+			code: "google_empty_response",
+			message: "Google Vertex returned a successful response without any output.",
+			model,
+		},
+	}), {
+		status: 502,
+		headers: { "Content-Type": "application/json" },
+	});
+}
+
 export function preprocess(ir: IRChatRequest, args: ExecutorExecuteArgs): IRChatRequest {
 	return cherryPickIRParams(ir, args.capabilityParams);
 }
@@ -203,6 +228,17 @@ export async function execute(args: ExecutorExecuteArgs): Promise<ExecutorResult
 				);
 			}
 		}
+		if (!hasUsableIRResponse(ir)) {
+			return {
+				kind: "completed",
+				ir: undefined,
+				bill,
+				upstream: emptyVertexResponse(model),
+				keySource: keyInfo.source,
+				byokKeyId: keyInfo.byokId,
+				mappedRequest,
+			};
+		}
 
 		const usageMeters = normalizeTextUsageForPricing(ir?.usage ?? usage);
 		if (usageMeters) {
@@ -235,6 +271,17 @@ export async function execute(args: ExecutorExecuteArgs): Promise<ExecutorResult
 		applyGoogleOutputTokenFallback(ir);
 	} else {
 		ir = openAIChatToIR(json, args.requestId, model, args.providerId);
+	}
+	if (!hasUsableIRResponse(ir)) {
+		return {
+			kind: "completed",
+			ir: undefined,
+			bill,
+			upstream: emptyVertexResponse(model),
+			keySource: keyInfo.source,
+			byokKeyId: keyInfo.byokId,
+			mappedRequest,
+		};
 	}
 
 	return finalizeResult({

--- a/apps/api/tests/aimock/harness.ts
+++ b/apps/api/tests/aimock/harness.ts
@@ -183,6 +183,53 @@ function createOpenAIChatMount(): Mountable {
     };
 }
 
+function createGoogleInteractionsMount(): Mountable {
+    let journal: Journal | null = null;
+    return {
+        setJournal(nextJournal) { journal = nextJournal; },
+        async handleRequest(req: IncomingMessage, res: ServerResponse, pathname: string) {
+            if (pathname !== "/" || req.method !== "POST") return false;
+            const body = JSON.parse(await readIncomingBody(req)) as Record<string, any>;
+            const headers = flattenHeaders(req.headers as Record<string, string | string[] | undefined>);
+            const serialized = JSON.stringify(body);
+            const prompt = serialized.includes("[aimock-tool] weather")
+                ? "[aimock-tool] weather"
+                : serialized.includes("[aimock-structured] person")
+                    ? "[aimock-structured] person"
+                    : "[aimock-chat] hello";
+            const tool = prompt === "[aimock-tool] weather" ? body.tools?.[0] : undefined;
+            const content = prompt === "[aimock-structured] person"
+                ? JSON.stringify({ name: "Ava", city: "London" })
+                : "Hello from AIMock via Phaseo.";
+            const payload = {
+                id: "interaction_cross_provider",
+                status: "completed",
+                model: body.model,
+                steps: tool
+                    ? [{
+                        type: "function_call",
+                        id: "call_aimock_weather",
+                        name: tool.name,
+                        arguments: { city: "London", unit: "celsius" },
+                    }]
+                    : [{
+                        type: "model_output",
+                        content: [{ type: "text", text: content }],
+                    }],
+                usage: {
+                    total_input_tokens: 4,
+                    total_output_tokens: 3,
+                    total_tokens: 7,
+                },
+            };
+            journal?.add({ method: req.method, path: req.url ?? pathname, headers, body, service: "chat", response: { status: 200, fixture: null } });
+            res.writeHead(200, { "Content-Type": "application/json" });
+            res.end(JSON.stringify(payload));
+            return true;
+        },
+    };
+}
+
 function createAnthropicMessagesMount(): Mountable {
     let journal: Journal | null = null;
     return {
@@ -493,6 +540,7 @@ export async function startAimock(): Promise<LLMock> {
     ]);
     aimock.mount("/v1/rerank", createOpenAIRerankMount());
     aimock.mount("/v1/tts", createXAiTtsMount());
+    aimock.mount("/v1beta/interactions", createGoogleInteractionsMount());
     aimock.mount("/v1/openai", createOpenAIChatMount());
     aimock.mount("/api/v1", createOpenAIChatMount());
     aimock.mount("/v1/projects/aimock-project/locations/us-east5/publishers/anthropic/models", createAnthropicMessagesMount());

--- a/apps/web/src/components/(chat)/ChatPlayground.tsx
+++ b/apps/web/src/components/(chat)/ChatPlayground.tsx
@@ -2536,6 +2536,13 @@ function ChatPlaygroundContent({
 				if (traceEvents.length) {
 					mergedMeta.trace_events = traceEvents;
 				}
+				if (!assistantContent.trim() && !reasoningContent.trim() && toolCalls.length === 0) {
+					const emptyResponseError = new Error(
+						"The provider returned an empty response. Please retry.",
+					) as Error & { code: string };
+					emptyResponseError.code = "empty_response";
+					throw emptyResponseError;
+				}
 				const totalCostUsd = extractTotalCostUsd(finalUsage);
 				if (totalCostUsd) {
 					mergedMeta.total_cost_usd = totalCostUsd;

--- a/apps/web/src/components/(chat)/ChatPlayground.tsx
+++ b/apps/web/src/components/(chat)/ChatPlayground.tsx
@@ -1615,6 +1615,18 @@ function ChatPlaygroundContent({
 								toolCallId: toolCall.id,
 							});
 						}
+						if (
+							!reply.trim() &&
+							images.length === 0 &&
+							!reasoningText.trim() &&
+							toolCalls.length === 0
+						) {
+							const emptyResponseError = new Error(
+								"The provider returned an empty response. Please retry.",
+							) as Error & { code: string };
+							emptyResponseError.code = "empty_response";
+							throw emptyResponseError;
+						}
 						const totalCostUsd = extractTotalCostUsd(finalUsage);
 						if (totalCostUsd) {
 							mergedMeta.total_cost_usd = totalCostUsd;

--- a/packages/testing/provider-mock/src/providers/google-ai-studio.ts
+++ b/packages/testing/provider-mock/src/providers/google-ai-studio.ts
@@ -25,8 +25,42 @@ function streamGenerateContent(request: MockRequest): MockResponse {
   return { headers: { "content-type": "text/event-stream" }, body: `data: ${JSON.stringify(payload(request))}\n\n` };
 }
 
+function interactions(request: MockRequest): MockResponse {
+  const body = request.body as any;
+  const tool = body?.tools?.[0];
+  return {
+    body: {
+      id: `interaction_${request.id}`,
+      status: "completed",
+      steps: tool
+        ? [{
+            type: "function_call",
+            id: "call_google_weather",
+            name: tool.name,
+            arguments: { city: "London" },
+          }]
+        : [{
+            type: "model_output",
+            content: [{ type: "text", text: "Hello from the Phaseo Google contract mock." }],
+          }],
+      usage: {
+        total_input_tokens: 4,
+        total_output_tokens: 3,
+        total_tokens: 7,
+      },
+    },
+  };
+}
+
 export function registerGoogleAIStudioProvider(server: ProviderMockServer, contract: ProviderContract): ProviderMockServer {
   if (contract.manifest.providerId !== "google-ai-studio") throw new Error("registerGoogleAIStudioProvider requires the Google AI Studio contract");
+  server.register({
+    providerId: "google-ai-studio",
+    operationId: "interactions",
+    method: "POST",
+    path: "/v1beta/interactions",
+    response: interactions,
+  });
   return server.registerOpenApi("google-ai-studio", contract.document, {
     basePath: "/v1beta",
     strict: true,


### PR DESCRIPTION
## What changed

- Route Gemini 3.6 Flash, Gemini 3.5 Flash-Lite, and the Gemini 3.5 Flash family through Google's Interactions request shape in AI Studio.
- Omit the deprecated sampling fields for those current Gemini models.
- Treat zero-output responses as provider failures so routing can fail over.
- Add equivalent empty-output protection for Vertex and a client-side guard so blank assistant messages are never persisted.

## Root cause

Google was returning successful `stop` responses with no candidate content or tokens. The gateway accepted the transport-level success, and the streaming chat path persisted the empty completion as a blank assistant turn.

## Validation

- `pnpm exec vitest run src/executors/google-ai-studio/text-generate/__tests__/request-map.test.ts src/executors/google-ai-studio/text-generate/__tests__/execute-usage-fallback.test.ts src/executors/google-ai-studio/text-generate/__tests__/stream-transform.test.ts src/executors/google-vertex/text-generate/__tests__/mapping.test.ts`
- `pnpm run typecheck` in `apps/api`
- Targeted ESLint passed with existing max-lines warnings only.
- `apps/web` typecheck still reports pre-existing `LayoutProps` and `ProcessEnv` errors unrelated to this change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated support for current Google Gemini Flash request and response formats.
  * Empty provider responses now return a structured error, enabling failover instead of creating blank messages.
  * Improved streaming support for text, reasoning, tool calls, images, and audio.
  * Added clearer handling for empty responses in the chat interface, prompting users to retry.
* **Compatibility**
  * Legacy Gemini models continue using their existing request format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->