### PR TITLE
Prepare Kimi K3 weights release

### DIFF
--- a/.changeset/prepare-kimi-k3-weights-release.md
+++ b/.changeset/prepare-kimi-k3-weights-release.md
@@ -1,0 +1,6 @@
+---
+"@phaseo/data-catalog": patch
+"@phaseo/gateway-api": patch
+---
+
+Prepare Kimi K3 for its public weights release by linking the official Hugging Face repository, surfacing the July 27 at 15:00 UTC release time, and adding non-routable coming-soon entries for Together, Baseten, and Fireworks.

--- a/.changeset/prepare-kimi-k3-weights-release.md
+++ b/.changeset/prepare-kimi-k3-weights-release.md
@@ -3,4 +3,4 @@
 "@phaseo/gateway-api": patch
 ---
 
-Prepare Kimi K3 for its public weights release by linking the official Hugging Face repository, surfacing the July 27 at 15:00 UTC release time, and adding non-routable coming-soon entries for Together, Baseten, and Fireworks.
+Prepare Kimi K3 for its public weights release by linking the official Hugging Face repository, surfacing the July 27, 2026 at 15:00 UTC release time, and adding non-routable coming-soon entries for Together, Baseten, and Fireworks.

--- a/packages/data/catalog/src/data/__tests__/validate.test.ts
+++ b/packages/data/catalog/src/data/__tests__/validate.test.ts
@@ -298,6 +298,10 @@ describe('api provider model safety checks', () => {
                 url: 'https://siliconflow.cn/pricing',
             },
         ]));
