### PR TITLE
Fix CLI OAuth read access

### DIFF
--- a/.changeset/release-phaseo-cli-oauth-fixes.md
+++ b/.changeset/release-phaseo-cli-oauth-fixes.md
@@ -1,0 +1,5 @@
+---
+"@phaseo/cli": patch
+---
+
+Publish the native Phaseo CLI package and allow its scoped OAuth session to use catalogue, pricing, analytics, and generation read commands.

--- a/apps/api/src/pipeline/before/auth.management.test.ts
+++ b/apps/api/src/pipeline/before/auth.management.test.ts
@@ -341,6 +341,9 @@ describe("authenticateManagement", () => {
 		const jwt = "eyJhbGciOiJIUzI1NiJ9.eyJ1c2VyX2lkIjoidTEiLCJ3b3Jrc3BhY2VfaWQiOiJ3MSIsImNsaWVudF9pZCI6ImMxIn0.sig";
 		runtime.oauthAuthorizationRow.value = { revoked_at: null };
 		const { guardAuth } = await import("./guards");
+		const rejected = await guardAuth(buildRequest(jwt));
+		expect(rejected.ok).toBe(false);
+
 		const result = await guardAuth(buildRequest(jwt), { allowOAuthJwt: true });
 		await flushBackground();
 

--- a/apps/api/src/pipeline/before/auth.management.test.ts
+++ b/apps/api/src/pipeline/before/auth.management.test.ts
@@ -337,6 +337,25 @@ describe("authenticateManagement", () => {
 		);
 	});
 
+	it("accepts CLI OAuth JWTs only when a control route opts in", async () => {
+		const jwt = "eyJhbGciOiJIUzI1NiJ9.eyJ1c2VyX2lkIjoidTEiLCJ3b3Jrc3BhY2VfaWQiOiJ3MSIsImNsaWVudF9pZCI6ImMxIn0.sig";
+		runtime.oauthAuthorizationRow.value = { revoked_at: null };
+		const { guardAuth } = await import("./guards");
+		const result = await guardAuth(buildRequest(jwt), { allowOAuthJwt: true });
+		await flushBackground();
+
+		expect(result).toMatchObject({
+			ok: true,
+			value: {
+				workspaceId: "w1",
+				apiKeyId: "c1",
+				authMethod: "oauth",
+				oauthClientId: "c1",
+				oauthScopes: ["keys:read", "keys:write"],
+			},
+		});
+	});
+
 	it("rejects non-gateway JWT bearer tokens for management auth", async () => {
 		const jwt = "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ1MSJ9.sig";
 		const { authenticateManagement } = await import("./auth");

--- a/apps/api/src/pipeline/before/auth.ts
+++ b/apps/api/src/pipeline/before/auth.ts
@@ -201,6 +201,7 @@ export type AuthSuccess = {
 type AuthenticateOptions = {
     useKvCache?: boolean;
     allowResourceBoundOAuthKey?: boolean;
+    allowOAuthJwt?: boolean;
 };
 
 type KeyRow = {
@@ -377,7 +378,10 @@ export async function authenticate(req: Request, options: AuthenticateOptions = 
         if (!isGatewayOAuthJwt(token)) {
             return { ok: false, reason: "invalid_key_format" };
         }
-		return { ok: false, reason: "oauth_delegated_key_required" };
+        if (options.allowOAuthJwt) {
+            return authenticateOAuth(req, token, options);
+        }
+        return { ok: false, reason: "oauth_delegated_key_required" };
     }
 
     const bindings = getBindings();

--- a/apps/api/src/pipeline/before/guards.ts
+++ b/apps/api/src/pipeline/before/guards.ts
@@ -286,6 +286,7 @@ export type GuardResult<T> = GuardOk<T> | GuardErr;
 
 type GuardAuthOptions = {
     useKvCache?: boolean;
+    allowOAuthJwt?: boolean;
 };
 
 export async function guardAuth(req: Request, options: GuardAuthOptions = {}): Promise<GuardResult<{
@@ -303,7 +304,10 @@ export async function guardAuth(req: Request, options: GuardAuthOptions = {}): P
     scopes?: string[];
 }>> {
     const requestId = generatePublicId();
-    const auth = await authenticate(req, { useKvCache: options.useKvCache });
+    const auth = await authenticate(req, {
+        useKvCache: options.useKvCache,
+        allowOAuthJwt: options.allowOAuthJwt,
+    });
     if (!auth.ok) {
         const reason = (auth as AuthFailure).reason;
         return { ok: false, response: err("unauthorised", { reason, request_id: requestId }) };

--- a/apps/api/src/routes/v1/control/analytics.ts
+++ b/apps/api/src/routes/v1/control/analytics.ts
@@ -252,7 +252,7 @@ async function loadAnalyticsRollupRows(args: {
 }
 
 async function handleAnalytics(req: Request) {
-	const auth = await guardAuth(req);
+	const auth = await guardAuth(req, { allowOAuthJwt: true });
 	if (!auth.ok) {
 		return (auth as GuardErr).response;
 	}

--- a/apps/api/src/routes/v1/control/generations.test.ts
+++ b/apps/api/src/routes/v1/control/generations.test.ts
@@ -145,6 +145,27 @@ describe("generationsRoutes", () => {
 		expect(isGatewayIoLoggingFeatureEnabledMock).not.toHaveBeenCalled();
 	});
 
+	it("rejects OAuth sessions without the generation-read capability", async () => {
+		authenticateMock.mockResolvedValue({
+			ok: true,
+			workspaceId: "ws_test",
+			apiKeyId: "phaseo_cli",
+			apiKeyRef: null,
+			apiKeyKid: null,
+			authMethod: "oauth",
+			oauthScopes: ["activity:read"],
+		});
+
+		const response = await generationsRoutes.request("https://example.com/?id=gen_123");
+
+		expect(response.status).toBe(403);
+		await expect(response.json()).resolves.toEqual({
+			error: "insufficient_scope",
+			message: "Token requires generations:read",
+		});
+		expect(getSupabaseAdminMock).not.toHaveBeenCalled();
+	});
+
 	it("returns raw I/O logs only with an explicit log-read capability", async () => {
 		authenticateMock.mockResolvedValue({
 			ok: true,

--- a/apps/api/src/routes/v1/control/generations.ts
+++ b/apps/api/src/routes/v1/control/generations.ts
@@ -11,6 +11,7 @@ import { readGatewayIoLogObject } from "@pipeline/audit/io-logging";
 import { isGatewayIoLoggingFeatureEnabled } from "@core/feature-flags";
 import { CAPABILITIES } from "@/lib/authz/capabilities";
 import { json, withRuntime } from "../../utils";
+import { requireCapability } from "./route-helpers";
 
 function canReadGenerationIoLog(auth: AuthSuccess): boolean {
 	if (auth.internal) return true;
@@ -53,6 +54,10 @@ async function handleGeneration(req: Request) {
         const reason = (auth as AuthFailure).reason;
         return json({ ok: false, error: "unauthorised", reason }, 401, { "Cache-Control": "no-store" });
     }
+	if (auth.authMethod === "oauth") {
+		const scopeError = requireCapability(auth, CAPABILITIES.GENERATIONS_READ);
+		if (scopeError) return scopeError;
+	}
 
     const supabase = getSupabaseAdmin();
     const { data, error } = await supabase

--- a/apps/api/src/routes/v1/control/generations.ts
+++ b/apps/api/src/routes/v1/control/generations.ts
@@ -48,7 +48,7 @@ async function handleGeneration(req: Request) {
         return json({ ok: false, error: "missing_id" }, 400, { "Cache-Control": "no-store" });
     }
 
-    const auth = await authenticate(req);
+    const auth = await authenticate(req, { allowOAuthJwt: true });
     if (!auth.ok) {
         const reason = (auth as AuthFailure).reason;
         return json({ ok: false, error: "unauthorised", reason }, 401, { "Cache-Control": "no-store" });

--- a/apps/api/src/routes/v1/control/models.ts
+++ b/apps/api/src/routes/v1/control/models.ts
@@ -530,7 +530,7 @@ export async function handleModels(req: Request) {
         );
     }
 
-    const auth = await guardAuth(req);
+    const auth = await guardAuth(req, { allowOAuthJwt: true });
     if (!auth.ok) {
         return (auth as GuardErr).response;
     }
@@ -676,7 +676,7 @@ export async function handleModels(req: Request) {
 }
 
 export async function handleMyModels(req: Request) {
-    const auth = await guardAuth(req);
+    const auth = await guardAuth(req, { allowOAuthJwt: true });
     if (!auth.ok) {
         return (auth as GuardErr).response;
     }

--- a/apps/api/src/routes/v1/control/organisations.ts
+++ b/apps/api/src/routes/v1/control/organisations.ts
@@ -39,7 +39,7 @@ type Organisation = {
 };
 
 async function handleOrganisations(req: Request) {
-    const auth = await guardAuth(req, { useKvCache: false });
+    const auth = await guardAuth(req, { useKvCache: false, allowOAuthJwt: true });
     if (!auth.ok) {
         return (auth as GuardErr).response;
     }

--- a/apps/api/src/routes/v1/control/placeholders.ts
+++ b/apps/api/src/routes/v1/control/placeholders.ts
@@ -29,7 +29,7 @@ const KNOWN_ENDPOINTS = [
 ];
 
 async function handleListEndpoints(req: Request) {
-	const auth = await guardAuth(req, { useKvCache: false });
+	const auth = await guardAuth(req, { useKvCache: false, allowOAuthJwt: true });
 	if (!auth.ok) {
 		return (auth as GuardErr).response;
 	}

--- a/apps/api/src/routes/v1/control/pricing.ts
+++ b/apps/api/src/routes/v1/control/pricing.ts
@@ -45,7 +45,7 @@ function parseModelKey(value?: string | null): {
 }
 
 async function handlePricingModels(req: Request) {
-    const auth = await guardAuth(req);
+    const auth = await guardAuth(req, { allowOAuthJwt: true });
     if (!auth.ok) {
         return (auth as GuardErr).response;
     }
@@ -211,7 +211,7 @@ async function handlePricingModels(req: Request) {
 }
 
 async function handlePricingCalculate(req: Request) {
-    const auth = await guardAuth(req, { useKvCache: false });
+    const auth = await guardAuth(req, { useKvCache: false, allowOAuthJwt: true });
     if (!auth.ok) {
         return (auth as GuardErr).response;
     }

--- a/apps/api/src/routes/v1/control/providers.ts
+++ b/apps/api/src/routes/v1/control/providers.ts
@@ -39,7 +39,7 @@ type Provider = {
 };
 
 async function handleProviders(req: Request) {
-    const auth = await guardAuth(req);
+    const auth = await guardAuth(req, { allowOAuthJwt: true });
     if (!auth.ok) {
         return (auth as GuardErr).response;
     }


### PR DESCRIPTION
## Summary

- allow scoped Phaseo OAuth JWT sessions on explicit read-only control-plane routes used by the CLI
- preserve the delegated opaque-key requirement for inference and the resource-bound-token boundary for MCP
- add regression coverage proving the opt-in is forwarded through the shared auth guard
- add a changeset so the native `@phaseo/cli` package replaces the currently published transition wrapper

## Security boundary

OAuth JWT acceptance is opt-in per control-plane route. Gateway inference continues to reject session JWTs with `oauth_delegated_key_required`, and MCP resource tokens remain valid only for the MCP resource server. Existing route capability checks continue to enforce granted scopes.

## Validation

- `pnpm --filter @phaseo/gateway-api exec vitest run src/pipeline/before/auth.management.test.ts src/pipeline/before/auth.cache.test.ts src/routes/v1/control/models.route.test.ts src/routes/v1/control/models.test.ts` (38 passed)
- `pnpm --filter @phaseo/gateway-api typecheck`
- focused API ESLint on all changed TypeScript files
- `pnpm --filter @phaseo/cli test` (28 passed)
- `pnpm --filter @phaseo/mcp test` (13 passed)
- OAuth and web consent security suites (47 passed)
- native CLI build and npm package dry-run

Created with Codex


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded scoped OAuth CLI access to read catalogue, pricing, analytics, generation, model, organisation, endpoint, and provider information.
  * Enabled OAuth-authenticated access across supported control-plane endpoints while preserving existing permissions and response behavior.

* **Bug Fixes**
  * Corrected authentication handling so OAuth JWTs are accepted only by explicitly supported endpoints.

* **Tests**
  * Added coverage confirming OAuth JWT validation, scope handling, and authentication results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->