### PR TITLE
Improve catalogue not-found pages

### DIFF
--- a/apps/web/src/app/(dashboard)/api-providers/[apiProvider]/models/page.tsx
+++ b/apps/web/src/app/(dashboard)/api-providers/[apiProvider]/models/page.tsx
@@ -6,11 +6,13 @@ import {
 } from "@/lib/fetchers/frontend/fetchPublicCatalog";
 import { buildMetadata } from "@/lib/seo";
 import ProviderModelsClient from "./ProviderModelsClient";
+import { notFound } from "next/navigation";
 
 async function fetchProviderMeta(apiProviderId: string) {
 	try {
 		return await fetchFrontendAPIProviderHeader(apiProviderId);
 	} catch (error) {
+		// eslint-disable-next-line no-console
 		console.warn("[seo] failed to load api provider metadata", {
 			apiProviderId,
 			error,
@@ -55,9 +57,11 @@ export default async function Page({
 }) {
 	const { apiProvider } = await params;
 	const header = await fetchProviderMeta(apiProvider);
+	if (!header) notFound();
 	const providerLabel = header?.api_provider_name ?? apiProvider;
 
-	const models = await fetchFrontendAPIProviderModels(apiProvider);
+	const models = await fetchFrontendAPIProviderModels(apiProvider).catch(() => null);
+	if (!models) notFound();
 
 	return (
 		<APIProviderDetailShell apiProviderId={apiProvider}>

--- a/apps/web/src/app/(dashboard)/api-providers/[apiProvider]/not-found.tsx
+++ b/apps/web/src/app/(dashboard)/api-providers/[apiProvider]/not-found.tsx
@@ -1,0 +1,5 @@
+import CatalogNotFoundState from "@/components/(data)/CatalogNotFoundState";
+
+export default function APIProviderNotFound() {
+	return <CatalogNotFoundState resourceType="provider" />;
+}

--- a/apps/web/src/app/(dashboard)/api-providers/[apiProvider]/page.tsx
+++ b/apps/web/src/app/(dashboard)/api-providers/[apiProvider]/page.tsx
@@ -5,11 +5,13 @@ import { fetchFrontendAPIProviderHeader } from "@/lib/fetchers/frontend/fetchPub
 import type { Metadata } from "next";
 import { absoluteUrl, buildMetadata } from "@/lib/seo";
 import Script from "next/script";
+import { notFound } from "next/navigation";
 
 async function fetchProviderMeta(apiProviderId: string) {
 	try {
 		return await fetchFrontendAPIProviderHeader(apiProviderId);
 	} catch (error) {
+		// eslint-disable-next-line no-console
 		console.warn("[seo] failed to load api provider metadata", {
 			apiProviderId,
 			error,
@@ -23,6 +25,7 @@ export async function generateMetadata(props: {
 }): Promise<Metadata> {
 	const { apiProvider } = await props.params;
 	const header = await fetchProviderMeta(apiProvider);
+	if (!header) notFound();
 	const imagePath = `/og/api-providers/${apiProvider}`;
 
 	// Fallback: provider not found / fetch failed

--- a/apps/web/src/app/(dashboard)/countries/[iso]/models/page.tsx
+++ b/apps/web/src/app/(dashboard)/countries/[iso]/models/page.tsx
@@ -9,6 +9,7 @@ import {
 } from "@/components/(data)/countries/utils";
 import { fetchFrontendCountry } from "@/lib/fetchers/frontend/fetchPublicCatalog";
 import { buildMetadata } from "@/lib/seo";
+import { notFound } from "next/navigation";
 
 export async function generateMetadata({
 	params,
@@ -17,7 +18,7 @@ export async function generateMetadata({
 }): Promise<Metadata> {
 	const { iso } = await params;
 	const isoNormalized = normaliseIso(iso);
-	const country = await fetchFrontendCountry(isoNormalized);
+	const country = await fetchFrontendCountry(isoNormalized).catch(() => null);
 	const path = `/countries/${isoNormalized.toLowerCase()}/models`;
 	const imagePath = `/og/countries/${isoNormalized.toLowerCase()}`;
 
@@ -51,6 +52,7 @@ export default async function CountryModelsPage({
 	const country = await fetchFrontendCountry(isoNormalized);
 
 	if (!country) {
+		notFound();
 		return (
 			<CountryDetailShell iso={isoNormalized} country={undefined}>
 				<div className="rounded-2xl border border-dashed border-zinc-300 bg-white/70 p-6 text-sm text-muted-foreground dark:border-zinc-700 dark:bg-zinc-900/70">

--- a/apps/web/src/app/(dashboard)/countries/[iso]/not-found.tsx
+++ b/apps/web/src/app/(dashboard)/countries/[iso]/not-found.tsx
@@ -1,0 +1,5 @@
+import CatalogNotFoundState from "@/components/(data)/CatalogNotFoundState";
+
+export default function CountryNotFound() {
+	return <CatalogNotFoundState resourceType="country" />;
+}

--- a/apps/web/src/app/(dashboard)/countries/[iso]/page.tsx
+++ b/apps/web/src/app/(dashboard)/countries/[iso]/page.tsx
@@ -12,10 +12,11 @@ import {
 } from "@/components/(data)/countries/utils";
 import { fetchFrontendCountry } from "@/lib/fetchers/frontend/fetchPublicCatalog";
 import { buildMetadata } from "@/lib/seo";
+import { notFound } from "next/navigation";
 
 async function loadCountry(isoInput: string) {
 	const iso = normaliseIso(isoInput);
-	return fetchFrontendCountry(iso);
+	return fetchFrontendCountry(iso).catch(() => null);
 }
 
 export async function generateMetadata({
@@ -74,6 +75,7 @@ export default async function CountryDetailPage({
 	const country = await loadCountry(iso);
 
 	if (!country) {
+		notFound();
 		return (
 			<CountryDetailShell iso={iso} country={undefined}>
 				<div className="rounded-2xl border border-dashed border-zinc-300 bg-white/70 p-6 text-sm text-muted-foreground dark:border-zinc-700 dark:bg-zinc-900/70">

--- a/apps/web/src/app/(dashboard)/organisations/[organisationId]/models/page.tsx
+++ b/apps/web/src/app/(dashboard)/organisations/[organisationId]/models/page.tsx
@@ -6,11 +6,13 @@ import {
 	fetchFrontendOrganisation,
 	fetchFrontendOrganisationModels,
 } from "@/lib/fetchers/frontend/fetchPublicCatalog";
+import { notFound } from "next/navigation";
 
 async function fetchOrganisation(organisationId: string) {
 	try {
 		return await fetchFrontendOrganisation(organisationId, 8);
 	} catch (error) {
+		// eslint-disable-next-line no-console
 		console.warn("[seo] failed to load organisation metadata", {
 			organisationId,
 			error,
@@ -77,7 +79,8 @@ export default async function Page({
 }) {
 	const { organisationId } = await params;
 
-	const models = await fetchFrontendOrganisationModels(organisationId);
+	const models = await fetchFrontendOrganisationModels(organisationId).catch(() => null);
+	if (!models) notFound();
 
 	return (
 		<OrganisationDetailShell organisationId={organisationId}>

--- a/apps/web/src/app/(dashboard)/organisations/[organisationId]/not-found.tsx
+++ b/apps/web/src/app/(dashboard)/organisations/[organisationId]/not-found.tsx
@@ -1,0 +1,5 @@
+import CatalogNotFoundState from "@/components/(data)/CatalogNotFoundState";
+
+export default function OrganisationNotFound() {
+	return <CatalogNotFoundState resourceType="organisation" />;
+}

--- a/apps/web/src/app/(dashboard)/organisations/[organisationId]/page.tsx
+++ b/apps/web/src/app/(dashboard)/organisations/[organisationId]/page.tsx
@@ -5,11 +5,13 @@ import OrganisationDetailShell from "@/components/(data)/organisation/Organisati
 import type { Metadata } from "next";
 import { absoluteUrl, buildMetadata } from "@/lib/seo";
 import Script from "next/script";
+import { notFound } from "next/navigation";
 
 async function fetchOrganisation(organisationId: string) {
 	try {
 		return await fetchFrontendOrganisation(organisationId, 12);
 	} catch (error) {
+		// eslint-disable-next-line no-console
 		console.warn("[seo] failed to load organisation metadata", {
 			organisationId,
 			error,
@@ -81,7 +83,7 @@ export default async function Page({
 }) {
 	const { organisationId } = await params;
 
-	const organisation = await fetchFrontendOrganisation(organisationId, 12);
+	const organisation = await fetchFrontendOrganisation(organisationId, 12).catch(() => null);
 
 	// Generate structured data for the organisation page.
 	const generateStructuredData = () => {
@@ -131,6 +133,7 @@ export default async function Page({
 	const structuredData = generateStructuredData();
 
 	if (!organisation) {
+		notFound();
 		return (
 			<main className="flex min-h-screen flex-col">
 				<div className="container mx-auto px-4 py-8">

--- a/apps/web/src/app/error.tsx
+++ b/apps/web/src/app/error.tsx
@@ -1,0 +1,55 @@
+"use client";
+
+import { useEffect } from "react";
+import Link from "next/link";
+import { Button } from "@/components/ui/button";
+
+export default function Error({
+	error,
+	reset,
+}: {
+	error: Error & { digest?: string };
+	reset: () => void;
+}) {
+	useEffect(() => {
+		// eslint-disable-next-line no-console
+		console.error(error);
+	}, [error]);
+
+	return (
+		<main className="flex min-h-[70vh] flex-1 items-center justify-center px-4 py-16 sm:px-6">
+			<div className="w-full max-w-xl text-center">
+				<p className="text-xs font-semibold uppercase tracking-[0.24em] text-muted-foreground">
+					Phaseo / temporary error
+				</p>
+				<h1 className="mt-5 text-3xl font-bold leading-tight tracking-tight sm:text-4xl">
+					Something went wrong.
+				</h1>
+				<p className="mx-auto mt-4 max-w-md text-sm leading-6 text-muted-foreground sm:text-base">
+					The page hit an unexpected problem. Try again, or return to the catalogue while we investigate.
+				</p>
+
+				<div className="mt-8 flex flex-wrap justify-center gap-3">
+					<Button type="button" onClick={() => reset()}>
+						Try again
+					</Button>
+					<Button asChild variant="outline">
+						<Link href="/models">Browse models</Link>
+					</Button>
+				</div>
+
+				<p className="mt-7 text-sm text-muted-foreground">
+					Still stuck?{" "}
+					<a
+						href="https://discord.gg/aQyywCvgZ5"
+						target="_blank"
+						rel="noopener noreferrer"
+						className="font-medium text-foreground underline-offset-4 hover:underline"
+					>
+						Contact us on Discord
+					</a>
+				</p>
+			</div>
+		</main>
+	);
+}

--- a/apps/web/src/components/(data)/CatalogNotFoundState.tsx
+++ b/apps/web/src/components/(data)/CatalogNotFoundState.tsx
@@ -1,0 +1,140 @@
+"use client";
+
+import Image from "next/image";
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { ArrowLeft } from "lucide-react";
+import { Button } from "@/components/ui/button";
+
+export type CatalogResourceType = "model" | "organisation" | "country" | "provider";
+
+const resourceConfig: Record<
+	CatalogResourceType,
+	{
+		articleNoun: string;
+		browseHref: string;
+		browseLabel: string;
+		requestLabel: string;
+		description: string;
+		pathSegments: number;
+	}
+> = {
+	model: {
+		articleNoun: "model",
+		browseHref: "/models",
+		browseLabel: "Browse models",
+		requestLabel: "Request a Model",
+		description:
+			"Recent announcements can arrive before the public catalogue cache catches up. Try again shortly, or tell us where you found the link.",
+		pathSegments: 2,
+	},
+	organisation: {
+		articleNoun: "organisation",
+		browseHref: "/organisations",
+		browseLabel: "Browse organisations",
+		requestLabel: "Request an Organisation",
+		description:
+			"New labs and organisations can arrive before their public profile is available. Try again shortly, or tell us where you found the link.",
+		pathSegments: 1,
+	},
+	country: {
+		articleNoun: "country",
+		browseHref: "/countries",
+		browseLabel: "Browse countries",
+		requestLabel: "Request a Country",
+		description:
+			"Country coverage is still expanding. Try again shortly, or tell us which AI ecosystem you would like to see tracked.",
+		pathSegments: 1,
+	},
+	provider: {
+		articleNoun: "API provider",
+		browseHref: "/api-providers",
+		browseLabel: "Browse providers",
+		requestLabel: "Request a Provider",
+		description:
+			"Provider coverage can arrive after a model or route is announced. Try again shortly, or tell us where you found the link.",
+		pathSegments: 1,
+	},
+};
+
+function getResourceIdFromPathname(
+	pathname: string | null,
+	resourceType: CatalogResourceType,
+): string | null {
+	if (!pathname) return null;
+	const segments = pathname.split("/").filter(Boolean);
+	const config = resourceConfig[resourceType];
+	const resourceIndex = segments.findIndex((segment) =>
+		(resourceType === "model" && segment === "models") ||
+		(resourceType === "organisation" && segment === "organisations") ||
+		(resourceType === "country" && segment === "countries") ||
+		(resourceType === "provider" && segment === "api-providers"),
+	);
+	if (resourceIndex === -1) return null;
+	const resourceId = segments.slice(resourceIndex + 1, resourceIndex + 1 + config.pathSegments);
+	if (resourceId.length !== config.pathSegments) return null;
+	return resourceId.map((segment) => decodeURIComponent(segment)).join("/");
+}
+
+export default function CatalogNotFoundState({
+	resourceType,
+	resourceId,
+}: {
+	resourceType: CatalogResourceType;
+	resourceId?: string;
+}) {
+	const pathname = usePathname();
+	const config = resourceConfig[resourceType];
+	const requestedId = resourceId ?? getResourceIdFromPathname(pathname, resourceType) ?? `the requested ${config.articleNoun}`;
+
+	return (
+		<main className="flex flex-1 flex-col">
+			<div className="container mx-auto flex min-h-[62vh] w-full flex-1 items-center justify-center px-4 py-16 sm:px-6 lg:px-8">
+				<div className="w-full max-w-2xl text-center">
+					<h1 className="mx-auto max-w-2xl text-2xl font-bold leading-tight tracking-tight sm:text-3xl">
+						<span className="block break-words">
+							The {config.articleNoun}{" "}
+							<span className="font-mono text-[0.9em]">{requestedId}</span>
+						</span>
+						<span className="block">is not available yet</span>
+					</h1>
+					<p className="mx-auto mt-5 max-w-lg text-sm leading-6 text-muted-foreground sm:text-base">
+						{config.description}
+					</p>
+
+					<div className="mt-8 flex flex-wrap items-center justify-center gap-x-4 gap-y-2 text-sm text-muted-foreground">
+						<span>{config.requestLabel}</span>
+						<a
+							href="https://discord.gg/aQyywCvgZ5"
+							target="_blank"
+							rel="noopener noreferrer"
+							className="inline-flex items-center gap-1.5 font-medium text-foreground underline-offset-4 hover:underline"
+						>
+							<Image src="/social/discord.svg" alt="" width={15} height={15} />
+							Discord
+						</a>
+						<a
+							href="https://github.com/phaseoteam/Phaseo/issues/new"
+							target="_blank"
+							rel="noopener noreferrer"
+							className="inline-flex items-center gap-1.5 font-medium text-foreground underline-offset-4 hover:underline"
+						>
+							<Image src="/social/github_light.svg" alt="" width={15} height={15} className="dark:hidden" />
+							<Image src="/social/github_dark.svg" alt="" width={15} height={15} className="hidden dark:block" />
+							GitHub
+						</a>
+					</div>
+
+					<div className="mt-5 flex flex-wrap items-center justify-center gap-3">
+						<Button asChild>
+							<Link href={config.browseHref}>
+								<ArrowLeft className="h-4 w-4" />
+								{config.browseLabel}
+							</Link>
+						</Button>
+					</div>
+				</div>
+			</div>
+		</main>
+	);
+}

--- a/apps/web/src/components/(data)/api-providers/APIProviderDetailShell.tsx
+++ b/apps/web/src/components/(data)/api-providers/APIProviderDetailShell.tsx
@@ -3,6 +3,7 @@ import Image from "next/image";
 import Link from "next/link";
 
 import { fetchFrontendAPIProviderHeader } from "@/lib/fetchers/frontend/fetchPublicCatalog";
+import { notFound } from "next/navigation";
 import TabBar from "@/components/(data)/api-providers/APIProviderTabs";
 import { Logo } from "@/components/Logo";
 import APIProviderEditButton from "./edit/APIProviderEditButton";
@@ -16,9 +17,10 @@ export default async function APIProviderDetailShell({
 	apiProviderId,
 	children,
 }: APIProviderDetailShellProps) {
-	const header = await fetchFrontendAPIProviderHeader(apiProviderId);
+	const header = await fetchFrontendAPIProviderHeader(apiProviderId).catch(() => null);
 
 	if (!header) {
+		notFound();
 		return (
 			<main className="flex min-h-screen flex-col">
 				<div className="container mx-auto px-4 py-8">

--- a/apps/web/src/components/(data)/model/ModelNotFoundState.tsx
+++ b/apps/web/src/components/(data)/model/ModelNotFoundState.tsx
@@ -1,73 +1,9 @@
-"use client";
-
-import Image from "next/image";
-import Link from "next/link";
-import { usePathname } from "next/navigation";
-import { ArrowLeft } from "lucide-react";
-import { Button } from "@/components/ui/button";
+import CatalogNotFoundState from "@/components/(data)/CatalogNotFoundState";
 
 interface ModelNotFoundStateProps {
 	modelId?: string;
 }
 
-function getModelIdFromPathname(pathname: string | null): string | null {
-	if (!pathname) return null;
-	const segments = pathname.split("/").filter(Boolean).slice(1, 3);
-	if (segments.length !== 2) return null;
-	return segments.map((segment) => decodeURIComponent(segment)).join("/");
-}
-
 export default function ModelNotFoundState({ modelId }: ModelNotFoundStateProps) {
-	const pathname = usePathname();
-	const requestedModelId = modelId ?? getModelIdFromPathname(pathname) ?? "the requested model";
-
-	return (
-		<main className="flex flex-1 flex-col">
-			<div className="container mx-auto flex min-h-[62vh] w-full flex-1 items-center justify-center px-4 py-16 sm:px-6 lg:px-8">
-				<div className="w-full max-w-2xl text-center">
-					<h1 className="mx-auto max-w-2xl text-2xl font-bold leading-tight tracking-tight sm:text-3xl">
-						<span className="block break-words">
-							The model <span className="font-mono text-[0.9em]">{requestedModelId}</span>
-						</span>
-						<span className="block">is not available yet</span>
-					</h1>
-					<p className="mx-auto mt-5 max-w-lg text-sm leading-6 text-muted-foreground sm:text-base">
-						Recent announcements can arrive before the public catalogue cache catches up. Try again shortly, or tell us where you found the link.
-					</p>
-
-					<div className="mt-8 flex flex-wrap items-center justify-center gap-x-4 gap-y-2 text-sm text-muted-foreground">
-						<span>Request a Model</span>
-						<a
-							href="https://discord.gg/aQyywCvgZ5"
-							target="_blank"
-							rel="noopener noreferrer"
-							className="inline-flex items-center gap-1.5 font-medium text-foreground underline-offset-4 hover:underline"
-						>
-							<Image src="/social/discord.svg" alt="" width={15} height={15} />
-							Discord
-						</a>
-						<a
-							href="https://github.com/phaseoteam/Phaseo/issues/new"
-							target="_blank"
-							rel="noopener noreferrer"
-							className="inline-flex items-center gap-1.5 font-medium text-foreground underline-offset-4 hover:underline"
-						>
-							<Image src="/social/github_light.svg" alt="" width={15} height={15} className="dark:hidden" />
-							<Image src="/social/github_dark.svg" alt="" width={15} height={15} className="hidden dark:block" />
-							GitHub
-						</a>
-					</div>
-
-					<div className="mt-5 flex flex-wrap items-center justify-center gap-3">
-						<Button asChild>
-							<Link href="/models">
-								<ArrowLeft className="h-4 w-4" />
-								Browse models
-							</Link>
-						</Button>
-					</div>
-				</div>
-			</div>
-		</main>
-	);
+	return <CatalogNotFoundState resourceType="model" resourceId={modelId} />;
 }

--- a/apps/web/src/components/(data)/organisation/OrganisationDetailShell.tsx
+++ b/apps/web/src/components/(data)/organisation/OrganisationDetailShell.tsx
@@ -3,6 +3,7 @@ import Image from "next/image";
 import Link from "next/link";
 
 import { fetchFrontendOrganisationHeader } from "@/lib/fetchers/frontend/fetchPublicCatalog";
+import { notFound } from "next/navigation";
 import TabBar from "@/components/(data)/organisation/OrganisationTabs";
 import { Logo } from "@/components/Logo";
 import OrganisationEditButton from "./edit/OrganisationEditButton";
@@ -16,9 +17,10 @@ export default async function OrganisationDetailShell({
 	organisationId,
 	children,
 }: OrganisationDetailShellProps) {
-	const header = await fetchFrontendOrganisationHeader(organisationId);
+	const header = await fetchFrontendOrganisationHeader(organisationId).catch(() => null);
 
 	if (!header) {
+		notFound();
 		return (
 			<main className="flex min-h-screen flex-col">
 				<div className="container mx-auto px-4 py-8">


### PR DESCRIPTION
## Summary

- Add a shared Phaseo-styled not-found state for models, organisations/labs, countries, and API providers.
- Route missing catalogue records through resource-specific `not-found.tsx` pages so stale links render a useful page instead of a server error.
- Add a global error boundary with retry, catalogue navigation, and Discord support links for unexpected failures.
- Keep the model route on the same shared component and preserve the requested two-line message: `The {id}` / `is not available yet`.

## Validation

- `git diff --check`
- Playwright smoke checks for unknown organisation, country, and API provider routes on the local web app.
- `pnpm --filter @phaseo/web exec tsc --noEmit --pretty false` (only the repository's existing baseline errors remain in unrelated layout/auth test files).
- Focused ESLint run was attempted; the command exceeded the local 120-second timeout after the new console warnings were explicitly annotated.

Created with Codex