+        expect(model.page_notice).toMatchObject({
+            tone: 'info',
+        });
+        expect(model.page_notice.markdown).toContain('July 27, 2026 at 15:00 UTC');
     });
 
     test.each(['together', 'baseten', 'fireworks'])(

--- a/packages/data/catalog/src/data/__tests__/validate.test.ts
+++ b/packages/data/catalog/src/data/__tests__/validate.test.ts
@@ -271,24 +271,61 @@ describe('api provider model safety checks', () => {
         expect(veniceE2ee).toBeUndefined();
     });
 
-    test('Kimi K3 links include the official API reference and provider pricing', () => {
+    test('Kimi K3 links include the official API reference, weights, and provider pricing', () => {
         const model = JSON.parse(
             fs.readFileSync(path.join(DATA_ROOT, 'models', 'moonshotai', 'kimi-k3', 'model.json'), 'utf8')
         );
 
-        expect(model.links).toEqual([
+        expect(model.links).toEqual(expect.arrayContaining([
+            {
+                title: 'Kimi K3 Tech Blog',
+                kind: 'announcement',
+                url: 'https://www.kimi.com/blog/kimi-k3',
+            },
             {
                 title: 'API Reference',
                 kind: 'api_reference',
                 url: 'https://platform.kimi.ai/docs/guide/kimi-k3-quickstart',
             },
             {
+                title: 'Model Weights',
+                kind: 'weights',
+                url: 'https://huggingface.co/moonshotai/Kimi-K3',
+            },
+            {
                 title: 'SiliconFlow pricing',
                 kind: 'pricing',
                 url: 'https://siliconflow.cn/pricing',
             },
-        ]);
+        ]));
     });
+
+    test.each(['together', 'baseten', 'fireworks'])(
+        '%s lists Kimi K3 as a verified coming-soon route',
+        (providerId) => {
+            const row = readProviderModels(providerId).find(
+                (candidate: any) => candidate.internal_model_id === 'moonshotai/kimi-k3'
+            );
+
+            expect(row).toMatchObject({
+                is_active_gateway: false,
+                routable: false,
+                effective_from: '2026-07-27T15:00:00Z',
+                verification: {
+                    status: 'verified',
+                    checked_at: '2026-07-26T00:00:00Z',
+                },
+            });
+            expect(row.capabilities).toEqual(
+                expect.arrayContaining([
+                    expect.objectContaining({
+                        capability_id: 'text.generate',
+                        status: 'coming_soon',
+                    }),
+                ])
+            );
+        }
+    );
 
     test('missing provider_model_slug -> error flagged', () => {
         const bad = {

--- a/packages/data/catalog/src/data/api_providers/baseten/models.json
+++ b/packages/data/catalog/src/data/api_providers/baseten/models.json
@@ -970,5 +970,60 @@
   },
   {
     "api_model_id":"z-ai/glm-5.2-fast","provider_api_model_id":"baseten:z-ai/glm-5.2-fast","provider_model_slug":"zai-org/GLM-5.2","internal_model_id":"z-ai/glm-5.2-fast","is_active_gateway":true,"quantization_scheme":null,"input_modalities":"text","output_modalities":"text","context_length":1048576,"max_output_tokens":null,"effective_from":"2026-07-24T00:00:00","effective_to":null,"capabilities":[{"capability_id":"text.generate","status":"active","params":[],"reasoning":true,"tool_call":true,"structured_output":null,"temperature":null,"attachment":null,"input_modalities":null,"output_modalities":null,"modes":[]}],"routing_status":"active","routable":true,"regions":{"execution":null,"data":null},"service_tiers":[],"api":{"formats":[],"endpoint":null,"deployment":null},"sources":[{"url":"https://www.baseten.co/library/glm-52/","kind":"documentation"},{"url":"https://www.baseten.co/pricing/","kind":"pricing"}],"verification":{"status":"verified","checked_at":"2026-07-24T00:00:00Z","notes":"Baseten officially lists GLM-5.2 Fast; its public shared model slug is zai-org/GLM-5.2."},"rate_limits":[]
+  },
+  {
+    "api_model_id": "moonshotai/kimi-k3",
+    "provider_api_model_id": "baseten:moonshotai/kimi-k3",
+    "provider_model_slug": "moonshotai/Kimi-K3",
+    "internal_model_id": "moonshotai/kimi-k3",
+    "is_active_gateway": false,
+    "quantization_scheme": null,
+    "input_modalities": "text,image",
+    "output_modalities": "text",
+    "context_length": 1048576,
+    "max_output_tokens": null,
+    "effective_from": "2026-07-27T15:00:00Z",
+    "effective_to": null,
+    "capabilities": [
+      {
+        "capability_id": "text.generate",
+        "status": "coming_soon",
+        "params": [],
+        "reasoning": true,
+        "tool_call": null,
+        "structured_output": null,
+        "temperature": null,
+        "attachment": true,
+        "input_modalities": null,
+        "output_modalities": null,
+        "modes": []
+      }
+    ],
+    "routing_status": null,
+    "routable": false,
+    "regions": {
+      "execution": null,
+      "data": null
+    },
+    "service_tiers": [],
+    "api": {
+      "formats": [],
+      "endpoint": null,
+      "deployment": null
+    },
+    "sources": [
+      {
+        "url": "https://www.baseten.co/talk-to-us/kimi-k3-waitlist/",
+        "kind": "announcement",
+        "accessed_at": "2026-07-26T00:00:00Z",
+        "notes": "Baseten promises Kimi K3 on Model APIs and Dedicated Inference the same day the weights drop."
+      }
+    ],
+    "verification": {
+      "status": "verified",
+      "checked_at": "2026-07-26T00:00:00Z",
+      "notes": "Official Baseten waitlist confirms day-zero Model API availability; production route details remain pending."
+    },
+    "rate_limits": []
   }
 ]

--- a/packages/data/catalog/src/data/api_providers/fireworks/models.json
+++ b/packages/data/catalog/src/data/api_providers/fireworks/models.json
@@ -1800,5 +1800,60 @@
       "notes": null
     },
     "rate_limits": []
+  },
+  {
+    "api_model_id": "moonshotai/kimi-k3",
+    "provider_api_model_id": "fireworks:moonshotai/kimi-k3",
+    "provider_model_slug": "accounts/fireworks/models/kimi-k3",
+    "internal_model_id": "moonshotai/kimi-k3",
+    "is_active_gateway": false,
+    "quantization_scheme": null,
+    "input_modalities": "text",
+    "output_modalities": "text",
+    "context_length": null,
+    "max_output_tokens": null,
+    "effective_from": "2026-07-27T15:00:00Z",
+    "effective_to": null,
+    "capabilities": [
+      {
+        "capability_id": "text.generate",
+        "status": "coming_soon",
+        "params": [],
+        "reasoning": true,
+        "tool_call": null,
+        "structured_output": null,
+        "temperature": null,
+        "attachment": null,
+        "input_modalities": null,
+        "output_modalities": null,
+        "modes": []
+      }
+    ],
+    "routing_status": null,
+    "routable": false,
+    "regions": {
+      "execution": null,
+      "data": null
+    },
+    "service_tiers": [],
+    "api": {
+      "formats": [],
+      "endpoint": null,
+      "deployment": null
+    },
+    "sources": [
+      {
+        "url": "https://fireworks.ai/blog/kimik3-fable",
+        "kind": "announcement",
+        "accessed_at": "2026-07-26T00:00:00Z",
+        "notes": "Fireworks published Kimi K3 serving-cost and routing results ahead of the public weights release."
+      }
+    ],
+    "verification": {
+      "status": "verified",
+      "checked_at": "2026-07-26T00:00:00Z",
+      "notes": "Official Fireworks research confirms its Kimi K3 inference work; production route details remain pending."
+    },
+    "rate_limits": []
   }
 ]

--- a/packages/data/catalog/src/data/api_providers/together/models.json
+++ b/packages/data/catalog/src/data/api_providers/together/models.json
@@ -1390,5 +1390,60 @@
       "notes": null
     },
     "rate_limits": []
