### PR TITLE
Prepare language SDK publishing

### DIFF
--- a/.changeset/bright-sdks-publish.md
+++ b/.changeset/bright-sdks-publish.md
@@ -1,0 +1,5 @@
+---
+"@phaseo/go-sdk": patch
+---
+
+Publish the Go SDK as a valid v2 module and update its imports and installation guidance to use the `/v2` semantic import path.

--- a/.github/workflows/publish-sdk-csharp.yml
+++ b/.github/workflows/publish-sdk-csharp.yml
@@ -1,6 +1,11 @@
 name: Publish C# SDK
 
 on:
+  push:
+    branches:
+      - main
+    paths:
+      - "packages/sdk/sdk-csharp/package.json"
   workflow_dispatch:
     inputs:
       version:
@@ -15,6 +20,7 @@ permissions:
 jobs:
   publish-csharp:
     runs-on: ubuntu-latest
+    environment: release
     steps:
       - name: Require main branch
         shell: bash
@@ -45,10 +51,10 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          if [ -n "${INPUT_VERSION:-}" ]; then
-            version="${INPUT_VERSION}"
-          else
-            version="$(node -p "require('./packages/sdk/sdk-csharp/package.json').version")"
+          version="$(node -p "require('./packages/sdk/sdk-csharp/package.json').version")"
+          if [ -n "${INPUT_VERSION:-}" ] && [ "${INPUT_VERSION}" != "${version}" ]; then
+            echo "::error::Requested version ${INPUT_VERSION} does not match committed version ${version}."
+            exit 1
           fi
           if [[ ! "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+([.-][0-9A-Za-z.-]+)?$ ]]; then
             echo "::error::Invalid version: $version"
@@ -56,7 +62,31 @@ jobs:
           fi
           echo "value=$version" >> "$GITHUB_OUTPUT"
 
+      - name: Check NuGet release status
+        id: registry
+        env:
+          VERSION: ${{ steps.version.outputs.value }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          status="$(curl -sS -o /dev/null -w '%{http_code}' "https://api.nuget.org/v3-flatcontainer/phaseo.sdk/${VERSION}/phaseo.sdk.${VERSION}.nupkg")"
+          case "$status" in
+            200)
+              echo "should_publish=false" >> "$GITHUB_OUTPUT"
+              echo "Phaseo.Sdk ${VERSION} already exists on NuGet."
+              ;;
+            404)
+              echo "should_publish=true" >> "$GITHUB_OUTPUT"
+              echo "Phaseo.Sdk ${VERSION} is missing from NuGet."
+              ;;
+            *)
+              echo "::error::Unexpected NuGet response: HTTP ${status}"
+              exit 1
+              ;;
+          esac
+
       - name: Validate telemetry literal matches publish version
+        if: steps.registry.outputs.should_publish == 'true'
         env:
           VERSION: ${{ steps.version.outputs.value }}
         shell: bash
@@ -80,6 +110,7 @@ jobs:
           NODE
 
       - name: Build package
+        if: steps.registry.outputs.should_publish == 'true'
         run: |
           dotnet test packages/sdk/sdk-csharp/tests/Phaseo.Sdk.Tests/Phaseo.Sdk.Tests.csproj -c Release
           dotnet pack packages/sdk/sdk-csharp/Phaseo.Sdk.csproj \
@@ -89,12 +120,14 @@ jobs:
             /p:PackageVersion=${{ steps.version.outputs.value }}
 
       - name: NuGet login (OIDC -> temporary API key)
+        if: steps.registry.outputs.should_publish == 'true'
         id: nuget_login
         uses: NuGet/login@8d196754b4036150537f80ac539e15c2f1028841
         with:
           user: ${{ vars.NUGET_TRUSTED_PUBLISHING_USER || github.repository_owner }}
 
       - name: Publish to NuGet
+        if: steps.registry.outputs.should_publish == 'true'
         run: |
           dotnet nuget push "artifacts/csharp/*.nupkg" \
             --api-key "${{ steps.nuget_login.outputs.NUGET_API_KEY }}" \

--- a/.github/workflows/publish-sdk-csharp.yml
+++ b/.github/workflows/publish-sdk-csharp.yml
@@ -62,31 +62,7 @@ jobs:
           fi
           echo "value=$version" >> "$GITHUB_OUTPUT"
 
-      - name: Check NuGet release status
-        id: registry
-        env:
-          VERSION: ${{ steps.version.outputs.value }}
-        shell: bash
-        run: |
-          set -euo pipefail
-          status="$(curl -sS -o /dev/null -w '%{http_code}' "https://api.nuget.org/v3-flatcontainer/phaseo.sdk/${VERSION}/phaseo.sdk.${VERSION}.nupkg")"
-          case "$status" in
-            200)
-              echo "should_publish=false" >> "$GITHUB_OUTPUT"
-              echo "Phaseo.Sdk ${VERSION} already exists on NuGet."
-              ;;
-            404)
-              echo "should_publish=true" >> "$GITHUB_OUTPUT"
-              echo "Phaseo.Sdk ${VERSION} is missing from NuGet."
-              ;;
-            *)
-              echo "::error::Unexpected NuGet response: HTTP ${status}"
-              exit 1
-              ;;
-          esac
-
       - name: Validate telemetry literal matches publish version
-        if: steps.registry.outputs.should_publish == 'true'
         env:
           VERSION: ${{ steps.version.outputs.value }}
         shell: bash
@@ -110,7 +86,6 @@ jobs:
           NODE
 
       - name: Build package
-        if: steps.registry.outputs.should_publish == 'true'
         run: |
           dotnet test packages/sdk/sdk-csharp/tests/Phaseo.Sdk.Tests/Phaseo.Sdk.Tests.csproj -c Release
           dotnet pack packages/sdk/sdk-csharp/Phaseo.Sdk.csproj \
@@ -120,14 +95,12 @@ jobs:
             /p:PackageVersion=${{ steps.version.outputs.value }}
 
       - name: NuGet login (OIDC -> temporary API key)
-        if: steps.registry.outputs.should_publish == 'true'
         id: nuget_login
         uses: NuGet/login@8d196754b4036150537f80ac539e15c2f1028841
         with:
           user: ${{ vars.NUGET_TRUSTED_PUBLISHING_USER || github.repository_owner }}
 
       - name: Publish to NuGet
-        if: steps.registry.outputs.should_publish == 'true'
         run: |
           dotnet nuget push "artifacts/csharp/*.nupkg" \
             --api-key "${{ steps.nuget_login.outputs.NUGET_API_KEY }}" \

--- a/.github/workflows/publish-sdk-go.yml
+++ b/.github/workflows/publish-sdk-go.yml
@@ -1,6 +1,11 @@
 name: Publish Go SDK
 
 on:
+  push:
+    branches:
+      - main
+    paths:
+      - "packages/sdk/sdk-go/package.json"
   workflow_dispatch:
     inputs:
       version:
@@ -14,6 +19,7 @@ permissions:
 jobs:
   publish-go:
     runs-on: ubuntu-latest
+    environment: release
     steps:
       - name: Require main branch
         shell: bash
