### PR TITLE
fix(web): handle missing model pages gracefully

### DIFF
--- a/apps/web/src/app/(dashboard)/models/[organisationId]/[modelId]/not-found.tsx
+++ b/apps/web/src/app/(dashboard)/models/[organisationId]/[modelId]/not-found.tsx
@@ -1,0 +1,5 @@
+import ModelNotFoundState from "@/components/(data)/model/ModelNotFoundState";
+
+export default function ModelNotFound() {
+	return <ModelNotFoundState />;
+}

--- a/apps/web/src/app/(dashboard)/models/[organisationId]/[modelId]/page.tsx
+++ b/apps/web/src/app/(dashboard)/models/[organisationId]/[modelId]/page.tsx
@@ -27,7 +27,7 @@ import {
 	buildModelOverviewMetadataDescription,
 	buildModelOverviewMetadataTitle,
 } from "@/lib/models/modelDescription";
-import { permanentRedirect } from "next/navigation";
+import { notFound, permanentRedirect } from "next/navigation";
 import { Suspense } from "react";
 import { isFreeRouterModelId } from "@/lib/models/freeRouter";
 import FreeRouterOverview from "@/components/(data)/model/free-router/FreeRouterOverview";
@@ -194,7 +194,7 @@ export default async function Page({
 			</ModelDetailShell>
 		);
 	}
-	const modelPromise = fetchFrontendModelOverview(modelId);
+	const modelPromise = fetchFrontendModelOverview(modelId).catch(() => null);
 	const benchmarkPromise = fetchFrontendModelBenchmarkHighlights(modelId).catch(() => []);
 	const subscriptionPromise = fetchFrontendModelSubscriptionPlans(modelId).catch(() => []);
 	const availabilityPromise = fetchFrontendModelAvailability(modelId).catch(() => undefined);
@@ -206,6 +206,7 @@ export default async function Page({
 			subscriptionPromise,
 			availabilityPromise,
 		]);
+	if (!modelOverview) notFound();
 	const showBenchmarks = benchmarkHighlights.length > 0;
 	const showSubscriptions = subscriptionPlans.length > 0;
 	const isGatewayActive =

--- a/apps/web/src/components/(data)/model/ModelDetailShell.tsx
+++ b/apps/web/src/components/(data)/model/ModelDetailShell.tsx
@@ -7,10 +7,9 @@ import {
 } from "@/lib/fetchers/frontend/fetchPublicCatalog";
 import { Logo } from "@/components/Logo";
 import { Badge } from "@/components/ui/badge";
-import ModelNotFoundState from "@/components/(data)/model/ModelNotFoundState";
 import { Button } from "@/components/ui/button";
 import { MessageSquare, Scale } from "lucide-react";
-import { redirect } from "next/navigation";
+import { notFound, redirect } from "next/navigation";
 import { Skeleton } from "@/components/ui/skeleton";
 import ModelIdentifierControl from "./ModelIdentifierControl";
 import ModelDescriptionPanel from "./ModelDescriptionPanel";
