### PR TITLE
Run required checks for status refresh PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,7 +78,6 @@ jobs:
         name: OpenAPI lint
         runs-on: ubuntu-latest
         needs: data
-        if: github.event_name == 'push' || !startsWith(github.head_ref, 'chore/auto-model-statuses')
         steps:
             - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
 
@@ -122,7 +121,6 @@ jobs:
         name: Apps ${{ matrix.app }}
         runs-on: ubuntu-latest
         needs: openapi-lint
-        if: github.event_name == 'push' || !startsWith(github.head_ref, 'chore/auto-model-statuses')
         strategy:
             matrix:
                 app: [api, docs, web, web-api]
@@ -171,7 +169,6 @@ jobs:
         name: API AIMock matrix
         runs-on: ubuntu-latest
         needs: openapi-lint
-        if: github.event_name == 'push' || !startsWith(github.head_ref, 'chore/auto-model-statuses')
         steps:
             - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
 
@@ -200,7 +197,6 @@ jobs:
         name: Devtools build
         runs-on: ubuntu-latest
         needs: openapi-lint
-        if: github.event_name == 'push' || !startsWith(github.head_ref, 'chore/auto-model-statuses')
         steps:
             - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
 
@@ -366,7 +362,6 @@ jobs:
         name: Generate SDKs
         runs-on: ubuntu-latest
         needs: openapi-lint
-        if: github.event_name == 'push' || !startsWith(github.head_ref, 'chore/auto-model-statuses')
         strategy:
             fail-fast: false
             matrix:
@@ -443,7 +438,6 @@ jobs:
         name: Build & test SDK packages
         runs-on: ubuntu-latest
         needs: sdk-gen
-        if: github.event_name == 'push' || !startsWith(github.head_ref, 'chore/auto-model-statuses')
         steps:
             - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
 
@@ -482,7 +476,6 @@ jobs:
         name: CLI package
         runs-on: ubuntu-latest
         needs: sdk-gen
-        if: github.event_name == 'push' || !startsWith(github.head_ref, 'chore/auto-model-statuses')
         steps:
             - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
               with:
@@ -513,7 +506,6 @@ jobs:
         name: SDK lifecycle tests (${{ matrix.sdk }})
         runs-on: ubuntu-latest
         needs: sdk-gen
-        if: github.event_name == 'push' || !startsWith(github.head_ref, 'chore/auto-model-statuses')
         strategy:
             fail-fast: false
             matrix:
@@ -586,7 +578,6 @@ jobs:
         if: >
             github.event_name == 'pull_request' &&
             (
-                !startsWith(github.head_ref, 'chore/auto-model-statuses') &&
                 github.event.pull_request.head.repo.full_name == github.repository &&
                 contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.pull_request.author_association)
             )


### PR DESCRIPTION
## Summary

- run the required app, SDK-generation, packaging, lifecycle, and preview jobs for automated model-status pull requests
- ensure matrix-expanded required contexts are created so status refresh PRs can enter the merge queue
- retain the existing trusted-preview security boundary

## Root cause

The `chore/auto-model-statuses` branch skipped matrix jobs. GitHub created generic skipped results for non-matrix jobs, but it never created the 14 expanded matrix contexts required by the main ruleset, leaving PR #1202 permanently blocked.

## Validation

- `pnpm run validate:ci-security`
- `git diff --check origin/main...HEAD`

Created with Codex