### PR TITLE
Restore CLI analytics and pricing

### DIFF
--- a/apps/api/src/routes/v1/control/analytics.test.ts
+++ b/apps/api/src/routes/v1/control/analytics.test.ts
@@ -1,0 +1,90 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const guardAuthMock = vi.fn();
+const getSupabaseAdminMock = vi.fn();
+
+vi.mock("@/pipeline/before/guards", () => ({
+	guardAuth: (...args: unknown[]) => guardAuthMock(...args),
+}));
+
+vi.mock("@/runtime/env", () => ({
+	getSupabaseAdmin: (...args: unknown[]) => getSupabaseAdminMock(...args),
+}));
+
+vi.mock("../../utils", () => ({
+	withRuntime:
+		(handler: (req: Request) => Promise<Response>) =>
+		async (c: { req: { raw: Request } }) =>
+			handler(c.req.raw),
+	json: (data: unknown, status = 200, headers: Record<string, string> = {}) =>
+		new Response(JSON.stringify(data), { status, headers: { "Content-Type": "application/json", ...headers } }),
+}));
+
+import { analyticsRoutes } from "./analytics";
+
+function queryResult(result: { data: unknown[]; error: unknown }) {
+	const query: Record<string, unknown> = {};
+	for (const method of ["select", "eq", "gte", "lt", "in"]) {
+		query[method] = vi.fn(() => query);
+	}
+	query.then = (resolve: (value: unknown) => unknown) => Promise.resolve(result).then(resolve);
+	return query;
+}
+
+describe("analyticsRoutes", () => {
+	beforeEach(() => {
+		guardAuthMock.mockReset();
+		getSupabaseAdminMock.mockReset();
+		guardAuthMock.mockResolvedValue({
+			ok: true,
+			value: {
+				workspaceId: "ws_test",
+				authMethod: "oauth",
+				oauthScopes: ["analytics:read"],
+			},
+		});
+	});
+
+	it("loads the current v2 daily rollup and aggregates meter totals", async () => {
+		const yesterday = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString().slice(0, 10);
+		getSupabaseAdminMock.mockReturnValue({
+			from: vi.fn((table: string) => {
+				if (table === "v2_private_usage_daily") return queryResult({ data: [{
+					usage_date: yesterday,
+					model_slug: "openai/gpt-test",
+					provider_model_id: "openai:gpt-test",
+					cost_nanos: "1500000000",
+					requests: 3,
+					successful_requests: 2,
+					v2_private_usage_daily_meters: [
+						{ meter_key: "input_tokens", quantity: 20 },
+						{ meter_key: "output_tokens", quantity: 5 },
+						{ meter_key: "reasoning_tokens", quantity: 2 },
+					],
+				}], error: null });
+				if (table === "v2_model_provider_routes") return queryResult({ data: [{
+					provider_model_id: "openai:gpt-test",
+					provider_slug: "openai",
+				}], error: null });
+				throw new Error(`unexpected table: ${table}`);
+			}),
+		});
+
+		const response = await analyticsRoutes.request("https://example.com/");
+		const body = await response.json() as { data: Array<Record<string, unknown>> };
+
+		expect(response.status).toBe(200);
+		expect(body.data).toEqual([
+			expect.objectContaining({
+				date: yesterday,
+				model_permaslug: "openai/gpt-test",
+				provider_name: "OpenAI",
+				usage: 1.5,
+				requests: 2,
+				prompt_tokens: 20,
+				completion_tokens: 5,
+				reasoning_tokens: 2,
+			}),
+		]);
+	});
+});

