### PR TITLE
Fix free variant pricing projection

### DIFF
--- a/apps/web/scripts/importer/v2.test.ts
+++ b/apps/web/scripts/importer/v2.test.ts
@@ -3,7 +3,26 @@ jest.mock("./paths", () => ({
     DIR_ALIASES: "",
 }));
 
-import { preflightV2Benchmarks, preflightV2Models } from "./v2";
+import { preflightV2Benchmarks, preflightV2Models, pricingModelPart } from "./v2";
+
+describe("pricingModelPart", () => {
+    it.each([
+        "mindai/macaron-v1-venti:free",
+        "inclusionai/ling-3.0-flash:free",
+    ])("preserves the %s variant when removing the capability suffix", (apiModelId) => {
+        expect(pricingModelPart(`novita:${apiModelId}:text.generate`)).toEqual({
+            providerSlug: "novita",
+            apiModelId,
+        });
+    });
+
+    it("parses standard model keys", () => {
+        expect(pricingModelPart("openai:openai/gpt-5:text.generate")).toEqual({
+            providerSlug: "openai",
+            apiModelId: "openai/gpt-5",
+        });
+    });
+});
 
 describe("preflightV2Models", () => {
     it("canonicalizes authored legacy aliases without mutating the legacy row", () => {

--- a/apps/web/scripts/importer/v2.ts
+++ b/apps/web/scripts/importer/v2.ts
@@ -55,15 +55,14 @@ function slug(value: unknown, fallback = "standard"): string {
     return normalized || fallback;
 }
 
-function pricingModelPart(modelKey: string): { providerSlug: string; apiModelId: string } | null {
+export function pricingModelPart(modelKey: string): { providerSlug: string; apiModelId: string } | null {
     const firstColon = modelKey.indexOf(":");
-    if (firstColon <= 0) return null;
+    const lastColon = modelKey.lastIndexOf(":");
+    if (firstColon <= 0 || lastColon <= firstColon + 1) return null;
     const providerSlug = modelKey.slice(0, firstColon);
-    const rest = modelKey.slice(firstColon + 1);
-    const secondColon = rest.indexOf(":");
     return {
         providerSlug,
-        apiModelId: secondColon >= 0 ? rest.slice(0, secondColon) : rest,
+        apiModelId: modelKey.slice(firstColon + 1, lastColon),
     };
 }
 


### PR DESCRIPTION
## Summary

- preserve colon-bearing model variants when the v2 importer separates a pricing key from its capability suffix
- restore v2 free-pricing projection for Novita Macaron V1 Venti and Ling 3.0 Flash
- add regression coverage for both `:free` routes and a standard route

## Root cause

The v2 pricing importer stopped parsing at the first colon after the provider. Keys such as `novita:mindai/macaron-v1-venti:free:text.generate` and `novita:inclusionai/ling-3.0-flash:free:text.generate` therefore lost the `:free` variant before route matching. Their authored zero-dollar rules were valid, but were omitted from the v2 pricing projection and the public pricing API returned an empty rule list.

## User impact

Macaron V1 Venti and Ling 3.0 Flash will display their verified free input and output pricing instead of appearing to have no pricing data after the v2 catalog import runs.

## Validation

- `pnpm --dir apps/web exec jest --rootDir ../.. apps/web/scripts/importer/v2.test.ts --runInBand`
- `pnpm validate:pricing`
- `pnpm validate:data`
- `git diff --check`

## Sources

- [Novita Macaron V1 Venti](https://novita.ai/models/model-detail/mindai-macaron-v1-venti)
- [Novita Ling 3.0 Flash](https://novita.ai/de/models/model-detail/inclusionai-ling-3.0-flash)
- [Novita pricing](https://novita.ai/pricing)

Created with Codex
