### PR TITLE
Restore model weekly usage and chart emphasis

### DIFF
--- a/apps/api/src/pipeline/usage-columns.test.ts
+++ b/apps/api/src/pipeline/usage-columns.test.ts
@@ -72,6 +72,7 @@ describe("buildGatewayRequestUsageColumns", () => {
 			endpoint: "video.generation",
 			usage: {
 				audio_seconds: 12,
+				output_video_seconds: 4,
 				video_pixel_seconds: 1280 * 720 * 4,
 			},
 			requestPayload: {
@@ -84,6 +85,7 @@ describe("buildGatewayRequestUsageColumns", () => {
 		expect(columns.usage_text_quad_tokens).toBeGreaterThan(0);
 		expect(columns.usage_image_megapixels).toBeCloseTo(2.097152);
 		expect(columns.usage_audio_seconds).toBe(12);
+		expect(columns.usage_video_seconds).toBe(4);
 		expect(columns.usage_video_pixel_seconds).toBe(1280 * 720 * 4);
 	});
 
@@ -138,6 +140,7 @@ describe("buildV2RequestUsageMeters", () => {
 				output_tokens: 20,
 				input_tokens_details: { cached_tokens: 40 },
 				output_image_count: 2,
+				output_video_seconds: 6.5,
 			},
 			requestPayload: { messages: [{ role: "user", content: "private prompt" }] },
 			gatewayResponse: { output_text: "private response" },
@@ -148,6 +151,7 @@ describe("buildV2RequestUsageMeters", () => {
 			expect.objectContaining({ meter_key: "output_tokens", quantity: 20, unit: "tokens" }),
 			expect.objectContaining({ meter_key: "cached_input_tokens", quantity: 40, unit: "tokens" }),
 			expect.objectContaining({ meter_key: "output_images", quantity: 2, unit: "images" }),
+			expect.objectContaining({ meter_key: "output_video_seconds", quantity: 6.5, unit: "seconds" }),
 		]));
 		expect(JSON.stringify(meters)).not.toContain("private prompt");
 		expect(JSON.stringify(meters)).not.toContain("private response");

--- a/apps/api/src/pipeline/usage-columns.ts
+++ b/apps/api/src/pipeline/usage-columns.ts
@@ -42,6 +42,7 @@ export type GatewayRequestUsageColumns = {
 	usage_ocr_quad_tokens: number;
 	usage_image_megapixels: number;
 	usage_audio_seconds: number;
+	usage_video_seconds: number;
 	usage_video_pixel_seconds: number;
 	usage_input_characters: number;
 	usage_output_characters: number;
@@ -100,6 +101,7 @@ export const GATEWAY_REQUEST_USAGE_COLUMN_NAMES = [
 	"usage_ocr_quad_tokens",
 	"usage_image_megapixels",
 	"usage_audio_seconds",
+	"usage_video_seconds",
 	"usage_video_pixel_seconds",
 	"usage_input_characters",
 	"usage_output_characters",
@@ -452,6 +454,7 @@ export function buildGatewayRequestUsageColumns(args: {
 			gatewayResponse: args.gatewayResponse,
 		}),
 		usage_audio_seconds: estimateAudioSeconds(usageForUnits),
+		usage_video_seconds: firstUnitNumber(shaped, ["output_video_seconds", "video_seconds"]),
 		usage_video_pixel_seconds: estimateVideoPixelSeconds({
 			usage: usageForUnits,
 			requestPayload: args.requestPayload,
@@ -508,6 +511,7 @@ const V2_USAGE_METER_COLUMNS: Array<{
 	{ column: "usage_cached_write_video_tokens", meterKey: "cached_write_video_tokens", modality: "video", unit: "tokens" },
 	{ column: "usage_image_megapixels", meterKey: "image_megapixels", modality: "image", unit: "megapixels" },
 	{ column: "usage_audio_seconds", meterKey: "audio_seconds", modality: "audio", unit: "seconds" },
+	{ column: "usage_video_seconds", meterKey: "output_video_seconds", modality: "video", unit: "seconds" },
 	{ column: "usage_video_pixel_seconds", meterKey: "video_pixel_seconds", modality: "video", unit: "pixel_seconds" },
 	{ column: "usage_input_characters", meterKey: "input_characters", modality: "text", unit: "characters" },
 	{ column: "usage_output_characters", meterKey: "output_characters", modality: "text", unit: "characters" },

--- a/apps/web-api/src/models/page-catalogue.test.ts
+++ b/apps/web-api/src/models/page-catalogue.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import { mergeModelWeeklyMetrics } from "@/models/page-catalogue";
+
+describe("mergeModelWeeklyMetrics", () => {
+	it("replaces catalogue placeholders with v2 rollup metrics", () => {
+		const rows = mergeModelWeeklyMetrics([
+			{
+				model_id: "poolside/laguna-s-2.1",
+				popularity_tokens_week: null,
+				throughput_week: null,
+				latency_week: null,
+			},
+			{ model_id: "catalogue/only", popularity_tokens_week: null },
+		], [
+			{
+				model_slug: "poolside/laguna-s-2.1",
+				popularity_tokens_week: 12_345,
+				weekly_usage_metric: "tokens",
+				weekly_usage_quantity: 12_345,
+				weekly_usage_unit: "tokens",
+				throughput_week: 8.75,
+				latency_week: 245.5,
+			},
+		]);
+
+		expect(rows[0]).toMatchObject({
+			model_id: "poolside/laguna-s-2.1",
+			popularity_tokens_week: 12_345,
+			weekly_usage_metric: "tokens",
+			weekly_usage_quantity: 12_345,
+			weekly_usage_unit: "tokens",
+			throughput_week: 8.75,
+			latency_week: 245.5,
+		});
+		expect(rows[1]).toEqual({
+			model_id: "catalogue/only",
+			popularity_tokens_week: null,
+		});
+	});
+});

--- a/apps/web-api/src/models/page-catalogue.ts
+++ b/apps/web-api/src/models/page-catalogue.ts
@@ -5,6 +5,16 @@ type Row = Record<string, unknown>;
 
 type OptionCount = { value: string; count: number };
 
+type WeeklyMetricRow = {
+	model_slug: string;
+	popularity_tokens_week: number | null;
+	weekly_usage_metric: string;
+	weekly_usage_quantity: number;
+	weekly_usage_unit: string;
+	throughput_week: number | null;
+	latency_week: number | null;
+};
+
 export type ModelsPageFacets = {
 	statusCounts: { active: number; coming_soon: number; not_active: number };
 	endpointOptions: OptionCount[];
@@ -171,6 +181,32 @@ async function databasePageRows(env: Env, query: ModelsPageQuery = {}): Promise<
 	return rows;
 }
 
+async function weeklyMetrics(env: Env): Promise<WeeklyMetricRow[]> {
+	const result = await getDataClient(env).rpc("get_v2_public_model_weekly_metrics");
+	if (result.error) throw result.error;
+	return (result.data ?? []) as WeeklyMetricRow[];
+}
+
+export function mergeModelWeeklyMetrics(rows: Row[], metrics: WeeklyMetricRow[]): Row[] {
+	const metricsByModel = new Map(
+		metrics.map((metric) => [String(metric.model_slug ?? "").trim(), metric]),
+	);
+	return rows.map((row) => {
+		const metric = metricsByModel.get(String(row.model_id ?? "").trim());
+		return metric
+			? {
+				...row,
+				popularity_tokens_week: metric.popularity_tokens_week,
+				weekly_usage_metric: metric.weekly_usage_metric,
+				weekly_usage_quantity: metric.weekly_usage_quantity,
+				weekly_usage_unit: metric.weekly_usage_unit,
+				throughput_week: metric.throughput_week,
+				latency_week: metric.latency_week,
+			}
+			: row;
+	});
+}
+
 async function baseRows(env: Env): Promise<Row[]> {
 	const rows: Row[] = [];
 	for (let offset = 0; ; offset += 1_000) {
@@ -205,8 +241,16 @@ function gatewayTiers(row: Row): string[] {
 }
 
 export async function fetchModelsPageCatalogue(env: Env, query: ModelsPageQuery = {}): Promise<{ models: Row[]; pricingComplete: boolean }> {
-	const databaseRows = await databasePageRows(env, query);
-	if (databaseRows) return { models: databaseRows, pricingComplete: true };
+	const [databaseRows, modelWeeklyMetrics] = await Promise.all([
+		databasePageRows(env, query),
+		weeklyMetrics(env),
+	]);
+	if (databaseRows) {
+		return {
+			models: mergeModelWeeklyMetrics(databaseRows, modelWeeklyMetrics),
+			pricingComplete: true,
+		};
+	}
 
 	const [gatewayRows, catalogueRows, regions] = await Promise.all([aggregatedRows(env), baseRows(env), providerRegions(env)]);
 	const baseById = new Map(catalogueRows.map((row) => [String(row.model_id), row]));
@@ -280,7 +324,7 @@ export async function fetchModelsPageCatalogue(env: Env, query: ModelsPageQuery 
 	});
 
 	return {
-		models: [...gatewayModels, ...catalogueOnly].sort((left, right) => Number(right.primary_timestamp ?? Number.NEGATIVE_INFINITY) - Number(left.primary_timestamp ?? Number.NEGATIVE_INFINITY) || String(left.organisation_name ?? "").localeCompare(String(right.organisation_name ?? "")) || String(left.name ?? "").localeCompare(String(right.name ?? ""))),
+		models: mergeModelWeeklyMetrics([...gatewayModels, ...catalogueOnly], modelWeeklyMetrics).sort((left, right) => Number(right.primary_timestamp ?? Number.NEGATIVE_INFINITY) - Number(left.primary_timestamp ?? Number.NEGATIVE_INFINITY) || String(left.organisation_name ?? "").localeCompare(String(right.organisation_name ?? "")) || String(left.name ?? "").localeCompare(String(right.name ?? ""))),
 		pricingComplete: false,
 	};
 }

--- a/apps/web-api/src/models/page-catalogue.ts
+++ b/apps/web-api/src/models/page-catalogue.ts
@@ -182,9 +182,16 @@ async function databasePageRows(env: Env, query: ModelsPageQuery = {}): Promise<
 }
 
 async function weeklyMetrics(env: Env): Promise<WeeklyMetricRow[]> {
-	const result = await getDataClient(env).rpc("get_v2_public_model_weekly_metrics");
-	if (result.error) throw result.error;
-	return (result.data ?? []) as WeeklyMetricRow[];
+	const rows: WeeklyMetricRow[] = [];
+	for (let offset = 0; ; offset += 1_000) {
+		const result = await getDataClient(env)
+			.rpc("get_v2_public_model_weekly_metrics")
+			.range(offset, offset + 999);
+		if (result.error) throw result.error;
+		rows.push(...((result.data ?? []) as WeeklyMetricRow[]));
+		if ((result.data?.length ?? 0) < 1_000) break;
+	}
+	return rows;
 }
 
 export function mergeModelWeeklyMetrics(rows: Row[], metrics: WeeklyMetricRow[]): Row[] {

--- a/apps/web-api/src/models/page-catalogue.ts
+++ b/apps/web-api/src/models/page-catalogue.ts
@@ -187,7 +187,13 @@ async function weeklyMetrics(env: Env): Promise<WeeklyMetricRow[]> {
 		const result = await getDataClient(env)
 			.rpc("get_v2_public_model_weekly_metrics")
 			.range(offset, offset + 999);
-		if (result.error) throw result.error;
+		if (result.error) {
+			console.error("models_weekly_metrics_failed", {
+				code: result.error.code,
+				message: result.error.message,
+			});
+			return [];
+		}
 		rows.push(...((result.data ?? []) as WeeklyMetricRow[]));
 		if ((result.data?.length ?? 0) < 1_000) break;
 	}

--- a/apps/web/src/components/(data)/models/ModelProviderTrendChart.test.ts
+++ b/apps/web/src/components/(data)/models/ModelProviderTrendChart.test.ts
@@ -1,0 +1,21 @@
+import { getSeriesEmphasis } from "./ModelProviderTrendChart";
+
+describe("getSeriesEmphasis", () => {
+	it("emphasizes the hovered series and dims every other series", () => {
+		expect(getSeriesEmphasis("p90", "p90")).toEqual({
+			isActive: true,
+			isDimmed: false,
+		});
+		expect(getSeriesEmphasis("p90", "p50")).toEqual({
+			isActive: false,
+			isDimmed: true,
+		});
+	});
+
+	it("keeps all series at their normal emphasis without a hover target", () => {
+		expect(getSeriesEmphasis(null, "provider-openai")).toEqual({
+			isActive: false,
+			isDimmed: false,
+		});
+	});
+});

--- a/apps/web/src/components/(data)/models/ModelProviderTrendChart.tsx
+++ b/apps/web/src/components/(data)/models/ModelProviderTrendChart.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo } from "react";
+import { useMemo, useState } from "react";
 import {
 	CartesianGrid,
 	Line,
@@ -23,6 +23,14 @@ type ModelProviderTrendChartProps = {
 	activeDay: string | null;
 	onActiveDayChange: (day: string | null) => void;
 };
+
+export function getSeriesEmphasis(activeSeriesKey: string | null, seriesKey: string) {
+	const isActive = activeSeriesKey === seriesKey;
+	return {
+		isActive,
+		isDimmed: activeSeriesKey != null && !isActive,
+	};
+}
 
 type MetricConfig = {
 	label: string;
@@ -86,6 +94,7 @@ export default function ModelProviderTrendChart({
 	activeDay,
 	onActiveDayChange,
 }: ModelProviderTrendChartProps) {
+	const [activeSeriesKey, setActiveSeriesKey] = useState<string | null>(null);
 	const metricConfig = METRICS[metric];
 	const observedData = data.filter(
 		(point) => point.requests > 0 && point[metricConfig.valueKey] != null,
@@ -294,35 +303,59 @@ export default function ModelProviderTrendChart({
 								strokeWidth={1}
 							/>
 						) : null}
-						{providers.map((provider) => (
+						{providers.map((provider) => {
+							const { isActive, isDimmed } = getSeriesEmphasis(
+								activeSeriesKey,
+								provider.seriesKey,
+							);
+							return (
 							<Line
 								key={provider.seriesKey}
 								type="monotone"
 								dataKey={provider.seriesKey}
 								stroke={provider.color}
-								strokeWidth={2}
+								strokeWidth={isActive ? 3.5 : 2}
+								strokeOpacity={isDimmed ? 0.18 : 1}
+								style={{ transition: "stroke-opacity 150ms, stroke-width 150ms" }}
 								strokeLinecap="round"
 								strokeLinejoin="round"
 								dot={false}
 								connectNulls
 								isAnimationActive={false}
+								onMouseEnter={() => setActiveSeriesKey(provider.seriesKey)}
+								onMouseLeave={() => setActiveSeriesKey(null)}
 							/>
-						))}
+							);
+						})}
 					</LineChart>
 				</ResponsiveContainer>
 			</div>
 			<div className="space-y-1.5 pt-1">
-				{providerRows.map((provider) => (
+				{providerRows.map((provider) => {
+					const { isActive, isDimmed } = getSeriesEmphasis(
+						activeSeriesKey,
+						provider.seriesKey,
+					);
+					return (
 					<div
 						key={provider.seriesKey}
-						className="flex items-center justify-between gap-3 text-xs"
+						className="flex items-center justify-between gap-3 rounded-sm text-xs outline-none transition-[opacity,transform] duration-150 focus-visible:ring-1 focus-visible:ring-ring"
+						style={{
+							opacity: isDimmed ? 0.35 : 1,
+							transform: isActive ? "translateX(2px)" : "translateX(0)",
+						}}
+						tabIndex={0}
+						onMouseEnter={() => setActiveSeriesKey(provider.seriesKey)}
+						onMouseLeave={() => setActiveSeriesKey(null)}
+						onFocus={() => setActiveSeriesKey(provider.seriesKey)}
+						onBlur={() => setActiveSeriesKey(null)}
 					>
 						<span className="inline-flex min-w-0 items-center gap-2">
 							<span
 								className="inline-block h-2.5 w-2.5 shrink-0 rounded-full"
 								style={{ backgroundColor: provider.color }}
 							/>
-							<span className="truncate text-foreground">{provider.name}</span>
+							<span className={isActive ? "truncate font-medium text-foreground" : "truncate text-foreground"}>{provider.name}</span>
 						</span>
 						<span className="shrink-0 tabular-nums text-foreground">
 							{isHovering ? (
@@ -335,7 +368,8 @@ export default function ModelProviderTrendChart({
 							)}
 						</span>
 					</div>
-				))}
+					);
+				})}
 			</div>
 		</div>
 	);

--- a/apps/web/src/components/(data)/models/ModelProviderTrendChart.tsx
+++ b/apps/web/src/components/(data)/models/ModelProviderTrendChart.tsx
@@ -94,7 +94,9 @@ export default function ModelProviderTrendChart({
 	activeDay,
 	onActiveDayChange,
 }: ModelProviderTrendChartProps) {
-	const [activeSeriesKey, setActiveSeriesKey] = useState<string | null>(null);
+	const [hoveredSeriesKey, setHoveredSeriesKey] = useState<string | null>(null);
+	const [focusedSeriesKey, setFocusedSeriesKey] = useState<string | null>(null);
+	const activeSeriesKey = hoveredSeriesKey ?? focusedSeriesKey;
 	const metricConfig = METRICS[metric];
 	const observedData = data.filter(
 		(point) => point.requests > 0 && point[metricConfig.valueKey] != null,
@@ -322,8 +324,8 @@ export default function ModelProviderTrendChart({
 								dot={false}
 								connectNulls
 								isAnimationActive={false}
-								onMouseEnter={() => setActiveSeriesKey(provider.seriesKey)}
-								onMouseLeave={() => setActiveSeriesKey(null)}
+								onMouseEnter={() => setHoveredSeriesKey(provider.seriesKey)}
+								onMouseLeave={() => setHoveredSeriesKey(null)}
 							/>
 							);
 						})}
@@ -345,10 +347,10 @@ export default function ModelProviderTrendChart({
 							transform: isActive ? "translateX(2px)" : "translateX(0)",
 						}}
 						tabIndex={0}
-						onMouseEnter={() => setActiveSeriesKey(provider.seriesKey)}
-						onMouseLeave={() => setActiveSeriesKey(null)}
-						onFocus={() => setActiveSeriesKey(provider.seriesKey)}
-						onBlur={() => setActiveSeriesKey(null)}
+						onMouseEnter={() => setHoveredSeriesKey(provider.seriesKey)}
+						onMouseLeave={() => setHoveredSeriesKey(null)}
+						onFocus={() => setFocusedSeriesKey(provider.seriesKey)}
+						onBlur={() => setFocusedSeriesKey(null)}
 					>
 						<span className="inline-flex min-w-0 items-center gap-2">
 							<span

--- a/apps/web/src/components/(data)/models/Models/ModelCard.tsx
+++ b/apps/web/src/components/(data)/models/Models/ModelCard.tsx
@@ -22,6 +22,7 @@ import {
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
+import { resolveWeeklyUsageDisplay } from "./weeklyUsage";
 import type { ModelCard as ModelCardType } from "@/lib/fetchers/models/getAllModels";
 import { getModelDetailsHref } from "@/lib/models/modelHref";
 import { normalizeOrganisationDisplayName } from "@/lib/models/organisationDisplay";
@@ -846,9 +847,8 @@ function ModelCardImpl({
 	};
 	const inputModalityDisplay = formatModalities(inputModalities);
 	const outputModalityDisplay = formatModalities(outputModalities);
-	const weeklyTokens = Number.isFinite(Number(model.popularity_tokens_week))
-		? Math.max(0, Number(model.popularity_tokens_week))
-		: 0;
+	const weeklyUsage = resolveWeeklyUsageDisplay(model);
+	const weeklyUsageValue = `${formatTokenCount(weeklyUsage.quantity)}${weeklyUsage.unitSuffix}`;
 
 	const copyModelId = async () => {
 		if (!apiModelId) return;
@@ -1331,12 +1331,12 @@ function ModelCardImpl({
 									size="sm"
 									variant="ghost"
 									className="hidden h-8 px-2 tabular-nums text-muted-foreground md:inline-flex"
-									aria-label="Weekly tokens"
+									aria-label={weeklyUsage.label}
 								>
-									{formatTokenCount(weeklyTokens)}
+									{weeklyUsageValue}
 								</Button>
 							</TooltipTrigger>
-							<TooltipContent side="top">Weekly tokens</TooltipContent>
+							<TooltipContent side="top">{weeklyUsage.label}</TooltipContent>
 						</Tooltip>
 
 						<Popover>
@@ -1346,9 +1346,9 @@ function ModelCardImpl({
 									size="sm"
 									variant="ghost"
 									className="h-8 px-2 tabular-nums text-muted-foreground md:hidden"
-									aria-label="Weekly tokens"
+									aria-label={weeklyUsage.label}
 								>
-									{formatTokenCount(weeklyTokens)}
+									{weeklyUsageValue}
 								</Button>
 							</PopoverTrigger>
 							<PopoverContent
@@ -1356,7 +1356,7 @@ function ModelCardImpl({
 								align="end"
 								className="w-auto px-2.5 py-1.5 text-xs"
 							>
-								Weekly tokens
+								{weeklyUsage.label}
 							</PopoverContent>
 						</Popover>
 					</div>

--- a/apps/web/src/components/(data)/models/Models/ModelsDisplay.tsx
+++ b/apps/web/src/components/(data)/models/Models/ModelsDisplay.tsx
@@ -1253,9 +1253,12 @@ function ModelsDisplayContent({
 					sortPrice: getSortPrice(model),
 					sortContext: getSortContext(model),
 					popularityWeek:
-						Number.isFinite(Number(model.popularity_tokens_week)) &&
-						Number(model.popularity_tokens_week) > 0
-							? Number(model.popularity_tokens_week)
+						Number.isFinite(Number(model.weekly_usage_quantity)) &&
+						Number(model.weekly_usage_quantity) > 0
+							? Number(model.weekly_usage_quantity)
+							: Number.isFinite(Number(model.popularity_tokens_week)) &&
+									Number(model.popularity_tokens_week) > 0
+								? Number(model.popularity_tokens_week)
 							: null,
 					throughputWeek:
 						Number.isFinite(Number(model.throughput_week)) &&

--- a/apps/web/src/components/(data)/models/Models/ModelsDisplay.tsx
+++ b/apps/web/src/components/(data)/models/Models/ModelsDisplay.tsx
@@ -1253,12 +1253,9 @@ function ModelsDisplayContent({
 					sortPrice: getSortPrice(model),
 					sortContext: getSortContext(model),
 					popularityWeek:
-						Number.isFinite(Number(model.weekly_usage_quantity)) &&
-						Number(model.weekly_usage_quantity) > 0
-							? Number(model.weekly_usage_quantity)
-							: Number.isFinite(Number(model.popularity_tokens_week)) &&
-									Number(model.popularity_tokens_week) > 0
-								? Number(model.popularity_tokens_week)
+						Number.isFinite(Number(model.popularity_tokens_week)) &&
+						Number(model.popularity_tokens_week) > 0
+							? Number(model.popularity_tokens_week)
 							: null,
 					throughputWeek:
 						Number.isFinite(Number(model.throughput_week)) &&

--- a/apps/web/src/components/(data)/models/Models/modelsDisplay.types.ts
+++ b/apps/web/src/components/(data)/models/Models/modelsDisplay.types.ts
@@ -63,6 +63,9 @@ export type ModelsPageModel = Omit<
 		| "lowest_from_price_unit"
 		| "pricing_detail_rows"
 		| "popularity_tokens_week"
+		| "weekly_usage_metric"
+		| "weekly_usage_quantity"
+		| "weekly_usage_unit"
 		| "throughput_week"
 		| "latency_week"
 	>,

--- a/apps/web/src/components/(data)/models/Models/weeklyUsage.test.ts
+++ b/apps/web/src/components/(data)/models/Models/weeklyUsage.test.ts
@@ -1,0 +1,37 @@
+import { resolveWeeklyUsageDisplay } from "./weeklyUsage";
+
+describe("resolveWeeklyUsageDisplay", () => {
+	it("shows generated video time in hours", () => {
+		expect(resolveWeeklyUsageDisplay({
+			weekly_usage_metric: "video_seconds",
+			weekly_usage_quantity: 7_200,
+		})).toEqual({
+			label: "Video hours generated",
+			quantity: 2,
+			unitSuffix: "h",
+		});
+	});
+
+	it("labels audio-input text-output models as transcription", () => {
+		expect(resolveWeeklyUsageDisplay({
+			weekly_usage_metric: "audio_seconds",
+			weekly_usage_quantity: 95,
+			gateway_input_modalities: ["audio"],
+			gateway_output_modalities: ["text"],
+		})).toMatchObject({
+			label: "Transcription seconds",
+			quantity: 95,
+			unitSuffix: "s",
+		});
+	});
+
+	it("falls back to weekly tokens for the compatibility response", () => {
+		expect(resolveWeeklyUsageDisplay({
+			popularity_tokens_week: 12_345,
+		})).toEqual({
+			label: "Weekly tokens",
+			quantity: 12_345,
+			unitSuffix: "",
+		});
+	});
+});

--- a/apps/web/src/components/(data)/models/Models/weeklyUsage.test.ts
+++ b/apps/web/src/components/(data)/models/Models/weeklyUsage.test.ts
@@ -34,4 +34,16 @@ describe("resolveWeeklyUsageDisplay", () => {
 			unitSuffix: "",
 		});
 	});
+
+	it("does not reinterpret legacy tokens as a classified media unit", () => {
+		expect(resolveWeeklyUsageDisplay({
+			weekly_usage_metric: "video_seconds",
+			weekly_usage_quantity: null,
+			popularity_tokens_week: 7_200,
+		})).toEqual({
+			label: "Video hours generated",
+			quantity: 0,
+			unitSuffix: "h",
+		});
+	});
 });

--- a/apps/web/src/components/(data)/models/Models/weeklyUsage.ts
+++ b/apps/web/src/components/(data)/models/Models/weeklyUsage.ts
@@ -1,0 +1,66 @@
+import type { ModelCard } from "@/lib/fetchers/models/getAllModels";
+
+type WeeklyUsageSource = Pick<
+	ModelCard,
+	| "gateway_input_modalities"
+	| "gateway_output_modalities"
+	| "popularity_tokens_week"
+	| "weekly_usage_metric"
+	| "weekly_usage_quantity"
+>;
+
+export type WeeklyUsageDisplay = {
+	label: string;
+	quantity: number;
+	unitSuffix: string;
+};
+
+function finiteQuantity(value: unknown): number | null {
+	const quantity = Number(value);
+	return Number.isFinite(quantity) && quantity >= 0 ? quantity : null;
+}
+
+export function resolveWeeklyUsageDisplay(model: WeeklyUsageSource): WeeklyUsageDisplay {
+	const metric = String(model.weekly_usage_metric ?? "").trim().toLowerCase();
+	const quantity = finiteQuantity(model.weekly_usage_quantity)
+		?? finiteQuantity(model.popularity_tokens_week)
+		?? 0;
+
+	if (metric === "video_seconds") {
+		return {
+			label: "Video hours generated",
+			quantity: quantity / 3_600,
+			unitSuffix: "h",
+		};
+	}
+
+	if (metric === "audio_seconds") {
+		const hasAudioInput = (model.gateway_input_modalities ?? []).some((value) =>
+			String(value).toLowerCase().includes("audio"),
+		);
+		const hasTextOutput = (model.gateway_output_modalities ?? []).some((value) =>
+			String(value).toLowerCase().includes("text"),
+		);
+		return {
+			label: hasAudioInput && hasTextOutput
+				? "Transcription seconds"
+				: "Audio seconds",
+			quantity,
+			unitSuffix: "s",
+		};
+	}
+
+	if (metric === "images") {
+		return { label: "Images generated", quantity, unitSuffix: "" };
+	}
+
+	if (metric === "characters") {
+		return { label: "Characters processed", quantity, unitSuffix: "" };
+	}
+
+	if (metric === "requests") {
+		return { label: "Weekly requests", quantity, unitSuffix: "" };
+	}
+
+	return { label: "Weekly tokens", quantity, unitSuffix: "" };
+}

--- a/apps/web/src/components/(data)/models/Models/weeklyUsage.ts
+++ b/apps/web/src/components/(data)/models/Models/weeklyUsage.ts
@@ -16,15 +16,22 @@ export type WeeklyUsageDisplay = {
 };
 
 function finiteQuantity(value: unknown): number | null {
+	if (
+		value === null
+		|| value === undefined
+		|| (typeof value === "string" && !value.trim())
+	) {
+		return null;
+	}
 	const quantity = Number(value);
 	return Number.isFinite(quantity) && quantity >= 0 ? quantity : null;
 }
 
 export function resolveWeeklyUsageDisplay(model: WeeklyUsageSource): WeeklyUsageDisplay {
 	const metric = String(model.weekly_usage_metric ?? "").trim().toLowerCase();
-	const quantity = finiteQuantity(model.weekly_usage_quantity)
-		?? finiteQuantity(model.popularity_tokens_week)
-		?? 0;
+	const weeklyQuantity = finiteQuantity(model.weekly_usage_quantity);
+	const legacyTokenQuantity = finiteQuantity(model.popularity_tokens_week);
+	const quantity = metric ? (weeklyQuantity ?? 0) : (legacyTokenQuantity ?? 0);
 
 	if (metric === "video_seconds") {
 		return {

--- a/apps/web/src/lib/fetchers/models/getAllModels.ts
+++ b/apps/web/src/lib/fetchers/models/getAllModels.ts
@@ -63,6 +63,9 @@ export interface ModelCard {
         value: string;
     }>;
     popularity_tokens_week?: number | null;
+    weekly_usage_metric?: string | null;
+    weekly_usage_quantity?: number | null;
+    weekly_usage_unit?: string | null;
     throughput_week?: number | null;
     latency_week?: number | null;
     model_page_notice?: ModelPageNotice | null;

--- a/supabase/migrations/20260723123000_v2_public_model_weekly_metrics.sql
+++ b/supabase/migrations/20260723123000_v2_public_model_weekly_metrics.sql
@@ -1,0 +1,138 @@
+-- Restore the seven-day usage and performance fields consumed by /models.
+-- The optimized catalogue RPC intentionally stopped scanning raw requests, but
+-- left these fields null. Read the compact v2 daily rollups instead.
+
+create or replace function public.get_v2_public_model_weekly_metrics()
+returns table (
+  model_slug text,
+  popularity_tokens_week numeric,
+  weekly_usage_metric text,
+  weekly_usage_quantity numeric,
+  weekly_usage_unit text,
+  throughput_week numeric,
+  latency_week numeric
+)
+language sql
+stable
+security invoker
+set search_path = public
+as $$
+  with recent_rollups as materialized (
+    select
+      rollup.rollup_id,
+      rollup.model_slug,
+      rollup.requests,
+      rollup.latency_sum_ms,
+      rollup.latency_count,
+      rollup.throughput_sum,
+      rollup.throughput_count
+    from public.v2_public_usage_daily rollup
+    where rollup.usage_date >= current_date - 6
+      and rollup.usage_date <= current_date
+  ),
+  meter_totals as (
+    select
+      rollup.model_slug,
+      sum(meter.quantity) filter (
+        where meter.meter_key in ('input_tokens', 'output_tokens')
+          and meter.unit in ('token', 'tokens')
+      ) as total_tokens,
+      sum(meter.quantity) filter (
+        where meter.meter_key in ('output_images', 'output_image')
+          and meter.unit in ('image', 'images')
+      ) as output_images,
+      sum(meter.quantity) filter (
+        where meter.meter_key in ('output_video_seconds', 'video_seconds')
+          and meter.unit in ('second', 'seconds')
+      ) as video_seconds,
+      sum(meter.quantity) filter (
+        where meter.meter_key in ('audio_seconds', 'input_audio_seconds', 'output_audio_seconds')
+          and meter.unit in ('second', 'seconds')
+      ) as audio_seconds,
+      sum(meter.quantity) filter (
+        where meter.meter_key in ('input_characters', 'output_characters', 'total_characters')
+          and meter.unit in ('character', 'characters')
+      ) as characters
+    from public.v2_public_usage_daily_meters meter
+    join recent_rollups rollup on rollup.rollup_id = meter.rollup_id
+    group by rollup.model_slug
+  ),
+  model_totals as (
+    select
+      rollup.model_slug,
+      sum(rollup.requests)::numeric as requests,
+      sum(rollup.latency_sum_ms)::numeric as latency_sum_ms,
+      sum(rollup.latency_count)::numeric as latency_count,
+      sum(rollup.throughput_sum)::numeric as throughput_sum,
+      sum(rollup.throughput_count)::numeric as throughput_count,
+      coalesce(meter.total_tokens, 0)::numeric as total_tokens,
+      coalesce(meter.output_images, 0)::numeric as output_images,
+      coalesce(meter.video_seconds, 0)::numeric as video_seconds,
+      coalesce(meter.audio_seconds, 0)::numeric as audio_seconds,
+      coalesce(meter.characters, 0)::numeric as characters
+    from recent_rollups rollup
+    left join meter_totals meter on meter.model_slug = rollup.model_slug
+    group by
+      rollup.model_slug,
+      meter.total_tokens,
+      meter.output_images,
+      meter.video_seconds,
+      meter.audio_seconds,
+      meter.characters
+  ),
+  classified as (
+    select
+      totals.*,
+      lower(coalesce(model.metadata->>'model_type', '')) as model_type,
+      array_to_string(model.input_modalities, ',') as input_modalities,
+      array_to_string(model.output_modalities, ',') as output_modalities
+    from model_totals totals
+    join public.v2_models model on model.model_slug = totals.model_slug
+  )
+  select
+    totals.model_slug,
+    totals.total_tokens as popularity_tokens_week,
+    case
+      when (totals.model_type = 'video' or totals.output_modalities ~ 'video') and totals.video_seconds > 0 then 'video_seconds'
+      when (totals.model_type = 'image' or totals.output_modalities ~ 'image') and totals.output_images > 0 then 'images'
+      when (totals.input_modalities ~ 'audio' or totals.output_modalities ~ 'audio') and totals.audio_seconds > 0 then 'audio_seconds'
+      when totals.model_type in ('embedding', 'rerank', 'moderation') then 'requests'
+      when totals.total_tokens > 0 then 'tokens'
+      when totals.characters > 0 then 'characters'
+      else 'requests'
+    end as weekly_usage_metric,
+    case
+      when (totals.model_type = 'video' or totals.output_modalities ~ 'video') and totals.video_seconds > 0 then totals.video_seconds
+      when (totals.model_type = 'image' or totals.output_modalities ~ 'image') and totals.output_images > 0 then totals.output_images
+      when (totals.input_modalities ~ 'audio' or totals.output_modalities ~ 'audio') and totals.audio_seconds > 0 then totals.audio_seconds
+      when totals.model_type in ('embedding', 'rerank', 'moderation') then totals.requests
+      when totals.total_tokens > 0 then totals.total_tokens
+      when totals.characters > 0 then totals.characters
+      else totals.requests
+    end as weekly_usage_quantity,
+    case
+      when (totals.model_type = 'video' or totals.output_modalities ~ 'video') and totals.video_seconds > 0 then 'seconds'
+      when (totals.model_type = 'image' or totals.output_modalities ~ 'image') and totals.output_images > 0 then 'images'
+      when (totals.input_modalities ~ 'audio' or totals.output_modalities ~ 'audio') and totals.audio_seconds > 0 then 'seconds'
+      when totals.model_type in ('embedding', 'rerank', 'moderation') then 'requests'
+      when totals.total_tokens > 0 then 'tokens'
+      when totals.characters > 0 then 'characters'
+      else 'requests'
+    end as weekly_usage_unit,
+    round(
+      totals.throughput_sum / nullif(totals.throughput_count, 0),
+      2
+    ) as throughput_week,
+    round(
+      totals.latency_sum_ms / nullif(totals.latency_count, 0),
+      2
+    ) as latency_week
+  from classified totals
+  order by weekly_usage_quantity desc, totals.model_slug;
+$$;
+
+grant execute on function public.get_v2_public_model_weekly_metrics()
+  to anon, authenticated, service_role;
+
+comment on function public.get_v2_public_model_weekly_metrics() is
+  'Returns seven-day primary usage, token totals, and sample-weighted performance from v2 public daily rollups.';

--- a/supabase/migrations/20260723123100_v2_recent_non_text_usage_backfill.sql
+++ b/supabase/migrations/20260723123100_v2_recent_non_text_usage_backfill.sql
@@ -1,0 +1,71 @@
+-- Complete the v2 usage-meter backfill for the recent window used by /models.
+-- The original compatibility backfill projected token meters only, despite
+-- normalized non-text usage already existing on gateway_requests.
+
+insert into public.v2_request_usage (
+  request_event_id,
+  meter_key,
+  modality,
+  unit,
+  quantity,
+  source,
+  billable
+)
+select
+  fact.request_event_id,
+  meter.meter_key,
+  meter.modality,
+  meter.unit,
+  meter.quantity,
+  'legacy_gateway_usage',
+  true
+from public.gateway_requests request
+join public.v2_request_facts fact
+  on fact.workspace_id = request.workspace_id
+  and fact.request_id = request.request_id
+cross join lateral (
+  values
+    ('output_images', 'image', 'images', greatest(coalesce(request.usage_image_outputs, 0), 0)::numeric),
+    ('audio_seconds', 'audio', 'seconds', greatest(coalesce(request.usage_audio_seconds, 0), 0)::numeric),
+    ('output_video_seconds', 'video', 'seconds', greatest(coalesce(request.usage_video_seconds, 0), 0)::numeric),
+    ('input_characters', 'text', 'characters', greatest(coalesce(request.usage_input_characters, 0), 0)::numeric),
+    ('output_characters', 'text', 'characters', greatest(coalesce(request.usage_output_characters, 0), 0)::numeric)
+) as meter(meter_key, modality, unit, quantity)
+where fact.occurred_at >= current_date - 6
+  and fact.occurred_at < current_date + 1
+  and meter.quantity > 0
+on conflict (request_event_id, meter_key, sequence) do update set
+  modality = excluded.modality,
+  unit = excluded.unit,
+  quantity = excluded.quantity,
+  source = excluded.source,
+  billable = excluded.billable;
+
+insert into public.v2_analytics_outbox (
+  request_event_id,
+  workspace_id,
+  occurred_at,
+  status,
+  attempt_count,
+  available_at,
+  last_error,
+  updated_at
+)
+select
+  fact.request_event_id,
+  fact.workspace_id,
+  fact.occurred_at,
+  'pending',
+  0,
+  now(),
+  null,
+  now()
+from public.v2_request_facts fact
+where fact.occurred_at >= current_date - 6
+  and fact.occurred_at < current_date + 1
+on conflict (request_event_id) do update set
+  status = 'pending',
+  attempt_count = 0,
+  available_at = now(),
+  last_error = null,
+  updated_at = now();

--- a/supabase/migrations/20260723123100_v2_recent_non_text_usage_backfill.sql
+++ b/supabase/migrations/20260723123100_v2_recent_non_text_usage_backfill.sql
@@ -9,7 +9,8 @@ insert into public.v2_request_usage (
   unit,
   quantity,
   source,
-  billable
+  billable,
+  sequence
 )
 select
   fact.request_event_id,
@@ -18,22 +19,29 @@ select
   meter.unit,
   meter.quantity,
   'legacy_gateway_usage',
-  true
+  true,
+  meter.sequence
 from public.gateway_requests request
 join public.v2_request_facts fact
   on fact.workspace_id = request.workspace_id
   and fact.request_id = request.request_id
 cross join lateral (
   values
-    ('output_images', 'image', 'images', greatest(coalesce(request.usage_image_outputs, 0), 0)::numeric),
-    ('audio_seconds', 'audio', 'seconds', greatest(coalesce(request.usage_audio_seconds, 0), 0)::numeric),
-    ('output_video_seconds', 'video', 'seconds', greatest(coalesce(request.usage_video_seconds, 0), 0)::numeric),
-    ('input_characters', 'text', 'characters', greatest(coalesce(request.usage_input_characters, 0), 0)::numeric),
-    ('output_characters', 'text', 'characters', greatest(coalesce(request.usage_output_characters, 0), 0)::numeric)
-) as meter(meter_key, modality, unit, quantity)
+    ('output_images', 'image', 'images', greatest(coalesce(request.usage_image_outputs, 0), 0)::numeric, 12),
+    ('audio_seconds', 'audio', 'seconds', greatest(coalesce(request.usage_audio_seconds, 0), 0)::numeric, 30),
+    ('output_video_seconds', 'video', 'seconds', greatest(coalesce(request.usage_video_seconds, 0), 0)::numeric, 31),
+    ('input_characters', 'text', 'characters', greatest(coalesce(request.usage_input_characters, 0), 0)::numeric, 33),
+    ('output_characters', 'text', 'characters', greatest(coalesce(request.usage_output_characters, 0), 0)::numeric, 34)
+) as meter(meter_key, modality, unit, quantity, sequence)
 where fact.occurred_at >= current_date - 6
   and fact.occurred_at < current_date + 1
   and meter.quantity > 0
+  and not exists (
+    select 1
+    from public.v2_request_usage existing
+    where existing.request_event_id = fact.request_event_id
+      and existing.meter_key = meter.meter_key
+  )
 on conflict (request_event_id, meter_key, sequence) do update set
   modality = excluded.modality,
   unit = excluded.unit,

--- a/supabase/migrations/20260723123200_v2_public_model_primary_usage_classification.sql
+++ b/supabase/migrations/20260723123200_v2_public_model_primary_usage_classification.sql
@@ -1,0 +1,72 @@
+-- Keep character counts from becoming the public primary metric for ordinary
+-- text models. They are useful for character-priced audio workflows, while a
+-- request count is the honest fallback when a text provider omits token usage.
+
+alter function public.get_v2_public_model_weekly_metrics()
+  rename to get_v2_public_model_weekly_metrics_base;
+
+create or replace function public.get_v2_public_model_weekly_metrics()
+returns table (
+  model_slug text,
+  popularity_tokens_week numeric,
+  weekly_usage_metric text,
+  weekly_usage_quantity numeric,
+  weekly_usage_unit text,
+  throughput_week numeric,
+  latency_week numeric
+)
+language sql
+stable
+security definer
+set search_path = ''
+as $$
+  with request_totals as (
+    select
+      rollup.model_slug,
+      sum(rollup.requests)::numeric as requests
+    from public.v2_public_usage_daily rollup
+    where rollup.usage_date >= current_date - 6
+      and rollup.usage_date <= current_date
+    group by rollup.model_slug
+  )
+  select
+    metric.model_slug,
+    metric.popularity_tokens_week,
+    case
+      when metric.weekly_usage_metric = 'characters'
+        and lower(coalesce(model.metadata->>'model_type', '')) <> 'audio'
+        and array_to_string(model.output_modalities, ',') !~ 'audio'
+        then 'requests'
+      else metric.weekly_usage_metric
+    end as weekly_usage_metric,
+    case
+      when metric.weekly_usage_metric = 'characters'
+        and lower(coalesce(model.metadata->>'model_type', '')) <> 'audio'
+        and array_to_string(model.output_modalities, ',') !~ 'audio'
+        then coalesce(requests.requests, 0)
+      else metric.weekly_usage_quantity
+    end as weekly_usage_quantity,
+    case
+      when metric.weekly_usage_metric = 'characters'
+        and lower(coalesce(model.metadata->>'model_type', '')) <> 'audio'
+        and array_to_string(model.output_modalities, ',') !~ 'audio'
+        then 'requests'
+      else metric.weekly_usage_unit
+    end as weekly_usage_unit,
+    metric.throughput_week,
+    metric.latency_week
+  from public.get_v2_public_model_weekly_metrics_base() metric
+  join public.v2_models model on model.model_slug = metric.model_slug
+  left join request_totals requests on requests.model_slug = metric.model_slug
+  order by weekly_usage_quantity desc, metric.model_slug;
+$$;
+
+revoke all on function public.get_v2_public_model_weekly_metrics_base()
+  from public, anon, authenticated;
+grant execute on function public.get_v2_public_model_weekly_metrics_base()
+  to service_role;
+grant execute on function public.get_v2_public_model_weekly_metrics()
+  to anon, authenticated, service_role;
+
+comment on function public.get_v2_public_model_weekly_metrics() is
+  'Returns model-appropriate seven-day primary usage plus token and sample-weighted performance metrics.';

--- a/supabase/migrations/20260723123300_v2_recent_usage_meter_sequence_repair.sql
+++ b/supabase/migrations/20260723123300_v2_recent_usage_meter_sequence_repair.sql
@@ -1,0 +1,64 @@
+-- Repair rows written by the first recent non-text backfill, which used the
+-- default sequence 0 rather than the gateway meter-definition sequence.
+
+delete from public.v2_request_usage legacy
+using public.v2_request_usage canonical
+where legacy.request_event_id = canonical.request_event_id
+  and legacy.meter_key = canonical.meter_key
+  and legacy.sequence = 0
+  and legacy.source = 'legacy_gateway_usage'
+  and canonical.source <> 'legacy_gateway_usage'
+  and legacy.meter_key in (
+    'output_images',
+    'audio_seconds',
+    'output_video_seconds',
+    'input_characters',
+    'output_characters'
+  );
+
+update public.v2_request_usage usage
+set sequence = case usage.meter_key
+  when 'output_images' then 12
+  when 'audio_seconds' then 30
+  when 'output_video_seconds' then 31
+  when 'input_characters' then 33
+  when 'output_characters' then 34
+end
+where usage.sequence = 0
+  and usage.source = 'legacy_gateway_usage'
+  and usage.meter_key in (
+    'output_images',
+    'audio_seconds',
+    'output_video_seconds',
+    'input_characters',
+    'output_characters'
+  );
+
+insert into public.v2_analytics_outbox (
+  request_event_id,
+  workspace_id,
+  occurred_at,
+  status,
+  attempt_count,
+  available_at,
+  last_error,
+  updated_at
+)
+select
+  fact.request_event_id,
+  fact.workspace_id,
+  fact.occurred_at,
+  'pending',
+  0,
+  now(),
+  null,
+  now()
+from public.v2_request_facts fact
+where fact.occurred_at >= current_date - 6
+  and fact.occurred_at < current_date + 1
+on conflict (request_event_id) do update set
+  status = 'pending',
+  attempt_count = 0,
+  available_at = now(),
+  last_error = null,
+  updated_at = now();

--- a/supabase/migrations/20260723123400_v2_recent_usage_meter_deduplicate.sql
+++ b/supabase/migrations/20260723123400_v2_recent_usage_meter_deduplicate.sql
@@ -1,0 +1,45 @@
+-- Remove any legacy compatibility meter when an atomic gateway meter already
+-- exists for the same request and dimension, regardless of sequence version.
+
+delete from public.v2_request_usage legacy
+using public.v2_request_usage canonical
+where legacy.request_event_id = canonical.request_event_id
+  and legacy.meter_key = canonical.meter_key
+  and legacy.source = 'legacy_gateway_usage'
+  and canonical.source <> 'legacy_gateway_usage'
+  and legacy.meter_key in (
+    'output_images',
+    'audio_seconds',
+    'output_video_seconds',
+    'input_characters',
+    'output_characters'
+  );
+
+insert into public.v2_analytics_outbox (
+  request_event_id,
+  workspace_id,
+  occurred_at,
+  status,
+  attempt_count,
+  available_at,
+  last_error,
+  updated_at
+)
+select
+  fact.request_event_id,
+  fact.workspace_id,
+  fact.occurred_at,
+  'pending',
+  0,
+  now(),
+  null,
+  now()
+from public.v2_request_facts fact
+where fact.occurred_at >= current_date - 6
+  and fact.occurred_at < current_date + 1
+on conflict (request_event_id) do update set
+  status = 'pending',
+  attempt_count = 0,
+  available_at = now(),
+  last_error = null,
+  updated_at = now();


### PR DESCRIPTION
## Summary

- make percentile/provider trend series visually emphasize on hover and keyboard focus while fading other lines
- restore `/models` rolling seven-day usage from the compact v2 daily rollups
- select a model-appropriate weekly metric: tokens for text, generated video hours, transcription/audio seconds, generated images, character usage where appropriate, and requests as the fallback
- persist generated video seconds into v2 request usage meters and backfill recent non-text usage

## Root cause

The optimized v2 catalogue RPC deliberately returned `popularity_tokens_week`, `throughput_week`, and `latency_week` as null. The Web API passed those placeholders through, so all model cards rendered zero despite populated daily rollups. The initial v2 compatibility backfill also projected only token meters, leaving normalized image/audio/video/character usage out of the new rollups.

## Validation

- `pnpm --filter @phaseo/web-api test -- src/models/page-catalogue.test.ts`
- `pnpm --filter @phaseo/web-api typecheck`
- `pnpm --filter @phaseo/web-api build`
- `pnpm --filter @phaseo/gateway-api test -- src/pipeline/usage-columns.test.ts`
- `pnpm --filter @phaseo/gateway-api typecheck`
- `pnpm --filter @phaseo/gateway-api build`
- targeted web Jest tests: 2 suites, 5 tests passed
- targeted web ESLint: no errors (3 pre-existing warnings)
- linked Supabase migrations applied and synchronized
- public weekly-metrics RPC smoke-tested with nonzero token and request-fallback results

## Notes

The full web typecheck still reports the existing unrelated `LayoutProps` and `authOrigin.test.ts` errors on main.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added weekly model usage, performance, throughput, and latency metrics to the model catalogue.
  - Weekly usage now supports tokens, images, characters, requests, audio, and video, with clearer units such as hours and transcription seconds.
  - Added interactive chart highlighting for provider series, including keyboard focus support.
  - Added accurate tracking and reporting of video usage in seconds.

- **Bug Fixes**
  - Improved weekly usage fallbacks for models with incomplete compatibility data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->