### PR TITLE
Fix Cloudflare catalogue endpoints

### DIFF
--- a/apps/web-api/src/routes/public/gateway.test.ts
+++ b/apps/web-api/src/routes/public/gateway.test.ts
@@ -16,4 +16,37 @@ describe("public gateway catalogue", () => {
 		expect(response.headers.get("cloudflare-cdn-cache-control")).toBe("public, max-age=300, stale-while-revalidate=300");
 		await expect(response.json()).resolves.toMatchObject({ models: [{ modelId: "gpt-test", internalModelId: "openai/gpt-test", providerId: "openai", capabilities: ["responses"], isAvailable: true }] });
 	});
+
+	it("chunks model metadata lookups to keep Supabase URLs bounded", async () => {
+		const providerModels = Array.from({ length: 201 }, (_, index) => ({
+			provider_api_model_id: `pm-${index}`,
+			provider_id: "openai",
+			api_model_id: `gpt-test-${index}`,
+			model_id: `openai/gpt-test-${index}`,
+			is_active_gateway: true,
+		}));
+		const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+			const url = String(input);
+			if (url.includes("data_api_provider_model_capabilities")) {
+				return new Response(JSON.stringify(providerModels.map((row) => ({
+					provider_api_model_id: row.provider_api_model_id,
+					capability_id: "responses",
+					status: "active",
+				}))), { status: 200 });
+			}
+			if (url.includes("data_api_provider_models")) {
+				return new Response(JSON.stringify(providerModels), { status: 200 });
+			}
+			if (url.includes("data_api_providers")) {
+				return new Response(JSON.stringify([{ api_provider_id: "openai", api_provider_name: "OpenAI" }]), { status: 200 });
+			}
+			return new Response(JSON.stringify([]), { status: 200 });
+		});
+		vi.stubGlobal("fetch", fetchMock);
+
+		const response = await app.request("https://phaseo.app/api/_web/gateway/models", {}, env);
+		expect(response.status).toBe(200);
+		const modelRequests = fetchMock.mock.calls.filter(([input]) => String(input).includes("data_models"));
+		expect(modelRequests).toHaveLength(2);
+	});
 });

