### PR TITLE
Align SDK release versions with policy

### DIFF
--- a/.changeset/retire-crofai-sdk-model-ids.md
+++ b/.changeset/retire-crofai-sdk-model-ids.md
@@ -1,12 +1,12 @@
 ---
-"@phaseo/sdk": major
-"@phaseo/go-sdk": major
-"@phaseo/py-sdk": major
-"@phaseo/csharp-sdk": major
-"@phaseo/java-sdk": major
-"@phaseo/php-sdk": major
-"@phaseo/ruby-sdk": major
-"@phaseo/rust-sdk": major
+"@phaseo/sdk": patch
+"@phaseo/go-sdk": patch
+"@phaseo/py-sdk": patch
+"@phaseo/csharp-sdk": patch
+"@phaseo/java-sdk": patch
+"@phaseo/php-sdk": patch
+"@phaseo/ruby-sdk": patch
+"@phaseo/rust-sdk": patch
 ---
 
 Refresh generated callable model ID constants from the current OpenAPI snapshot.

--- a/.changeset/retired-anthropic-sdk-ids.md
+++ b/.changeset/retired-anthropic-sdk-ids.md
@@ -1,7 +1,7 @@
 ---
-"@phaseo/sdk": major
-"@phaseo/go-sdk": major
-"@phaseo/py-sdk": major
+"@phaseo/sdk": patch
+"@phaseo/go-sdk": patch
+"@phaseo/py-sdk": patch
 ---
 
 Remove retired Anthropic Claude 4 model ID constants from SDK surfaces and align provider retirement metadata across Anthropic provider catalogs.

--- a/scripts/check-sdk-version-literals.ts
+++ b/scripts/check-sdk-version-literals.ts
@@ -10,7 +10,7 @@ type Check = {
 };
 
 type Spec = {
-  sdkKey: "ts" | "py" | "go" | "csharp" | "java" | "php" | "ruby";
+  sdkKey: "ts" | "py" | "go" | "csharp" | "java" | "php" | "ruby" | "agent";
   sdkLabel: string;
   packageJsonPath: string;
   checks: Check[];
@@ -24,6 +24,7 @@ const SDK_VERSION_OVERRIDE_ENV: Record<Spec["sdkKey"], string> = {
   java: "PHASEO_SDK_VERSION_OVERRIDE_JAVA",
   php: "PHASEO_SDK_VERSION_OVERRIDE_PHP",
   ruby: "PHASEO_SDK_VERSION_OVERRIDE_RUBY",
+  agent: "PHASEO_SDK_VERSION_OVERRIDE_AGENT",
 };
 
 async function readJson<T>(filePath: string): Promise<T> {
@@ -151,6 +152,18 @@ async function main(): Promise<void> {
           filePath: file("packages", "sdk", "sdk-ruby", "lib", "index.rb"),
           pattern: /def initialize\(config = nil, sdk_version = "([^"]+)"\)/m,
           label: "TelemetryRecorder default version",
+        },
+      ],
+    },
+    {
+      sdkKey: "agent",
+      sdkLabel: "Agent TypeScript",
+      packageJsonPath: file("packages", "sdk", "agent-sdk-ts", "package.json"),
+      checks: [
+        {
+          filePath: file("packages", "sdk", "agent-sdk-ts", "src", "devtools.ts"),
+          pattern: /const AGENT_SDK_VERSION = "([^"]+)"/m,
+          label: "AGENT_SDK_VERSION constant",
         },
       ],
     },

--- a/scripts/update-sdk-language-manifest-versions.ts
+++ b/scripts/update-sdk-language-manifest-versions.ts
@@ -181,6 +181,20 @@ async function syncRubyTelemetryVersion(version: string): Promise<void> {
   }
 }
 
+async function syncAgentTelemetryVersion(version: string): Promise<void> {
+  const devtoolsPath = path.join(ROOT, "packages", "sdk", "agent-sdk-ts", "src", "devtools.ts");
+  const updated = await replaceInFile(
+    devtoolsPath,
+    /const AGENT_SDK_VERSION = "([^"]+)"/m,
+    () => `const AGENT_SDK_VERSION = "${version}"`,
+  );
+  if (updated) {
+    console.log(`[sdk-sync] Updated agent SDK telemetry version to ${version}`);
+  } else {
+    console.log("[sdk-sync] Agent SDK telemetry version already up to date");
+  }
+}
+
 async function syncAll(): Promise<void> {
   const syncConfigs: NpmPackageVersionConfig[] = [
     {
@@ -222,6 +236,10 @@ async function syncAll(): Promise<void> {
     {
       packageJsonPath: path.join(ROOT, "packages", "sdk", "sdk-ruby", "package.json"),
       apply: syncRubyTelemetryVersion,
+    },
+    {
+      packageJsonPath: path.join(ROOT, "packages", "sdk", "agent-sdk-ts", "package.json"),
+      apply: syncAgentTelemetryVersion,
     },
   ];
 


### PR DESCRIPTION
## Summary

- change model-helper snapshot changesets from major to patch releases, matching the documented SDK semver policy
- synchronize the agent SDK devtools version from its package manifest during changeset versioning
- include the agent SDK telemetry constant in version-literal validation

## Validation

- `pnpm --filter @phaseo/sdk build`
- `pnpm --filter @phaseo/agent-sdk test` (23 passed)
- `pnpm --filter @phaseo/agent-sdk build`
- `pnpm sdk:sync-language-manifests`
- `pnpm sdk:check-version-literals`

Created with Codex


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added callable model identifiers for several newly available AI models.
  * Added version tracking and validation for the Agent SDK.

* **Bug Fixes**
  * Removed retired and non-callable model identifiers, including outdated Claude, CrofAI, Gemma, NVIDIA, Qwen, and Grok entries.
  * Synchronized provider retirement metadata and SDK telemetry versions across supported packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->