--- a/apps/api/src/routes/v1/control/analytics.test.ts
+++ b/apps/api/src/routes/v1/control/analytics.test.ts
@@ -24,7 +24,7 @@ import { analyticsRoutes } from "./analytics";
 
 function queryResult(result: { data: unknown[]; error: unknown }) {
 	const query: Record<string, unknown> = {};
-	for (const method of ["select", "eq", "gte", "lt", "in"]) {
+	for (const method of ["select", "eq", "gte", "lt", "in", "order", "range"]) {
 		query[method] = vi.fn(() => query);
 	}
 	query.then = (resolve: (value: unknown) => unknown) => Promise.resolve(result).then(resolve);
@@ -49,14 +49,15 @@ describe("analyticsRoutes", () => {
 		const yesterday = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString().slice(0, 10);
 		getSupabaseAdminMock.mockReturnValue({
 			from: vi.fn((table: string) => {
-				if (table === "v2_private_usage_daily") return queryResult({ data: [{
-					usage_date: yesterday,
-					model_slug: "openai/gpt-test",
+				if (table === "v2_request_facts") return queryResult({ data: [{
+					occurred_at: `${yesterday}T12:00:00.000Z`,
+					endpoint: "chat/completions",
+					requested_model_slug: "openai/gpt-test",
+					routed_model_slug: "openai/gpt-test",
 					provider_model_id: "openai:gpt-test",
 					cost_nanos: "1500000000",
-					requests: 3,
-					successful_requests: 2,
-					v2_private_usage_daily_meters: [
+					byok: true,
+					v2_request_usage: [
 						{ meter_key: "input_tokens", quantity: 20 },
 						{ meter_key: "output_tokens", quantity: 5 },
 						{ meter_key: "reasoning_tokens", quantity: 2 },
@@ -79,8 +80,10 @@ describe("analyticsRoutes", () => {
 				date: yesterday,
 				model_permaslug: "openai/gpt-test",
 				provider_name: "OpenAI",
+				endpoint_id: "chat/completions",
 				usage: 1.5,
-				requests: 2,
+				byok_usage_inference: 1.5,
+				requests: 1,
 				prompt_tokens: 20,
 				completion_tokens: 5,
 				reasoning_tokens: 2,

--- a/apps/api/src/routes/v1/control/analytics.ts
+++ b/apps/api/src/routes/v1/control/analytics.ts
@@ -117,14 +117,15 @@ function resolveScopedTeamId(args: {
     return { ok: true, workspaceId: requested };
 }
 
-type AnalyticsRollupRow = {
-    usage_date: string | null;
-    model_slug: string | null;
+type AnalyticsFactRow = {
+    occurred_at: string | null;
+    endpoint: string | null;
+    requested_model_slug: string | null;
+    routed_model_slug: string | null;
     provider_model_id: string | null;
     cost_nanos: number | string | null;
-    requests: number | string | null;
-    successful_requests: number | string | null;
-    v2_private_usage_daily_meters: Array<{
+    byok: boolean | null;
+    v2_request_usage: Array<{
         meter_key: string | null;
         quantity: number | string | null;
     }> | null;
@@ -168,28 +169,33 @@ function toRoundedUsage(value: number): number {
     return Number(value.toFixed(9));
 }
 
-async function loadAnalyticsRollupRows(args: {
+async function loadAnalyticsFactRows(args: {
     workspaceId: string;
     startIso: string;
     endIso: string;
-}): Promise<AnalyticsRollupRow[]> {
+}): Promise<AnalyticsFactRow[]> {
     const supabase = getSupabaseAdmin();
-    const startDay = args.startIso.slice(0, 10);
-    const endDay = args.endIso.slice(0, 10);
-    const { data, error } = await supabase
-        .from("v2_private_usage_daily")
-        .select(
-            "usage_date,model_slug,provider_model_id,cost_nanos,requests,successful_requests,v2_private_usage_daily_meters(meter_key,quantity)"
-        )
-        .eq("workspace_id", args.workspaceId)
-        .gte("usage_date", startDay)
-        .lt("usage_date", endDay);
-
-    if (error) {
-        throw new Error(error.message || "Failed to load v2 analytics rollup rows");
+    const rows: AnalyticsFactRow[] = [];
+    const pageSize = 1000;
+    for (let offset = 0; ; offset += pageSize) {
+        const { data, error } = await supabase
+            .from("v2_request_facts")
+            .select(
+                "occurred_at,endpoint,requested_model_slug,routed_model_slug,provider_model_id,cost_nanos,byok,v2_request_usage(meter_key,quantity)"
+            )
+            .eq("workspace_id", args.workspaceId)
+            .gte("occurred_at", args.startIso)
+            .lt("occurred_at", args.endIso)
+            .order("occurred_at", { ascending: true })
+            .range(offset, offset + pageSize - 1);
+        if (error) {
+            throw new Error(error.message || "Failed to load v2 analytics request facts");
+        }
+        const page = (data ?? []) as AnalyticsFactRow[];
+        rows.push(...page);
+        if (page.length < pageSize) break;
     }
-
-    return (data ?? []) as AnalyticsRollupRow[];
+    return rows;
 }
 
 async function loadProviderNames(providerModelIds: string[]): Promise<Map<string, string>> {
@@ -209,9 +215,9 @@ async function loadProviderNames(providerModelIds: string[]): Promise<Map<string
     return names;
 }
 
-function meterQuantity(row: AnalyticsRollupRow, keys: string[]): number {
+function meterQuantity(row: AnalyticsFactRow, keys: string[]): number {
     const wanted = new Set(keys);
-    return (row.v2_private_usage_daily_meters ?? []).reduce((total, meter) => {
+    return (row.v2_request_usage ?? []).reduce((total, meter) => {
         return wanted.has(meter.meter_key ?? "") ? total + (toFiniteNumber(meter.quantity) ?? 0) : total;
     }, 0);
 }
@@ -239,7 +245,7 @@ async function handleAnalytics(req: Request) {
 	const endIso = range.end.toISOString();
 
 	try {
-		const rows = await loadAnalyticsRollupRows({
+		const rows = await loadAnalyticsFactRows({
 			workspaceId,
 			startIso,
             endIso,
@@ -262,17 +268,18 @@ async function handleAnalytics(req: Request) {
 			reasoning_tokens: number;
 		}>();
 		for (const row of rows) {
-			const date = toDayBucket(row.usage_date);
+			const date = toDayBucket(row.occurred_at?.slice(0, 10));
 			if (!date) continue;
-			const modelPermaslug = toNonEmptyString(row.model_slug, "unknown/unknown");
+			const modelPermaslug = toNonEmptyString(row.routed_model_slug ?? row.requested_model_slug, "unknown/unknown");
 			const providerModelId = toNonEmptyString(row.provider_model_id, "unknown");
 			const providerId = providerNames.get(providerModelId) ?? providerModelId.split(":", 1)[0] ?? "unknown";
-			const key = `${date}\u0000${modelPermaslug}\u0000${providerModelId}`;
+			const endpointId = toNonEmptyString(row.endpoint, "unknown");
+			const key = `${date}\u0000${modelPermaslug}\u0000${providerModelId}\u0000${endpointId}`;
 			const existing = grouped.get(key) ?? {
 				date,
 				model: toModelDisplay(modelPermaslug),
 				model_permaslug: modelPermaslug,
-				endpoint_id: "unknown",
+				endpoint_id: endpointId,
 				provider_name: toProviderName(providerId),
 				usage: 0,
 				byok_usage_inference: 0,
@@ -281,8 +288,10 @@ async function handleAnalytics(req: Request) {
 				completion_tokens: 0,
 				reasoning_tokens: 0,
 			};
-			existing.usage += toUsdFromNanos(toFiniteNumber(row.cost_nanos));
-			existing.requests += Math.max(0, Math.round(toFiniteNumber(row.successful_requests ?? row.requests) ?? 0));
+			const usage = toUsdFromNanos(toFiniteNumber(row.cost_nanos));
+			existing.usage += usage;
+			if (row.byok) existing.byok_usage_inference += usage;
+			existing.requests += 1;
 			existing.prompt_tokens += Math.max(0, Math.round(meterQuantity(row, ["input_tokens", "prompt_tokens"])));
 			existing.completion_tokens += Math.max(0, Math.round(meterQuantity(row, ["output_tokens", "completion_tokens"])));
 			existing.reasoning_tokens += Math.max(0, Math.round(meterQuantity(row, ["reasoning_tokens"])));
@@ -290,7 +299,11 @@ async function handleAnalytics(req: Request) {
 		}
 
         const data = Array.from(grouped.values())
-			.map((item) => ({ ...item, usage: toRoundedUsage(item.usage) }))
+			.map((item) => ({
+				...item,
+				usage: toRoundedUsage(item.usage),
+				byok_usage_inference: toRoundedUsage(item.byok_usage_inference),
+			}))
             .sort((a, b) => {
                 if (a.date !== b.date) return b.date.localeCompare(a.date);
                 if (a.usage !== b.usage) return b.usage - a.usage;

--- a/apps/api/src/routes/v1/control/analytics.ts
+++ b/apps/api/src/routes/v1/control/analytics.ts
@@ -6,7 +6,7 @@
 import { Hono } from "hono";
 import type { Env } from "@/runtime/types";
 import { withRuntime, json } from "../../utils";
-import { getCache, getSupabaseAdmin } from "@/runtime/env";
+import { getSupabaseAdmin } from "@/runtime/env";
 import { guardAuth, type GuardErr } from "@/pipeline/before/guards";
 import { CAPABILITIES } from "@/lib/authz/capabilities";
 import { requireCapability } from "./route-helpers";
@@ -14,8 +14,6 @@ import { requireCapability } from "./route-helpers";
 const COMPLETED_DAYS_WINDOW = 30;
 const MS_PER_DAY = 24 * 60 * 60 * 1000;
 const DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
-const ANALYTICS_REFRESH_MARKER_PREFIX = "gateway:analytics:rollup-refresh";
-const ANALYTICS_REFRESH_COOLDOWN_SECONDS = 600;
 
 function startOfUtcDay(date: Date): Date {
     return new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate()));
@@ -120,16 +118,16 @@ function resolveScopedTeamId(args: {
 }
 
 type AnalyticsRollupRow = {
-    day_bucket: string | null;
-    model_id: string | null;
-    endpoint: string | null;
-    provider: string | null;
-    usage_nanos: number | string | null;
-    byok_usage_nanos: number | string | null;
+    usage_date: string | null;
+    model_slug: string | null;
+    provider_model_id: string | null;
+    cost_nanos: number | string | null;
     requests: number | string | null;
-    prompt_tokens: number | string | null;
-    completion_tokens: number | string | null;
-    reasoning_tokens: number | string | null;
+    successful_requests: number | string | null;
+    v2_private_usage_daily_meters: Array<{
+        meter_key: string | null;
+        quantity: number | string | null;
+    }> | null;
 };
 
 function toModelDisplay(permaslug: string): string {
@@ -170,63 +168,6 @@ function toRoundedUsage(value: number): number {
     return Number(value.toFixed(9));
 }
 
-async function refreshAnalyticsRollup(args: {
-	workspaceId: string;
-	startIso: string;
-	endIso: string;
-}): Promise<void> {
-    const supabase = getSupabaseAdmin();
-    const { error } = await supabase.rpc("refresh_gateway_activity_rollup_daily", {
-        p_workspace_id: args.workspaceId,
-        p_start: args.startIso,
-        p_end: args.endIso,
-    });
-    if (error) {
-        throw new Error(error.message || "Failed to refresh analytics rollup");
-	}
-}
-
-function buildRefreshMarkerKey(args: {
-	workspaceId: string;
-	startIso: string;
-	endIso: string;
-}): string {
-	const startDay = args.startIso.slice(0, 10);
-	const endDay = args.endIso.slice(0, 10);
-	return `${ANALYTICS_REFRESH_MARKER_PREFIX}:${args.workspaceId}:${startDay}:${endDay}`;
-}
-
-async function shouldRefreshAnalyticsRollup(args: {
-	workspaceId: string;
-	startIso: string;
-	endIso: string;
-}): Promise<boolean> {
-	try {
-		const cache = getCache();
-		const markerKey = buildRefreshMarkerKey(args);
-		const marker = await cache.get(markerKey, "text");
-		return !marker;
-	} catch {
-		// Fail open if cache is unavailable so analytics data still updates.
-		return true;
-	}
-}
-
-async function markAnalyticsRollupRefresh(args: {
-	workspaceId: string;
-	startIso: string;
-	endIso: string;
-}): Promise<void> {
-	try {
-		const cache = getCache();
-		await cache.put(buildRefreshMarkerKey(args), "1", {
-			expirationTtl: ANALYTICS_REFRESH_COOLDOWN_SECONDS,
-		});
-	} catch {
-		// Ignore marker write failures so successful refreshes still return data.
-	}
-}
-
 async function loadAnalyticsRollupRows(args: {
     workspaceId: string;
     startIso: string;
@@ -236,19 +177,43 @@ async function loadAnalyticsRollupRows(args: {
     const startDay = args.startIso.slice(0, 10);
     const endDay = args.endIso.slice(0, 10);
     const { data, error } = await supabase
-        .from("gateway_activity_rollup_daily")
+        .from("v2_private_usage_daily")
         .select(
-            "day_bucket,model_id,endpoint,provider,usage_nanos,byok_usage_nanos,requests,prompt_tokens,completion_tokens,reasoning_tokens"
+            "usage_date,model_slug,provider_model_id,cost_nanos,requests,successful_requests,v2_private_usage_daily_meters(meter_key,quantity)"
         )
         .eq("workspace_id", args.workspaceId)
-        .gte("day_bucket", startDay)
-        .lt("day_bucket", endDay);
+        .gte("usage_date", startDay)
+        .lt("usage_date", endDay);
 
     if (error) {
-        throw new Error(error.message || "Failed to load analytics rollup rows");
+        throw new Error(error.message || "Failed to load v2 analytics rollup rows");
     }
 
     return (data ?? []) as AnalyticsRollupRow[];
+}
+
+async function loadProviderNames(providerModelIds: string[]): Promise<Map<string, string>> {
+    const names = new Map<string, string>();
+    if (providerModelIds.length === 0) return names;
+    const supabase = getSupabaseAdmin();
+    for (let offset = 0; offset < providerModelIds.length; offset += 200) {
+        const { data, error } = await supabase
+            .from("v2_model_provider_routes")
+            .select("provider_model_id,provider_slug")
+            .in("provider_model_id", providerModelIds.slice(offset, offset + 200));
+        if (error) throw new Error(error.message || "Failed to load analytics provider names");
+        for (const row of data ?? []) {
+            if (row.provider_model_id && row.provider_slug) names.set(row.provider_model_id, row.provider_slug);
+        }
+    }
+    return names;
+}
+
+function meterQuantity(row: AnalyticsRollupRow, keys: string[]): number {
+    const wanted = new Set(keys);
+    return (row.v2_private_usage_daily_meters ?? []).reduce((total, meter) => {
+        return wanted.has(meter.meter_key ?? "") ? total + (toFiniteNumber(meter.quantity) ?? 0) : total;
+    }, 0);
 }
 
 async function handleAnalytics(req: Request) {
@@ -274,54 +239,58 @@ async function handleAnalytics(req: Request) {
 	const endIso = range.end.toISOString();
 
 	try {
-		if (
-			await shouldRefreshAnalyticsRollup({
-				workspaceId,
-				startIso,
-				endIso,
-			})
-		) {
-			await refreshAnalyticsRollup({
-				workspaceId,
-				startIso,
-				endIso,
-			});
-			await markAnalyticsRollupRefresh({
-				workspaceId,
-				startIso,
-				endIso,
-			});
-		}
 		const rows = await loadAnalyticsRollupRows({
 			workspaceId,
 			startIso,
             endIso,
         });
+		const providerModelIds = Array.from(new Set(rows
+			.map((row) => row.provider_model_id)
+			.filter((value): value is string => Boolean(value))));
+		const providerNames = await loadProviderNames(providerModelIds);
+		const grouped = new Map<string, {
+			date: string;
+			model: string;
+			model_permaslug: string;
+			endpoint_id: string;
+			provider_name: string;
+			usage: number;
+			byok_usage_inference: number;
+			requests: number;
+			prompt_tokens: number;
+			completion_tokens: number;
+			reasoning_tokens: number;
+		}>();
+		for (const row of rows) {
+			const date = toDayBucket(row.usage_date);
+			if (!date) continue;
+			const modelPermaslug = toNonEmptyString(row.model_slug, "unknown/unknown");
+			const providerModelId = toNonEmptyString(row.provider_model_id, "unknown");
+			const providerId = providerNames.get(providerModelId) ?? providerModelId.split(":", 1)[0] ?? "unknown";
+			const key = `${date}\u0000${modelPermaslug}\u0000${providerModelId}`;
+			const existing = grouped.get(key) ?? {
+				date,
+				model: toModelDisplay(modelPermaslug),
+				model_permaslug: modelPermaslug,
+				endpoint_id: "unknown",
+				provider_name: toProviderName(providerId),
+				usage: 0,
+				byok_usage_inference: 0,
+				requests: 0,
+				prompt_tokens: 0,
+				completion_tokens: 0,
+				reasoning_tokens: 0,
+			};
+			existing.usage += toUsdFromNanos(toFiniteNumber(row.cost_nanos));
+			existing.requests += Math.max(0, Math.round(toFiniteNumber(row.successful_requests ?? row.requests) ?? 0));
+			existing.prompt_tokens += Math.max(0, Math.round(meterQuantity(row, ["input_tokens", "prompt_tokens"])));
+			existing.completion_tokens += Math.max(0, Math.round(meterQuantity(row, ["output_tokens", "completion_tokens"])));
+			existing.reasoning_tokens += Math.max(0, Math.round(meterQuantity(row, ["reasoning_tokens"])));
+			grouped.set(key, existing);
+		}
 
-        const data = rows
-            .map((row) => {
-                const date = toDayBucket(row.day_bucket);
-                if (!date) return null;
-                const modelPermaslug = toNonEmptyString(row.model_id, "unknown/unknown");
-                const endpointId = toNonEmptyString(row.endpoint, "unknown");
-                const providerId = toNonEmptyString(row.provider, "unknown");
-                return {
-                    date,
-                    model: toModelDisplay(modelPermaslug),
-                    model_permaslug: modelPermaslug,
-                    endpoint_id: endpointId,
-                    provider_name: toProviderName(providerId),
-                    usage: toRoundedUsage(toUsdFromNanos(toFiniteNumber(row.usage_nanos))),
-                    byok_usage_inference: toRoundedUsage(
-                        toUsdFromNanos(toFiniteNumber(row.byok_usage_nanos))
-                    ),
-                    requests: Math.max(0, Math.round(toFiniteNumber(row.requests) ?? 0)),
-                    prompt_tokens: Math.max(0, Math.round(toFiniteNumber(row.prompt_tokens) ?? 0)),
-                    completion_tokens: Math.max(0, Math.round(toFiniteNumber(row.completion_tokens) ?? 0)),
-                    reasoning_tokens: Math.max(0, Math.round(toFiniteNumber(row.reasoning_tokens) ?? 0)),
-                };
-            })
-            .filter((item): item is NonNullable<typeof item> => item !== null)
+        const data = Array.from(grouped.values())
+			.map((item) => ({ ...item, usage: toRoundedUsage(item.usage) }))
             .sort((a, b) => {
                 if (a.date !== b.date) return b.date.localeCompare(a.date);
                 if (a.usage !== b.usage) return b.usage - a.usage;

--- a/apps/api/src/routes/v1/control/pricing.test.ts
+++ b/apps/api/src/routes/v1/control/pricing.test.ts
@@ -1,0 +1,97 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const guardAuthMock = vi.fn();
+const getSupabaseAdminMock = vi.fn();
+
+vi.mock("@pipeline/before/guards", () => ({
+	guardAuth: (...args: unknown[]) => guardAuthMock(...args),
+}));
+
+vi.mock("@/runtime/env", () => ({
+	getSupabaseAdmin: (...args: unknown[]) => getSupabaseAdminMock(...args),
+}));
+
+vi.mock("../../utils", () => ({
+	withRuntime:
+		(handler: (req: Request) => Promise<Response>) =>
+		async (c: { req: { raw: Request } }) =>
+			handler(c.req.raw),
+	json: (data: unknown, status = 200, headers: Record<string, string> = {}) =>
+		new Response(JSON.stringify(data), { status, headers: { "Content-Type": "application/json", ...headers } }),
+	cacheHeaders: () => ({ "Cache-Control": "private, max-age=300" }),
+}));
+
+import { pricingRoutes } from "./pricing";
+
+function queryResult(result: { data: unknown[]; error: unknown }) {
+	const query: Record<string, unknown> = {};
+	for (const method of ["select", "eq", "in", "or", "order"]) {
+		query[method] = vi.fn(() => query);
+	}
+	query.then = (resolve: (value: unknown) => unknown) => Promise.resolve(result).then(resolve);
+	return query;
+}
+
+describe("pricingRoutes", () => {
+	beforeEach(() => {
+		guardAuthMock.mockReset();
+		getSupabaseAdminMock.mockReset();
+		guardAuthMock.mockResolvedValue({
+			ok: true,
+			value: {
+				workspaceId: "ws_test",
+				authMethod: "oauth",
+				oauthScopes: ["pricing:read"],
+			},
+		});
+	});
+
+	it("includes active rows with open effective windows and avoids empty in filters", async () => {
+		getSupabaseAdminMock.mockReturnValue({
+			from: vi.fn((table: string) => {
+				if (table === "data_api_provider_models") return queryResult({ data: [{
+					provider_api_model_id: "pm_1",
+					provider_id: "openai",
+					api_model_id: "gpt-test",
+					model_id: "openai/gpt-test",
+					is_active_gateway: true,
+					effective_from: null,
+					effective_to: null,
+				}], error: null });
+				if (table === "data_api_provider_model_capabilities") return queryResult({ data: [{
+					provider_api_model_id: "pm_1",
+					capability_id: "chat/completions",
+					effective_from: null,
+					effective_to: null,
+				}], error: null });
+				if (table === "data_models") return queryResult({ data: [{
+					model_id: "openai/gpt-test",
+					name: "GPT Test",
+					hidden: false,
+				}], error: null });
+				if (table === "data_api_pricing_rules") return queryResult({ data: [{
+					model_key: "openai:gpt-test:chat/completions",
+					capability_id: "chat/completions",
+					pricing_plan: "standard",
+					meter: "input_tokens",
+					unit: "token",
+					unit_size: 1_000_000,
+					price_per_unit: "1.5",
+					currency: "USD",
+					priority: 1,
+					match: [],
+				}], error: null });
+				throw new Error(`unexpected table: ${table}`);
+			}),
+		});
+
+		const response = await pricingRoutes.request("https://example.com/models");
+		const body = await response.json() as { ok: boolean; models: Array<{ model: string; meters: unknown[] }> };
+
+		expect(response.status).toBe(200);
+		expect(body.ok).toBe(true);
+		expect(body.models).toEqual([
+			expect.objectContaining({ model: "openai/gpt-test", meters: [expect.objectContaining({ meter: "input_tokens" })] }),
+		]);
+	});
+});

--- a/apps/api/src/routes/v1/control/pricing.ts
+++ b/apps/api/src/routes/v1/control/pricing.ts
@@ -44,6 +44,16 @@ function parseModelKey(value?: string | null): {
     return { providerId, apiModelId, capabilityId };
 }
 
+function isWithinEffectiveWindow(
+    effectiveFrom: string | null | undefined,
+    effectiveTo: string | null | undefined,
+    now: Date,
+): boolean {
+    const start = effectiveFrom ? Date.parse(effectiveFrom) : Number.NEGATIVE_INFINITY;
+    const end = effectiveTo ? Date.parse(effectiveTo) : Number.POSITIVE_INFINITY;
+    return (Number.isNaN(start) || start <= now.getTime()) && (Number.isNaN(end) || end > now.getTime());
+}
+
 async function handlePricingModels(req: Request) {
     const auth = await guardAuth(req, { allowOAuthJwt: true });
     if (!auth.ok) {
@@ -54,33 +64,44 @@ async function handlePricingModels(req: Request) {
 
     try {
         const supabase = getSupabaseAdmin();
-        const nowIso = new Date().toISOString();
+        const now = new Date();
+        const nowIso = now.toISOString();
 
-        const { data: providerModels, error: pmError } = await supabase
+        const { data: providerModelRows, error: pmError } = await supabase
             .from("data_api_provider_models")
             .select("provider_api_model_id, provider_id, api_model_id, model_id, is_active_gateway, effective_from, effective_to")
-            .eq("is_active_gateway", true)
-            .lte("effective_from", nowIso)
-            .or(`effective_to.is.null,effective_to.gt.${nowIso}`);
+            .eq("is_active_gateway", true);
 
         if (pmError) {
             throw new Error(pmError.message || "Failed to load provider models");
         }
 
+        const providerModels = (providerModelRows ?? []).filter((row) =>
+            isWithinEffectiveWindow(row.effective_from, row.effective_to, now)
+        );
+
         const providerModelIds = (providerModels ?? [])
             .map((row) => row.provider_api_model_id)
             .filter((id): id is string => Boolean(id));
 
-        const { data: capabilities, error: capError } = await supabase
-            .from("data_api_provider_model_capabilities")
-            .select("provider_api_model_id, capability_id, effective_from, effective_to")
-            .eq("status", "active")
-            .in("provider_api_model_id", providerModelIds)
-            .lte("effective_from", nowIso)
-            .or(`effective_to.is.null,effective_to.gt.${nowIso}`);
-
-        if (capError) {
-            throw new Error(capError.message || "Failed to load provider capabilities");
+        const capabilities: Array<{
+            provider_api_model_id: string | null;
+            capability_id: string | null;
+            effective_from: string | null;
+            effective_to: string | null;
+        }> = [];
+        for (let offset = 0; offset < providerModelIds.length; offset += 200) {
+            const { data, error } = await supabase
+                .from("data_api_provider_model_capabilities")
+                .select("provider_api_model_id, capability_id, effective_from, effective_to")
+                .eq("status", "active")
+                .in("provider_api_model_id", providerModelIds.slice(offset, offset + 200));
+            if (error) {
+                throw new Error(error.message || "Failed to load provider capabilities");
+            }
+            capabilities.push(...(data ?? []).filter((row) =>
+                isWithinEffectiveWindow(row.effective_from, row.effective_to, now)
+            ));
         }
 
         // Get model names
@@ -91,13 +112,16 @@ async function handlePricingModels(req: Request) {
                     .filter(Boolean)
             )
         );
-        const { data: models, error: mError } = await supabase
-            .from("data_models")
-            .select("model_id, name, hidden")
-            .in("model_id", modelIds);
-
-        if (mError) {
-            throw new Error(mError.message || "Failed to load model names");
+        const models: Array<{ model_id: string | null; name: string | null; hidden: boolean | null }> = [];
+        for (let offset = 0; offset < modelIds.length; offset += 200) {
+            const { data, error } = await supabase
+                .from("data_models")
+                .select("model_id, name, hidden")
+                .in("model_id", modelIds.slice(offset, offset + 200));
+            if (error) {
+                throw new Error(error.message || "Failed to load model names");
+            }
+            models.push(...(data ?? []));
         }
 
         const modelNameMap = new Map<string, string>();


### PR DESCRIPTION
## Summary

- read CLI analytics from the current workspace-scoped v2 daily rollups instead of the intentionally removed legacy table
- aggregate v2 usage meters and resolve provider names without exposing request content
- handle open-ended pricing effective windows correctly and avoid invalid empty `in` filters
- chunk pricing lookups to keep Supabase query URLs bounded
- add route-level regression tests for both production failures found during release acceptance

## Validation

- `pnpm --filter @phaseo/gateway-api exec vitest run src/routes/v1/control/pricing.test.ts src/routes/v1/control/analytics.test.ts`
- `pnpm --filter @phaseo/gateway-api typecheck`
- focused ESLint on both routes and tests

Created with Codex
