### PR TITLE
Simplify model relative date styling

### DIFF
--- a/apps/web/src/components/(data)/model/overview/KeyDates.tsx
+++ b/apps/web/src/components/(data)/model/overview/KeyDates.tsx
@@ -85,7 +85,7 @@ export default function KeyDates({
 									<span className="text-muted-foreground/50">·</span>
 									<RelativeDateBadge
 										date={value}
-										className="border-transparent bg-transparent px-0 py-0 text-[11px] font-medium text-muted-foreground hover:text-foreground"
+										className="text-muted-foreground hover:text-foreground"
 									/>
 								</>
 							) : (

--- a/apps/web/src/components/(data)/model/overview/RelativeDateBadge.tsx
+++ b/apps/web/src/components/(data)/model/overview/RelativeDateBadge.tsx
@@ -15,9 +15,11 @@ import { cn } from "@/lib/utils";
 const REFRESH_INTERVAL_MS = 60 * 60 * 1000;
 
 const toneClassNames: Record<RelativeCalendarTone, string> = {
-	past: "border-current/10 bg-white/70 dark:bg-black/10",
-	today: "border-current/20 bg-white/90 shadow-sm dark:bg-black/20",
-	future: "border-current/15 bg-white/85 dark:bg-black/15",
+	// Relative dates are inline metadata, not status controls. Keep the tone
+	// hook available without adding a surface behind the text.
+	past: "text-muted-foreground",
+	today: "text-foreground",
+	future: "text-muted-foreground",
 };
 
 type RelativeDateBadgeProps = {
@@ -49,7 +51,7 @@ export default function RelativeDateBadge({
 					suppressHydrationWarning
 					tabIndex={0}
 					className={cn(
-						"inline-flex cursor-help items-center rounded-full border px-2 py-0.5 text-[11px] font-medium leading-4",
+						"inline-flex cursor-help items-center text-[11px] font-medium leading-4",
 						toneClassNames[relativeDate.tone],
 						className,
 					)}


### PR DESCRIPTION
## Summary

- remove the unintended badge surface behind relative model lifecycle dates
- keep relative dates as lightweight inline metadata
- preserve the existing tooltip and relative-date behavior

## Validation

- focused diff and whitespace checks passed
- this is the exact two-file styling change previously validated on the model page

Created with Codex