### PR TITLE
Refresh Poolside policy metadata

### DIFF
--- a/.changeset/fresh-poolside-policy-import.md
+++ b/.changeset/fresh-poolside-policy-import.md
@@ -1,0 +1,5 @@
+---
+"@phaseo/data-catalog": patch
+---
+
+Refresh Poolside's provider policy metadata so the importer persists the corrected data-policy classification.

--- a/packages/data/catalog/src/data/api_providers/poolside/api_provider.json
+++ b/packages/data/catalog/src/data/api_providers/poolside/api_provider.json
@@ -14,5 +14,5 @@
   "data_policy_tier": "logs",
   "data_policy_confidence": "maybe",
   "data_policy_contract_mode": "none",
-  "data_policy_contract_notes": "The public Terms establish an opt-out mechanism but do not provide a general zero-retention guarantee. This route is classified as logs based on the opted-out account configuration; verify the account or upstream platform setting if it changes."
+  "data_policy_contract_notes": "The public Terms establish an opt-out mechanism but do not provide a general zero-retention guarantee. This route is classified as logs based on the opted-out account configuration; verify the account or upstream platform setting if it changes. Poolside may still use content for safety review or when feedback is provided."
 }


### PR DESCRIPTION
## Summary

- Refresh Poolside policy metadata after the importer fix landed.
- Trigger the normal main-branch data import so `data_policy_tier: logs` is persisted to the provider database.

## Validation

- `git diff --check`
- Provider JSON parsed successfully