--- a/apps/web-api/src/routes/public/gateway.ts
+++ b/apps/web-api/src/routes/public/gateway.ts
@@ -12,12 +12,25 @@ async function gatewayModels(env: Env) {
 	const providerModelIds = providerModels.map((row) => String(row.provider_api_model_id ?? "")).filter(Boolean); const capabilities = new Map<string, Set<string>>(); const capabilityParams = new Map<string, Record<string, unknown>>();
 	for (let offset = 0; offset < providerModelIds.length; offset += 200) { const result = await client.from("data_api_provider_model_capabilities").select("provider_api_model_id,capability_id,capability_params,status").in("provider_api_model_id", providerModelIds.slice(offset, offset + 200)); if (result.error) throw result.error; for (const row of result.data ?? []) { if (!row.provider_api_model_id || !row.capability_id || ["disabled", "internal_testing"].includes(String(row.status ?? "").toLowerCase())) continue; const values = capabilities.get(row.provider_api_model_id) ?? new Set<string>(); values.add(row.capability_id); capabilities.set(row.provider_api_model_id, values); const params = capabilityParams.get(row.provider_api_model_id) ?? {}; params[String(row.capability_id)] = row.capability_params && typeof row.capability_params === "object" ? row.capability_params : {}; capabilityParams.set(row.provider_api_model_id, params); } }
 	const providerIds = [...new Set(providerModels.map((row) => String(row.provider_id ?? "")).filter(Boolean))]; const modelIds = [...new Set(providerModels.map((row) => String(row.model_id ?? "")).filter(Boolean))];
-	const [providersResult, modelsResult] = await Promise.all([
-		providerIds.length ? client.from("data_api_providers").select("api_provider_id,api_provider_name,provider_family_id,offer_label,offer_scope,prompt_training_policy").in("api_provider_id", providerIds) : Promise.resolve({ data: [], error: null }),
-		modelIds.length ? client.from("data_models").select("model_id,name,status,organisation_id,previous_model_id,release_date,announcement_date,organisation:data_organisations!data_models_organisation_id_fkey(name)").in("model_id", modelIds).eq("hidden", false) : Promise.resolve({ data: [], error: null }),
-	]);
-	if (providersResult.error) throw providersResult.error; if (modelsResult.error) throw modelsResult.error;
-	const providers = new Map((providersResult.data ?? []).map((row) => [row.api_provider_id, row])); const models = new Map((modelsResult.data ?? []).map((row) => [row.model_id, row])); const now = Date.now(); const seen = new Set<string>(); const output: Array<Record<string, unknown>> = [];
+	const idChunkSize = 200;
+	const providerResults = await Promise.all(
+		Array.from({ length: Math.ceil(providerIds.length / idChunkSize) }, (_, index) =>
+			client.from("data_api_providers")
+				.select("api_provider_id,api_provider_name,provider_family_id,offer_label,offer_scope,prompt_training_policy")
+				.in("api_provider_id", providerIds.slice(index * idChunkSize, (index + 1) * idChunkSize))),
+	);
+	const modelResults = await Promise.all(
+		Array.from({ length: Math.ceil(modelIds.length / idChunkSize) }, (_, index) =>
+			client.from("data_models")
+				.select("model_id,name,status,organisation_id,previous_model_id,release_date,announcement_date,organisation:data_organisations!data_models_organisation_id_fkey(name)")
+				.in("model_id", modelIds.slice(index * idChunkSize, (index + 1) * idChunkSize))
+				.eq("hidden", false)),
+	);
+	for (const result of [...providerResults, ...modelResults]) {
+		if (result.error) throw result.error;
+	}
+	const providers = new Map(providerResults.flatMap((result) => result.data ?? []).map((row) => [row.api_provider_id, row]));
+	const models = new Map(modelResults.flatMap((result) => result.data ?? []).map((row) => [row.model_id, row])); const now = Date.now(); const seen = new Set<string>(); const output: Array<Record<string, unknown>> = [];
 	for (const row of providerModels) { const providerModelId = String(row.provider_api_model_id ?? ""); const apiModelId = String(row.api_model_id ?? ""); const providerId = String(row.provider_id ?? ""); if (!providerModelId || !apiModelId || !providerId || !capabilities.has(providerModelId)) continue; const key = `${providerId}:${apiModelId}`; if (seen.has(key)) continue; seen.add(key); const model = models.get(String(row.model_id ?? "")); const provider = providers.get(providerId); const organisation = Array.isArray(model?.organisation) ? model.organisation[0] : model?.organisation; const from = row.effective_from ? Date.parse(String(row.effective_from)) : Number.NEGATIVE_INFINITY; const to = row.effective_to ? Date.parse(String(row.effective_to)) : Number.POSITIVE_INFINITY; const isAvailable = Boolean(row.is_active_gateway) && now >= from && now < to && !["deprecated", "retired"].includes(String(model?.status ?? "").toLowerCase()); const internalModelId = model?.model_id ?? null; const selectorModelId = apiModelId.endsWith(":free") && internalModelId && !String(internalModelId).endsWith(":free") ? `${internalModelId}:free` : internalModelId || apiModelId; output.push({ modelId: apiModelId, internalModelId, selectorModelId, providerId, capabilities: [...(capabilities.get(providerModelId) ?? [])], capabilityParamsById: capabilityParams.get(providerModelId) ?? {}, effectiveFrom: row.effective_from ?? null, effectiveTo: row.effective_to ?? null, providerName: provider?.api_provider_name ?? null, providerFamilyId: provider?.provider_family_id ?? null, providerOfferLabel: provider?.offer_label ?? null, providerOfferScope: provider?.offer_scope ?? null, providerPromptTrainingPolicy: provider?.prompt_training_policy ?? null, modelName: model?.name ?? null, modelStatus: model?.status ?? null, organisationId: model?.organisation_id ?? null, organisationName: organisation?.name ?? null, previousModelId: model?.previous_model_id ?? null, releaseDate: model?.release_date ?? null, announcementDate: model?.announcement_date ?? null, isAvailable }); }
 	return output.sort((a, b) => String(a.providerId).localeCompare(String(b.providerId)) || String(a.modelId).localeCompare(String(b.modelId)));
 }

--- a/apps/web-api/src/routes/public/models.test.ts
+++ b/apps/web-api/src/routes/public/models.test.ts
@@ -116,9 +116,9 @@ describe("public model routes", () => {
 			return new Response(
 				JSON.stringify([
 					{
-						model_id: "openai/gpt-test",
-						full_name: "GPT Test",
-						organisation_id: "openai",
+						model_slug: "openai/gpt-test",
+						name: "GPT Test",
+						lab_slug: "openai",
 					},
 				]),
 				{ status: 200, headers: { "content-range": "0-0/1" } },
@@ -137,7 +137,7 @@ describe("public model routes", () => {
 			total: 1,
 		});
 		expect(v2.headers.get("cache-tag")).toBe("web-api-models,web-api-models-v2");
-		expect(fetchMock.mock.calls.some(([input]) => String(input).includes("data_models_v2"))).toBe(true);
+		expect(fetchMock.mock.calls.some(([input]) => String(input).includes("v2_models"))).toBe(true);
 		expect(invalid.status).toBe(400);
 	});
 

--- a/apps/web-api/src/routes/public/models.test.ts
+++ b/apps/web-api/src/routes/public/models.test.ts
@@ -138,6 +138,7 @@ describe("public model routes", () => {
 		});
 		expect(v2.headers.get("cache-tag")).toBe("web-api-models,web-api-models-v2");
 		expect(fetchMock.mock.calls.some(([input]) => String(input).includes("v2_models"))).toBe(true);
+		expect(fetchMock.mock.calls.some(([input]) => String(input).includes("status=neq.disabled"))).toBe(true);
 		expect(invalid.status).toBe(400);
 	});
 

