### PR TITLE
chore: refresh model statuses

### DIFF
--- a/packages/data/catalog/src/data/models/openai/computer-use-preview/model.json
+++ b/packages/data/catalog/src/data/models/openai/computer-use-preview/model.json
@@ -2,7 +2,7 @@
   "model_id": "openai/computer-use-preview",
   "organisation_id": "openai",
   "name": "Computer Use Preview",
-  "status": "Deprecated",
+  "status": "Retired",
   "previous_model_id": null,
   "description": "Computer Use Preview is a multimodal model from OpenAI that can work across text and visual inputs. This entry tracks a preview release and capabilities may change before general availability.",
   "announced_date": "2025-03-11T00:00:00",

--- a/packages/data/catalog/src/data/models/openai/gpt-4o-mini-search-preview/model.json
+++ b/packages/data/catalog/src/data/models/openai/gpt-4o-mini-search-preview/model.json
@@ -2,7 +2,7 @@
   "model_id": "openai/gpt-4o-mini-search-preview",
   "organisation_id": "openai",
   "name": "GPT 4o Mini Search Preview",
-  "status": "Deprecated",
+  "status": "Retired",
   "previous_model_id": null,
   "description": "GPT 4o Mini Search Preview is a specialized model for web search in Chat Completions. It is trained to understand and execute web search queries. This entry tracks a preview release and capabilities may change before general availability.",
   "announced_date": "2025-03-11T00:00:00",

--- a/packages/data/catalog/src/data/models/openai/gpt-4o-mini-tts-2025-03-20/model.json
+++ b/packages/data/catalog/src/data/models/openai/gpt-4o-mini-tts-2025-03-20/model.json
@@ -2,7 +2,7 @@
   "model_id": "openai/gpt-4o-mini-tts-2025-03-20",
   "organisation_id": "openai",
   "name": "GPT 4o Mini TTS (2025-03-20)",
-  "status": "Deprecated",
+  "status": "Retired",
   "previous_model_id": null,
   "description": "GPT 4o Mini TTS (2025-03-20) is OpenAI's cost-efficient text-to-speech model. It converts text input into natural-sounding audio output, supporting a variety of voices and tones.",
   "announced_date": "2025-03-20T00:00:00",

--- a/packages/data/catalog/src/data/models/openai/gpt-4o-search-preview/model.json
+++ b/packages/data/catalog/src/data/models/openai/gpt-4o-search-preview/model.json
@@ -2,7 +2,7 @@
   "model_id": "openai/gpt-4o-search-preview",
   "organisation_id": "openai",
   "name": "GPT 4o Search Preview",
-  "status": "Deprecated",
+  "status": "Retired",
   "previous_model_id": null,
   "description": "GPT 4o Search Preview is trained to understand and execute web search queries. This entry tracks a preview release and capabilities may change before general availability.",
   "announced_date": "2025-03-11T00:00:00",

--- a/packages/data/catalog/src/data/models/openai/gpt-5-chat/model.json
+++ b/packages/data/catalog/src/data/models/openai/gpt-5-chat/model.json
@@ -2,7 +2,7 @@
   "model_id": "openai/gpt-5-chat",
   "organisation_id": "openai",
   "name": "GPT 5 Chat",
-  "status": "Deprecated",
+  "status": "Retired",
   "previous_model_id": "openai/chatgpt-4o-2024-05-13",
   "description": "GPT 5 Chat is designed for advanced, natural, multimodal, and context-aware conversations for enterprise applications. It supports up to 400K of input context for long documents, codebases, and agent workflows.",
   "announced_date": "2025-08-07T00:00:00",

--- a/packages/data/catalog/src/data/models/openai/gpt-5-codex/model.json
+++ b/packages/data/catalog/src/data/models/openai/gpt-5-codex/model.json
@@ -2,7 +2,7 @@
   "model_id": "openai/gpt-5-codex",
   "organisation_id": "openai",
   "name": "GPT 5 Codex",
-  "status": "Deprecated",
+  "status": "Retired",
   "previous_model_id": "openai/codex-mini-2025-05-16",
   "description": "GPT 5 Codex is a specialized version of GPT-5 optimized for software engineering and coding workflows. It accepts text and image inputs and produces text outputs.",
   "announced_date": "2025-09-15T00:00:00",

--- a/packages/data/catalog/src/data/models/openai/gpt-5.1-chat/model.json
+++ b/packages/data/catalog/src/data/models/openai/gpt-5.1-chat/model.json
@@ -2,7 +2,7 @@
   "model_id": "openai/gpt-5.1-chat",
   "organisation_id": "openai",
   "name": "GPT 5.1 Chat",
-  "status": "Deprecated",
+  "status": "Retired",
   "previous_model_id": "openai/gpt-5-chat-2025-08-07",
   "description": "GPT 5.1 Chat is the fast, lightweight member of the 5.1 family, optimized for low-latency chat while retaining strong general intelligence. It accepts text and image inputs and produces text outputs.",
   "announced_date": "2025-11-13T00:00:00",

--- a/packages/data/catalog/src/data/models/openai/gpt-5.1-codex-max/model.json
+++ b/packages/data/catalog/src/data/models/openai/gpt-5.1-codex-max/model.json
@@ -2,7 +2,7 @@
   "model_id": "openai/gpt-5.1-codex-max",
   "organisation_id": "openai",
   "name": "GPT 5.1 Codex Max",
-  "status": "Deprecated",
+  "status": "Retired",
   "previous_model_id": "openai/gpt-5-1-codex-2025-11-13",
   "description": "GPT 5.1 Codex Max is OpenAI's latest agentic coding model, designed for long-running, high-context software development tasks. It targets higher-capability workloads where depth, quality, or scale matter more than raw speed.",
   "announced_date": "2025-11-19T00:00:00",