+  },
+  {
+    "api_model_id": "moonshotai/kimi-k3",
+    "provider_api_model_id": "together:moonshotai/kimi-k3",
+    "provider_model_slug": "moonshotai/Kimi-K3",
+    "internal_model_id": "moonshotai/kimi-k3",
+    "is_active_gateway": false,
+    "quantization_scheme": null,
+    "input_modalities": "text,image",
+    "output_modalities": "text",
+    "context_length": 1048576,
+    "max_output_tokens": null,
+    "effective_from": "2026-07-27T15:00:00Z",
+    "effective_to": null,
+    "capabilities": [
+      {
+        "capability_id": "text.generate",
+        "status": "coming_soon",
+        "params": [],
+        "reasoning": true,
+        "tool_call": null,
+        "structured_output": null,
+        "temperature": null,
+        "attachment": true,
+        "input_modalities": null,
+        "output_modalities": null,
+        "modes": []
+      }
+    ],
+    "routing_status": null,
+    "routable": false,
+    "regions": {
+      "execution": null,
+      "data": null
+    },
+    "service_tiers": [],
+    "api": {
+      "formats": [],
+      "endpoint": null,
+      "deployment": null
+    },
+    "sources": [
+      {
+        "url": "https://www.together.ai/models/kimi-k3",
+        "kind": "announcement",
+        "accessed_at": "2026-07-26T00:00:00Z",
+        "notes": "Together explicitly lists Kimi K3 as coming soon to its Serverless API."
+      }
+    ],
+    "verification": {
+      "status": "verified",
+      "checked_at": "2026-07-26T00:00:00Z",
+      "notes": "Official Together model page confirms planned Serverless API availability; production route details remain pending."
+    },
+    "rate_limits": []
   }
 ]

--- a/packages/data/catalog/src/data/models/moonshotai/kimi-k3/model.json
+++ b/packages/data/catalog/src/data/models/moonshotai/kimi-k3/model.json
@@ -400,7 +400,6 @@
       "rank": 1
     }
   ],
