### PR TITLE
Persist provider data policy metadata

### DIFF
--- a/.changeset/curvy-policy-import.md
+++ b/.changeset/curvy-policy-import.md
@@ -1,0 +1,5 @@
+---
+"@phaseo/web": patch
+---
+
+Import provider data-policy metadata into the public provider records used by the model catalogue.

--- a/apps/web/scripts/importer/loaders/providers.ts
+++ b/apps/web/scripts/importer/loaders/providers.ts
@@ -30,6 +30,12 @@ type ProviderZeroDataRetentionMode =
     | "unsupported"
     | "optional"
     | "default";
+type ProviderDataPolicyTier = "unknown" | "private" | "logs" | "trains";
+type ProviderDataPolicyConfidence = "unknown" | "confirmed" | "maybe";
+type ProviderDataPolicyContractMode =
+    | "none"
+    | "customer_agreement"
+    | "enterprise_agreement";
 
 const PROVIDER_ORG_ALIASES: Record<string, string> = {
     "amazon-bedrock": "amazon",
@@ -190,6 +196,44 @@ const parseZeroDataRetentionMode = (value: unknown): ProviderZeroDataRetentionMo
     if (raw === "optional") return "optional";
     if (raw === "default") return "default";
     return "unknown";
+};
+
+const parseProviderDataPolicyTier = (value: unknown): ProviderDataPolicyTier => {
+    const raw = String(value ?? "").trim().toLowerCase();
+    if (raw === "private") return "private";
+    if (raw === "logs" || raw === "logged") return "logs";
+    if (raw === "trains" || raw === "train") return "trains";
+    return "unknown";
+};
+
+const parseProviderDataPolicyConfidence = (
+    value: unknown,
+): ProviderDataPolicyConfidence => {
+    const raw = String(value ?? "").trim().toLowerCase();
+    if (raw === "confirmed" || raw === "certain") return "confirmed";
+    if (raw === "maybe" || raw === "uncertain" || raw === "inferred") return "maybe";
+    return "unknown";
+};
+
+const parseProviderDataPolicyContractMode = (
+    value: unknown,
+): ProviderDataPolicyContractMode => {
+    const raw = String(value ?? "").trim().toLowerCase();
+    if (
+        raw === "customer_agreement" ||
+        raw === "customer-agreement" ||
+        raw === "agreement"
+    ) {
+        return "customer_agreement";
+    }
+    if (
+        raw === "enterprise_agreement" ||
+        raw === "enterprise-agreement" ||
+        raw === "enterprise"
+    ) {
+        return "enterprise_agreement";
+    }
+    return "none";
 };
 
 const parseProviderOfferScope = (value: unknown): ProviderOfferScope => {
@@ -769,6 +813,18 @@ export async function loadProviders(
                 typeof j.prompt_training_source_url === "string" &&
                 j.prompt_training_source_url.trim()
                     ? j.prompt_training_source_url.trim()
+                    : null,
+            data_policy_tier: parseProviderDataPolicyTier(j.data_policy_tier),
+            data_policy_confidence: parseProviderDataPolicyConfidence(
+                j.data_policy_confidence,
+            ),
+            data_policy_contract_mode: parseProviderDataPolicyContractMode(
+                j.data_policy_contract_mode,
+            ),
+            data_policy_contract_notes:
+                typeof j.data_policy_contract_notes === "string" &&
+                j.data_policy_contract_notes.trim()
+                    ? j.data_policy_contract_notes.trim()
                     : null,
             user_identifier_policy:
                 typeof j.user_identifier_policy === "string" &&


### PR DESCRIPTION
## Summary

- Persist `data_policy_tier`, confidence, contract mode, and notes from provider catalog metadata during the Supabase importer.
- Fix the live Poolside catalogue route so its opted-out configuration can display `Logs` instead of `Unknown`.

## Validation

- `pnpm validate:data`
- `pnpm validate:gateway`
- `git diff --check`

## Context

Poolside's provider metadata was already corrected to `opt_out_available` and `logs`, but the importer did not copy the new `data_policy_*` fields into `data_api_providers`.
