### PR TITLE
Fix Mind Lab importer record

### DIFF
--- a/packages/data/catalog/src/data/organisations/mindai/organisation.json
+++ b/packages/data/catalog/src/data/organisations/mindai/organisation.json
@@ -1,7 +1,7 @@
 {
   "organisation_id":"mindai",
   "name":"Mind Lab",
-  "country_code":null,
+  "country_code":"SG",
   "description":"Mind Lab develops the Macaron V1 family of model-specialist systems.",
   "colour":"#6366F1",
   "organisation_links":[{"platform":"website","url":"https://novita.ai/models/model-detail/mindai-macaron-v1-venti"}],

--- a/packages/data/catalog/src/data/validate.ts
+++ b/packages/data/catalog/src/data/validate.ts
@@ -815,6 +815,10 @@ function checkOrganisations(state: ValidationState): string[] {
         if (typeof data.name !== 'string' || !data.name.trim()) {
             errors.push(`Organisation ${organisationId} missing name`);
         }
+        const countryCode = typeof data.country_code === 'string' ? data.country_code.trim() : '';
+        if (!/^[A-Z]{2,3}$/.test(countryCode)) {
+            errors.push(`Organisation ${organisationId} has invalid country_code`);
+        }
         const links = Array.isArray(data.organisation_links) ? data.organisation_links : [];
         const seenPlatforms = new Set<string>();
         for (const [index, link] of links.entries()) {


### PR DESCRIPTION
## Summary

- Set Mind Lab (`mindai`) country code to `SG`, verified against Mind Lab's official MinT privacy policy identifying MINDAI PTE. LTD. as incorporated in Singapore.
- Validate organisation country codes before import so future null/invalid values fail in catalogue validation rather than reaching the database importer.

This unblocks the main importer, which previously stopped before importing the new model/provider/pricing records with a `data_organisations.country_code` NOT NULL violation.

## Validation

- `pnpm --filter @phaseo/web validate`
- `git diff --check`
- Local importer dry-run attempted but requires production Supabase configuration; GitHub main CI will run the real importer after merge.

Created with Codex