### PR TITLE
fix(data): stabilize importer state updates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -335,13 +335,26 @@ jobs:
                     exit 0
                   fi
 
-                  branch="automation/importer-state-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+                  # Keep one moving branch/PR for importer state. The importer is
+                  # serialized above, so force-updating this branch cannot race
+                  # another importer run and avoids accumulating snapshot PRs.
+                  branch="automation/importer-state"
                   git config user.name "github-actions[bot]"
                   git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-                  git switch --create "${branch}"
+                  git fetch origin "${branch}" || true
+                  remote_branch_sha=""
+                  if git show-ref --verify --quiet "refs/remotes/origin/${branch}"; then
+                    remote_branch_sha="$(git rev-parse "refs/remotes/origin/${branch}")"
+                  fi
+                  git switch --force-create "${branch}" HEAD
                   git add "${state_file}"
                   git commit -m "chore(data): persist importer state"
-                  git push --set-upstream "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" "${branch}"
+                  remote_url="https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+                  if [[ -n "${remote_branch_sha}" ]]; then
+                    git push --force-with-lease="${branch}:${remote_branch_sha}" "${remote_url}" "${branch}"
+                  else
+                    git push --set-upstream "${remote_url}" "${branch}"
+                  fi
                   echo "changed=true" >> "${GITHUB_OUTPUT}"
                   echo "branch=${branch}" >> "${GITHUB_OUTPUT}"
 
@@ -352,11 +365,31 @@ jobs:
               shell: bash
               run: |
                   set -euo pipefail
+                  branch="${{ steps.importer-state-update.outputs.branch }}"
+                  existing_pr="$(gh pr list --state open --base main --head "${branch}" --json number --jq '.[0].number')"
+                  if [[ -n "${existing_pr}" ]]; then
+                    echo "Importer state PR #${existing_pr} already exists; updated its branch."
+                    exit 0
+                  fi
                   gh pr create \
                     --base main \
-                    --head "${{ steps.importer-state-update.outputs.branch }}" \
+                    --head "${branch}" \
                     --title "chore(data): persist importer state" \
-                    --body "Automated update of the committed importer hash state after a successful main import."
+                    --body "Automated update of the committed importer hash state after a successful main import. This PR is intentionally reused and updated by subsequent imports."
+
+            - name: Close superseded importer state PRs
+              if: steps.importer-state-update.outputs.changed == 'true'
+              env:
+                  GH_TOKEN: ${{ steps.importer-app-token.outputs.token }}
+              shell: bash
+              run: |
+                  set -euo pipefail
+                  legacy_prs="$(gh pr list --state open --base main --json number,headRefName --limit 100 --jq '[.[] | select(.headRefName | startswith("automation/importer-state-")) | .number] | .[]')"
+                  while IFS= read -r pr_number; do
+                    [[ -z "${pr_number}" ]] && continue
+                    gh pr close "${pr_number}" \
+                      --comment "Superseded by the reusable automation/importer-state PR; future importer runs update that single PR."
+                  done <<< "${legacy_prs}"
 
     sdk-gen:
         name: Generate SDKs

--- a/packages/data/catalog/src/data/organisations/mindai/organisation.json
+++ b/packages/data/catalog/src/data/organisations/mindai/organisation.json
@@ -4,6 +4,6 @@
   "country_code":"SG",
   "description":"Mind Lab develops the Macaron V1 family of model-specialist systems.",
   "colour":"#6366F1",
-  "organisation_links":[{"platform":"website","url":"https://novita.ai/models/model-detail/mindai-macaron-v1-venti"}],
-  "status":"active","routable":null,"sources":[],"verification":{"status":"verified","checked_at":"2026-07-24T00:00:00Z","notes":"Organisation identity and model association verified from the official Novita model page."}
+  "organisation_links":[{"platform":"website","url":"https://macaron.im/mindlab"}],
+  "status":"active","routable":null,"sources":[{"kind":"website","url":"https://macaron.im/mindlab","accessed_at":"2026-07-25T00:00:00Z","notes":"Official Mind Lab site identifies the organisation behind the Macaron model family."},{"kind":"terms","url":"https://mint-doc.macaron.im/en/enterprise/support/terms","accessed_at":"2026-07-25T00:00:00Z","notes":"Official Mind Lab Toolkit terms identify MINDAI PTE. LTD. as incorporated in Singapore."}],"verification":{"status":"verified","checked_at":"2026-07-25T00:00:00Z","notes":"Organisation identity and Macaron model association verified from the official Mind Lab site and Novita model page; country code SG is supported by Mindai's official terms."}
 }


### PR DESCRIPTION
## Summary

- Fix the main importer’s deterministic failure by giving Mind Lab the verified SG country code and recording its official Mind Lab/terms sources.
- Reuse one automation/importer-state branch and PR for committed importer hash state.
- Force-update the serialized state branch safely, avoid duplicate PR creation, and close legacy run-ID importer-state PRs once the reusable PR is created.

## Validation

- pnpm.cmd validate:data ✅
- pnpm.cmd validate:pricing ✅
- pnpm.cmd validate:gateway ✅
- Python YAML parse of .github/workflows/ci.yml ✅
- Mind Lab organisation JSON and duplicate-platform check ✅
- git diff --check ✅
- Focused Jest test not run: the fresh worktree’s locked dependency install timed out before the Jest binary was available.

Official sources: [Mind Lab](https://macaron.im/mindlab), [Mindai terms](https://mint-doc.macaron.im/en/enterprise/support/terms), [Novita Macaron V1 Venti](https://novita.ai/models/model-detail/mindai-macaron-v1-venti).

Created with Codex