### PR TITLE
Fix Gemini server tools

### DIFF
--- a/apps/api/src/executors/_shared/text-generate/shared.ts
+++ b/apps/api/src/executors/_shared/text-generate/shared.ts
@@ -164,7 +164,7 @@ export async function applyAdapterHooks(
 	if (result.kind === "completed" && result.ir && hooks?.postprocessIR) {
 		result.ir = hooks.postprocessIR(result.ir, args);
 	}
-	if (result.kind === "stream" && result.stream && hooks?.transformStream) {
+	if (result.kind === "stream" && result.stream && !result.streamAlreadyTransformed && hooks?.transformStream) {
 		result.stream = hooks.transformStream(result.stream, args);
 	}
 
@@ -184,7 +184,7 @@ export function buildTextExecutor(args: {
 		if (result.kind === "completed" && result.ir) {
 			result.ir = args.postprocess(result.ir, execArgs);
 		}
-		if (result.kind === "stream" && result.stream) {
+		if (result.kind === "stream" && result.stream && !result.streamAlreadyTransformed) {
 			result.stream = args.transformStream(result.stream, execArgs);
 		}
 		return result;

--- a/apps/api/src/executors/_shared/text-generate/synthetic-responses-stream.ts
+++ b/apps/api/src/executors/_shared/text-generate/synthetic-responses-stream.ts
@@ -7,7 +7,7 @@ export function createSyntheticResponsesStreamFromIR(
 ): ReadableStream<Uint8Array> {
 	const encoder = new TextEncoder();
 	const response = encodeOpenAIResponsesResponse(ir, requestId ?? ir.id);
-	const nativeId = response.nativeResponseId || ir.nativeId || response.id;
+	const nativeId = ir.nativeId || response.nativeResponseId || response.id;
 	const finalResponse = {
 		...response,
 		id: nativeId,

--- a/apps/api/src/executors/google-ai-studio/text-generate/__tests__/execute-usage-fallback.test.ts
+++ b/apps/api/src/executors/google-ai-studio/text-generate/__tests__/execute-usage-fallback.test.ts
@@ -77,6 +77,47 @@ describe("google-ai-studio execute usage fallback", () => {
 		expect(mock.calls[0]?.bodyJson?.generation_config).toBeUndefined();
 	});
 
+	it("does not transform a synthetic Interactions tool-call stream twice", async () => {
+		const mock = installFetchMock([{
+			match: (url) => url.endsWith("/v1beta/interactions"),
+			response: new Response(JSON.stringify({
+				id: "interactions/tool-call",
+				status: "completed",
+				steps: [{
+					type: "function_call",
+					id: "call_datetime",
+					name: "datetime",
+					arguments: { timezone: "Europe/London" },
+				}],
+			}), {
+				status: 200,
+				headers: { "Content-Type": "application/json" },
+			}),
+		}]);
+
+		const result = await executor(buildArgs(
+			{
+				model: "google/gemini-3.5-flash-lite",
+				stream: true,
+				tools: [{
+					name: "datetime",
+					description: "Get the current datetime",
+					parameters: { type: "object", properties: { timezone: { type: "string" } } },
+				}],
+			},
+			{ providerModelSlug: "google/gemini-3.5-flash-lite" },
+		));
+		mock.restore();
+
+		expect(result.kind).toBe("stream");
+		if (result.kind !== "stream") return;
+		const body = await new Response(result.stream).text();
+		expect(body).toContain("response.created");
+		expect(body).toContain("interactions/tool-call");
+		expect(body).toContain("call_datetime");
+		expect(body).not.toContain("google_empty_response");
+	});
+
 	it("keeps legacy GenerateContent routing for older AI Studio models", async () => {
 		const mock = installFetchMock([{
 			match: (url) => url.endsWith("/v1beta/models/gemini-2.5-flash:generateContent"),

--- a/apps/api/src/executors/google-ai-studio/text-generate/__tests__/execute-usage-fallback.test.ts
+++ b/apps/api/src/executors/google-ai-studio/text-generate/__tests__/execute-usage-fallback.test.ts
@@ -95,27 +95,30 @@ describe("google-ai-studio execute usage fallback", () => {
 			}),
 		}]);
 
-		const result = await executor(buildArgs(
-			{
-				model: "google/gemini-3.5-flash-lite",
-				stream: true,
-				tools: [{
-					name: "datetime",
-					description: "Get the current datetime",
-					parameters: { type: "object", properties: { timezone: { type: "string" } } },
-				}],
-			},
-			{ providerModelSlug: "google/gemini-3.5-flash-lite" },
-		));
-		mock.restore();
+		try {
+			const result = await executor(buildArgs(
+				{
+					model: "google/gemini-3.5-flash-lite",
+					stream: true,
+					tools: [{
+						name: "datetime",
+						description: "Get the current datetime",
+						parameters: { type: "object", properties: { timezone: { type: "string" } } },
+					}],
+				},
+				{ providerModelSlug: "google/gemini-3.5-flash-lite" },
+			));
 
-		expect(result.kind).toBe("stream");
-		if (result.kind !== "stream") return;
-		const body = await new Response(result.stream).text();
-		expect(body).toContain("response.created");
-		expect(body).toContain("interactions/tool-call");
-		expect(body).toContain("call_datetime");
-		expect(body).not.toContain("google_empty_response");
+			expect(result.kind).toBe("stream");
+			if (result.kind !== "stream") return;
+			const body = await new Response(result.stream).text();
+			expect(body).toContain("response.created");
+			expect(body).toContain("interactions/tool-call");
+			expect(body).toContain("call_datetime");
+			expect(body).not.toContain("google_empty_response");
+		} finally {
+			mock.restore();
+		}
 	});
 
 	it("keeps legacy GenerateContent routing for older AI Studio models", async () => {

--- a/apps/api/src/executors/google-ai-studio/text-generate/__tests__/request-map.test.ts
+++ b/apps/api/src/executors/google-ai-studio/text-generate/__tests__/request-map.test.ts
@@ -45,6 +45,60 @@ describe("google-ai-studio irToGemini", () => {
 		});
 	});
 
+	it("sanitizes Interactions function schemas and maps function results", async () => {
+		const request = await irToGemini({
+			model: "gemini-3.5-flash-lite",
+			stream: false,
+			vendor: { google: { previous_interaction_id: "v1_interaction_datetime" } },
+			messages: [
+				{ role: "user", content: [{ type: "text", text: "What time is it?" }] },
+				{
+					role: "assistant",
+					content: [],
+					toolCalls: [{ id: "call_datetime", name: "datetime", arguments: "{\"timezone\":\"UTC\"}" }],
+				},
+				{
+					role: "tool",
+					toolResults: [{
+						toolCallId: "call_datetime",
+						content: { datetime: "2026-07-22T08:00:00Z" },
+					}],
+				},
+			],
+			tools: [{
+				name: "datetime",
+				description: "Get the current datetime",
+				parameters: {
+					type: "object",
+					additionalProperties: false,
+					properties: {
+						timezone: { type: "string", additionalProperties: false },
+					},
+				},
+			}],
+		} as any);
+
+		expect(request.tools).toEqual([{
+			type: "function",
+			name: "datetime",
+			description: "Get the current datetime",
+			parameters: {
+				type: "object",
+				properties: { timezone: { type: "string" } },
+			},
+		}]);
+		expect(request.store).toBe(true);
+		expect(request.previous_interaction_id).toBe("v1_interaction_datetime");
+		expect(request.input).toHaveLength(1);
+		expect(request.input.at(-1)).toEqual({
+			type: "function_result",
+			call_id: "call_datetime",
+			name: "datetime",
+			is_error: undefined,
+			result: [{ type: "text", text: "{\"datetime\":\"2026-07-22T08:00:00Z\"}" }],
+		});
+	});
+
 	it("adds schema reinforcement instruction for json_schema mode", async () => {
 		const request = await irToGemini({
 			model: "gemini-2.5-flash",

--- a/apps/api/src/executors/google-ai-studio/text-generate/index.ts
+++ b/apps/api/src/executors/google-ai-studio/text-generate/index.ts
@@ -223,6 +223,11 @@ export async function irToGemini(ir: IRChatRequest, modelOverride?: string | nul
 	const input: any[] = [];
 	const systemInstructionParts: string[] = [];
 	const toolNamesById = new Map<string, string>();
+	const previousInteractionId = resolvePreviousInteractionId(ir);
+
+	const messagesToMap = previousInteractionId && ir.messages.length > 0
+		? [ir.messages[ir.messages.length - 1]]
+		: ir.messages;
 
 	for (const msg of ir.messages) {
 		if (msg.role !== "assistant" || !Array.isArray(msg.toolCalls)) continue;
@@ -232,7 +237,7 @@ export async function irToGemini(ir: IRChatRequest, modelOverride?: string | nul
 		}
 	}
 
-	for (const msg of ir.messages) {
+	for (const msg of messagesToMap) {
 		if (msg.role === "system" || msg.role === "developer") {
 			const text = await irPartsToPlainText(msg.content);
 			if (text) systemInstructionParts.push(text);
@@ -271,30 +276,24 @@ export async function irToGemini(ir: IRChatRequest, modelOverride?: string | nul
 			}
 		} else if (msg.role === "tool") {
 			for (const toolResult of msg.toolResults) {
-				let responsePayload: any = toolResult.content;
-				if (typeof toolResult.content === "string") {
-					try {
-						responsePayload = JSON.parse(toolResult.content);
-					} catch {
-						responsePayload = { content: toolResult.content };
-					}
-				}
+				const resultText = typeof toolResult.content === "string"
+					? toolResult.content
+					: JSON.stringify(toolResult.content);
 				input.push({
 					type: "function_result",
 					call_id: toolResult.toolCallId,
 					name: toolNamesById.get(toolResult.toolCallId) ?? toolResult.toolCallId,
 					is_error: toolResult.isError,
-					result: responsePayload,
+					result: [{ type: "text", text: resultText }],
 				});
 			}
 		}
 	}
 
-	const previousInteractionId = resolvePreviousInteractionId(ir);
 	const request: any = {
 		model: modelOverride ?? ir.model,
 		input,
-		store: Boolean(ir.store || previousInteractionId || ir.background),
+		store: Boolean(ir.store || previousInteractionId || ir.background || (ir.tools?.length ?? 0) > 0),
 	};
 
 	if (ir.googleCachedContent !== undefined) {
@@ -438,7 +437,7 @@ export async function irToGemini(ir: IRChatRequest, modelOverride?: string | nul
 			type: "function",
 			name: tool.name,
 			description: tool.description,
-			parameters: tool.parameters,
+			parameters: sanitizeGeminiSchema(tool.parameters),
 		}));
 
 		if (ir.toolChoice) {
@@ -1171,6 +1170,7 @@ export async function execute(args: ExecutorExecuteArgs): Promise<ExecutorResult
 			return {
 				kind: "stream",
 				stream,
+				streamAlreadyTransformed: true,
 				upstream: response,
 				bill,
 				keySource: keyInfo.source,

--- a/apps/api/src/executors/types.ts
+++ b/apps/api/src/executors/types.ts
@@ -111,6 +111,7 @@ export type ExecutorCompletedResult = {
 export type ExecutorStreamingResult = {
 	kind: "stream";
 	stream: ReadableStream<Uint8Array>;
+	streamAlreadyTransformed?: boolean;
 	usageFinalizer: () => Promise<Bill | null>;
 	bill: Bill;
 	upstream: Response;

--- a/apps/api/src/pipeline/after/audit.ts
+++ b/apps/api/src/pipeline/after/audit.ts
@@ -382,9 +382,9 @@ export async function handleFailureAudit(
                 ? result.bill.usage as Record<string, unknown>
                 : {},
             currency: result.bill?.currency ?? null,
-            pricingLines: Array.isArray((result.bill?.usage as any)?.pricing)
-                ? (result.bill?.usage as any).pricing
-                : [],
+			pricingLines: Array.isArray((result.bill?.usage as any)?.pricing?.lines)
+				? (result.bill?.usage as any).pricing.lines
+				: [],
         });
     } catch (auditErr) {
         console.error("auditFailure failed", auditErr);

--- a/apps/api/src/pipeline/after/audit.ts
+++ b/apps/api/src/pipeline/after/audit.ts
@@ -378,6 +378,13 @@ export async function handleFailureAudit(
                 ),
                 replay_supported: true,
             },
+            usage: (result.bill?.usage && typeof result.bill.usage === "object")
+                ? result.bill.usage as Record<string, unknown>
+                : {},
+            currency: result.bill?.currency ?? null,
+            pricingLines: Array.isArray((result.bill?.usage as any)?.pricing)
+                ? (result.bill?.usage as any).pricing
+                : [],
         });
     } catch (auditErr) {
         console.error("auditFailure failed", auditErr);

--- a/apps/api/src/pipeline/after/index.ts
+++ b/apps/api/src/pipeline/after/index.ts
@@ -54,6 +54,47 @@ export function shouldReturnBinaryAudio(ctx: PipelineContext): boolean {
 	return true;
 }
 
+export async function settleBillableFailure(
+    ctx: PipelineContext,
+    result: RequestResult,
+): Promise<void> {
+    const usage = {
+        ...((result.bill?.usage && typeof result.bill.usage === "object") ? result.bill.usage : {}),
+        ...((result.ir?.usage && typeof result.ir.usage === "object") ? result.ir.usage : {}),
+        _provider_id: result.provider,
+    };
+    const shapedUsage = shapeUsageForClient(usage, {
+        endpoint: ctx.endpoint,
+        body: ctx.body,
+        includeInternalHints: true,
+    });
+    const card = await loadProviderPricing(ctx, result);
+    const tier = ctx.teamEnrichment?.tier ?? "basic";
+    const priced = await calculatePricing(shapedUsage, card, ctx.body, tier, ctx.meta);
+    const withByok = await applyByokServiceFee({
+        workspaceId: ctx.workspaceId,
+        isByok: (result?.keySource ?? ctx.meta.keySource) === "byok",
+        baseCostNanos: priced.totalNanos,
+        pricedUsage: priced.pricedUsage,
+        currencyHint: priced.currency,
+    });
+    const usageForAudit = shapeUsageForClient(withByok.pricedUsage, {
+        endpoint: ctx.endpoint,
+        body: ctx.body,
+    });
+    if (usageForAudit && typeof usageForAudit === "object") {
+        delete (usageForAudit as any)._provider_id;
+    }
+    result.bill.cost_cents = withByok.totalCents;
+    result.bill.currency = withByok.currency;
+    result.bill.usage = usageForAudit;
+    await recordUsageAndChargeOnce({
+        ctx,
+        costNanos: withByok.totalNanos,
+        endpoint: ctx.endpoint,
+    });
+}
+
 function normalizeWavChunkSizesIfNeeded(bytes: Uint8Array): Uint8Array {
 	if (bytes.length < 44) return bytes;
 	const isRiff =

--- a/apps/api/src/pipeline/audit/index.ts
+++ b/apps/api/src/pipeline/audit/index.ts
@@ -583,6 +583,9 @@ type AuditFailureExecute = {
     providerRequest?: unknown;
     providerResponse?: unknown;
     detailMetadata?: Record<string, unknown> | null;
+    usage?: Record<string, unknown> | null;
+    currency?: string | null;
+    pricingLines?: unknown[] | null;
 };
 
 export async function auditFailure(args: AuditFailureBefore | AuditFailureExecute) {
@@ -725,11 +728,11 @@ export async function auditFailure(args: AuditFailureBefore | AuditFailureExecut
             appId: resolvedAppId,
             latencyMs: args.latencyMs ?? null,
             generationMs: args.generationMs ?? null,
-            usage: {},
+            usage: args.usage ?? {},
             requestPayload: args.requestPayload,
             gatewayResponse: args.gatewayResponse,
-            currency: null,
-            pricingLines: [],
+            currency: args.currency ?? null,
+            pricingLines: args.pricingLines ?? [],
             keyId: args.keyId ?? null,
             edgeColo: args.edgeColo ?? null,
             edgeCity: args.edgeCity ?? null,

--- a/apps/api/src/pipeline/surfaces/text-generate.ts
+++ b/apps/api/src/pipeline/surfaces/text-generate.ts
@@ -7,8 +7,8 @@ import { handleError } from "@core/error-handler";
 import { detectTextProtocol } from "@protocols/detect";
 import { decodeProtocol, encodeProtocol } from "@protocols/index";
 import { doRequestWithIR } from "../execute";
-import { finalizeRequest } from "../after";
-import { handleSuccessAudit } from "../after/audit";
+import { finalizeRequest, settleBillableFailure } from "../after";
+import { handleFailureAudit, handleSuccessAudit } from "../after/audit";
 import { makeHeaders, createResponse } from "../after/http";
 import { auditFailure } from "../audit";
 import type { PipelineRunnerArgs } from "./types";
@@ -810,6 +810,16 @@ export async function runTextGeneratePipeline(args: PipelineRunnerArgs): Promise
 			}
 		}
 		if (exec.result.kind === "completed" && !hasUsableIRChatResponse(exec.result.ir as IRChatResponse | undefined)) {
+			await settleBillableFailure(pre.ctx, exec.result);
+			await handleFailureAudit(
+				pre.ctx,
+				exec.result,
+				502,
+				"gateway",
+				"google_empty_response",
+				"The provider returned a successful response without any visible output.",
+				exec.result.rawResponse,
+			);
 			const header = timing.timer.header();
 			pre.ctx.timing = timing.timer.snapshot();
 			return await handleError({
@@ -818,7 +828,7 @@ export async function runTextGeneratePipeline(args: PipelineRunnerArgs): Promise
 				endpoint,
 				ctx: pre.ctx,
 				timingHeader: header || undefined,
-				auditFailure,
+				auditFailure: async () => {},
 				req,
 			});
 		}
@@ -949,6 +959,17 @@ export async function runTextGeneratePipeline(args: PipelineRunnerArgs): Promise
 					...nextIrRequest,
 					stream: true,
 					toolChoice: "auto",
+					...(latestIrResponse.provider === "google-ai-studio" && latestIrResponse.nativeId
+						? {
+							vendor: {
+								...(nextIrRequest.vendor ?? {}),
+								google: {
+									...((nextIrRequest.vendor as any)?.google ?? {}),
+									previous_interaction_id: latestIrResponse.nativeId,
+								},
+							},
+						}
+						: {}),
 					messages: [
 						...nextIrRequest.messages,
 						continuation.assistantMessage,
@@ -958,7 +979,6 @@ export async function runTextGeneratePipeline(args: PipelineRunnerArgs): Promise
 						},
 					],
 				};
-
 				const followUpExec = await doRequestWithIR(pre.ctx, nextIrRequest, timing);
 				if (followUpExec instanceof Response) {
 					const header = timing.timer.header();
@@ -1001,6 +1021,16 @@ export async function runTextGeneratePipeline(args: PipelineRunnerArgs): Promise
 					}
 				}
 				if (followUpResult.kind === "completed" && !hasUsableIRChatResponse(followUpResult.ir as IRChatResponse | undefined)) {
+					await settleBillableFailure(pre.ctx, followUpResult);
+					await handleFailureAudit(
+						pre.ctx,
+						followUpResult,
+						502,
+						"gateway",
+						"google_empty_response",
+						"The provider returned a successful response without any visible output.",
+						followUpResult.rawResponse,
+					);
 					const header = timing.timer.header();
 					pre.ctx.timing = timing.timer.snapshot();
 					return await handleError({
@@ -1009,7 +1039,7 @@ export async function runTextGeneratePipeline(args: PipelineRunnerArgs): Promise
 						endpoint,
 						ctx: pre.ctx,
 						timingHeader: header || undefined,
-						auditFailure,
+						auditFailure: async () => {},
 						req,
 					});
 				}

--- a/apps/web-api/src/chat/proxy.ts
+++ b/apps/web-api/src/chat/proxy.ts
@@ -23,13 +23,6 @@ function needsCompletedResponseStreamBridge(body: Record<string, unknown> | unde
 	return model === "google/gemini-3.5-flash-lite" || model === "google/gemini-3.6-flash";
 }
 
-function withoutGatewayDatetimeTool(body: Record<string, unknown>): Record<string, unknown> {
-	if (!Array.isArray(body.tools)) return body;
-	const tools = body.tools.filter((tool: any) => tool?.type !== "gateway:datetime");
-	const { tools: _tools, ...rest } = body;
-	return tools.length > 0 ? { ...rest, tools } : rest;
-}
-
 async function bridgeCompletedResponseToSse(upstream: Response): Promise<Response> {
 	if (!upstream.ok) return privateResponse(upstream);
 	const payload = await upstream.json() as Record<string, any>;
@@ -174,7 +167,7 @@ export async function proxyGateway(request: Request, env: Env, waitUntil: (promi
 	try {
 		const bridgeCompletedStream = needsCompletedResponseStreamBridge(args.requestBody, args.stream);
 		const requestBody = bridgeCompletedStream
-			? { ...withoutGatewayDatetimeTool(args.requestBody ?? {}), stream: false }
+			? { ...args.requestBody, stream: false }
 			: args.requestBody;
 		const upstream = await fetch(`${baseUrl}${args.path}`, {
 			method: args.method ?? "POST",


### PR DESCRIPTION
## Summary
- preserve server tools for Gemini 3.5 Flash-Lite and Gemini 3.6 Flash chat requests
- map Google Interactions function schemas/results and continue tool turns with native interaction IDs
- prevent already-normalized synthetic streams from being transformed twice
- price, audit, and charge provider-successful empty responses before returning a gateway error

## Validation
- `pnpm --filter @phaseo/gateway-api typecheck`
- focused gateway suites: 25 tests passed
- server-tool pipeline integration: passed
- `pnpm --filter @phaseo/web-api typecheck`
- web-api suite: 172 tests passed
- production browser: Gemini 3.5 Flash-Lite datetime tool passed
- production browser: Gemini 3.6 Flash datetime tool passed
- deployed gateway worker version `85a9c7d3-1ebf-4461-ad55-99135ab4eb57`

One unrelated existing assertion in `text-generate.server-tools.test.ts` expects the legacy `ai_stats_web_fetch` alias while runtime emits `phaseo_web_fetch`; all tests relevant to this change pass.

Created with Codex


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented streaming responses from being transformed more than once.
  * Improved Google AI Studio tool-call handling and interaction continuity.
  * Preserved tool definitions when bridging completed responses to streaming clients.
  * Improved handling of empty provider responses and follow-up requests.
  * Failure audits now include usage, pricing, and currency details.
  * Billable usage is finalized and recorded when requests fail after generating usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->