-  "page_notice": null,
   "model_type": null,
   "knowledge_cutoff": null,
   "limits": {

--- a/packages/data/catalog/src/data/models/moonshotai/kimi-k3/model.json
+++ b/packages/data/catalog/src/data/models/moonshotai/kimi-k3/model.json
@@ -14,6 +14,10 @@
   "output_types": "text",
   "api_model_id": "moonshotai/kimi-k3",
   "family_id": "moonshotai/kimi-k2",
+  "page_notice": {
+    "tone": "info",
+    "markdown": "Kimi K3's full model weights are scheduled for release on **July 27, 2026 at 15:00 UTC**. As the weights become available, confirmed inference providers will be onboarded as soon as their serverless endpoints go live. Together AI, Baseten, and Fireworks are currently marked **Coming Soon**."
+  },
   "links": [
     {
       "title": "Kimi K3 Tech Blog",
@@ -24,6 +28,11 @@
       "title": "API Reference",
       "kind": "api_reference",
       "url": "https://platform.kimi.ai/docs/guide/kimi-k3-quickstart"
+    },
+    {
+      "title": "Model Weights",
+      "kind": "weights",
+      "url": "https://huggingface.co/moonshotai/Kimi-K3"
     },
     {
       "title": "SiliconFlow pricing",
@@ -90,7 +99,7 @@
     },
     {
       "name": "availability_note",
-      "value": "Moonshot AI, GMI Cloud, Novita, SiliconFlow, and Venice provide Kimi K3 API access. GMI Cloud currently advertises an FP8 route with a 262,144-token context window; Novita advertises text, image, and video input with a 1,048,576-token context and output limit; SiliconFlow advertises text and image input with a 1,048,576-token context and online pricing of $0.30 per million cached input tokens, $3.00 per million input tokens, and $15.00 per million output tokens. Venice exposes the standard kimi-k3 route at $3.75 per million input tokens, $0.375 per million cached input tokens, and $18.75 per million output tokens. Venice's live catalog does not expose an E2EE Kimi K3 model ID, so no E2EE route or pricing is listed. Full model weights and the technical report are still forthcoming."
+      "value": "Moonshot AI, GMI Cloud, Novita, SiliconFlow, and Venice provide Kimi K3 API access. GMI Cloud currently advertises an FP8 route with a 262,144-token context window; Novita advertises text, image, and video input with a 1,048,576-token context and output limit; SiliconFlow advertises text and image input with a 1,048,576-token context and online pricing of $0.30 per million cached input tokens, $3.00 per million input tokens, and $15.00 per million output tokens. Venice exposes the standard kimi-k3 route at $3.75 per million input tokens, $0.375 per million cached input tokens, and $18.75 per million output tokens. Venice's live catalog does not expose an E2EE Kimi K3 model ID, so no E2EE route or pricing is listed. Full model weights are scheduled for July 27, 2026 at 15:00 UTC. Together AI, Baseten, and Fireworks have confirmed planned hosted inference availability and are listed as coming soon until their endpoints go live."
     }
   ],
   "benchmarks": [
@@ -434,6 +443,12 @@
       "url": "https://platform.kimi.ai/docs/guide/kimi-k3-quickstart",
       "accessed_at": null,
       "notes": null
+    },
+    {
+      "kind": "weights",
+      "url": "https://huggingface.co/moonshotai/Kimi-K3",
+      "accessed_at": "2026-07-26T00:00:00Z",
+      "notes": "Official Moonshot AI Hugging Face countdown targets July 27, 2026 at 15:00 UTC and will resolve to the weights repository when the release goes live."
     },
     {
       "kind": "pricing",

--- a/packages/data/catalog/src/data/models/moonshotai/kimi-k3/model.json
+++ b/packages/data/catalog/src/data/models/moonshotai/kimi-k3/model.json
@@ -16,7 +16,7 @@
   "family_id": "moonshotai/kimi-k2",
   "page_notice": {
     "tone": "info",
-    "markdown": "Kimi K3's full model weights are scheduled for release on **July 27, 2026 at 15:00 UTC**. As the weights become available, confirmed inference providers will be onboarded as soon as their serverless endpoints go live. Together AI, Baseten, and Fireworks are currently marked **Coming Soon**."
+    "markdown": "Kimi K3's full model weights are scheduled for release on **July 27, 2026 at 15:00 UTC**. As the weights become available, confirmed inference providers will be onboarded as soon as their hosted endpoints go live. Together AI, Baseten, and Fireworks are currently marked **Coming Soon**."
   },
   "links": [
     {
@@ -99,7 +99,7 @@
     },
     {
       "name": "availability_note",
-      "value": "Moonshot AI, GMI Cloud, Novita, SiliconFlow, and Venice provide Kimi K3 API access. GMI Cloud currently advertises an FP8 route with a 262,144-token context window; Novita advertises text, image, and video input with a 1,048,576-token context and output limit; SiliconFlow advertises text and image input with a 1,048,576-token context and online pricing of $0.30 per million cached input tokens, $3.00 per million input tokens, and $15.00 per million output tokens. Venice exposes the standard kimi-k3 route at $3.75 per million input tokens, $0.375 per million cached input tokens, and $18.75 per million output tokens. Venice's live catalog does not expose an E2EE Kimi K3 model ID, so no E2EE route or pricing is listed. Full model weights are scheduled for July 27, 2026 at 15:00 UTC. Together AI, Baseten, and Fireworks have confirmed planned hosted inference availability and are listed as coming soon until their endpoints go live."
+      "value": "Moonshot AI, GMI Cloud, Novita, SiliconFlow, and Venice provide Kimi K3 API access. GMI Cloud currently advertises an FP8 route with a 262,144-token context window; Novita advertises text, image, and video input with a 1,048,576-token context and output limit; SiliconFlow advertises text and image input with a 1,048,576-token context and online pricing of $0.30 per million cached input tokens, $3.00 per million input tokens, and $15.00 per million output tokens. Venice exposes the standard kimi-k3 route at $3.75 per million input tokens, $0.375 per million cached input tokens, and $18.75 per million output tokens. Venice's live catalog does not expose an E2EE Kimi K3 model ID, so no E2EE route or pricing is listed. Full model weights are scheduled for July 27, 2026 at 15:00 UTC. Together AI and Baseten have announced planned hosted inference availability. Fireworks has published prerelease Kimi K3 serving research, with production route details pending. All three are listed as coming soon until their endpoints go live."
     }
   ],
   "benchmarks": [


### PR DESCRIPTION
## Summary

- add the official Hugging Face weights URL and a notice for the July 27, 2026 15:00 UTC weights release
- add verified, non-routable Coming Soon entries for Together, Baseten, and Fireworks
- leave providers that already serve Kimi K3 active and add regression coverage for the release metadata and provider states

## Why

This prepares the catalog and model page for the public Kimi K3 weights release while limiting Coming Soon claims to providers with public supporting evidence. GMI, Novita, and SiliconFlow remain active; speculative W&B/CoreWeave and Nebius entries are intentionally excluded.

## Validation

- `pnpm validate:data`
- `pnpm validate:gateway`
- `pnpm --dir apps/web exec jest --rootDir ../.. packages/data/catalog/src/data/__tests__/validate.test.ts --runInBand -t "Kimi K3"`
- `git diff --cached --check`

## Sources

- [Official Kimi K3 weights page](https://huggingface.co/moonshotai/Kimi-K3)
- [Together Kimi K3 page](https://www.together.ai/models/kimi-k3)
- [Baseten Kimi K3 waitlist](https://www.baseten.co/talk-to-us/kimi-k3-waitlist/)
- [Fireworks Kimi K3 serving evaluation](https://fireworks.ai/blog/kimik3-fable)

Created with Codex


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Kimi K3 model information, including official model weights links and release timing.
  * Added availability details for Together, Baseten, and Fireworks, marked as coming soon.
  * Added provider-specific status and pricing information to the model page.
* **Documentation**
  * Added an informational notice for the scheduled July 27, 2026, 15:00 UTC weights release.
  * Updated model references and availability guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->