--- a/packages/data/catalog/src/data/models/openai/gpt-5.1-codex-mini/model.json
+++ b/packages/data/catalog/src/data/models/openai/gpt-5.1-codex-mini/model.json
@@ -2,7 +2,7 @@
   "model_id": "openai/gpt-5.1-codex-mini",
   "organisation_id": "openai",
   "name": "GPT 5.1 Codex Mini",
-  "status": "Deprecated",
+  "status": "Retired",
   "previous_model_id": "openai/gpt-5-codex-mini-2025-11-07",
   "description": "GPT 5.1 Codex Mini is a smaller and faster version of GPT-5.1-Codex. It is a smaller-footprint option suited to tighter latency or deployment budgets.",
   "announced_date": "2025-11-13T00:00:00",

--- a/packages/data/catalog/src/data/models/openai/gpt-5.1-codex/model.json
+++ b/packages/data/catalog/src/data/models/openai/gpt-5.1-codex/model.json
@@ -2,7 +2,7 @@
   "model_id": "openai/gpt-5.1-codex",
   "organisation_id": "openai",
   "name": "GPT 5.1 Codex",
-  "status": "Deprecated",
+  "status": "Retired",
   "previous_model_id": "openai/gpt-5-codex-2025-09-15",
   "description": "GPT 5.1 Codex is a specialized version of GPT-5.1 optimized for software engineering and coding workflows. It accepts text and image inputs and produces text outputs.",
   "announced_date": "2025-11-13T00:00:00",

--- a/packages/data/catalog/src/data/models/openai/gpt-5.2-codex/model.json
+++ b/packages/data/catalog/src/data/models/openai/gpt-5.2-codex/model.json
@@ -2,7 +2,7 @@
   "model_id": "openai/gpt-5.2-codex",
   "organisation_id": "openai",
   "name": "GPT 5.2 Codex",
-  "status": "Deprecated",
+  "status": "Retired",
   "previous_model_id": "openai/gpt-5-1-codex-max-2025-11-19",
   "description": "GPT 5.2 Codex is an upgraded version of GPT-5.1-Codex optimized for software engineering and coding workflows. It accepts text and image inputs and produces text outputs.",
   "announced_date": "2025-12-18T00:00:00",

--- a/packages/data/catalog/src/data/models/openai/gpt-audio-mini-2025-10-06/model.json
+++ b/packages/data/catalog/src/data/models/openai/gpt-audio-mini-2025-10-06/model.json
@@ -2,7 +2,7 @@
   "model_id": "openai/gpt-audio-mini-2025-10-06",
   "organisation_id": "openai",
   "name": "GPT Audio Mini (2025-10-06)",
-  "status": "Deprecated",
+  "status": "Retired",
   "previous_model_id": null,
   "description": "A cost-efficient version of GPT Audio. The new snapshot features an upgraded decoder for more natural sounding voices and maintains better voice consistency.",
   "announced_date": "2025-10-06T00:00:00",

--- a/packages/data/catalog/src/data/models/openai/gpt-realtime-mini-2025-10-06/model.json
+++ b/packages/data/catalog/src/data/models/openai/gpt-realtime-mini-2025-10-06/model.json
@@ -2,7 +2,7 @@
   "model_id": "openai/gpt-realtime-mini-2025-10-06",
   "organisation_id": "openai",
   "name": "GPT Realtime Mini (2025-10-06)",
-  "status": "Deprecated",
+  "status": "Retired",
   "previous_model_id": null,
   "description": "A cost-efficient version of GPT Audio. The new snapshot features an upgraded decoder for more natural sounding voices and maintains better voice consistency.",
   "announced_date": "2025-10-06T00:00:00",

--- a/packages/data/catalog/src/data/models/openai/o3-deep-research/model.json
+++ b/packages/data/catalog/src/data/models/openai/o3-deep-research/model.json
@@ -2,7 +2,7 @@
   "model_id": "openai/o3-deep-research",
   "organisation_id": "openai",
   "name": "o3 Deep Research",
-  "status": "Deprecated",
+  "status": "Retired",
   "previous_model_id": null,
   "description": "o3 Deep Research is OpenAI's advanced model for deep research, designed to tackle complex, multi-step research tasks. Note: This model always uses the 'web_search' tool which adds additional cost.",
   "announced_date": "2025-06-26T00:00:00",

--- a/packages/data/catalog/src/data/models/openai/o4-mini-deep-research/model.json
+++ b/packages/data/catalog/src/data/models/openai/o4-mini-deep-research/model.json
@@ -2,7 +2,7 @@
   "model_id": "openai/o4-mini-deep-research",
   "organisation_id": "openai",
   "name": "o4 mini Deep Research ",
-  "status": "Deprecated",
+  "status": "Retired",
   "previous_model_id": "openai/o3-deep-research-2025-06-26",
   "description": "o4 mini Deep Research is OpenAI's faster, more affordable deep research model-ideal for tackling complex, multi-step research tasks. Note: This model always uses the 'web_search' tool which adds additional cost.",
   "announced_date": "2025-06-26T00:00:00",


### PR DESCRIPTION
Automated status refresh recreated from PR #1202 on current `main`.

## Summary

- align 15 OpenAI model statuses with their announced, release, deprecation, and retirement dates
- replace #1202, whose protected automation branch could not be updated after its required matrix checks were skipped

## Validation

- `pnpm validate:data`
- `git diff --check origin/main...HEAD`

Created with Codex