### PR TITLE
docs: add verified model releases to changelog

### DIFF
--- a/apps/docs/v1/changelog.mdx
+++ b/apps/docs/v1/changelog.mdx
@@ -14,22 +14,22 @@ rss: true
 
 </Update>
 
-<Update label="July 23, 2026" tags={["Model Releases"]}>
+## July 23, 2026
 
-### Model Releases
+<p style={{ fontSize: "1rem", fontWeight: 600, marginTop: "1rem", marginBottom: "0.5rem" }}>New Models</p>
 
 - [InclusionAI: Ling 3.0 Flash](https://phaseo.app/models/inclusionai/ling-3.0-flash)
 
-</Update>
+***
 
-<Update label="July 21, 2026" tags={["Model Releases"]}>
+## July 21, 2026
 
-### Model Releases
+<p style={{ fontSize: "1rem", fontWeight: 600, marginTop: "1rem", marginBottom: "0.5rem" }}>New Models</p>
 
-- [MindAI: Macaron V1 Venti](https://phaseo.app/models/mindai/macaron-v1-venti)
+- [Mind Lab: Macaron V1 Venti](https://phaseo.app/models/mindai/macaron-v1-venti)
 - [Sakana AI: Fugu Cyber](https://phaseo.app/models/sakana/fugu-cyber)
 
-</Update>
+***
 
 <Update label="July 20, 2026" tags={["Features"]}>
 

--- a/apps/docs/v1/changelog.mdx
+++ b/apps/docs/v1/changelog.mdx
@@ -14,6 +14,23 @@ rss: true
 
 </Update>
 
+<Update label="July 23, 2026" tags={["Model Releases"]}>
+
+### Model Releases
+
+- [InclusionAI: Ling 3.0 Flash](https://phaseo.app/models/inclusionai/ling-3.0-flash)
+
+</Update>
+
+<Update label="July 21, 2026" tags={["Model Releases"]}>
+
+### Model Releases
+
+- [MindAI: Macaron V1 Venti](https://phaseo.app/models/mindai/macaron-v1-venti)
+- [Sakana AI: Fugu Cyber](https://phaseo.app/models/sakana/fugu-cyber)
+
+</Update>
+
 <Update label="July 20, 2026" tags={["Features"]}>
 
 - Model pages are now easier to discover in search.
@@ -251,6 +268,8 @@ rss: true
 ![Gemini 3.1 Flash Lite image (Nano Banana 2 Lite) model release artwork](../images/model-releases/2026-06-23--google--gemini-3-1-flash-lite-image.png)
 
 - [Google: Gemini 3.1 Flash Lite image (Nano Banana 2 Lite)](https://phaseo.app/models/google/gemini-3.1-flash-lite-image)
+- [ByteDance: Seed 2.1 Turbo](https://phaseo.app/models/bytedance/seed-2.1-turbo)
+- [z.AI: GLM 5.2 Fast](https://phaseo.app/models/z-ai/glm-5.2-fast)
 
 </Update>
 
@@ -697,9 +716,6 @@ rss: true
 
 ### Model Releases
 
-![Qwen 3.6 35B A3B model release artwork](../images/model-releases/2026-04-17--qwen--qwen3-6-35b-a3b.png)
-
-- [Qwen: Qwen 3.6 35B A3B](https://phaseo.app/models/qwen/qwen3.6-35b-a3b)
 - [xAI: Grok TTS](https://phaseo.app/models/x-ai/grok-tts)
 
 </Update>
@@ -719,8 +735,10 @@ rss: true
 ### Model Releases
 
 ![Gemini 3.1 Flash TTS Preview model release artwork](../images/model-releases/2026-04-15--google--gemini-3-1-flash-tts-preview.png)
+![Qwen 3.6 35B A3B model release artwork](../images/model-releases/2026-04-17--qwen--qwen3-6-35b-a3b.png)
 
 - [Google: Gemini 3.1 Flash TTS Preview](https://phaseo.app/models/google/gemini-3.1-flash-tts-preview)
+- [Qwen: Qwen 3.6 35B A3B](https://phaseo.app/models/qwen/qwen3.6-35b-a3b)
 
 </Update>
 


### PR DESCRIPTION
## Summary

- Add the model releases introduced by merged PR #1228 to the dated changelog sections.
- Correct Qwen 3.6 35B A3B from April 17 to its catalogued April 15 release date.

## Validation

- pnpm docs:links
- pnpm validate:data
- git diff --check

Created with Codex