### PR TITLE
Fix performance provider attribution

### DIFF
--- a/apps/web-api/src/routes/public/models.test.ts
+++ b/apps/web-api/src/routes/public/models.test.ts
@@ -224,6 +224,52 @@ describe("public model routes", () => {
 		expect(performance.headers.get("cloudflare-cdn-cache-control")).toBe("public, max-age=900, stale-while-revalidate=900");
 	});
 
+	it("never exposes a synthetic unknown provider in performance data", async () => {
+		vi.stubGlobal("fetch", vi.fn(async (input: RequestInfo | URL) => {
+			const url = String(input);
+			if (url.includes("/rpc/get_v2_model_performance_overview")) {
+				return new Response(JSON.stringify({
+					last_24h: { total_requests: 12, successful_requests: 11 },
+					hourly_24h: [],
+					provider_uptime_24h: [
+						{ provider: "poolside", provider_name: "Poolside", requests: 11 },
+						{ provider: "unknown", provider_name: "unknown", requests: 1 },
+					],
+					provider_daily_7d: [
+						{ day: "2026-07-23", provider: "poolside", provider_name: "Poolside", requests: 11 },
+						{ day: "2026-07-23", provider: "unknown", provider_name: "unknown", requests: 1 },
+					],
+				}), { status: 200 });
+			}
+			if (url.includes("/rpc/get_v2_model_provider_health_metrics")) {
+				return new Response(JSON.stringify([]), { status: 200 });
+			}
+			return new Response(JSON.stringify([]), { status: 200 });
+		}));
+
+		const response = await app.request(
+			"https://phaseo.app/api/_web/models/poolside%2Flaguna-s-2.1/performance",
+			{},
+			env,
+		);
+		const payload = await response.json() as any;
+
+		expect(response.status).toBe(200);
+		expect(payload.performance.provider_uptime_24h).toEqual([
+			expect.objectContaining({ provider: "poolside" }),
+		]);
+		expect(payload.performance.provider_daily_7d).toEqual([
+			expect.objectContaining({ provider: "poolside" }),
+		]);
+		expect(payload.metrics.providerPerformance).toEqual([
+			expect.objectContaining({ provider: "poolside" }),
+		]);
+		expect(payload.metrics.providerDaily7d).toEqual([
+			expect.objectContaining({ provider: "poolside" }),
+		]);
+		expect(JSON.stringify(payload)).not.toContain('"unknown"');
+	});
+
 	it("returns compact gateway availability without loading full metadata", async () => {
 		const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
 			const url = String(input);

--- a/apps/web-api/src/routes/public/models.ts
+++ b/apps/web-api/src/routes/public/models.ts
@@ -1380,6 +1380,15 @@ publicModelsRouter.get("/:modelId/performance", async (c) => {
 			};
 		}
 		if (!performance) return withPublicCache(c.json({ modelId, performance: null, metrics: null, activity: null }), sectionPolicy("performance", modelId));
+		const isKnownProvider = (value: Record<string, unknown>) => {
+			const provider = String(value.provider ?? "").trim().toLowerCase();
+			return provider.length > 0 && provider !== "unknown";
+		};
+		performance = {
+			...performance,
+			provider_uptime_24h: (performance.provider_uptime_24h ?? []).filter(isKnownProvider),
+			provider_daily_7d: (performance.provider_daily_7d ?? []).filter(isKnownProvider),
+		};
 		const number = (value: unknown) => { const parsed = Number(value); return value == null || !Number.isFinite(parsed) ? null : parsed; };
 		const summary = (value: Record<string, unknown> | null | undefined) => ({ avgThroughput: number(value?.avg_throughput), avgLatencyMs: number(value?.avg_latency_ms), avgGenerationMs: number(value?.avg_generation_ms), uptimePct: number(value?.uptime_pct), totalRequests: Number(value?.total_requests ?? 0), successfulRequests: Number(value?.successful_requests ?? 0) });
 		const hourly = (performance.hourly_24h ?? []).map((value: Record<string, unknown>) => ({ bucket: value.bucket ?? "", avgThroughput: number(value.avg_throughput), avgLatencyMs: number(value.avg_latency_ms), avgGenerationMs: number(value.avg_generation_ms), requests: Number(value.requests ?? 0), successPct: number(value.success_pct) }));

--- a/supabase/migrations/20260723121000_v2_performance_provider_attribution.sql
+++ b/supabase/migrations/20260723121000_v2_performance_provider_attribution.sql
@@ -1,0 +1,180 @@
+-- Provider performance series must only contain real catalogue providers.
+-- Recover older facts from safe provider metadata where the route is
+-- unambiguous, and keep genuinely provider-less failures in overall metrics
+-- without presenting them as a synthetic "unknown" provider.
+
+with recoverable as (
+  select
+    fact.request_event_id,
+    candidate.provider_model_id
+  from public.v2_request_facts fact
+  cross join lateral (
+    select route.provider_model_id
+    from public.v2_model_provider_routes route
+    where route.provider_slug = nullif(lower(trim(fact.safe_metadata->>'provider')), '')
+      and route.model_slug = coalesce(fact.routed_model_slug, fact.requested_model_slug)
+      and (
+        route.provider_model_id =
+          nullif(lower(trim(fact.safe_metadata->>'provider')), '') || ':' ||
+          nullif(trim(fact.safe_metadata->>'routed_model'), '')
+        or route.provider_model_slug = nullif(trim(fact.safe_metadata->>'routed_model'), '')
+        or 1 = (
+          select count(*)
+          from public.v2_model_provider_routes sibling
+          where sibling.provider_slug = route.provider_slug
+            and sibling.model_slug = route.model_slug
+        )
+      )
+    order by
+      case
+        when route.provider_model_id =
+          nullif(lower(trim(fact.safe_metadata->>'provider')), '') || ':' ||
+          nullif(trim(fact.safe_metadata->>'routed_model'), '') then 0
+        when route.provider_model_slug = nullif(trim(fact.safe_metadata->>'routed_model'), '') then 1
+        else 2
+      end,
+      route.provider_model_id
+    limit 1
+  ) candidate
+  where fact.provider_model_id is null
+)
+update public.v2_request_facts fact
+set provider_model_id = recoverable.provider_model_id
+from recoverable
+where fact.request_event_id = recoverable.request_event_id;
+
+create or replace function public.get_v2_model_performance_overview(
+  p_model_slug text,
+  p_cloudflare_colo text default null,
+  p_percentile numeric default 0.5
+)
+returns jsonb
+language sql
+stable
+security invoker
+set search_path = public
+as $$
+  with params as (
+    select lower(trim(p_model_slug)) as model_slug,
+      nullif(upper(trim(p_cloudflare_colo)), '') as cloudflare_colo,
+      greatest(0.01, least(0.99, coalesce(p_percentile, 0.5)))::double precision as percentile,
+      now() as now_ts
+  ),
+  base as (
+    select date_trunc('hour', fact.occurred_at) as bucket_start,
+      fact.occurred_at::date as usage_day,
+      coalesce(route.provider_slug, metadata_provider.provider_slug) as provider_id,
+      fact.success, fact.latency_ms, fact.generation_ms, fact.throughput
+    from public.v2_request_facts fact
+    left join public.v2_model_provider_routes route
+      on route.provider_model_id = fact.provider_model_id
+    left join public.v2_providers metadata_provider
+      on metadata_provider.provider_slug = nullif(lower(trim(fact.safe_metadata->>'provider')), '')
+    cross join params
+    where coalesce(fact.routed_model_slug, fact.requested_model_slug) = params.model_slug
+      and fact.occurred_at >= params.now_ts - interval '7 days'
+      and (params.cloudflare_colo is null or upper(trim(fact.cloudflare_colo)) = params.cloudflare_colo)
+  ),
+  hourly as (
+    select bucket_start,
+      count(*)::bigint as requests,
+      count(*) filter (where success is true)::bigint as successful_requests,
+      percentile_cont((select percentile from params)) within group (order by latency_ms) filter (where success is true and latency_ms is not null)::numeric as percentile_latency_ms,
+      avg(generation_ms) filter (where success is true and generation_ms is not null)::numeric as avg_generation_ms,
+      percentile_cont((select percentile from params)) within group (order by throughput) filter (where success is true and throughput is not null)::numeric as percentile_throughput
+    from base
+    group by bucket_start
+  ),
+  recent as (
+    select * from base where bucket_start >= (select now_ts from params) - interval '24 hours'
+  ),
+  summary as (
+    select count(*)::bigint as requests, count(*) filter (where success is true)::bigint as successful_requests,
+      percentile_cont((select percentile from params)) within group (order by latency_ms) filter (where success is true and latency_ms is not null)::numeric as percentile_latency_ms,
+      avg(generation_ms) filter (where success is true and generation_ms is not null)::numeric as avg_generation_ms,
+      percentile_cont((select percentile from params)) within group (order by throughput) filter (where success is true and throughput is not null)::numeric as percentile_throughput
+    from recent
+  ),
+  previous as (
+    select count(*)::bigint as requests, count(*) filter (where success is true)::bigint as successful_requests,
+      percentile_cont((select percentile from params)) within group (order by latency_ms) filter (where success is true and latency_ms is not null)::numeric as percentile_latency_ms,
+      avg(generation_ms) filter (where success is true and generation_ms is not null)::numeric as avg_generation_ms,
+      percentile_cont((select percentile from params)) within group (order by throughput) filter (where success is true and throughput is not null)::numeric as percentile_throughput
+    from base
+    where bucket_start >= (select now_ts from params) - interval '48 hours'
+      and bucket_start < (select now_ts from params) - interval '24 hours'
+  ),
+  provider_rows as (
+    select provider_id, count(*)::bigint as requests, count(*) filter (where success is true)::bigint as successful_requests,
+      percentile_cont((select percentile from params)) within group (order by latency_ms) filter (where success is true and latency_ms is not null)::numeric as percentile_latency_ms,
+      avg(generation_ms) filter (where success is true and generation_ms is not null)::numeric as avg_generation_ms,
+      percentile_cont((select percentile from params)) within group (order by throughput) filter (where success is true and throughput is not null)::numeric as percentile_throughput
+    from recent
+    where provider_id is not null
+    group by provider_id
+  ),
+  provider_daily as (
+    select usage_day, provider_id, count(*)::bigint as requests,
+      percentile_cont((select percentile from params)) within group (order by latency_ms) filter (where success is true and latency_ms is not null)::numeric as percentile_latency_ms,
+      avg(generation_ms) filter (where success is true and generation_ms is not null)::numeric as avg_generation_ms,
+      percentile_cont((select percentile from params)) within group (order by throughput) filter (where success is true and throughput is not null)::numeric as percentile_throughput
+    from base
+    where provider_id is not null
+    group by usage_day, provider_id
+  ),
+  hourly_json as (
+    select coalesce(jsonb_agg(jsonb_build_object(
+      'bucket', bucket_start, 'requests', requests,
+      'success_pct', case when requests > 0 then successful_requests * 100.0 / requests else null end,
+      'avg_latency_ms', percentile_latency_ms, 'avg_generation_ms', avg_generation_ms, 'avg_throughput', percentile_throughput
+    ) order by bucket_start) filter (where bucket_start >= (select now_ts from params) - interval '24 hours'), '[]'::jsonb) as value
+    from hourly
+  ),
+  provider_json as (
+    select coalesce(jsonb_agg(jsonb_build_object(
+      'provider', p.provider_id, 'provider_name', v.name, 'requests', p.requests,
+      'uptime_pct', case when p.requests > 0 then p.successful_requests * 100.0 / p.requests else null end,
+      'avg_latency_ms', p.percentile_latency_ms, 'avg_generation_ms', p.avg_generation_ms, 'avg_throughput', p.percentile_throughput,
+      'uptime_buckets', '[]'::jsonb
+    ) order by p.requests desc, p.provider_id), '[]'::jsonb) as value
+    from provider_rows p
+    join public.v2_providers v on v.provider_slug = p.provider_id
+  ),
+  provider_daily_json as (
+    select coalesce(jsonb_agg(jsonb_build_object(
+      'day', d.usage_day, 'provider', d.provider_id, 'provider_name', v.name,
+      'requests', d.requests, 'avg_latency_ms', d.percentile_latency_ms, 'avg_generation_ms', d.avg_generation_ms,
+      'avg_throughput', d.percentile_throughput
+    ) order by d.usage_day, d.provider_id), '[]'::jsonb) as value
+    from provider_daily d
+    join public.v2_providers v on v.provider_slug = d.provider_id
+  )
+  select jsonb_build_object(
+    'percentile', (select percentile from params) * 100,
+    'last_24h', jsonb_build_object(
+      'total_requests', coalesce(summary.requests, 0), 'successful_requests', coalesce(summary.successful_requests, 0),
+      'avg_latency_ms', summary.percentile_latency_ms, 'avg_generation_ms', summary.avg_generation_ms,
+      'avg_throughput', summary.percentile_throughput,
+      'uptime_pct', case when summary.requests > 0 then summary.successful_requests * 100.0 / summary.requests else null end
+    ),
+    'prev_24h', jsonb_build_object(
+      'total_requests', coalesce(previous.requests, 0), 'successful_requests', coalesce(previous.successful_requests, 0),
+      'avg_latency_ms', previous.percentile_latency_ms, 'avg_generation_ms', previous.avg_generation_ms,
+      'avg_throughput', previous.percentile_throughput,
+      'uptime_pct', case when previous.requests > 0 then previous.successful_requests * 100.0 / previous.requests else null end
+    ),
+    'hourly_24h', (select value from hourly_json),
+    'provider_uptime_24h', (select value from provider_json),
+    'provider_daily_7d', (select value from provider_daily_json),
+    'time_of_day_5d', '[]'::jsonb,
+    'cumulative_tokens', null,
+    'cloudflare_colo', (select cloudflare_colo from params)
+  )
+  from summary cross join previous;
+$$;
+
+grant execute on function public.get_v2_model_performance_overview(text, text, numeric)
+  to anon, authenticated, service_role;
+
+comment on function public.get_v2_model_performance_overview(text, text, numeric) is
+  'Returns model performance percentiles; provider series include only real v2 catalogue providers.';

--- a/supabase/migrations/20260723121000_v2_performance_provider_attribution.sql
+++ b/supabase/migrations/20260723121000_v2_performance_provider_attribution.sql
@@ -63,13 +63,11 @@ as $$
   base as (
     select date_trunc('hour', fact.occurred_at) as bucket_start,
       fact.occurred_at::date as usage_day,
-      coalesce(route.provider_slug, metadata_provider.provider_slug) as provider_id,
+      route.provider_slug as provider_id,
       fact.success, fact.latency_ms, fact.generation_ms, fact.throughput
     from public.v2_request_facts fact
     left join public.v2_model_provider_routes route
       on route.provider_model_id = fact.provider_model_id
-    left join public.v2_providers metadata_provider
-      on metadata_provider.provider_slug = nullif(lower(trim(fact.safe_metadata->>'provider')), '')
     cross join params
     where coalesce(fact.routed_model_slug, fact.requested_model_slug) = params.model_slug
       and fact.occurred_at >= params.now_ts - interval '7 days'


### PR DESCRIPTION
## Summary

- backfill V2 request facts when safe provider metadata resolves to an unambiguous catalogue route
- prevent provider-less requests from becoming a synthetic `unknown` provider series
- filter legacy `unknown` sentinels at the Web API boundary

## Root cause

The percentile RPC grouped null route identities under the literal `unknown`. Ten Laguna S2.1 requests written before the final gateway deployment retained `provider = poolside` in safe metadata but lacked `provider_model_id`; one 429 request legitimately never selected a provider.

## Impact

Provider-specific performance tables and trends now contain only real V2 catalogue providers. Provider-less failures remain included in overall request and success metrics.

## Validation

- `pnpm --filter @phaseo/web-api test -- src/routes/public/models.test.ts` (15 tests passed)
- `pnpm --filter @phaseo/web-api typecheck`
- `pnpm --filter @phaseo/web-api lint` (no errors; existing max-lines warnings only)
- linked Supabase migration applied successfully
- live Laguna RPC: providers `[poolside]`, 129 provider-attributed requests, 130 overall requests, no `unknown`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Performance results now exclude unknown or unrecognized providers.
  * Provider performance metrics and nested summaries consistently show only valid provider information.
  * Historical performance data is better attributed to the correct model providers, improving uptime, latency, and throughput reporting.

* **Tests**
  * Added coverage to verify unknown providers never appear in performance responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->