### PR TITLE
Fix SDK release tag identity

### DIFF
--- a/.github/workflows/publish-sdk-go.yml
+++ b/.github/workflows/publish-sdk-go.yml
@@ -52,6 +52,7 @@ jobs:
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e
         with:
           go-version: "1.23"
+          cache: false
 
       - name: Resolve version
         id: version

--- a/.github/workflows/publish-sdk-go.yml
+++ b/.github/workflows/publish-sdk-go.yml
@@ -37,6 +37,18 @@ jobs:
           client-id: ${{ secrets.PHASEO_APP_CLIENT_ID }}
           private-key: ${{ secrets.PHASEO_APP_PRIVATE_KEY }}
 
+      - name: Resolve GitHub App identity
+        id: app-identity
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          bot="${{ steps.app-token.outputs.app-slug }}[bot]"
+          id="$(gh api "/users/${bot}" --jq .id)"
+          echo "name=${bot}" >> "$GITHUB_OUTPUT"
+          echo "email=${id}+${bot}@users.noreply.github.com" >> "$GITHUB_OUTPUT"
+
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
           fetch-depth: 0
@@ -120,11 +132,13 @@ jobs:
         env:
           VERSION: ${{ steps.version.outputs.value }}
           GH_APP_TOKEN: ${{ steps.app-token.outputs.token }}
+          GIT_USER_NAME: ${{ steps.app-identity.outputs.name }}
+          GIT_USER_EMAIL: ${{ steps.app-identity.outputs.email }}
         shell: bash
         run: |
           set -euo pipefail
-          git config user.name "phaseo-bot[bot]"
-          git config user.email "phaseo-bot[bot]@users.noreply.github.com"
+          git config user.name "$GIT_USER_NAME"
+          git config user.email "$GIT_USER_EMAIL"
           tag="packages/sdk/sdk-go/v${VERSION}"
           if git rev-parse "$tag" >/dev/null 2>&1; then
             echo "Tag already exists locally: $tag"

--- a/.github/workflows/publish-sdk-go.yml
+++ b/.github/workflows/publish-sdk-go.yml
@@ -122,6 +122,8 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
+          git config user.name "phaseo-bot[bot]"
+          git config user.email "phaseo-bot[bot]@users.noreply.github.com"
           tag="packages/sdk/sdk-go/v${VERSION}"
           if git rev-parse "$tag" >/dev/null 2>&1; then
             echo "Tag already exists locally: $tag"

--- a/.github/workflows/publish-sdk-php.yml
+++ b/.github/workflows/publish-sdk-php.yml
@@ -108,6 +108,8 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
+          git config user.name "phaseo-bot[bot]"
+          git config user.email "phaseo-bot[bot]@users.noreply.github.com"
           tag="sdk-php/v${VERSION}"
           if git rev-parse "$tag" >/dev/null 2>&1; then
             echo "Tag already exists locally: $tag"

--- a/.github/workflows/publish-sdk-php.yml
+++ b/.github/workflows/publish-sdk-php.yml
@@ -38,6 +38,18 @@ jobs:
           private-key: ${{ secrets.PHASEO_APP_PRIVATE_KEY }}
           owner: phaseoteam
 
+      - name: Resolve GitHub App identity
+        id: app-identity
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          bot="${{ steps.app-token.outputs.app-slug }}[bot]"
+          id="$(gh api "/users/${bot}" --jq .id)"
+          echo "name=${bot}" >> "$GITHUB_OUTPUT"
+          echo "email=${id}+${bot}@users.noreply.github.com" >> "$GITHUB_OUTPUT"
+
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
           fetch-depth: 0
@@ -105,11 +117,13 @@ jobs:
         env:
           VERSION: ${{ steps.version.outputs.value }}
           GH_APP_TOKEN: ${{ steps.app-token.outputs.token }}
+          GIT_USER_NAME: ${{ steps.app-identity.outputs.name }}
+          GIT_USER_EMAIL: ${{ steps.app-identity.outputs.email }}
         shell: bash
         run: |
           set -euo pipefail
-          git config user.name "phaseo-bot[bot]"
-          git config user.email "phaseo-bot[bot]@users.noreply.github.com"
+          git config user.name "$GIT_USER_NAME"
+          git config user.email "$GIT_USER_EMAIL"
           tag="sdk-php/v${VERSION}"
           if git rev-parse "$tag" >/dev/null 2>&1; then
             echo "Tag already exists locally: $tag"

--- a/.github/workflows/publish-sdk-ruby.yml
+++ b/.github/workflows/publish-sdk-ruby.yml
@@ -37,6 +37,18 @@ jobs:
           client-id: ${{ secrets.PHASEO_APP_CLIENT_ID }}
           private-key: ${{ secrets.PHASEO_APP_PRIVATE_KEY }}
 
+      - name: Resolve GitHub App identity
+        id: app-identity
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          bot="${{ steps.app-token.outputs.app-slug }}[bot]"
+          id="$(gh api "/users/${bot}" --jq .id)"
+          echo "name=${bot}" >> "$GITHUB_OUTPUT"
+          echo "email=${id}+${bot}@users.noreply.github.com" >> "$GITHUB_OUTPUT"
+
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
           fetch-depth: 0
@@ -156,11 +168,13 @@ jobs:
         env:
           VERSION: ${{ steps.version.outputs.value }}
           GH_APP_TOKEN: ${{ steps.app-token.outputs.token }}
+          GIT_USER_NAME: ${{ steps.app-identity.outputs.name }}
+          GIT_USER_EMAIL: ${{ steps.app-identity.outputs.email }}
         shell: bash
         run: |
           set -euo pipefail
-          git config user.name "phaseo-bot[bot]"
-          git config user.email "phaseo-bot[bot]@users.noreply.github.com"
+          git config user.name "$GIT_USER_NAME"
+          git config user.email "$GIT_USER_EMAIL"
           tag="sdk-ruby/v${VERSION}"
           if git rev-parse "$tag" >/dev/null 2>&1; then
             echo "Tag already exists locally: $tag"

--- a/.github/workflows/publish-sdk-ruby.yml
+++ b/.github/workflows/publish-sdk-ruby.yml
@@ -159,6 +159,8 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
+          git config user.name "phaseo-bot[bot]"
+          git config user.email "phaseo-bot[bot]@users.noreply.github.com"
           tag="sdk-ruby/v${VERSION}"
           if git rev-parse "$tag" >/dev/null 2>&1; then
             echo "Tag already exists locally: $tag"


### PR DESCRIPTION
## Summary

- configure the Phaseo Bot Git identity before creating annotated Go, PHP, and Ruby SDK release tags
- fixes the production Go publish failure observed after the SDK publishing rollout

## Validation

- parsed all three modified workflows with PyYAML
- `git diff --check`
- confirmed Go SDK v2.0.5 through the public Go proxy after manually pushing the merged release tag

Created with Codex
