### PR TITLE
Secure Gemini interaction storage

### DIFF
--- a/apps/api/src/executors/google-ai-studio/text-generate/__tests__/request-map.test.ts
+++ b/apps/api/src/executors/google-ai-studio/text-generate/__tests__/request-map.test.ts
@@ -99,6 +99,28 @@ describe("google-ai-studio irToGemini", () => {
 		});
 	});
 
+	it("honors store=false and ignores client previous response IDs", async () => {
+		const request = await irToGemini({
+			model: "gemini-3.5-flash-lite",
+			stream: false,
+			store: false,
+			previousResponseId: "interactions/another-workspace",
+			messages: [{ role: "user", content: [{ type: "text", text: "What time is it?" }] }],
+			tools: [{
+				name: "datetime",
+				description: "Get the current datetime",
+				parameters: { type: "object", properties: { timezone: { type: "string" } } },
+			}],
+		} as any);
+
+		expect(request.store).toBe(false);
+		expect(request).not.toHaveProperty("previous_interaction_id");
+		expect(request.input).toEqual([{
+			type: "user_input",
+			content: [{ type: "text", text: "What time is it?" }],
+		}]);
+	});
+
 	it("adds schema reinforcement instruction for json_schema mode", async () => {
 		const request = await irToGemini({
 			model: "gemini-2.5-flash",

--- a/apps/api/src/executors/google-ai-studio/text-generate/index.ts
+++ b/apps/api/src/executors/google-ai-studio/text-generate/index.ts
@@ -293,7 +293,9 @@ export async function irToGemini(ir: IRChatRequest, modelOverride?: string | nul
 	const request: any = {
 		model: modelOverride ?? ir.model,
 		input,
-		store: Boolean(ir.store || previousInteractionId || ir.background || (ir.tools?.length ?? 0) > 0),
+		store: ir.store === false
+			? false
+			: Boolean(ir.store || previousInteractionId || ir.background || (ir.tools?.length ?? 0) > 0),
 	};
 
 	if (ir.googleCachedContent !== undefined) {
@@ -564,9 +566,6 @@ function resolvePreviousInteractionId(ir: IRChatRequest): string | undefined {
 		vendorGoogle?.previousInteractionId,
 		vendorGoogle?.interaction_id,
 		vendorGoogle?.interactionId,
-		typeof ir.previousResponseId === "string" && ir.previousResponseId.startsWith("interactions/")
-			? ir.previousResponseId
-			: undefined,
 	];
 	return candidates.find((value): value is string => typeof value === "string" && value.length > 0);
 }

--- a/apps/api/src/pipeline/surfaces/text-generate.ts
+++ b/apps/api/src/pipeline/surfaces/text-generate.ts
@@ -959,7 +959,10 @@ export async function runTextGeneratePipeline(args: PipelineRunnerArgs): Promise
 					...nextIrRequest,
 					stream: true,
 					toolChoice: "auto",
-					...(latestIrResponse.provider === "google-ai-studio" && latestIrResponse.nativeId
+					...(latestIrResponse.provider === "google-ai-studio" &&
+						latestIrResponse.nativeId &&
+						latestIrResponse.nativeId !== pre.ctx.requestId &&
+						nextIrRequest.store !== false
 						? {
 							vendor: {
 								...(nextIrRequest.vendor ?? {}),


### PR DESCRIPTION
## Summary
- preserve explicit `store: false` for Gemini Interactions requests with tools
- stop translating public `previous_response_id` values into Google interaction IDs
- only use stateful Google continuation IDs created by the same in-flight server-tool request
- reject the gateway request ID fallback as a provider continuation token

## Validation
- `pnpm --filter @phaseo/gateway-api typecheck`
- focused Gemini mapper, executor, and server-tool integration suites: 18 tests passed
- production browser: Gemini 3.5 Flash-Lite still displays `Called Gateway Datetime` and completes the tool round trip
- deployed gateway worker version `c7d4d253-c72d-403d-a3e1-4676997ce64c`

Created with Codex


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected non-persistent Google AI Studio requests so they no longer include prior-response context.
  * Prevented previous interaction links from being added when response storage is disabled.
  * Improved follow-up request handling to avoid incorrect or duplicate response associations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->