### PR TITLE
Fix Agent SDK release readiness

### DIFF
--- a/.github/workflows/sdk-publish-readiness.yml
+++ b/.github/workflows/sdk-publish-readiness.yml
@@ -33,6 +33,8 @@ jobs:
         run: git checkout -- pnpm-lock.yaml
       - name: Install dependencies
         run: corepack pnpm install --frozen-lockfile
+      - name: Build TypeScript SDK dependency
+        run: pnpm --filter @phaseo/sdk build
       - name: Build, test, and pack
         working-directory: packages/sdk/agent-sdk-ts
         run: |


### PR DESCRIPTION
## Summary

- build the TypeScript SDK before testing the Agent SDK in publish readiness
- ensure the workspace dependency entrypoint exists for Agent SDK tests and packaging

## Validation

- pnpm --filter @phaseo/sdk build
- pnpm --filter @phaseo/agent-sdk build
- pnpm --filter @phaseo/agent-sdk test (23 tests passed)
- Agent SDK package build completed; local npm dry-run correctly stopped because main's 0.1.1 is already published

Created with Codex