### PR TITLE
Fix Gemini empty-response billing

### DIFF
--- a/apps/api/src/executors/google-ai-studio/text-generate/__tests__/execute-usage-fallback.test.ts
+++ b/apps/api/src/executors/google-ai-studio/text-generate/__tests__/execute-usage-fallback.test.ts
@@ -48,7 +48,7 @@ afterAll(() => {
 });
 
 describe("google-ai-studio execute usage fallback", () => {
-	it("routes current Gemini Flash models through Interactions and rejects empty output", async () => {
+	it("preserves billable usage when current Gemini Flash models return empty output", async () => {
 		const mock = installFetchMock([{
 			match: (url) => url.endsWith("/v1beta/interactions"),
 			response: new Response(JSON.stringify({
@@ -70,8 +70,18 @@ describe("google-ai-studio execute usage fallback", () => {
 
 		expect(result.kind).toBe("completed");
 		if (result.kind !== "completed") return;
-		expect(result.ir).toBeUndefined();
-		expect(result.upstream?.status).toBe(502);
+		expect(result.ir).toBeDefined();
+		expect(result.ir?.choices[0]?.message.content).toEqual([]);
+		expect(result.ir?.choices[0]?.message.toolCalls ?? []).toEqual([]);
+		expect(result.upstream?.status).toBe(200);
+		expect(result.bill.usage).toMatchObject({
+			input_text_tokens: 8,
+			total_tokens: 8,
+		});
+		expect(result.rawResponse).toMatchObject({
+			id: "v1_empty_response",
+			usage: { total_input_tokens: 8, total_tokens: 8 },
+		});
 		expect(mock.calls).toHaveLength(1);
 		expect(mock.calls[0]?.bodyJson?.model).toBe("gemini-3.6-flash");
 		expect(mock.calls[0]?.bodyJson?.generation_config).toBeUndefined();

--- a/apps/api/src/executors/google-ai-studio/text-generate/index.ts
+++ b/apps/api/src/executors/google-ai-studio/text-generate/index.ts
@@ -73,20 +73,6 @@ function hasUsableIRResponse(response: IRChatResponse | undefined): boolean {
 	});
 }
 
-function emptyGoogleResponse(model: string, provider: string): Response {
-	return new Response(JSON.stringify({
-		error: {
-			code: "google_empty_response",
-			message: "Google returned a successful response without any output.",
-			model,
-			provider,
-		},
-	}), {
-		status: 502,
-		headers: { "Content-Type": "application/json" },
-	});
-}
-
 function isRetryableGoogleStatus(status: number): boolean {
 	return status === 429 || status >= 500;
 }
@@ -1127,18 +1113,6 @@ export async function execute(args: ExecutorExecuteArgs): Promise<ExecutorResult
 			const data = normalizeGeminiResponsePayload(rawData);
 			const irResponse = providerPayloadToIR(data, requestId, model, providerId);
 			applyGoogleOutputTokenFallback(irResponse);
-			if (!hasUsableIRResponse(irResponse)) {
-				return {
-					kind: "completed",
-					ir: undefined,
-					upstream: emptyGoogleResponse(model, providerId),
-					bill: { cost_cents: 0, currency: "USD" },
-					keySource: keyInfo.source,
-					byokKeyId: keyInfo.byokId,
-					mappedRequest,
-				};
-			}
-
 			const bill: any = {
 				cost_cents: 0,
 				currency: "USD",
@@ -1146,6 +1120,18 @@ export async function execute(args: ExecutorExecuteArgs): Promise<ExecutorResult
 			const usageMeters = normalizeTextUsageForPricing(irResponse.usage ?? data?.usageMetadata);
 			if (usageMeters) {
 				bill.usage = usageMeters;
+			}
+			if (!hasUsableIRResponse(irResponse)) {
+				return {
+					kind: "completed",
+					ir: irResponse,
+					upstream: response,
+					bill,
+					keySource: keyInfo.source,
+					byokKeyId: keyInfo.byokId,
+					mappedRequest,
+					rawResponse: rawData,
+				};
 			}
 
 			const totalMs = Date.now() - upstreamStartMs;
@@ -1235,26 +1221,25 @@ export async function execute(args: ExecutorExecuteArgs): Promise<ExecutorResult
 					irResponse.usage?.totalTokens ?? 0,
 				);
 			}
-			if (!hasUsableIRResponse(irResponse)) {
-				return {
-					kind: "completed",
-					ir: undefined,
-					upstream: emptyGoogleResponse(model, providerId),
-					bill: { cost_cents: 0, currency: "USD" },
-					keySource: keyInfo.source,
-					byokKeyId: keyInfo.byokId,
-					mappedRequest,
-				};
-			}
-
 			const bill: any = {
 				cost_cents: 0,
 				currency: "USD",
 			};
-
 			const usageMeters = normalizeTextUsageForPricing(irResponse?.usage ?? usage);
 			if (usageMeters) {
 				bill.usage = usageMeters;
+			}
+			if (!hasUsableIRResponse(irResponse)) {
+				return {
+					kind: "completed",
+					ir: irResponse,
+					upstream: response,
+					bill,
+					keySource: keyInfo.source,
+					byokKeyId: keyInfo.byokId,
+					mappedRequest,
+					rawResponse,
+				};
 			}
 
 			return {
@@ -1277,29 +1262,28 @@ export async function execute(args: ExecutorExecuteArgs): Promise<ExecutorResult
 		const data = normalizeGeminiResponsePayload(rawData);
 		const irResponse = providerPayloadToIR(data, requestId, model, providerId);
 		applyGoogleOutputTokenFallback(irResponse);
-		if (!hasUsableIRResponse(irResponse)) {
-			return {
-				kind: "completed",
-				ir: undefined,
-				upstream: emptyGoogleResponse(model, providerId),
-				bill: { cost_cents: 0, currency: "USD" },
-				keySource: keyInfo.source,
-				byokKeyId: keyInfo.byokId,
-				mappedRequest,
-			};
-		}
-
-		// Calculate pricing
 		const bill: any = {
 			cost_cents: 0,
 			currency: "USD",
 		};
-
 		const usageMeters = normalizeTextUsageForPricing(irResponse.usage ?? data?.usageMetadata);
 		if (usageMeters) {
 			bill.usage = usageMeters;
 		}
+		if (!hasUsableIRResponse(irResponse)) {
+			return {
+				kind: "completed",
+				ir: irResponse,
+				upstream: response,
+				bill,
+				keySource: keyInfo.source,
+				byokKeyId: keyInfo.byokId,
+				mappedRequest,
+				rawResponse: rawData,
+			};
+		}
 
+		// Calculate pricing
 		const totalMs = Date.now() - upstreamStartMs;
 
 		return {


### PR DESCRIPTION
## Summary
- preserve decoded IR, raw provider payload, and normalized usage when Gemini returns successful empty output
- route those results through the existing centralized billable-failure handling instead of converting them to zero-cost executor failures
- add regression coverage for billable usage retention

## Security impact
Prevents successful-but-empty Google responses from bypassing usage recording and wallet settlement.

## Validation
- `pnpm --filter @phaseo/gateway-api test -- src/executors/google-ai-studio/text-generate/__tests__/execute-usage-fallback.test.ts` (7 passed)
- `pnpm --filter @phaseo/gateway-api typecheck`
- `git diff --check`

A broader server-tools test currently has an unrelated pre-existing expectation for `ai_stats_web_fetch` while main emits `phaseo_web_fetch`; this patch does not alter that behavior.

Created with Codex