--- a/apps/web-api/src/routes/public/models.ts
+++ b/apps/web-api/src/routes/public/models.ts
@@ -534,6 +534,9 @@ publicModelsRouter.get("/", async (c) => {
 				.order("name", {
 					ascending: true,
 				});
+			if (catalogueVersion === "v2") {
+				query = query.neq("status", "disabled");
+			}
 			if (search) {
 				query = query.ilike(
 					"name",

--- a/apps/web-api/src/routes/public/models.ts
+++ b/apps/web-api/src/routes/public/models.ts
@@ -522,21 +522,21 @@ publicModelsRouter.get("/", async (c) => {
 			c.env,
 			catalogueVersion,
 		);
-		const table = catalogueVersion === "v2" ? "data_models_v2" : "data_models";
+		const table = catalogueVersion === "v2" ? "v2_models" : "data_models";
 		const select = catalogueVersion === "v2"
-			? "model_id,full_name,organisation_id,description,status,release_date,announcement_date,updated_at,input_modalities,output_modalities,organisation:data_organisations!data_models_v2_organisation_id_fkey(name,colour)"
+			? "model_slug,lab_slug,name,description,status,released_at,announced_at,updated_at,input_modalities,output_modalities,organisation:v2_labs!v2_models_lab_slug_fkey(name,metadata)"
 			: "model_id,name,organisation_id,description,status,release_date,announcement_date,updated_at,input_types,output_types,organisation:data_organisations(name,colour)";
 		const createQuery = () => {
 			let query = getDataClient(c.env)
 				.from(table)
 				.select(select, { count: "exact" })
 				.eq("hidden", false)
-				.order(catalogueVersion === "v2" ? "full_name" : "name", {
+				.order("name", {
 					ascending: true,
 				});
 			if (search) {
 				query = query.ilike(
-					catalogueVersion === "v2" ? "full_name" : "name",
+					"name",
 					`%${search.replace(/[\\%_]/g, "\\$&")}%`,
 				);
 			}
@@ -564,13 +564,24 @@ publicModelsRouter.get("/", async (c) => {
 			...model,
 			...(catalogueVersion === "v2"
 				? {
-					name: model.full_name,
+					model_id: model.model_slug,
+					full_name: model.name,
+					organisation_id: model.lab_slug,
+					status: v2ModelStatus(model.status),
+					release_date: model.released_at,
+					announcement_date: model.announced_at,
 					input_types: model.input_modalities,
 					output_types: model.output_modalities,
+					organisation: model.organisation && typeof model.organisation === "object"
+						? {
+							name: (model.organisation as Record<string, unknown>).name,
+							colour: ((model.organisation as Record<string, unknown>).metadata as Record<string, unknown> | null)?.colour ?? null,
+						}
+						: null,
 				}
 				: {}),
 			gateway_monitor_rows:
-				gatewayRowsByModelId.get(String(model.model_id ?? "")) ?? [],
+				gatewayRowsByModelId.get(String(model.model_slug ?? model.model_id ?? "")) ?? [],
 		}));
 		const response = withPublicCache(
 			c.json({ models, total: count, limit, offset, catalogue_version: catalogueVersion }),


### PR DESCRIPTION
## Summary

- restore the explicit V2 catalogue endpoint against canonical `v2_models` and `v2_labs`
- exclude disabled V2 rows explicitly because the Worker uses service-role reads
- chunk gateway model/provider metadata lookups so large catalogues do not exceed Supabase/PostgREST URL limits
- preserve the legacy V2 response contract during deployment and profile drift

## Root causes

Production exposed a stale admin Feature Preview toggle. Enabling it requested `catalogue_version=v2`, but the Worker queried the removed `data_models_v2` table and returned `503 {error:models_unavailable}`.

Separately, `/api/_web/gateway/models` sent every model ID in one `.in(...)` request. The expanded catalogue made that URL too large, returning `503 {error:gateway_models_unavailable}` and breaking Chat model discovery.

## Validation

- `pnpm --filter @phaseo/web-api test -- src/routes/public/gateway.test.ts src/routes/public/models.test.ts` (18 tests passed)
- `pnpm --filter @phaseo/web-api typecheck`
- targeted ESLint (0 errors; existing models route file-length warning only)
- reproduced both production 503 responses directly

Created with Codex