@@ -35,12 +34,6 @@ interface ModelDetailShellProps {
 	includeHidden?: boolean;
 	header?: ModelOverviewHeader;
 	modelOverview?: ModelOverviewPage | null;
-}
-
-function isModelNotFoundError(error: unknown): boolean {
-	const message = error instanceof Error ? error.message.toLowerCase() : String(error ?? "").toLowerCase();
-	if (message.includes("model not found")) return true;
-	return false;
 }
 
 function getVisibleTabKeys(modelStatus?: string | null): string[] {
@@ -96,12 +89,7 @@ export default async function ModelDetailShell({
 				null,
 			]
 		: await Promise.all([
-				prefetchedHeader ?? fetchFrontendModelHeader(modelId, includeHidden).catch((error) => {
-					if (isModelNotFoundError(error)) {
-						return null;
-					}
-					throw error;
-				}),
+				prefetchedHeader ?? fetchFrontendModelHeader(modelId, includeHidden).catch(() => null),
 				prefetchedModelOverview !== undefined
 					? Promise.resolve(prefetchedModelOverview)
 					: fetchFrontendModelOverview(modelId).catch(() => null),
@@ -109,7 +97,7 @@ export default async function ModelDetailShell({
 			]);
 
 	if (!header) {
-		return <ModelNotFoundState modelId={modelId} />;
+		notFound();
 	}
 	const modelDescription = isFreeRouter
 		? FREE_ROUTER_DESCRIPTION

--- a/apps/web/src/components/(data)/model/ModelNotFoundState.tsx
+++ b/apps/web/src/components/(data)/model/ModelNotFoundState.tsx
@@ -26,7 +26,10 @@ export default function ModelNotFoundState({ modelId }: ModelNotFoundStateProps)
 			<div className="container mx-auto flex min-h-[62vh] w-full flex-1 items-center justify-center px-4 py-16 sm:px-6 lg:px-8">
 				<div className="w-full max-w-2xl text-center">
 					<h1 className="mx-auto max-w-2xl text-2xl font-bold leading-tight tracking-tight sm:text-3xl">
-						The model <span className="font-mono text-[0.9em]">{requestedModelId}</span> is not available yet
+						<span className="block break-words">
+							The model <span className="font-mono text-[0.9em]">{requestedModelId}</span>
+						</span>
+						<span className="block">is not available yet</span>
 					</h1>
 					<p className="mx-auto mt-5 max-w-lg text-sm leading-6 text-muted-foreground sm:text-base">
 						Recent announcements can arrive before the public catalogue cache catches up. Try again shortly, or tell us where you found the link.

--- a/apps/web/src/components/(data)/model/ModelNotFoundState.tsx
+++ b/apps/web/src/components/(data)/model/ModelNotFoundState.tsx
@@ -25,7 +25,7 @@ export default function ModelNotFoundState({ modelId }: ModelNotFoundStateProps)
 		<main className="flex flex-1 flex-col">
 			<div className="container mx-auto flex min-h-[62vh] w-full flex-1 items-center justify-center px-4 py-16 sm:px-6 lg:px-8">
 				<div className="w-full max-w-2xl text-center">
-					<h1 className="mx-auto max-w-2xl text-3xl font-normal tracking-tight sm:text-4xl">
+					<h1 className="mx-auto max-w-2xl text-2xl font-bold leading-tight tracking-tight sm:text-3xl">
 						The model <span className="font-mono text-[0.9em]">&quot;{requestedModelId}&quot;</span> is not available yet
 					</h1>
 					<p className="mx-auto mt-5 max-w-lg text-sm leading-6 text-muted-foreground sm:text-base">

--- a/apps/web/src/components/(data)/model/ModelNotFoundState.tsx
+++ b/apps/web/src/components/(data)/model/ModelNotFoundState.tsx
@@ -1,6 +1,7 @@
 import Image from "next/image";
 import Link from "next/link";
-import { ArrowLeft } from "lucide-react";
+import { ArrowLeft, RadioTower, Sparkles } from "lucide-react";
+import { Button } from "@/components/ui/button";
 
 interface ModelNotFoundStateProps {
 	fullScreen?: boolean;
@@ -11,65 +12,90 @@ export default function ModelNotFoundState({
 	fullScreen = true,
 	modelId,
 }: ModelNotFoundStateProps) {
+	const displayModelId = modelId?.trim() || "the requested model";
+
 	return (
 		<main className={fullScreen ? "flex flex-1 flex-col" : "flex flex-col"}>
 			<div
 				className={
 					fullScreen
-						? "container mx-auto flex min-h-[60vh] w-full flex-1 items-center justify-center px-4 py-8"
+						? "container mx-auto flex min-h-[64vh] w-full flex-1 items-center justify-center px-4 py-10 sm:px-6 lg:px-8"
 						: "container mx-auto px-4 py-8"
 				}
 			>
-				<div className="w-full max-w-xl rounded-lg border border-dashed bg-muted/30 p-6 text-center md:p-8">
-					<p className="text-base font-medium">
-						{modelId ? (
-							<>
-								Model{" "}
-								<code className="rounded bg-muted px-1.5 py-0.5 font-mono text-sm">
-									{modelId}
-								</code>{" "}
-								is not found
-							</>
-						) : (
-							"Model is not found"
-						)}
-					</p>
-					<p className="mt-1 text-sm text-muted-foreground">
-						We&apos;re continuously adding new models.
-					</p>
-					<div className="mt-4 flex flex-col items-center gap-3">
-						<p className="text-sm text-muted-foreground">Got one to suggest?</p>
-						<a
-							href="https://github.com/phaseoteam/Phaseo/issues/new"
-							target="_blank"
-							rel="noopener noreferrer"
-							className="inline-flex items-center gap-2 rounded-md border px-3 py-1.5 text-sm font-medium transition-colors hover:bg-accent hover:text-accent-foreground"
-						>
-							<Image
-								src="/social/github_light.svg"
-								alt="GitHub Logo"
-								width={16}
-								height={16}
-								className="inline dark:hidden"
-							/>
-							<Image
-								src="/social/github_dark.svg"
-								alt="GitHub Logo"
-								width={16}
-								height={16}
-								className="hidden dark:inline"
-							/>
-							Suggest a Model
-						</a>
-						<p className="text-xs font-medium uppercase tracking-wide text-muted-foreground/80">
-							or
-						</p>
-						<Link
-							href="/models"
-							className="inline-flex items-center gap-2 rounded-md border px-3 py-1.5 text-sm font-medium transition-colors hover:bg-accent hover:text-accent-foreground"
-						>
-							<ArrowLeft className="h-4 w-4" />
-							Back to Models
+				<div className="relative w-full max-w-4xl overflow-hidden rounded-[2rem] border border-border/70 bg-card/80 shadow-2xl shadow-primary/5 backdrop-blur-sm">
+					<div
+						aria-hidden="true"
+						className="absolute inset-0 bg-[radial-gradient(circle_at_15%_10%,color-mix(in_oklch,var(--primary)_13%,transparent),transparent_32%),radial-gradient(circle_at_90%_85%,color-mix(in_oklch,var(--chart-2)_12%,transparent),transparent_28%)]"
+					/>
+					<div className="relative grid gap-0 lg:grid-cols-[0.72fr_1.28fr]">
+						<div className="flex min-h-64 flex-col justify-between border-b border-border/70 bg-muted/20 p-6 sm:p-8 lg:border-b-0 lg:border-r">
+							<div className="flex items-center justify-between text-[0.68rem] font-semibold uppercase tracking-[0.22em] text-muted-foreground">
+								<span>Model catalogue</span>
+								<span>404</span>
+							</div>
+							<div className="relative mx-auto flex h-36 w-36 items-center justify-center sm:h-44 sm:w-44">
+								<div className="absolute inset-0 rounded-full border border-primary/20" />
+								<div className="absolute inset-5 rounded-full border border-dashed border-primary/30" />
+								<div className="flex h-20 w-20 items-center justify-center rounded-3xl border border-primary/30 bg-background/80 text-primary shadow-lg shadow-primary/10">
+									<RadioTower className="h-9 w-9" strokeWidth={1.5} />
+								</div>
+							</div>
+							<div className="flex items-center gap-2 text-xs text-muted-foreground">
+								<span className="h-2 w-2 rounded-full bg-amber-500 shadow-[0_0_0_4px_color-mix(in_oklch,#f59e0b_15%,transparent)]" />
+								Catalog sync pending
+							</div>
+						</div>
+
+						<div className="p-6 sm:p-10">
+							<div className="flex items-center gap-2 text-xs font-semibold uppercase tracking-[0.18em] text-primary">
+								<Sparkles className="h-4 w-4" />
+								Nearly there
+							</div>
+							<h1 className="mt-4 max-w-xl text-3xl font-bold tracking-tight sm:text-4xl">
+								This model is still catching up.
+							</h1>
+							<p className="mt-4 max-w-xl text-sm leading-6 text-muted-foreground sm:text-base">
+								The link is valid, but the model has not reached Phaseo&apos;s public catalogue yet. Recent announcements can briefly arrive before the next catalogue sync completes.
+							</p>
+
+							<div className="mt-6 rounded-2xl border border-border/70 bg-background/70 p-3">
+								<p className="px-2 pb-2 text-[0.68rem] font-semibold uppercase tracking-[0.16em] text-muted-foreground">
+									Requested identifier
+								</p>
+								<code className="block overflow-x-auto rounded-xl bg-muted/70 px-3 py-2.5 font-mono text-sm text-foreground">
+									{displayModelId}
+								</code>
+							</div>
+
+							<div className="mt-7 flex flex-wrap gap-2">
+								<Button asChild>
+									<Link href="/models">
+										<ArrowLeft className="h-4 w-4" />
+										Browse models
+									</Link>
+								</Button>
+								<Button asChild variant="outline">
+									<a href="https://discord.gg/aQyywCvgZ5" target="_blank" rel="noopener noreferrer">
+										<Image src="/social/discord.svg" alt="" width={16} height={16} />
+										Join Discord
+									</a>
+								</Button>
+								<Button asChild variant="ghost">
+									<a href="https://github.com/phaseoteam/Phaseo/issues/new" target="_blank" rel="noopener noreferrer">
+										<Image src="/social/github_light.svg" alt="" width={16} height={16} className="dark:hidden" />
+										<Image src="/social/github_dark.svg" alt="" width={16} height={16} className="hidden dark:block" />
+										Suggest on GitHub
+									</a>
+								</Button>
+							</div>
+						</div>
+					</div>
+
+					<div className="relative flex flex-col gap-2 border-t border-border/70 bg-muted/10 px-6 py-4 text-xs text-muted-foreground sm:flex-row sm:items-center sm:justify-between sm:px-10">
+						<span>Model announcements land here first; catalogue availability follows shortly after.</span>
+						<Link href="/contact" className="font-medium text-foreground underline-offset-4 hover:underline">
+							Need help?
 						</Link>
 					</div>
 				</div>

--- a/apps/web/src/components/(data)/model/ModelNotFoundState.tsx
+++ b/apps/web/src/components/(data)/model/ModelNotFoundState.tsx
@@ -1,102 +1,68 @@
+"use client";
+
 import Image from "next/image";
 import Link from "next/link";
-import { ArrowLeft, RadioTower, Sparkles } from "lucide-react";
+import { usePathname } from "next/navigation";
+import { ArrowLeft } from "lucide-react";
 import { Button } from "@/components/ui/button";
 
 interface ModelNotFoundStateProps {
-	fullScreen?: boolean;
 	modelId?: string;
 }
 
-export default function ModelNotFoundState({
-	fullScreen = true,
-	modelId,
-}: ModelNotFoundStateProps) {
-	const displayModelId = modelId?.trim() || "the requested model";
+function getModelIdFromPathname(pathname: string | null): string | null {
+	if (!pathname) return null;
+	const segments = pathname.split("/").filter(Boolean).slice(1, 3);
+	if (segments.length !== 2) return null;
+	return segments.map((segment) => decodeURIComponent(segment)).join("/");
+}
+
+export default function ModelNotFoundState({ modelId }: ModelNotFoundStateProps) {
+	const pathname = usePathname();
+	const requestedModelId = modelId ?? getModelIdFromPathname(pathname) ?? "the requested model";
 
 	return (
-		<main className={fullScreen ? "flex flex-1 flex-col" : "flex flex-col"}>
-			<div
-				className={
-					fullScreen
-						? "container mx-auto flex min-h-[64vh] w-full flex-1 items-center justify-center px-4 py-10 sm:px-6 lg:px-8"
-						: "container mx-auto px-4 py-8"
-				}
-			>
-				<div className="relative w-full max-w-4xl overflow-hidden rounded-[2rem] border border-border/70 bg-card/80 shadow-2xl shadow-primary/5 backdrop-blur-sm">
-					<div
-						aria-hidden="true"
-						className="absolute inset-0 bg-[radial-gradient(circle_at_15%_10%,color-mix(in_oklch,var(--primary)_13%,transparent),transparent_32%),radial-gradient(circle_at_90%_85%,color-mix(in_oklch,var(--chart-2)_12%,transparent),transparent_28%)]"
-					/>
-					<div className="relative grid gap-0 lg:grid-cols-[0.72fr_1.28fr]">
-						<div className="flex min-h-64 flex-col justify-between border-b border-border/70 bg-muted/20 p-6 sm:p-8 lg:border-b-0 lg:border-r">
-							<div className="flex items-center justify-between text-[0.68rem] font-semibold uppercase tracking-[0.22em] text-muted-foreground">
-								<span>Model catalogue</span>
-								<span>404</span>
-							</div>
-							<div className="relative mx-auto flex h-36 w-36 items-center justify-center sm:h-44 sm:w-44">
-								<div className="absolute inset-0 rounded-full border border-primary/20" />
-								<div className="absolute inset-5 rounded-full border border-dashed border-primary/30" />
-								<div className="flex h-20 w-20 items-center justify-center rounded-3xl border border-primary/30 bg-background/80 text-primary shadow-lg shadow-primary/10">
-									<RadioTower className="h-9 w-9" strokeWidth={1.5} />
-								</div>
-							</div>
-							<div className="flex items-center gap-2 text-xs text-muted-foreground">
-								<span className="h-2 w-2 rounded-full bg-amber-500 shadow-[0_0_0_4px_color-mix(in_oklch,#f59e0b_15%,transparent)]" />
-								Catalog sync pending
-							</div>
-						</div>
+		<main className="flex flex-1 flex-col">
+			<div className="container mx-auto flex min-h-[62vh] w-full flex-1 items-center justify-center px-4 py-16 sm:px-6 lg:px-8">
+				<div className="w-full max-w-2xl text-center">
+					<h1 className="mx-auto max-w-2xl text-3xl font-bold tracking-tight sm:text-4xl">
+						The model <span className="font-mono text-[0.9em]">&quot;{requestedModelId}&quot;</span> is not available yet
+					</h1>
+					<p className="mx-auto mt-5 max-w-lg text-sm leading-6 text-muted-foreground sm:text-base">
+						Recent announcements can arrive before the public catalogue cache catches up. Try again shortly, or tell us where you found the link.
+					</p>
 
-						<div className="p-6 sm:p-10">
-							<div className="flex items-center gap-2 text-xs font-semibold uppercase tracking-[0.18em] text-primary">
-								<Sparkles className="h-4 w-4" />
-								Nearly there
-							</div>
-							<h1 className="mt-4 max-w-xl text-3xl font-bold tracking-tight sm:text-4xl">
-								This model is still catching up.
-							</h1>
-							<p className="mt-4 max-w-xl text-sm leading-6 text-muted-foreground sm:text-base">
-								The link is valid, but the model has not reached Phaseo&apos;s public catalogue yet. Recent announcements can briefly arrive before the next catalogue sync completes.
-							</p>
-
-							<div className="mt-6 rounded-2xl border border-border/70 bg-background/70 p-3">
-								<p className="px-2 pb-2 text-[0.68rem] font-semibold uppercase tracking-[0.16em] text-muted-foreground">
-									Requested identifier
-								</p>
-								<code className="block overflow-x-auto rounded-xl bg-muted/70 px-3 py-2.5 font-mono text-sm text-foreground">
-									{displayModelId}
-								</code>
-							</div>
-
-							<div className="mt-7 flex flex-wrap gap-2">
-								<Button asChild>
-									<Link href="/models">
-										<ArrowLeft className="h-4 w-4" />
-										Browse models
-									</Link>
-								</Button>
-								<Button asChild variant="outline">
-									<a href="https://discord.gg/aQyywCvgZ5" target="_blank" rel="noopener noreferrer">
-										<Image src="/social/discord.svg" alt="" width={16} height={16} />
-										Join Discord
-									</a>
-								</Button>
-								<Button asChild variant="ghost">
-									<a href="https://github.com/phaseoteam/Phaseo/issues/new" target="_blank" rel="noopener noreferrer">
-										<Image src="/social/github_light.svg" alt="" width={16} height={16} className="dark:hidden" />
-										<Image src="/social/github_dark.svg" alt="" width={16} height={16} className="hidden dark:block" />
-										Suggest on GitHub
-									</a>
-								</Button>
-							</div>
-						</div>
+					<div className="mt-8 flex flex-wrap items-center justify-center gap-3">
+						<Button asChild>
+							<Link href="/models">
+								<ArrowLeft className="h-4 w-4" />
+								Browse models
+							</Link>
+						</Button>
 					</div>
 
-					<div className="relative flex flex-col gap-2 border-t border-border/70 bg-muted/10 px-6 py-4 text-xs text-muted-foreground sm:flex-row sm:items-center sm:justify-between sm:px-10">
-						<span>Model announcements land here first; catalogue availability follows shortly after.</span>
-						<Link href="/contact" className="font-medium text-foreground underline-offset-4 hover:underline">
-							Need help?
-						</Link>
+					<div className="mt-7 flex flex-wrap items-center justify-center gap-x-4 gap-y-2 text-sm text-muted-foreground">
+						<span>Request an update:</span>
+						<a
+							href="https://discord.gg/aQyywCvgZ5"
+							target="_blank"
+							rel="noopener noreferrer"
+							className="inline-flex items-center gap-1.5 font-medium text-foreground underline-offset-4 hover:underline"
+						>
+							<Image src="/social/discord.svg" alt="" width={15} height={15} />
+							Discord
+						</a>
+						<span aria-hidden="true" className="text-border">•</span>
+						<a
+							href="https://github.com/phaseoteam/Phaseo/issues/new"
+							target="_blank"
+							rel="noopener noreferrer"
+							className="inline-flex items-center gap-1.5 font-medium text-foreground underline-offset-4 hover:underline"
+						>
+							<Image src="/social/github_light.svg" alt="" width={15} height={15} className="dark:hidden" />
+							<Image src="/social/github_dark.svg" alt="" width={15} height={15} className="hidden dark:block" />
+							GitHub
+						</a>
 					</div>
 				</div>
 			</div>

--- a/apps/web/src/components/(data)/model/ModelNotFoundState.tsx
+++ b/apps/web/src/components/(data)/model/ModelNotFoundState.tsx
@@ -56,7 +56,7 @@ export default function ModelNotFoundState({ modelId }: ModelNotFoundStateProps)
 					</div>
 
 					<div className="mt-5 flex flex-wrap items-center justify-center gap-3">
-						<Button asChild variant="outline">
+						<Button asChild>
 							<Link href="/models">
 								<ArrowLeft className="h-4 w-4" />
 								Browse models

--- a/apps/web/src/components/(data)/model/ModelNotFoundState.tsx
+++ b/apps/web/src/components/(data)/model/ModelNotFoundState.tsx
@@ -32,16 +32,7 @@ export default function ModelNotFoundState({ modelId }: ModelNotFoundStateProps)
 						Recent announcements can arrive before the public catalogue cache catches up. Try again shortly, or tell us where you found the link.
 					</p>
 
-					<div className="mt-8 flex flex-wrap items-center justify-center gap-3">
-						<Button asChild>
-							<Link href="/models">
-								<ArrowLeft className="h-4 w-4" />
-								Browse models
-							</Link>
-						</Button>
-					</div>
-
-					<div className="mt-7 flex flex-wrap items-center justify-center gap-x-4 gap-y-2 text-sm text-muted-foreground">
+					<div className="mt-8 flex flex-wrap items-center justify-center gap-x-4 gap-y-2 text-sm text-muted-foreground">
 						<span>Request a Model</span>
 						<a
 							href="https://discord.gg/aQyywCvgZ5"
@@ -62,6 +53,15 @@ export default function ModelNotFoundState({ modelId }: ModelNotFoundStateProps)
 							<Image src="/social/github_dark.svg" alt="" width={15} height={15} className="hidden dark:block" />
 							GitHub
 						</a>
+					</div>
+
+					<div className="mt-5 flex flex-wrap items-center justify-center gap-3">
+						<Button asChild variant="outline">
+							<Link href="/models">
+								<ArrowLeft className="h-4 w-4" />
+								Browse models
+							</Link>
+						</Button>
 					</div>
 				</div>
 			</div>

--- a/apps/web/src/components/(data)/model/ModelNotFoundState.tsx
+++ b/apps/web/src/components/(data)/model/ModelNotFoundState.tsx
@@ -26,7 +26,7 @@ export default function ModelNotFoundState({ modelId }: ModelNotFoundStateProps)
 			<div className="container mx-auto flex min-h-[62vh] w-full flex-1 items-center justify-center px-4 py-16 sm:px-6 lg:px-8">
 				<div className="w-full max-w-2xl text-center">
 					<h1 className="mx-auto max-w-2xl text-2xl font-bold leading-tight tracking-tight sm:text-3xl">
-						The model <span className="font-mono text-[0.9em]">&quot;{requestedModelId}&quot;</span> is not available yet
+						The model <code className="font-mono text-[0.9em]">{`\`${requestedModelId}\``}</code> is not available yet
 					</h1>
 					<p className="mx-auto mt-5 max-w-lg text-sm leading-6 text-muted-foreground sm:text-base">
 						Recent announcements can arrive before the public catalogue cache catches up. Try again shortly, or tell us where you found the link.
@@ -52,7 +52,6 @@ export default function ModelNotFoundState({ modelId }: ModelNotFoundStateProps)
 							<Image src="/social/discord.svg" alt="" width={15} height={15} />
 							Discord
 						</a>
-						<span aria-hidden="true" className="text-border">•</span>
 						<a
 							href="https://github.com/phaseoteam/Phaseo/issues/new"
 							target="_blank"

--- a/apps/web/src/components/(data)/model/ModelNotFoundState.tsx
+++ b/apps/web/src/components/(data)/model/ModelNotFoundState.tsx
@@ -25,7 +25,7 @@ export default function ModelNotFoundState({ modelId }: ModelNotFoundStateProps)
 		<main className="flex flex-1 flex-col">
 			<div className="container mx-auto flex min-h-[62vh] w-full flex-1 items-center justify-center px-4 py-16 sm:px-6 lg:px-8">
 				<div className="w-full max-w-2xl text-center">
-					<h1 className="mx-auto max-w-2xl text-3xl font-bold tracking-tight sm:text-4xl">
+					<h1 className="mx-auto max-w-2xl text-3xl font-normal tracking-tight sm:text-4xl">
 						The model <span className="font-mono text-[0.9em]">&quot;{requestedModelId}&quot;</span> is not available yet
 					</h1>
 					<p className="mx-auto mt-5 max-w-lg text-sm leading-6 text-muted-foreground sm:text-base">
@@ -42,7 +42,7 @@ export default function ModelNotFoundState({ modelId }: ModelNotFoundStateProps)
 					</div>
 
 					<div className="mt-7 flex flex-wrap items-center justify-center gap-x-4 gap-y-2 text-sm text-muted-foreground">
-						<span>Request an update:</span>
+						<span>Request a Model:</span>
 						<a
 							href="https://discord.gg/aQyywCvgZ5"
 							target="_blank"

--- a/apps/web/src/components/(data)/model/ModelNotFoundState.tsx
+++ b/apps/web/src/components/(data)/model/ModelNotFoundState.tsx
@@ -26,7 +26,7 @@ export default function ModelNotFoundState({ modelId }: ModelNotFoundStateProps)
 			<div className="container mx-auto flex min-h-[62vh] w-full flex-1 items-center justify-center px-4 py-16 sm:px-6 lg:px-8">
 				<div className="w-full max-w-2xl text-center">
 					<h1 className="mx-auto max-w-2xl text-2xl font-bold leading-tight tracking-tight sm:text-3xl">
-						The model <code className="font-mono text-[0.9em]">{`\`${requestedModelId}\``}</code> is not available yet
+						The model <span className="font-mono text-[0.9em]">{requestedModelId}</span> is not available yet
 					</h1>
 					<p className="mx-auto mt-5 max-w-lg text-sm leading-6 text-muted-foreground sm:text-base">
 						Recent announcements can arrive before the public catalogue cache catches up. Try again shortly, or tell us where you found the link.

--- a/apps/web/src/components/(data)/model/ModelNotFoundState.tsx
+++ b/apps/web/src/components/(data)/model/ModelNotFoundState.tsx
@@ -42,7 +42,7 @@ export default function ModelNotFoundState({ modelId }: ModelNotFoundStateProps)
 					</div>
 
 					<div className="mt-7 flex flex-wrap items-center justify-center gap-x-4 gap-y-2 text-sm text-muted-foreground">
-						<span>Request a Model:</span>
+						<span>Request a Model</span>
 						<a
 							href="https://discord.gg/aQyywCvgZ5"
 							target="_blank"

--- a/apps/web/src/components/(data)/model/model-route-helpers.ts
+++ b/apps/web/src/components/(data)/model/model-route-helpers.ts
@@ -177,10 +177,22 @@ export async function resolveModelRouteIds(
 			internalModelId: null,
 		};
 	}
-	const resolved = await fetchFrontendCanonicalModelId(
-		requestedModelId,
-		includeHidden,
-	);
+	let resolved: Awaited<ReturnType<typeof fetchFrontendCanonicalModelId>>;
+	try {
+		resolved = await fetchFrontendCanonicalModelId(
+			requestedModelId,
+			includeHidden,
+		);
+	} catch {
+		// A just-announced model can briefly be ahead of the public catalogue
+		// cache. Let the detail shell turn the subsequent missing header into the
+		// route's designed 404 instead of surfacing an upstream server error.
+		return {
+			requestedModelId,
+			canonicalModelId: requestedModelId,
+			internalModelId: null,
+		};
+	}
 	return {
 		requestedModelId,
 		canonicalModelId: resolved.canonicalModelId ?? requestedModelId,


### PR DESCRIPTION
## Summary

- Add a model-route-specific 404 page for links that arrive before the catalogue cache/import catches up.
- Turn canonical-model and model-detail fetch failures into the designed missing-model state instead of surfacing a full server error.
- Refresh the missing-model UI with a Phaseo-styled catalogue-sync card, requested identifier, Browse Models, Discord, GitHub, and support actions.

## Validation

- `git diff --check` ✅
- Dependencies installed with `pnpm.cmd install --frozen-lockfile --filter @phaseo/web...` ✅
- Full TypeScript check reached only existing unrelated errors in `api-providers/layout.tsx`, `apps/layout.tsx`, `benchmarks/layout.tsx`, and `authOrigin.test.ts`.
- Web lint and local Next build exceeded the local command capture window without actionable diagnostics; CI is enabled for the PR.

Created with Codex

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a dedicated “model not found” page for unavailable models.
  * Updated the unavailable-model screen with clearer messaging, requested model details, retry guidance, and links to request or browse models.

* **Bug Fixes**
  * Improved handling of failed model lookups by showing the appropriate not-found experience instead of an error.
  * Added fallback routing behavior when model identification services are unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->