@@ -54,16 +60,33 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          if [ -n "${INPUT_VERSION:-}" ]; then
-            version="${INPUT_VERSION}"
-          else
-            version="$(node -p "require('./packages/sdk/sdk-go/package.json').version")"
+          version="$(node -p "require('./packages/sdk/sdk-go/package.json').version")"
+          if [ -n "${INPUT_VERSION:-}" ] && [ "${INPUT_VERSION}" != "${version}" ]; then
+            echo "::error::Requested version ${INPUT_VERSION} does not match committed version ${version}."
+            exit 1
           fi
           if [[ ! "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+([.-][0-9A-Za-z.-]+)?$ ]]; then
             echo "::error::Invalid version: $version"
             exit 1
           fi
           echo "value=$version" >> "$GITHUB_OUTPUT"
+
+      - name: Validate Go major-version module path
+        env:
+          VERSION: ${{ steps.version.outputs.value }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          major="${VERSION%%.*}"
+          module="$(go -C packages/sdk/sdk-go list -m)"
+          expected="github.com/phaseoteam/Phaseo/packages/sdk/sdk-go/v${major}"
+          if [ "$major" -lt 2 ]; then
+            expected="github.com/phaseoteam/Phaseo/packages/sdk/sdk-go"
+          fi
+          if [ "$module" != "$expected" ]; then
+            echo "::error::Go module path ${module} does not match v${major} release path ${expected}."
+            exit 1
+          fi
 
       - name: Validate telemetry literal matches publish version
         env:

--- a/.github/workflows/publish-sdk-java.yml
+++ b/.github/workflows/publish-sdk-java.yml
@@ -1,6 +1,11 @@
 name: Publish Java SDK
 
 on:
+  push:
+    branches:
+      - main
+    paths:
+      - "packages/sdk/sdk-java/package.json"
   workflow_dispatch:
     inputs:
       version:
@@ -14,6 +19,7 @@ permissions:
 jobs:
   publish-java:
     runs-on: ubuntu-latest
+    environment: release
     steps:
       - name: Require main branch
         shell: bash
@@ -45,10 +51,10 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          if [ -n "${INPUT_VERSION:-}" ]; then
-            version="${INPUT_VERSION}"
-          else
-            version="$(node -p "require('./packages/sdk/sdk-java/package.json').version")"
+          version="$(node -p "require('./packages/sdk/sdk-java/package.json').version")"
+          if [ -n "${INPUT_VERSION:-}" ] && [ "${INPUT_VERSION}" != "${version}" ]; then
+            echo "::error::Requested version ${INPUT_VERSION} does not match committed version ${version}."
+            exit 1
           fi
           if [[ ! "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+([.-][0-9A-Za-z.-]+)?$ ]]; then
             echo "::error::Invalid version: $version"
@@ -56,7 +62,32 @@ jobs:
           fi
           echo "value=$version" >> "$GITHUB_OUTPUT"
 
+      - name: Check Maven Central release status
+        id: registry
+        env:
+          VERSION: ${{ steps.version.outputs.value }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          artifact="https://repo1.maven.org/maven2/app/phaseo/phaseo-sdk/${VERSION}/phaseo-sdk-${VERSION}.pom"
+          status="$(curl -sS -o /dev/null -w '%{http_code}' "$artifact")"
+          case "$status" in
+            200)
+              echo "should_publish=false" >> "$GITHUB_OUTPUT"
+              echo "app.phaseo:phaseo-sdk:${VERSION} already exists on Maven Central."
+              ;;
+            404)
+              echo "should_publish=true" >> "$GITHUB_OUTPUT"
+              echo "app.phaseo:phaseo-sdk:${VERSION} is missing from Maven Central."
+              ;;
+            *)
+              echo "::error::Unexpected Maven Central response: HTTP ${status}"
+              exit 1
+              ;;
+          esac
+
       - name: Validate telemetry literal matches publish version
+        if: steps.registry.outputs.should_publish == 'true'
         env:
           VERSION: ${{ steps.version.outputs.value }}
         shell: bash
@@ -80,6 +111,7 @@ jobs:
           NODE
 
       - name: Check required secrets
+        if: steps.registry.outputs.should_publish == 'true'
         env:
           MAVEN_CENTRAL_USERNAME: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
           MAVEN_CENTRAL_PASSWORD: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
@@ -98,7 +130,8 @@ jobs:
             exit 1
           fi
 
-      - name: Set pom version
+      - name: Validate committed pom version
+        if: steps.registry.outputs.should_publish == 'true'
         shell: bash
         env:
           VERSION: ${{ steps.version.outputs.value }}
@@ -113,13 +146,17 @@ jobs:
           pom = Path("packages/sdk/sdk-java/pom.xml")
           source = pom.read_text(encoding="utf-8")
           pattern = re.compile(r"(<artifactId>phaseo-sdk</artifactId>\s*[\r\n]+\s*<version>)([^<]+)(</version>)", re.MULTILINE)
-          updated, count = pattern.subn(rf"\1{version}\3", source, count=1)
-          if count != 1:
-            raise SystemExit("Unable to set version in pom.xml")
-          pom.write_text(updated, encoding="utf-8")
+          match = pattern.search(source)
+          if not match:
+              raise SystemExit("Unable to find phaseo-sdk version in pom.xml")
+          if match.group(2) != version:
+              raise SystemExit(
+                  f"Committed pom version {match.group(2)} does not match release version {version}"
+              )
           PY
 
       - name: Import GPG key
+        if: steps.registry.outputs.should_publish == 'true'
         env:
           MAVEN_GPG_PRIVATE_KEY: ${{ secrets.MAVEN_GPG_PRIVATE_KEY }}
         shell: bash
@@ -132,6 +169,7 @@ jobs:
           fi
 
       - name: Configure Maven credentials
+        if: steps.registry.outputs.should_publish == 'true'
         env:
           MAVEN_CENTRAL_USERNAME: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
           MAVEN_CENTRAL_PASSWORD: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
@@ -153,6 +191,7 @@ jobs:
           EOF
 
       - name: Build and publish to Maven Central
+        if: steps.registry.outputs.should_publish == 'true'
         env:
           MAVEN_GPG_PASSPHRASE: ${{ secrets.MAVEN_GPG_PASSPHRASE }}
         run: |

--- a/.github/workflows/publish-sdk-php.yml
+++ b/.github/workflows/publish-sdk-php.yml
@@ -37,9 +37,6 @@ jobs:
           client-id: ${{ secrets.PHASEO_APP_CLIENT_ID }}
           private-key: ${{ secrets.PHASEO_APP_PRIVATE_KEY }}
           owner: phaseoteam
-          repositories: |
-            Phaseo
-            phaseo-php-sdk
 
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
@@ -75,30 +72,7 @@ jobs:
           fi
           echo "value=$version" >> "$GITHUB_OUTPUT"
 
-      - name: Check Packagist release status
-        id: registry
-        env:
-          VERSION: ${{ steps.version.outputs.value }}
-        shell: bash
-        run: |
-          set -euo pipefail
-          node --input-type=module - <<'NODE'
-          import fs from "node:fs";
-          const version = process.env.VERSION;
-          const output = process.env.GITHUB_OUTPUT;
-          const response = await fetch("https://repo.packagist.org/p2/phaseo/sdk.json");
-          if (!response.ok && response.status !== 404) {
-            console.error(`::error::Unexpected Packagist response: HTTP ${response.status}`);
-            process.exit(1);
-          }
-          const releases = response.ok ? (await response.json()).packages?.["phaseo/sdk"] ?? [] : [];
-          const exists = releases.some((release) => release.version_normalized === `${version}.0` || release.version === version);
-          fs.appendFileSync(output, `should_publish=${exists ? "false" : "true"}\n`);
-          console.log(`phaseo/sdk ${version} ${exists ? "already exists on" : "is missing from"} Packagist.`);
-          NODE
-
       - name: Validate telemetry literal matches publish version
-        if: steps.registry.outputs.should_publish == 'true'
         env:
           VERSION: ${{ steps.version.outputs.value }}
         shell: bash
@@ -122,14 +96,12 @@ jobs:
           NODE
 
       - name: Validate composer package
-        if: steps.registry.outputs.should_publish == 'true'
         run: |
           php -v
           php -r "json_decode(file_get_contents('packages/sdk/sdk-php/composer.json')); if (json_last_error()) { fwrite(STDERR, 'Invalid composer.json'.PHP_EOL); exit(1);} "
           php packages/sdk/sdk-php/tests/lifecycle_test.php
 
       - name: Create and push SDK tag
-        if: steps.registry.outputs.should_publish == 'true'
         env:
           VERSION: ${{ steps.version.outputs.value }}
           GH_APP_TOKEN: ${{ steps.app-token.outputs.token }}
@@ -149,7 +121,6 @@ jobs:
           fi
 
       - name: Sync PHP split repo and publish split tag
-        if: steps.registry.outputs.should_publish == 'true'
         id: split_repo
         env:
           VERSION: ${{ steps.version.outputs.value }}
@@ -178,7 +149,6 @@ jobs:
           echo "repo_url=${split_repo_url}" >> "$GITHUB_OUTPUT"
 
       - name: Notify Packagist
-        if: steps.registry.outputs.should_publish == 'true'
         env:
           PACKAGIST_USERNAME: ${{ secrets.PACKAGIST_USERNAME }}
           PACKAGIST_MAIN_TOKEN: ${{ secrets.PACKAGIST_MAIN_TOKEN }}

--- a/.github/workflows/publish-sdk-php.yml
+++ b/.github/workflows/publish-sdk-php.yml
@@ -1,6 +1,11 @@
 name: Publish PHP SDK
 
 on:
+  push:
+    branches:
+      - main
+    paths:
+      - "packages/sdk/sdk-php/package.json"
   workflow_dispatch:
     inputs:
       version:
@@ -14,6 +19,7 @@ permissions:
 jobs:
   publish-php:
     runs-on: ubuntu-latest
+    environment: release
     steps:
       - name: Require main branch
         shell: bash
@@ -30,6 +36,10 @@ jobs:
         with:
           client-id: ${{ secrets.PHASEO_APP_CLIENT_ID }}
           private-key: ${{ secrets.PHASEO_APP_PRIVATE_KEY }}
+          owner: phaseoteam
+          repositories: |
+            Phaseo
+            phaseo-php-sdk
 
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
@@ -54,10 +64,10 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          if [ -n "${INPUT_VERSION:-}" ]; then
-            version="${INPUT_VERSION}"
-          else
-            version="$(node -p "require('./packages/sdk/sdk-php/package.json').version")"
+          version="$(node -p "require('./packages/sdk/sdk-php/package.json').version")"
+          if [ -n "${INPUT_VERSION:-}" ] && [ "${INPUT_VERSION}" != "${version}" ]; then
+            echo "::error::Requested version ${INPUT_VERSION} does not match committed version ${version}."
+            exit 1
           fi
           if [[ ! "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+([.-][0-9A-Za-z.-]+)?$ ]]; then
             echo "::error::Invalid version: $version"
@@ -65,7 +75,30 @@ jobs:
           fi
           echo "value=$version" >> "$GITHUB_OUTPUT"
 
+      - name: Check Packagist release status
+        id: registry
+        env:
+          VERSION: ${{ steps.version.outputs.value }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          node --input-type=module - <<'NODE'
+          import fs from "node:fs";
+          const version = process.env.VERSION;
+          const output = process.env.GITHUB_OUTPUT;
+          const response = await fetch("https://repo.packagist.org/p2/phaseo/sdk.json");
+          if (!response.ok && response.status !== 404) {
+            console.error(`::error::Unexpected Packagist response: HTTP ${response.status}`);
+            process.exit(1);
+          }
+          const releases = response.ok ? (await response.json()).packages?.["phaseo/sdk"] ?? [] : [];
+          const exists = releases.some((release) => release.version_normalized === `${version}.0` || release.version === version);
+          fs.appendFileSync(output, `should_publish=${exists ? "false" : "true"}\n`);
+          console.log(`phaseo/sdk ${version} ${exists ? "already exists on" : "is missing from"} Packagist.`);
+          NODE
+
       - name: Validate telemetry literal matches publish version
+        if: steps.registry.outputs.should_publish == 'true'
         env:
           VERSION: ${{ steps.version.outputs.value }}
         shell: bash
@@ -89,12 +122,14 @@ jobs:
           NODE
 
       - name: Validate composer package
+        if: steps.registry.outputs.should_publish == 'true'
         run: |
           php -v
           php -r "json_decode(file_get_contents('packages/sdk/sdk-php/composer.json')); if (json_last_error()) { fwrite(STDERR, 'Invalid composer.json'.PHP_EOL); exit(1);} "
           php packages/sdk/sdk-php/tests/lifecycle_test.php
 
       - name: Create and push SDK tag
+        if: steps.registry.outputs.should_publish == 'true'
         env:
           VERSION: ${{ steps.version.outputs.value }}
           GH_APP_TOKEN: ${{ steps.app-token.outputs.token }}
@@ -114,22 +149,18 @@ jobs:
           fi
 
       - name: Sync PHP split repo and publish split tag
+        if: steps.registry.outputs.should_publish == 'true'
         id: split_repo
         env:
           VERSION: ${{ steps.version.outputs.value }}
           PHP_SDK_SPLIT_REPO: ${{ vars.PHP_SDK_SPLIT_REPO }}
-          PHP_SDK_SPLIT_REPO_TOKEN: ${{ secrets.PHP_SDK_SPLIT_REPO_TOKEN }}
+          GH_APP_TOKEN: ${{ steps.app-token.outputs.token }}
         shell: bash
         run: |
           set -euo pipefail
-          if [ -z "${PHP_SDK_SPLIT_REPO_TOKEN:-}" ]; then
-            echo "::error::Missing PHP_SDK_SPLIT_REPO_TOKEN secret."
-            exit 1
-          fi
-
           split_repo="${PHP_SDK_SPLIT_REPO:-phaseoteam/phaseo-php-sdk}"
           split_repo_url="https://github.com/${split_repo}"
-          split_remote_url="https://x-access-token:${PHP_SDK_SPLIT_REPO_TOKEN}@github.com/${split_repo}.git"
+          split_remote_url="https://x-access-token:${GH_APP_TOKEN}@github.com/${split_repo}.git"
 
           git remote add split "$split_remote_url"
 
@@ -147,6 +178,7 @@ jobs:
           echo "repo_url=${split_repo_url}" >> "$GITHUB_OUTPUT"
 
       - name: Notify Packagist
+        if: steps.registry.outputs.should_publish == 'true'
         env:
           PACKAGIST_USERNAME: ${{ secrets.PACKAGIST_USERNAME }}
           PACKAGIST_MAIN_TOKEN: ${{ secrets.PACKAGIST_MAIN_TOKEN }}
@@ -155,8 +187,8 @@ jobs:
         run: |
           set -euo pipefail
           if [ -z "${PACKAGIST_USERNAME:-}" ] || [ -z "${PACKAGIST_MAIN_TOKEN:-}" ]; then
-            echo "::error::Missing PACKAGIST_USERNAME or PACKAGIST_MAIN_TOKEN."
-            exit 1
+            echo "Packagist credentials are not configured; relying on the repository webhook."
+            exit 0
           fi
           if [ -z "${PACKAGIST_REPOSITORY_URL:-}" ]; then
             echo "::error::Missing split repository URL output."

--- a/.github/workflows/publish-sdk-ruby.yml
+++ b/.github/workflows/publish-sdk-ruby.yml
@@ -1,6 +1,11 @@
 name: Publish Ruby SDK
 
 on:
+  push:
+    branches:
+      - main
+    paths:
+      - "packages/sdk/sdk-ruby/package.json"
   workflow_dispatch:
     inputs:
       version:
@@ -10,10 +15,12 @@ on:
 
 permissions:
   contents: read
+  id-token: write
 
 jobs:
   publish-ruby:
     runs-on: ubuntu-latest
+    environment: release
     steps:
       - name: Require main branch
         shell: bash
@@ -23,7 +30,6 @@ jobs:
             echo "::error::Run this workflow from refs/heads/main only."
             exit 1
           fi
-
       - name: Create GitHub App token (Phaseo Bot)
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1
@@ -54,10 +60,10 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          if [ -n "${INPUT_VERSION:-}" ]; then
-            version="${INPUT_VERSION}"
-          else
-            version="$(node -p "require('./packages/sdk/sdk-ruby/package.json').version")"
+          version="$(node -p "require('./packages/sdk/sdk-ruby/package.json').version")"
+          if [ -n "${INPUT_VERSION:-}" ] && [ "${INPUT_VERSION}" != "${version}" ]; then
+            echo "::error::Requested version ${INPUT_VERSION} does not match committed version ${version}."
+            exit 1
           fi
           if [[ ! "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+([.-][0-9A-Za-z.-]+)?$ ]]; then
             echo "::error::Invalid version: $version"
@@ -65,7 +71,29 @@ jobs:
           fi
           echo "value=$version" >> "$GITHUB_OUTPUT"
 
+      - name: Check RubyGems release status
+        id: registry
+        env:
+          VERSION: ${{ steps.version.outputs.value }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          node --input-type=module - <<'NODE'
+          import fs from "node:fs";
+          const version = process.env.VERSION;
+          const response = await fetch("https://rubygems.org/api/v1/versions/phaseo_sdk.json");
+          if (!response.ok && response.status !== 404) {
+            console.error(`::error::Unexpected RubyGems.org response: HTTP ${response.status}`);
+            process.exit(1);
+          }
+          const releases = response.ok ? await response.json() : [];
+          const exists = releases.some((release) => release.number === version);
+          fs.appendFileSync(process.env.GITHUB_OUTPUT, `should_publish=${exists ? "false" : "true"}\n`);
+          console.log(`phaseo_sdk ${version} ${exists ? "already exists on" : "is missing from"} RubyGems.org.`);
+          NODE
+
       - name: Validate telemetry literals match publish version
+        if: steps.registry.outputs.should_publish == 'true'
         env:
           VERSION: ${{ steps.version.outputs.value }}
         shell: bash
@@ -100,21 +128,32 @@ jobs:
           }
           NODE
 
-      - name: Set gem version
+      - name: Validate committed gem version
+        if: steps.registry.outputs.should_publish == 'true'
         env:
           VERSION: ${{ steps.version.outputs.value }}
         shell: bash
         run: |
           set -euo pipefail
-          ruby -e "f='packages/sdk/sdk-ruby/lib/phaseo_sdk/version.rb'; s=File.read(f); s=s.gsub(/VERSION\\s*=\\s*\"[^\"]+\"/, 'VERSION = \"' + ENV.fetch('VERSION') + '\"'); File.write(f,s)"
+          ruby -e 'require_relative "./packages/sdk/sdk-ruby/lib/phaseo_sdk/version"; abort("Committed gem version #{PhaseoSdk::VERSION} does not match release version #{ENV.fetch("VERSION")}") unless PhaseoSdk::VERSION == ENV.fetch("VERSION")'
 
       - name: Build gem
+        if: steps.registry.outputs.should_publish == 'true'
         working-directory: packages/sdk/sdk-ruby
         run: |
           ruby tests/lifecycle_test.rb
           gem build phaseo_sdk.gemspec
 
+      - name: Configure RubyGems trusted publishing credentials
+        if: steps.registry.outputs.should_publish == 'true'
+        uses: rubygems/configure-rubygems-credentials@dc5a8d8553e6ee01fc26761a49e99e733d17954a
+
+      - name: Publish to RubyGems
+        if: steps.registry.outputs.should_publish == 'true'
+        run: gem push packages/sdk/sdk-ruby/phaseo_sdk-${{ steps.version.outputs.value }}.gem
+
       - name: Create and push SDK tag
+        if: steps.registry.outputs.should_publish == 'true'
         env:
           VERSION: ${{ steps.version.outputs.value }}
           GH_APP_TOKEN: ${{ steps.app-token.outputs.token }}
@@ -132,21 +171,3 @@ jobs:
           else
             git push "https://x-access-token:${GH_APP_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" "$tag"
           fi
-
-      - name: Publish to RubyGems
-        env:
-          RUBYGEMS_API_KEY: ${{ secrets.RUBYGEMS_API_KEY }}
-        shell: bash
-        run: |
-          set -euo pipefail
-          if [ -z "${RUBYGEMS_API_KEY:-}" ]; then
-            echo "::error::Missing RUBYGEMS_API_KEY secret."
-            exit 1
-          fi
-          mkdir -p ~/.gem
-          cat > ~/.gem/credentials <<EOF
-          ---
-          :rubygems_api_key: ${RUBYGEMS_API_KEY}
-          EOF
-          chmod 0600 ~/.gem/credentials
-          gem push packages/sdk/sdk-ruby/phaseo_sdk-${{ steps.version.outputs.value }}.gem

--- a/.github/workflows/publish-sdk-ruby.yml
+++ b/.github/workflows/publish-sdk-ruby.yml
@@ -153,7 +153,6 @@ jobs:
         run: gem push packages/sdk/sdk-ruby/phaseo_sdk-${{ steps.version.outputs.value }}.gem
 
       - name: Create and push SDK tag
-        if: steps.registry.outputs.should_publish == 'true'
         env:
           VERSION: ${{ steps.version.outputs.value }}
           GH_APP_TOKEN: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/sdk-publish-readiness.yml
+++ b/.github/workflows/sdk-publish-readiness.yml
@@ -127,18 +127,17 @@ jobs:
         run: |
           composer validate --strict
           php tests/lifecycle_test.php
-      - name: Check Packagist secrets
+      - name: Check optional Packagist refresh credentials
         if: inputs.checkSecrets
         env:
           PACKAGIST_USERNAME: ${{ secrets.PACKAGIST_USERNAME }}
           PACKAGIST_MAIN_TOKEN: ${{ secrets.PACKAGIST_MAIN_TOKEN }}
-          PHP_SDK_SPLIT_REPO_TOKEN: ${{ secrets.PHP_SDK_SPLIT_REPO_TOKEN }}
         shell: bash
         run: |
           set -euo pipefail
-          [ -n "${PACKAGIST_USERNAME:-}" ] || { echo "::error::Missing PACKAGIST_USERNAME"; exit 1; }
-          [ -n "${PACKAGIST_MAIN_TOKEN:-}" ] || { echo "::error::Missing PACKAGIST_MAIN_TOKEN"; exit 1; }
-          [ -n "${PHP_SDK_SPLIT_REPO_TOKEN:-}" ] || { echo "::error::Missing PHP_SDK_SPLIT_REPO_TOKEN"; exit 1; }
+          if [ -z "${PACKAGIST_USERNAME:-}" ] || [ -z "${PACKAGIST_MAIN_TOKEN:-}" ]; then
+            echo "Packagist API refresh credentials are not set; publishing will rely on the repository webhook."
+          fi
 
   ruby:
     name: Ruby readiness
@@ -154,11 +153,6 @@ jobs:
         run: |
           ruby tests/lifecycle_test.rb
           gem build phaseo_sdk.gemspec
-      - name: Check RubyGems secret
+      - name: Trusted publishing note
         if: inputs.checkSecrets
-        env:
-          RUBYGEMS_API_KEY: ${{ secrets.RUBYGEMS_API_KEY }}
-        shell: bash
-        run: |
-          set -euo pipefail
-          [ -n "${RUBYGEMS_API_KEY:-}" ] || { echo "::error::Missing RUBYGEMS_API_KEY"; exit 1; }
+        run: echo "RubyGems publishing uses OIDC; verify the pending/existing trusted publisher in RubyGems.org."

--- a/.github/workflows/sync-sdk-php-split.yml
+++ b/.github/workflows/sync-sdk-php-split.yml
@@ -9,6 +9,7 @@ permissions:
 jobs:
   sync-php-split:
     runs-on: ubuntu-latest
+    environment: release
     steps:
       - name: Require main branch
         shell: bash
@@ -19,30 +20,31 @@ jobs:
             exit 1
           fi
 
+      - name: Create GitHub App token (Phaseo Bot)
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1
+        with:
+          client-id: ${{ secrets.PHASEO_APP_CLIENT_ID }}
+          private-key: ${{ secrets.PHASEO_APP_PRIVATE_KEY }}
+          owner: phaseoteam
+          repositories: |
+            Phaseo
+            phaseo-php-sdk
+
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
           fetch-depth: 0
-
-      - name: Verify split repo token
-        env:
-          PHP_SDK_SPLIT_REPO_TOKEN: ${{ secrets.PHP_SDK_SPLIT_REPO_TOKEN }}
-        shell: bash
-        run: |
-          set -euo pipefail
-          if [ -z "${PHP_SDK_SPLIT_REPO_TOKEN:-}" ]; then
-            echo "::error::Missing PHP_SDK_SPLIT_REPO_TOKEN secret."
-            exit 1
-          fi
+          persist-credentials: false
 
       - name: Sync subtree to split repo main
         env:
           PHP_SDK_SPLIT_REPO: ${{ vars.PHP_SDK_SPLIT_REPO }}
-          PHP_SDK_SPLIT_REPO_TOKEN: ${{ secrets.PHP_SDK_SPLIT_REPO_TOKEN }}
+          GH_APP_TOKEN: ${{ steps.app-token.outputs.token }}
         shell: bash
         run: |
           set -euo pipefail
           split_repo="${PHP_SDK_SPLIT_REPO:-phaseoteam/phaseo-php-sdk}"
-          split_remote_url="https://x-access-token:${PHP_SDK_SPLIT_REPO_TOKEN}@github.com/${split_repo}.git"
+          split_remote_url="https://x-access-token:${GH_APP_TOKEN}@github.com/${split_repo}.git"
 
           git remote add split "$split_remote_url"
 

--- a/.github/workflows/sync-sdk-php-split.yml
+++ b/.github/workflows/sync-sdk-php-split.yml
@@ -27,9 +27,6 @@ jobs:
           client-id: ${{ secrets.PHASEO_APP_CLIENT_ID }}
           private-key: ${{ secrets.PHASEO_APP_PRIVATE_KEY }}
           owner: phaseoteam
-          repositories: |
-            Phaseo
-            phaseo-php-sdk
 
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:

--- a/apps/docs/v1/cookbook/agent-sdk-go-ops-runbook.mdx
+++ b/apps/docs/v1/cookbook/agent-sdk-go-ops-runbook.mdx
@@ -8,7 +8,7 @@ Use this recipe when a Go service needs to answer operational questions with loc
 ## 1. Install the SDKs
 
 ```bash
-go get github.com/phaseoteam/Phaseo/packages/sdk/sdk-go@latest
+go get github.com/phaseoteam/Phaseo/packages/sdk/sdk-go/v2@latest
 go get github.com/phaseoteam/Phaseo/packages/sdk/agent-sdk-go@latest
 ```
 

--- a/apps/docs/v1/cookbook/free-router-first-deploy.mdx
+++ b/apps/docs/v1/cookbook/free-router-first-deploy.mdx
@@ -64,7 +64,7 @@ import (
   "context"
   "fmt"
 
-  phaseo "github.com/phaseoteam/Phaseo/packages/sdk/sdk-go"
+  phaseo "github.com/phaseoteam/Phaseo/packages/sdk/sdk-go/v2"
 )
 
 func main() {

--- a/apps/docs/v1/cookbook/sort-providers-by-price-latency-or-throughput.mdx
+++ b/apps/docs/v1/cookbook/sort-providers-by-price-latency-or-throughput.mdx
@@ -70,7 +70,7 @@ import (
   "context"
   "fmt"
 
-  phaseo "github.com/phaseoteam/Phaseo/packages/sdk/sdk-go"
+  phaseo "github.com/phaseoteam/Phaseo/packages/sdk/sdk-go/v2"
 )
 
 func main() {
@@ -235,7 +235,7 @@ import (
   "context"
   "fmt"
 
-  phaseo "github.com/phaseoteam/Phaseo/packages/sdk/sdk-go"
+  phaseo "github.com/phaseoteam/Phaseo/packages/sdk/sdk-go/v2"
 )
 
 func main() {

--- a/apps/docs/v1/developers/integrating-with-the-gateway.mdx
+++ b/apps/docs/v1/developers/integrating-with-the-gateway.mdx
@@ -124,7 +124,7 @@ import (
   "context"
   "fmt"
 
-  phaseo "github.com/phaseoteam/Phaseo/packages/sdk/sdk-go"
+  phaseo "github.com/phaseoteam/Phaseo/packages/sdk/sdk-go/v2"
 )
 
 func main() {

--- a/apps/docs/v1/guides/examples.mdx
+++ b/apps/docs/v1/guides/examples.mdx
@@ -65,7 +65,7 @@ import (
   "context"
   "fmt"
 
-  phaseo "github.com/phaseoteam/Phaseo/packages/sdk/sdk-go"
+  phaseo "github.com/phaseoteam/Phaseo/packages/sdk/sdk-go/v2"
 )
 
 func main() {

--- a/apps/docs/v1/quickstart.mdx
+++ b/apps/docs/v1/quickstart.mdx
@@ -125,7 +125,7 @@ import (
   "context"
   "fmt"
 
-  phaseo "github.com/phaseoteam/Phaseo/packages/sdk/sdk-go"
+  phaseo "github.com/phaseoteam/Phaseo/packages/sdk/sdk-go/v2"
 )
 
 func main() {

--- a/apps/docs/v1/sdk-reference/go/audio-speech.mdx
+++ b/apps/docs/v1/sdk-reference/go/audio-speech.mdx
@@ -11,7 +11,7 @@ Use the wrapper method:
 import (
   "context"
   "fmt"
-  phaseo "github.com/phaseoteam/Phaseo/packages/sdk/sdk-go"
+  phaseo "github.com/phaseoteam/Phaseo/packages/sdk/sdk-go/v2"
 )
 
 client := phaseo.New(apiKey, "https://api.phaseo.app/v1")

--- a/apps/docs/v1/sdk-reference/go/audio-transcriptions.mdx
+++ b/apps/docs/v1/sdk-reference/go/audio-transcriptions.mdx
@@ -11,7 +11,7 @@ Use the wrapper method:
 import (
   "context"
   "fmt"
-  phaseo "github.com/phaseoteam/Phaseo/packages/sdk/sdk-go"
+  phaseo "github.com/phaseoteam/Phaseo/packages/sdk/sdk-go/v2"
 )
 
 client := phaseo.New(apiKey, "https://api.phaseo.app/v1")

--- a/apps/docs/v1/sdk-reference/go/audio-translations.mdx
+++ b/apps/docs/v1/sdk-reference/go/audio-translations.mdx
@@ -11,7 +11,7 @@ Use the wrapper method:
 import (
   "context"
   "fmt"
-  phaseo "github.com/phaseoteam/Phaseo/packages/sdk/sdk-go"
+  phaseo "github.com/phaseoteam/Phaseo/packages/sdk/sdk-go/v2"
 )
 
 client := phaseo.New(apiKey, "https://api.phaseo.app/v1")

--- a/apps/docs/v1/sdk-reference/go/batches.mdx
+++ b/apps/docs/v1/sdk-reference/go/batches.mdx
@@ -9,7 +9,7 @@ description: "Create and retrieve batch jobs with the Go SDK wrapper."
 import (
   "context"
   "fmt"
-  phaseo "github.com/phaseoteam/Phaseo/packages/sdk/sdk-go"
+  phaseo "github.com/phaseoteam/Phaseo/packages/sdk/sdk-go/v2"
 )
 
 client := phaseo.New(apiKey, "https://api.phaseo.app/v1")

--- a/apps/docs/v1/sdk-reference/go/chat-completions.mdx
+++ b/apps/docs/v1/sdk-reference/go/chat-completions.mdx
@@ -11,7 +11,7 @@ Use the wrapper method:
 import (
   "context"
   "fmt"
-  phaseo "github.com/phaseoteam/Phaseo/packages/sdk/sdk-go"
+  phaseo "github.com/phaseoteam/Phaseo/packages/sdk/sdk-go/v2"
 )
 
 client := phaseo.New(apiKey, "https://api.phaseo.app/v1")

--- a/apps/docs/v1/sdk-reference/go/embeddings.mdx
+++ b/apps/docs/v1/sdk-reference/go/embeddings.mdx
@@ -11,7 +11,7 @@ Use the wrapper method:
 import (
   "context"
   "fmt"
-  phaseo "github.com/phaseoteam/Phaseo/packages/sdk/sdk-go"
+  phaseo "github.com/phaseoteam/Phaseo/packages/sdk/sdk-go/v2"
 )
 
 client := phaseo.New(apiKey, "https://api.phaseo.app/v1")

--- a/apps/docs/v1/sdk-reference/go/files.mdx
+++ b/apps/docs/v1/sdk-reference/go/files.mdx
@@ -9,7 +9,7 @@ description: "Use the Go SDK for file metadata and file-content retrieval."
 import (
   "fmt"
   "context"
-  phaseo "github.com/phaseoteam/Phaseo/packages/sdk/sdk-go"
+  phaseo "github.com/phaseoteam/Phaseo/packages/sdk/sdk-go/v2"
 )
 
 client := phaseo.New(apiKey, "https://api.phaseo.app/v1")

--- a/apps/docs/v1/sdk-reference/go/generation.mdx
+++ b/apps/docs/v1/sdk-reference/go/generation.mdx
@@ -11,7 +11,7 @@ Use the wrapper method:
 import (
   "context"
   "fmt"
-  phaseo "github.com/phaseoteam/Phaseo/packages/sdk/sdk-go"
+  phaseo "github.com/phaseoteam/Phaseo/packages/sdk/sdk-go/v2"
 )
 
 client := phaseo.New(apiKey, "https://api.phaseo.app/v1")

--- a/apps/docs/v1/sdk-reference/go/images-edits.mdx
+++ b/apps/docs/v1/sdk-reference/go/images-edits.mdx
@@ -11,7 +11,7 @@ Use the wrapper method:
 import (
   "context"
   "fmt"
-  phaseo "github.com/phaseoteam/Phaseo/packages/sdk/sdk-go"
+  phaseo "github.com/phaseoteam/Phaseo/packages/sdk/sdk-go/v2"
 )
 
 client := phaseo.New(apiKey, "https://api.phaseo.app/v1")

--- a/apps/docs/v1/sdk-reference/go/images-generations.mdx
+++ b/apps/docs/v1/sdk-reference/go/images-generations.mdx
@@ -11,7 +11,7 @@ Use the wrapper method:
 import (
   "context"
   "fmt"
-  phaseo "github.com/phaseoteam/Phaseo/packages/sdk/sdk-go"
+  phaseo "github.com/phaseoteam/Phaseo/packages/sdk/sdk-go/v2"
 )
 
 client := phaseo.New(apiKey, "https://api.phaseo.app/v1")

--- a/apps/docs/v1/sdk-reference/go/installation.mdx
+++ b/apps/docs/v1/sdk-reference/go/installation.mdx
@@ -25,13 +25,13 @@ pnpm openapi:gen:go
 ```go
 go 1.23
 
-require github.com/phaseoteam/Phaseo/packages/sdk/sdk-go v0.0.0
+require github.com/phaseoteam/Phaseo/packages/sdk/sdk-go/v2 v2.0.0
 
-replace github.com/phaseoteam/Phaseo/packages/sdk/sdk-go => ../phaseo/packages/sdk/sdk-go
+replace github.com/phaseoteam/Phaseo/packages/sdk/sdk-go/v2 => ../phaseo/packages/sdk/sdk-go
 ```
 
 3. Import the wrapper:
 
 ```go
-import phaseo "github.com/phaseoteam/Phaseo/packages/sdk/sdk-go"
+import phaseo "github.com/phaseoteam/Phaseo/packages/sdk/sdk-go/v2"
 ```

--- a/apps/docs/v1/sdk-reference/go/models.mdx
+++ b/apps/docs/v1/sdk-reference/go/models.mdx
@@ -11,7 +11,7 @@ Use the wrapper method:
 import (
   "context"
   "fmt"
-  phaseo "github.com/phaseoteam/Phaseo/packages/sdk/sdk-go"
+  phaseo "github.com/phaseoteam/Phaseo/packages/sdk/sdk-go/v2"
 )
 
 client := phaseo.New(apiKey, "https://api.phaseo.app/v1")

--- a/apps/docs/v1/sdk-reference/go/moderations.mdx
+++ b/apps/docs/v1/sdk-reference/go/moderations.mdx
@@ -11,7 +11,7 @@ Use the wrapper method:
 import (
   "context"
   "fmt"
-  phaseo "github.com/phaseoteam/Phaseo/packages/sdk/sdk-go"
+  phaseo "github.com/phaseoteam/Phaseo/packages/sdk/sdk-go/v2"
 )
 
 client := phaseo.New(apiKey, "https://api.phaseo.app/v1")

--- a/apps/docs/v1/sdk-reference/go/overview.mdx
+++ b/apps/docs/v1/sdk-reference/go/overview.mdx
@@ -44,7 +44,7 @@ For endpoints that are not yet promoted to the wrapper, use the generated client
 import (
   "context"
   "fmt"
-  phaseo "github.com/phaseoteam/Phaseo/packages/sdk/sdk-go"
+  phaseo "github.com/phaseoteam/Phaseo/packages/sdk/sdk-go/v2"
 )
 
 client := phaseo.New("YOUR_KEY", "https://api.phaseo.app/v1")

--- a/apps/docs/v1/sdk-reference/go/responses.mdx
+++ b/apps/docs/v1/sdk-reference/go/responses.mdx
@@ -11,7 +11,7 @@ Use the wrapper method:
 import (
   "context"
   "fmt"
-  phaseo "github.com/phaseoteam/Phaseo/packages/sdk/sdk-go"
+  phaseo "github.com/phaseoteam/Phaseo/packages/sdk/sdk-go/v2"
 )
 
 client := phaseo.New(apiKey, "https://api.phaseo.app/v1")

--- a/apps/docs/v1/sdk-reference/go/usage.mdx
+++ b/apps/docs/v1/sdk-reference/go/usage.mdx
@@ -8,7 +8,7 @@ description: "Current wrapper methods supported by the preview Go SDK."
 ```go
 import (
   "context"
-  phaseo "github.com/phaseoteam/Phaseo/packages/sdk/sdk-go"
+  phaseo "github.com/phaseoteam/Phaseo/packages/sdk/sdk-go/v2"
 )
 
 client := phaseo.New("<API_KEY>", "https://api.phaseo.app/v1")

--- a/apps/docs/v1/sdk-reference/go/video-generation.mdx
+++ b/apps/docs/v1/sdk-reference/go/video-generation.mdx
@@ -21,7 +21,7 @@ description: "Create and manage async video jobs with the Go SDK."
 import (
   "context"
   "fmt"
-  phaseo "github.com/phaseoteam/Phaseo/packages/sdk/sdk-go"
+  phaseo "github.com/phaseoteam/Phaseo/packages/sdk/sdk-go/v2"
 )
 
 client := phaseo.New(apiKey, "https://api.phaseo.app/v1")

--- a/apps/web/src/app/(dashboard)/settings/sdk/page.tsx
+++ b/apps/web/src/app/(dashboard)/settings/sdk/page.tsx
@@ -46,7 +46,7 @@ const SDKS: Sdk[] = [
 	},
 	{
 		name: "Go SDK",
-		packageName: "github.com/phaseoteam/Phaseo/packages/sdk/sdk-go",
+		packageName: "github.com/phaseoteam/Phaseo/packages/sdk/sdk-go/v2",
 		installCommand: "Coming soon",
 		logoId: "go",
 		docsLink: `${DOCS_BASE}/sdk-reference/go/overview`,

--- a/apps/web/src/components/(data)/model/playground/ModelPlayground.tsx
+++ b/apps/web/src/components/(data)/model/playground/ModelPlayground.tsx
@@ -1355,14 +1355,14 @@ print(response)`,
 			description: "Official Phaseo SDK for Go.",
 			lang: "go",
 			installCommand:
-				"go get github.com/phaseoteam/Phaseo/packages/sdk/sdk-go@latest",
+				"go get github.com/phaseoteam/Phaseo/packages/sdk/sdk-go/v2@latest",
 			code: `package main
 
 import (
     "context"
     "encoding/json"
     "fmt"
-    phaseo "github.com/phaseoteam/Phaseo/packages/sdk/sdk-go"
+    phaseo "github.com/phaseoteam/Phaseo/packages/sdk/sdk-go/v2"
 )
 
 func main() {

--- a/apps/web/src/components/(data)/model/quickstart/Quickstart.tsx
+++ b/apps/web/src/components/(data)/model/quickstart/Quickstart.tsx
@@ -1146,7 +1146,7 @@ import (
   "encoding/json"
   "fmt"
 
-  phaseo "github.com/phaseoteam/Phaseo/packages/sdk/sdk-go"
+  phaseo "github.com/phaseoteam/Phaseo/packages/sdk/sdk-go/v2"
 )
 
 func main() {
@@ -1174,7 +1174,7 @@ import (
   "encoding/json"
   "fmt"
 
-  phaseo "github.com/phaseoteam/Phaseo/packages/sdk/sdk-go"
+  phaseo "github.com/phaseoteam/Phaseo/packages/sdk/sdk-go/v2"
 )
 
 func main() {
@@ -1220,7 +1220,7 @@ import (
   "encoding/json"
   "fmt"
 
-  phaseo "github.com/phaseoteam/Phaseo/packages/sdk/sdk-go"
+  phaseo "github.com/phaseoteam/Phaseo/packages/sdk/sdk-go/v2"
 )
 
 func main() {
@@ -1265,7 +1265,7 @@ import (
   "encoding/json"
   "fmt"
 
-  phaseo "github.com/phaseoteam/Phaseo/packages/sdk/sdk-go"
+  phaseo "github.com/phaseoteam/Phaseo/packages/sdk/sdk-go/v2"
 )
 
 func main() {

--- a/apps/web/src/components/(data)/model/quickstart/quickstartSdkConfig.ts
+++ b/apps/web/src/components/(data)/model/quickstart/quickstartSdkConfig.ts
@@ -136,7 +136,7 @@ export function getInstallationCode(language: string): string {
 		case "python-sdk":
 			return "pip install phaseo";
 		case "go-sdk":
-			return "go get github.com/phaseoteam/Phaseo/packages/sdk/sdk-go@latest";
+			return "go get github.com/phaseoteam/Phaseo/packages/sdk/sdk-go/v2@latest";
 		case "csharp-sdk":
 			return "dotnet add package Phaseo.Sdk";
 		case "php-sdk":

--- a/packages/sdk/RELEASING.md
+++ b/packages/sdk/RELEASING.md
@@ -3,7 +3,8 @@
 This repo uses a hybrid release model:
 
 - TypeScript, TypeScript Agent SDK, and Python are auto-released from CI.
-- Go/C#/Java/PHP/Ruby use explicit publish workflows per ecosystem.
+- Go/C#/Java/PHP/Ruby publish automatically when their committed package version changes on `main`.
+- Their workflows also support manual dispatch for safe, idempotent recovery.
 - C++/Rust remain excluded until functional end-to-end.
 - Manual SDK release readiness can be checked with `.github/workflows/sdk-publish-readiness.yml`.
 
@@ -12,10 +13,10 @@ This repo uses a hybrid release model:
 - TypeScript (`@phaseo/sdk`) -> npm
 - TypeScript Agent SDK (`@phaseo/agent-sdk`) -> npm
 - Python (`phaseo`) -> PyPI
-- Go (`github.com/phaseoteam/Phaseo/packages/sdk/sdk-go`) -> Go proxy (`pkg.go.dev`) via git tags
+- Go (`github.com/phaseoteam/Phaseo/packages/sdk/sdk-go/v2`) -> Go proxy (`pkg.go.dev`) via git tags
 - C# (`Phaseo.Sdk`) -> NuGet
 - Java (`app.phaseo:phaseo-sdk`) -> Maven Central
-- PHP (`phaseo/php-sdk`) -> Packagist
+- PHP (`phaseo/sdk`) -> Packagist
 - Ruby (`phaseo_sdk`) -> RubyGems
 
 ## Auto Release (TS/Python)
@@ -71,7 +72,7 @@ General policy:
 - `minor`: backward-compatible feature additions (new optional params/endpoints).
 - `major`: breaking changes (removed/renamed params, signature/shape breaks).
 
-## Manual Publish Workflows (Other SDKs)
+## Language SDK Publish Workflows
 
 - First npm publish / bootstrap: `.github/workflows/npm-bootstrap-publish.yml`
   - Supports `@phaseo/agent-sdk`, `@phaseo/ai-sdk-provider`, and `@phaseo/devtools-viewer`
@@ -96,11 +97,11 @@ General policy:
 - PHP: `.github/workflows/publish-sdk-php.yml`
   - Publishes by creating/pushing monorepo tag `sdk-php/vX.Y.Z`
   - Syncs `packages/sdk/sdk-php` to split repo main and pushes split tag `vX.Y.Z`
-  - Triggers Packagist update against the split repo URL
-  - Required secrets:
+  - Uses the Phaseo GitHub App token to update the split repository
+  - Relies on the split repository's Packagist webhook by default
+  - Optional secrets for an immediate Packagist API refresh:
     - `PACKAGIST_USERNAME`
     - `PACKAGIST_MAIN_TOKEN`
-    - `PHP_SDK_SPLIT_REPO_TOKEN`
   - Optional repo variable:
     - `PHP_SDK_SPLIT_REPO` (defaults to `phaseoteam/phaseo-php-sdk`)
 
@@ -108,8 +109,8 @@ General policy:
   - Keeps split repo main in sync from monorepo path `packages/sdk/sdk-php/**` on pushes to main
 
 - Ruby: `.github/workflows/publish-sdk-ruby.yml`
-  - Builds gem, creates/pushes tag `sdk-ruby/vX.Y.Z`, pushes to RubyGems
-  - Required secret: `RUBYGEMS_API_KEY`
+  - Builds the gem, publishes through RubyGems trusted publishing, and creates/pushes tag `sdk-ruby/vX.Y.Z`
+  - Uses OIDC; no RubyGems API key is stored
 
 ## Publish Readiness Checks
 

--- a/packages/sdk/agent-sdk-go/agent.go
+++ b/packages/sdk/agent-sdk-go/agent.go
@@ -8,8 +8,8 @@ import (
 	"os"
 	"strings"
 
-	phaseo "github.com/phaseoteam/Phaseo/packages/sdk/sdk-go"
-	gen "github.com/phaseoteam/Phaseo/packages/sdk/sdk-go/src/gen"
+	phaseo "github.com/phaseoteam/Phaseo/packages/sdk/sdk-go/v2"
+	gen "github.com/phaseoteam/Phaseo/packages/sdk/sdk-go/v2/src/gen"
 )
 
 type ToolCall struct {

--- a/packages/sdk/agent-sdk-go/go.mod
+++ b/packages/sdk/agent-sdk-go/go.mod
@@ -2,6 +2,6 @@ module github.com/phaseoteam/Phaseo/packages/sdk/agent-sdk-go
 
 go 1.24.0
 
-require github.com/phaseoteam/Phaseo/packages/sdk/sdk-go v0.0.0
+require github.com/phaseoteam/Phaseo/packages/sdk/sdk-go/v2 v2.0.0
 
-replace github.com/phaseoteam/Phaseo/packages/sdk/sdk-go => ../sdk-go
+replace github.com/phaseoteam/Phaseo/packages/sdk/sdk-go/v2 => ../sdk-go

--- a/packages/sdk/sdk-csharp/README.md
+++ b/packages/sdk/sdk-csharp/README.md
@@ -6,10 +6,8 @@ Package ID: `Phaseo.Sdk`
 
 ## Installation
 
-If published in your feed:
-
 ```bash
-dotnet add package Phaseo.Sdk
+dotnet add package Phaseo.Sdk --version 2.0.5
 ```
 
 From this monorepo:

--- a/packages/sdk/sdk-go/README.md
+++ b/packages/sdk/sdk-go/README.md
@@ -4,12 +4,12 @@ Official Go SDK for Phaseo Gateway.
 
 Module path:
 
-`github.com/phaseoteam/Phaseo/packages/sdk/sdk-go`
+`github.com/phaseoteam/Phaseo/packages/sdk/sdk-go/v2`
 
 ## Installation
 
 ```bash
-go get github.com/phaseoteam/Phaseo/packages/sdk/sdk-go@latest
+go get github.com/phaseoteam/Phaseo/packages/sdk/sdk-go/v2@latest
 ```
 
 ## Quick start
@@ -21,7 +21,7 @@ import (
 	"context"
 	"fmt"
 
-	phaseo "github.com/phaseoteam/Phaseo/packages/sdk/sdk-go"
+	phaseo "github.com/phaseoteam/Phaseo/packages/sdk/sdk-go/v2"
 )
 
 func main() {

--- a/packages/sdk/sdk-go/chat_test.go
+++ b/packages/sdk/sdk-go/chat_test.go
@@ -7,7 +7,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	gen "github.com/phaseoteam/Phaseo/packages/sdk/sdk-go/src/gen"
+	gen "github.com/phaseoteam/Phaseo/packages/sdk/sdk-go/v2/src/gen"
 )
 
 func TestGenerateTextPreservesGatewayMetadata(t *testing.T) {

--- a/packages/sdk/sdk-go/devtools.go
+++ b/packages/sdk/sdk-go/devtools.go
@@ -13,7 +13,7 @@ import (
 	"sync/atomic"
 	"time"
 
-	gen "github.com/phaseoteam/Phaseo/packages/sdk/sdk-go/src/gen"
+	gen "github.com/phaseoteam/Phaseo/packages/sdk/sdk-go/v2/src/gen"
 )
 
 const goSDKVersion = "2.0.5"

--- a/packages/sdk/sdk-go/devtools_test.go
+++ b/packages/sdk/sdk-go/devtools_test.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 	"testing"
 
-	gen "github.com/phaseoteam/Phaseo/packages/sdk/sdk-go/src/gen"
+	gen "github.com/phaseoteam/Phaseo/packages/sdk/sdk-go/v2/src/gen"
 )
 
 func TestDevtoolsCapturesResponsesRequests(t *testing.T) {

--- a/packages/sdk/sdk-go/examples/embeddings.go
+++ b/packages/sdk/sdk-go/examples/embeddings.go
@@ -8,7 +8,7 @@ import (
 	"fmt"
 	"os"
 
-	phaseo "github.com/phaseoteam/Phaseo/packages/sdk/sdk-go"
+	phaseo "github.com/phaseoteam/Phaseo/packages/sdk/sdk-go/v2"
 )
 
 func main() {

--- a/packages/sdk/sdk-go/examples/models.go
+++ b/packages/sdk/sdk-go/examples/models.go
@@ -8,7 +8,7 @@ import (
 	"fmt"
 	"os"
 
-	phaseo "github.com/phaseoteam/Phaseo/packages/sdk/sdk-go"
+	phaseo "github.com/phaseoteam/Phaseo/packages/sdk/sdk-go/v2"
 )
 
 func main() {

--- a/packages/sdk/sdk-go/examples/moderations.go
+++ b/packages/sdk/sdk-go/examples/moderations.go
@@ -8,7 +8,7 @@ import (
 	"fmt"
 	"os"
 
-	phaseo "github.com/phaseoteam/Phaseo/packages/sdk/sdk-go"
+	phaseo "github.com/phaseoteam/Phaseo/packages/sdk/sdk-go/v2"
 )
 
 func main() {

--- a/packages/sdk/sdk-go/go.mod
+++ b/packages/sdk/sdk-go/go.mod
@@ -1,3 +1,3 @@
-module github.com/phaseoteam/Phaseo/packages/sdk/sdk-go
+module github.com/phaseoteam/Phaseo/packages/sdk/sdk-go/v2
 
 go 1.23

--- a/packages/sdk/sdk-go/index.go
+++ b/packages/sdk/sdk-go/index.go
@@ -11,7 +11,7 @@ import (
 	"sync"
 	"time"
 
-	gen "github.com/phaseoteam/Phaseo/packages/sdk/sdk-go/src/gen"
+	gen "github.com/phaseoteam/Phaseo/packages/sdk/sdk-go/v2/src/gen"
 )
 
 const defaultBaseURL = "https://api.phaseo.app/v1"

--- a/packages/sdk/sdk-go/lifecycle_test.go
+++ b/packages/sdk/sdk-go/lifecycle_test.go
@@ -9,7 +9,7 @@ import (
 	"sync/atomic"
 	"testing"
 
-	gen "github.com/phaseoteam/Phaseo/packages/sdk/sdk-go/src/gen"
+	gen "github.com/phaseoteam/Phaseo/packages/sdk/sdk-go/v2/src/gen"
 )
 
 func TestInactiveModelBlocksRequest(t *testing.T) {

--- a/packages/sdk/sdk-go/model_ids.go
+++ b/packages/sdk/sdk-go/model_ids.go
@@ -3,7 +3,7 @@
 
 package phaseo
 
-import gen "github.com/phaseoteam/Phaseo/packages/sdk/sdk-go/src/gen"
+import gen "github.com/phaseoteam/Phaseo/packages/sdk/sdk-go/v2/src/gen"
 
 // ModelIds contains known model IDs for editor autocomplete and hover docs.
 const (

--- a/packages/sdk/sdk-go/smoke_test.go
+++ b/packages/sdk/sdk-go/smoke_test.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 	"testing"
 
-	gen "github.com/phaseoteam/Phaseo/packages/sdk/sdk-go/src/gen"
+	gen "github.com/phaseoteam/Phaseo/packages/sdk/sdk-go/v2/src/gen"
 )
 
 type operation struct {

--- a/packages/sdk/sdk-go/tests/smoke_sdk_test.go
+++ b/packages/sdk/sdk-go/tests/smoke_sdk_test.go
@@ -6,8 +6,8 @@ import (
 	"strconv"
 	"testing"
 
-	phaseo "github.com/phaseoteam/Phaseo/packages/sdk/sdk-go"
-	gen "github.com/phaseoteam/Phaseo/packages/sdk/sdk-go/src/gen"
+	phaseo "github.com/phaseoteam/Phaseo/packages/sdk/sdk-go/v2"
+	gen "github.com/phaseoteam/Phaseo/packages/sdk/sdk-go/v2/src/gen"
 )
 
 func TestSmokeResponsesSDK(t *testing.T) {

--- a/packages/sdk/sdk-go/tests/smoke_test.go
+++ b/packages/sdk/sdk-go/tests/smoke_test.go
@@ -6,7 +6,7 @@ import (
 	"strconv"
 	"testing"
 
-	gen "github.com/phaseoteam/Phaseo/packages/sdk/sdk-go/src/gen"
+	gen "github.com/phaseoteam/Phaseo/packages/sdk/sdk-go/v2/src/gen"
 )
 
 func TestSmokeChat(t *testing.T) {

--- a/packages/sdk/sdk-java/README.md
+++ b/packages/sdk/sdk-java/README.md
@@ -13,7 +13,7 @@ Maven coordinates:
 <dependency>
   <groupId>app.phaseo</groupId>
   <artifactId>phaseo-sdk</artifactId>
-  <version>1.1.2</version>
+  <version>2.0.5</version>
 </dependency>
 ```
 

--- a/packages/sdk/sdk-java/pom.xml
+++ b/packages/sdk/sdk-java/pom.xml
@@ -122,7 +122,7 @@
           <plugin>
             <groupId>org.sonatype.central</groupId>
             <artifactId>central-publishing-maven-plugin</artifactId>
-            <version>0.7.0</version>
+            <version>0.9.0</version>
             <extensions>true</extensions>
             <configuration>
               <publishingServerId>central</publishingServerId>

--- a/scripts/sdk/generate-model-id-constants.mjs
+++ b/scripts/sdk/generate-model-id-constants.mjs
@@ -236,7 +236,7 @@ function renderPy(items, aliases) {
 }
 
 function renderGo(items, aliases) {
-	const lines = [renderHeader("//").trimEnd(), "", "package phaseo", "", "import gen \"github.com/phaseoteam/Phaseo/packages/sdk/sdk-go/src/gen\"", "", "// ModelIds contains known model IDs for editor autocomplete and hover docs.", "const (",];
+	const lines = [renderHeader("//").trimEnd(), "", "package phaseo", "", "import gen \"github.com/phaseoteam/Phaseo/packages/sdk/sdk-go/v2/src/gen\"", "", "// ModelIds contains known model IDs for editor autocomplete and hover docs.", "const (",];
 	for (const item of items) {
 		lines.push(
 			`	// Model ID: ${item.id}`,

--- a/skills.md
+++ b/skills.md
@@ -47,7 +47,7 @@ All of these SDKs exist and should be considered valid integration targets:
   - package: `phaseo`
   - local path: `packages/sdk/sdk-py`
 - Go:
-  - module: `github.com/phaseoteam/Phaseo/packages/sdk/sdk-go`
+  - module: `github.com/phaseoteam/Phaseo/packages/sdk/sdk-go/v2`
   - local path: `packages/sdk/sdk-go`
 - C#:
   - package: `Phaseo.Sdk`


### PR DESCRIPTION
## Summary

- prepare Go, C#, Java, PHP, and Ruby SDK publishing workflows for public registries
- make registry publishing idempotent and use trusted/OIDC publishing where supported
- migrate the Go v2 SDK to its required `/v2` semantic import path
- update SDK release documentation and installation examples

## Validation

- `go test ./...` (`packages/sdk/sdk-go`)
- `go test ./...` (`packages/sdk/agent-sdk-go`)
- C# tests: 38 passed; NuGet package built
- Java tests: 38 passed, 1 skipped; Maven verify passed
- `composer validate --strict` and PHP lifecycle tests
- Ruby lifecycle tests: 2 tests, 10 assertions; gem built
- `actionlint` over modified workflows
- YAML parse checks over modified workflows
- `pnpm docs:links`
- `pnpm docs:build`
- `git diff --check`

## Notes

`pnpm --filter @phaseo/web typecheck` remains blocked by existing unrelated type errors in dashboard layout files and `authOrigin.test.ts`; none are in the Go import-string files changed here.

Registry account/trusted-publisher setup and first publication will be performed after this change passes review and merges.

Created with Codex
