### PR TITLE
Fix OAuth consent submission routing

### DIFF
--- a/apps/web/src/app/(auth)/oauth/consent/submit/route.test.ts
+++ b/apps/web/src/app/(auth)/oauth/consent/submit/route.test.ts
@@ -1,0 +1,32 @@
+import { POST } from "./route";
+
+describe("OAuth consent submission route", () => {
+	it("rejects cross-origin submissions before processing consent", async () => {
+		const response = await POST(new Request("https://phaseo.app/oauth/consent/submit", {
+			method: "POST",
+			headers: {
+				"content-type": "application/json",
+				origin: "https://attacker.example",
+			},
+			body: JSON.stringify({ operation: "approve" }),
+		}));
+
+		expect(response.status).toBe(403);
+		expect(await response.json()).toEqual({ error: "Invalid request origin" });
+	});
+
+	it("keeps same-origin responses private and rejects unsupported operations", async () => {
+		const response = await POST(new Request("https://phaseo.app/oauth/consent/submit", {
+			method: "POST",
+			headers: {
+				"content-type": "application/json",
+				origin: "https://phaseo.app",
+			},
+			body: JSON.stringify({ operation: "unknown" }),
+		}));
+
+		expect(response.status).toBe(200);
+		expect(response.headers.get("cache-control")).toBe("no-store");
+		expect(await response.json()).toEqual({ error: "Unsupported consent operation" });
+	});
+});

--- a/apps/web/src/app/(auth)/oauth/consent/submit/route.ts
+++ b/apps/web/src/app/(auth)/oauth/consent/submit/route.ts
@@ -3,7 +3,7 @@ import { NextResponse } from "next/server";
 import {
 	approveAuthorizationAction,
 	denyAuthorizationAction,
-} from "@/app/(auth)/oauth/consent/actions";
+} from "../actions";
 
 export async function POST(request: Request) {
 	const origin = request.headers.get("origin");

--- a/apps/web/src/components/(gateway)/oauth/ConsentForm.tsx
+++ b/apps/web/src/components/(gateway)/oauth/ConsentForm.tsx
@@ -353,7 +353,7 @@ export default function ConsentForm({
 		setError(null);
 
 		try {
-			const response = await fetch("/api/internal/oauth/consent", {
+			const response = await fetch("/oauth/consent/submit", {
 				method: "POST",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify({
@@ -396,7 +396,7 @@ export default function ConsentForm({
 		setError(null);
 
 		try {
-			const response = await fetch("/api/internal/oauth/consent", {
+			const response = await fetch("/oauth/consent/submit", {
 				method: "POST",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify({


### PR DESCRIPTION
## Summary

- route OAuth consent approval through the Next.js web application instead of the `/api/internal/*` Worker catch-all
- preserve same-origin, JSON-only, session, membership, redirect, PKCE, scope, and resource validation
- add focused regression coverage for cross-origin rejection and private responses

## Root cause

Production routes `phaseo.app/api/internal/*` to the web-api Worker. The consent form posted to `/api/internal/oauth/consent`, but that Worker did not implement the route and returned `404 {"error":"not_found"}` before the OAuth API approval handler could run.

## Validation

- `pnpm exec jest --runInBand --runTestsByPath "src/app/(auth)/oauth/consent/submit/route.test.ts"`
- `pnpm exec vitest run src/routes/oauth.security.test.ts src/lib/oauth/service.security.test.ts`
- `pnpm exec vitest run` in `apps/mcp`
- focused ESLint: no errors (two pre-existing warnings in `ConsentForm`)
- `pnpm build` in `apps/web`
- linked Supabase migration history matches local history

Created with Codex


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated OAuth consent approvals and denials to use the supported submission flow.
  * Improved protection against cross-origin consent submissions and unsafe redirect destinations.
  * Unsupported consent operations now return a clear error response without caching.

* **Tests**
  * Added coverage for same-origin and cross-origin consent requests, response headers, validation, and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->