### PR TITLE
Clarify SDK availability

### DIFF
--- a/apps/docs/docs.json
+++ b/apps/docs/docs.json
@@ -871,87 +871,6 @@
 										]
 									}
 								]
-							},
-							{
-								"item": "Java SDK",
-								"groups": [
-									{
-										"group": "Introduction",
-										"pages": [
-											"v1/sdk-reference/java/overview",
-											"v1/sdk-reference/java/installation",
-											"v1/sdk-reference/java/usage"
-										]
-									},
-									{
-										"group": "Text",
-										"pages": [
-											"v1/sdk-reference/java/responses",
-											"v1/sdk-reference/java/chat-completions"
-										]
-									},
-									{
-										"group": "Image",
-										"pages": [
-											"v1/sdk-reference/java/images-generations",
-											"v1/sdk-reference/java/images-edits"
-										]
-									},
-									{
-										"group": "Audio",
-										"pages": [
-											"v1/sdk-reference/java/audio-speech",
-											"v1/sdk-reference/java/audio-transcriptions",
-											"v1/sdk-reference/java/audio-translations"
-										]
-									},
-									{
-										"group": "Video",
-										"pages": [
-											"v1/sdk-reference/java/video-generation"
-										]
-									},
-									{
-										"group": "Specialised",
-										"pages": [
-											"v1/sdk-reference/java/embeddings",
-											"v1/sdk-reference/java/moderations",
-											"v1/sdk-reference/java/batches",
-											"v1/sdk-reference/java/files"
-										]
-									},
-									{
-										"group": "Admin",
-										"pages": [
-											"v1/sdk-reference/java/models",
-											"v1/sdk-reference/java/generation"
-										]
-									}
-								]
-							},
-							{
-								"item": "Rust SDK",
-								"groups": [
-									{
-										"group": "Introduction",
-										"pages": [
-											"v1/sdk-reference/rust/overview",
-											"v1/sdk-reference/rust/installation"
-										]
-									}
-								]
-							},
-							{
-								"item": "C++ SDK",
-								"groups": [
-									{
-										"group": "Introduction",
-										"pages": [
-											"v1/sdk-reference/cpp/overview",
-											"v1/sdk-reference/cpp/installation"
-										]
-									}
-								]
 							}
 						]
 					},
@@ -1018,19 +937,6 @@
 											"v1/sdk-reference/csharp/agent-sdk-overview",
 											"v1/sdk-reference/csharp/agent-sdk-installation",
 											"v1/sdk-reference/csharp/agent-sdk"
-										]
-									}
-								]
-							},
-							{
-								"item": "Java Agent SDK",
-								"groups": [
-									{
-										"group": "Introduction",
-										"pages": [
-											"v1/sdk-reference/java/agent-sdk-overview",
-											"v1/sdk-reference/java/agent-sdk-installation",
-											"v1/sdk-reference/java/agent-sdk"
 										]
 									}
 								]

--- a/apps/docs/v1/cookbook/agent-sdk-csharp-ticket-triage.mdx
+++ b/apps/docs/v1/cookbook/agent-sdk-csharp-ticket-triage.mdx
@@ -5,12 +5,9 @@ description: "Use the C# Agent SDK for a local-tool ticket triage loop that stay
 
 Use this recipe when one .NET service should classify or summarize incoming support tickets.
 
-## 1. Install the SDKs
+## 1. Prepare the SDKs
 
-```bash
-dotnet add package Phaseo.Sdk
-dotnet add package Phaseo.AgentSdk
-```
+<Note type="warning">The C# Agent SDK package is not yet on NuGet. Follow the [source installation instructions](../sdk-reference/csharp/agent-sdk-installation).</Note>
 
 ## 2. Define one internal lookup tool
 

--- a/apps/docs/v1/cookbook/agent-sdk-go-ops-runbook.mdx
+++ b/apps/docs/v1/cookbook/agent-sdk-go-ops-runbook.mdx
@@ -5,12 +5,9 @@ description: "Use the Go Agent SDK to combine a few deterministic local tools in
 
 Use this recipe when a Go service needs to answer operational questions with local context.
 
-## 1. Install the SDKs
+## 1. Prepare the SDKs
 
-```bash
-go get github.com/phaseoteam/Phaseo/packages/sdk/sdk-go/v2@latest
-go get github.com/phaseoteam/Phaseo/packages/sdk/agent-sdk-go@latest
-```
+<Note type="warning">The Go Agent SDK does not yet have a public module version. Follow the [source installation instructions](../sdk-reference/go/agent-sdk-installation).</Note>
 
 ## 2. Define small runtime tools
 

--- a/apps/docs/v1/cookbook/agent-sdk-php-content-review.mdx
+++ b/apps/docs/v1/cookbook/agent-sdk-php-content-review.mdx
@@ -5,11 +5,9 @@ description: "Use the PHP Agent SDK to wrap one local content lookup tool in a b
 
 Use this recipe when a PHP app or admin backend needs quick content review help without offloading orchestration elsewhere.
 
-## 1. Install the SDKs
+## 1. Prepare the SDKs
 
-```bash
-composer require phaseo/sdk phaseo/agent-sdk
-```
+<Note type="warning">The PHP Agent SDK package is not yet on Packagist. Follow the [source installation instructions](../sdk-reference/php/agent-sdk-installation).</Note>
 
 ## 2. Define one content lookup tool
 

--- a/apps/docs/v1/cookbook/agent-sdk-python-structured-extraction.mdx
+++ b/apps/docs/v1/cookbook/agent-sdk-python-structured-extraction.mdx
@@ -9,11 +9,9 @@ Use this recipe when a Python workflow needs:
 - one bounded agent loop
 - one strict JSON output shape
 
-## 1. Install the SDKs
+## 1. Prepare the SDKs
 
-```bash
-pip install phaseo phaseo-agent-sdk
-```
+<Note type="warning">The Python Agent SDK package is not yet on PyPI. Follow the [source installation instructions](../sdk-reference/python/agent-sdk-installation).</Note>
 
 ## 2. Define one local tool
 

--- a/apps/docs/v1/cookbook/agent-sdk-ruby-rag-notes.mdx
+++ b/apps/docs/v1/cookbook/agent-sdk-ruby-rag-notes.mdx
@@ -5,11 +5,9 @@ description: "Use the Ruby Agent SDK to query local notes and return one bounded
 
 Use this recipe when a Ruby service needs a small internal-notes assistant without handing orchestration to another system.
 
-## 1. Install the SDKs
+## 1. Prepare the SDKs
 
-```bash
-gem install phaseo_sdk phaseo_agent_sdk
-```
+<Note type="warning">The Ruby Agent SDK package is not yet on RubyGems. Follow the [source installation instructions](../sdk-reference/ruby/agent-sdk-installation).</Note>
 
 ## 2. Define a notes lookup tool
 

--- a/apps/docs/v1/guides/examples.mdx
+++ b/apps/docs/v1/guides/examples.mdx
@@ -136,28 +136,6 @@ response = client.generate_response(
 puts response
 ```
 
-```java Java SDK
-import ai.stats.sdk.Phaseo;
-
-Phaseo client = new Phaseo(System.getenv("PHASEO_API_KEY"));
-
-String body = """
-{
-  "model": "google/gemma-3-27b:free",
-  "input": [
-    {
-      "role": "user",
-      "content": [
-        { "type": "input_text", "text": "Summarize this article in 3 bullet points." }
-      ]
-    }
-  ]
-}
-""";
-
-Object response = client.createResponse(body);
-System.out.println(String.valueOf(response));
-```
 </CodeGroup>
 
 ## Paid chat completion

--- a/apps/docs/v1/quickstart.mdx
+++ b/apps/docs/v1/quickstart.mdx
@@ -199,30 +199,6 @@ response = client.generate_response(
 puts response
 ```
 
-```java Java SDK
-import app.phaseo.sdk.Phaseo;
-
-Phaseo client = new Phaseo(System.getenv("PHASEO_API_KEY"));
-
-String body = """
-{
-  "model": "openai/gpt-5.6-sol",
-  "input": [
-    {
-      "role": "user",
-      "content": [
-        { "type": "input_text", "text": "Reply with: quickstart works" }
-      ]
-    }
-  ],
-  "temperature": 0
-}
-""";
-
-Object response = client.createResponse(body);
-System.out.println(String.valueOf(response));
-```
-
 ```typescript Vercel AI SDK
 import { phaseo } from "@phaseo/ai-sdk-provider";
 import { generateText } from "ai";

--- a/apps/docs/v1/sdk-reference/agent-sdk/overview.mdx
+++ b/apps/docs/v1/sdk-reference/agent-sdk/overview.mdx
@@ -25,7 +25,6 @@ The current Agent SDK language set matches the primary client SDK set exposed in
 - [Python](../python/agent-sdk)
 - [Go](../go/agent-sdk)
 - [C#](../csharp/agent-sdk)
-- [Java](../java/agent-sdk)
 - [PHP](../php/agent-sdk)
 - [Ruby](../ruby/agent-sdk)
 
@@ -40,20 +39,24 @@ Each Agent SDK keeps the same runtime model:
 - inspect lifecycle events or a Devtools trace
 - persist the returned run and resume after a human decision
 
-TypeScript is the reference API design. Python, Go, C#, Java, PHP, and Ruby expose the same run states and core controls using language-native callbacks, concurrency, timeout, and cancellation primitives. Rust and C++ Agent SDKs are intentionally deferred.
+TypeScript is the reference API design. Python, Go, C#, PHP, and Ruby expose the same run states and core controls using language-native callbacks, concurrency, timeout, and cancellation primitives. Java remains a work in progress; Rust and C++ Agent SDKs are intentionally deferred.
+
+<Note>
+  Only the TypeScript Agent SDK is currently published to a package registry as [`@phaseo/agent-sdk`](https://www.npmjs.com/package/@phaseo/agent-sdk). Use the source installation pages for the other runtimes until their independent packages are released.
+</Note>
 
 ## Cross-language capability contract
 
-| Capability | TypeScript | Python | Go | C# | Java | PHP | Ruby |
-| --- | --- | --- | --- | --- | --- | --- | --- |
-| Validated executable tools and recoverable errors | Yes | Yes | Yes | Yes | Yes | Yes | Yes |
-| Exact-ID approvals, HITL, and manual outputs | Yes | Yes | Yes | Yes | Yes | Yes | Yes |
-| Preliminary tool progress | Async generator | Iterator or callback | Callback | Callback | Callback | Callback | Callback |
-| Model streaming and replayable consumers | Async iterable | Iterator | Channel | Async enumerable | Iterable | Iterable | Enumerator |
-| Composable step, token, cost, duration, tool, finish, and custom stops | Yes | Yes | Yes | Yes | Yes | Yes | Yes |
-| Dynamic turns, mutable context, and persisted next-turn overrides | Yes | Yes | Yes | Yes | Yes | Yes | Yes |
-| Application-owned state accessor | Yes | Yes | Yes | Yes | Yes | Yes | Yes |
-| Normalized usage and cost | Yes | Yes | Yes | Yes | Yes | Yes | Yes |
+| Capability | TypeScript | Python | Go | C# | PHP | Ruby |
+| --- | --- | --- | --- | --- | --- | --- |
+| Validated executable tools and recoverable errors | Yes | Yes | Yes | Yes | Yes | Yes |
+| Exact-ID approvals, HITL, and manual outputs | Yes | Yes | Yes | Yes | Yes | Yes |
+| Preliminary tool progress | Async generator | Iterator or callback | Callback | Callback | Callback | Callback |
+| Model streaming and replayable consumers | Async iterable | Iterator | Channel | Async enumerable | Iterable | Enumerator |
+| Composable step, token, cost, duration, tool, finish, and custom stops | Yes | Yes | Yes | Yes | Yes | Yes |
+| Dynamic turns, mutable context, and persisted next-turn overrides | Yes | Yes | Yes | Yes | Yes | Yes |
+| Application-owned state accessor | Yes | Yes | Yes | Yes | Yes | Yes |
+| Normalized usage and cost | Yes | Yes | Yes | Yes | Yes | Yes |
 
 PHP and Ruby expose provider stream events through their normal synchronous iteration APIs. They do not require a hosted runtime or a background Phaseo service.
 

--- a/apps/docs/v1/sdk-reference/cpp/installation.mdx
+++ b/apps/docs/v1/sdk-reference/cpp/installation.mdx
@@ -1,13 +1,9 @@
 ---
-title: "C++ SDK Installation"
-description: "How to use the preview C++ SDK"
+title: "C++ SDK Installation (work in progress)"
+description: "Use the work-in-progress C++ headers from source."
 ---
 
-<Note type="warning">
-  **SDKs are in very early alpha**: We're working as hard as we can to get them into a stable state. Please bear with us as we iterate rapidly.
-</Note>
-
-<Note type="warning">This package is not yet published to a package registry.</Note>
+<Note type="warning">The C++ SDK is a work in progress and is not yet published to a package registry.</Note>
 
 ## Local usage
 

--- a/apps/docs/v1/sdk-reference/cpp/overview.mdx
+++ b/apps/docs/v1/sdk-reference/cpp/overview.mdx
@@ -1,12 +1,12 @@
 ---
-title: "C++ SDK (preview)"
-description: "Experimental C++ headers for the Phaseo Gateway."
+title: "C++ SDK (work in progress)"
+description: "Review the work-in-progress C++ headers."
 ---
 
 <Note type="warning">
-  **SDKs are in very early alpha**: We're working as hard as we can to get them into a stable state. Please bear with us as we iterate rapidly.
+  The C++ SDK is a work in progress and is not yet available through a package manager. Use the source headers for evaluation only.
 </Note>
 
-- Status: Preview (not yet published).
+- Status: Work in progress (not yet published).
 - Source lives in `packages/sdk/sdk-cpp`.
 - Generated headers are in `packages/sdk/sdk-cpp/src/gen`.

--- a/apps/docs/v1/sdk-reference/csharp/agent-sdk-installation.mdx
+++ b/apps/docs/v1/sdk-reference/csharp/agent-sdk-installation.mdx
@@ -1,13 +1,18 @@
 ---
 title: "Installation"
-description: "Install the C# Agent SDK and its core client dependency."
+description: "Evaluate the C# Agent SDK from source while its NuGet package is prepared."
 ---
 
 ## Install
 
+<Note type="warning">
+  The C# Agent SDK is implemented, but `Phaseo.AgentSdk` is not yet published to NuGet. Use the repository source for evaluation; the core [`Phaseo.Sdk`](https://www.nuget.org/packages/Phaseo.Sdk) package is public.
+</Note>
+
 ```bash
-dotnet add package Phaseo.Sdk
-dotnet add package Phaseo.AgentSdk
+git clone https://github.com/phaseoteam/Phaseo.git
+cd Phaseo/packages/sdk/agent-sdk-csharp
+dotnet test
 ```
 
 ## Environment

--- a/apps/docs/v1/sdk-reference/csharp/agent-sdk.mdx
+++ b/apps/docs/v1/sdk-reference/csharp/agent-sdk.mdx
@@ -3,12 +3,9 @@ title: "Usage"
 description: "Run tool loops, human review, retries, and resumable agents with the C# Agent SDK."
 ---
 
-## Install
+## Prepare the runtime
 
-```bash
-dotnet add package Phaseo.Sdk
-dotnet add package Phaseo.AgentSdk
-```
+The Agent SDK package is not yet on NuGet. Follow the [source installation instructions](./agent-sdk-installation).
 
 ## Quickstart
 

--- a/apps/docs/v1/sdk-reference/csharp/installation.mdx
+++ b/apps/docs/v1/sdk-reference/csharp/installation.mdx
@@ -1,30 +1,16 @@
 ---
 title: "C# SDK Installation"
-description: "Set up the preview C# SDK from source."
+description: "Install the Phaseo C# SDK from NuGet."
 ---
 
-<Note type="warning">
-  The C# SDK is not published on NuGet yet. Use it from source for now.
-</Note>
+The SDK is published as [`Phaseo.Sdk`](https://www.nuget.org/packages/Phaseo.Sdk) on NuGet.
 
 ## Requirements
 
-- .NET 8+
-- Access to this repository
+- .NET 8 or newer
 
-## Install from local source
-
-1. Regenerate generated files (optional but recommended after API changes):
+## Install
 
 ```bash
-pnpm openapi:gen:csharp
+dotnet add package Phaseo.Sdk
 ```
-
-2. Add these files to your project:
-
-- `packages/sdk/sdk-csharp/Client.cs`
-- `packages/sdk/sdk-csharp/src/gen/Client.cs`
-- `packages/sdk/sdk-csharp/src/gen/Models.cs`
-- `packages/sdk/sdk-csharp/src/gen/Operations.cs`
-
-This gives you the preview wrapper plus generated operations.

--- a/apps/docs/v1/sdk-reference/csharp/overview.mdx
+++ b/apps/docs/v1/sdk-reference/csharp/overview.mdx
@@ -1,11 +1,9 @@
 ---
-title: "C# SDK (preview)"
-description: "Local-preview C# wrapper for the Phaseo API."
+title: "C# SDK"
+description: "Official .NET client for the Phaseo Gateway."
 ---
 
-<Note type="warning">
-  The C# SDK is in preview and is not yet published to NuGet.
-</Note>
+Install the published [`Phaseo.Sdk`](https://www.nuget.org/packages/Phaseo.Sdk) package from NuGet.
 
 The local wrapper at `packages/sdk/sdk-csharp/Client.cs` currently exposes high-level helpers for chat, responses, Anthropic messages, images, audio, embeddings, moderations, files, batches, videos, generations, models/providers/endpoints/organisations/pricing, API-key discovery and lifecycle mutations, workspace/current-key lifecycle helpers, pricing calculation, activity/credits/analytics, health checks, model lifecycle validation, and async-job websocket URLs through both direct helpers and `client.AsyncJobs.WebSocketUrl(...)`.
 

--- a/apps/docs/v1/sdk-reference/csharp/usage.mdx
+++ b/apps/docs/v1/sdk-reference/csharp/usage.mdx
@@ -1,6 +1,6 @@
 ---
 title: "C# SDK Usage"
-description: "Current wrapper methods supported by the preview C# SDK."
+description: "Current wrapper methods supported by the C# SDK."
 ---
 
 ## Setup

--- a/apps/docs/v1/sdk-reference/go/agent-sdk-installation.mdx
+++ b/apps/docs/v1/sdk-reference/go/agent-sdk-installation.mdx
@@ -1,12 +1,18 @@
 ---
 title: "Installation"
-description: "Install the Go Agent SDK and its core client dependency."
+description: "Evaluate the Go Agent SDK from source while its module release is prepared."
 ---
 
 ## Install
 
+<Note type="warning">
+  The Go Agent SDK is implemented, but it does not yet have a public module version. Use the repository source for evaluation; the core [`sdk-go/v2`](https://pkg.go.dev/github.com/phaseoteam/Phaseo/packages/sdk/sdk-go/v2) module is public.
+</Note>
+
 ```bash
-go get github.com/phaseoteam/Phaseo/packages/sdk/agent-sdk-go@latest
+git clone https://github.com/phaseoteam/Phaseo.git
+cd Phaseo/packages/sdk/agent-sdk-go
+go test ./...
 ```
 
 ## Environment

--- a/apps/docs/v1/sdk-reference/go/agent-sdk.mdx
+++ b/apps/docs/v1/sdk-reference/go/agent-sdk.mdx
@@ -3,11 +3,9 @@ title: "Usage"
 description: "Run tool loops, human review, retries, and resumable agents with the Go Agent SDK."
 ---
 
-## Install
+## Prepare the runtime
 
-```bash
-go get github.com/phaseoteam/Phaseo/packages/sdk/agent-sdk-go@latest
-```
+The Agent SDK does not yet have a public Go module version. Follow the [source installation instructions](./agent-sdk-installation).
 
 ## Quickstart
 

--- a/apps/docs/v1/sdk-reference/go/installation.mdx
+++ b/apps/docs/v1/sdk-reference/go/installation.mdx
@@ -1,36 +1,21 @@
 ---
 title: "Go SDK Installation"
-description: "Set up the preview Go SDK from source."
+description: "Install the Phaseo Go SDK through Go modules."
 ---
 
-<Note type="warning">
-  The Go SDK is not published yet. Use it from source for now.
-</Note>
+The SDK is published as [`sdk-go/v2`](https://pkg.go.dev/github.com/phaseoteam/Phaseo/packages/sdk/sdk-go/v2).
 
 ## Requirements
 
-- Go 1.23+
-- Access to this repository
+- Go 1.23 or newer
 
-## Install from local source
-
-1. Regenerate the Go SDK (optional but recommended after API changes):
+## Install
 
 ```bash
-pnpm openapi:gen:go
+go get github.com/phaseoteam/Phaseo/packages/sdk/sdk-go/v2@latest
 ```
 
-2. In your `go.mod`, add a local `replace` to the SDK path:
-
-```go
-go 1.23
-
-require github.com/phaseoteam/Phaseo/packages/sdk/sdk-go/v2 v2.0.0
-
-replace github.com/phaseoteam/Phaseo/packages/sdk/sdk-go/v2 => ../phaseo/packages/sdk/sdk-go
-```
-
-3. Import the wrapper:
+Import the v2 module path:
 
 ```go
 import phaseo "github.com/phaseoteam/Phaseo/packages/sdk/sdk-go/v2"

--- a/apps/docs/v1/sdk-reference/go/overview.mdx
+++ b/apps/docs/v1/sdk-reference/go/overview.mdx
@@ -1,11 +1,9 @@
 ---
-title: "Go SDK (preview)"
-description: "Local-preview Go wrapper for the Phaseo API."
+title: "Go SDK"
+description: "Official Go client for the Phaseo Gateway."
 ---
 
-<Note type="warning">
-  The Go SDK is in preview and is not yet published to a package registry.
-</Note>
+Install the published [`sdk-go/v2`](https://pkg.go.dev/github.com/phaseoteam/Phaseo/packages/sdk/sdk-go/v2) module.
 
 The local wrapper at `packages/sdk/sdk-go/index.go` currently exposes these methods:
 

--- a/apps/docs/v1/sdk-reference/go/usage.mdx
+++ b/apps/docs/v1/sdk-reference/go/usage.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Go SDK Usage"
-description: "Current wrapper methods supported by the preview Go SDK."
+description: "Current wrapper methods supported by the Go SDK."
 ---
 
 ## Setup

--- a/apps/docs/v1/sdk-reference/java/agent-sdk-installation.mdx
+++ b/apps/docs/v1/sdk-reference/java/agent-sdk-installation.mdx
@@ -1,24 +1,26 @@
 ---
-title: "Installation"
-description: "Install the Java Agent SDK and Phaseo Java Client SDK."
+title: "Java Agent SDK Installation (work in progress)"
+description: "Build the work-in-progress Java Agent SDK from source."
 ---
 
-Add both artifacts to your Maven project:
+<Note type="warning">
+  The Java Agent SDK is not yet published to Maven Central. Use this source workflow for evaluation only.
+</Note>
 
-```xml
-<dependency>
-  <groupId>app.phaseo</groupId>
-  <artifactId>phaseo-sdk</artifactId>
-  <version>2.0.4</version>
-</dependency>
-<dependency>
-  <groupId>app.phaseo</groupId>
-  <artifactId>phaseo-agent-sdk</artifactId>
-  <version>0.1.0</version>
-</dependency>
+## Requirements
+
+- Java 17 or newer
+- Maven
+
+## Build from source
+
+```bash
+git clone https://github.com/phaseoteam/Phaseo.git
+cd Phaseo
+mvn -f packages/sdk/agent-sdk-java/pom.xml package
 ```
 
-Set `PHASEO_API_KEY` in the application environment. `AgentSdk.createGatewayAgentClient()` reads it automatically.
+Set `PHASEO_API_KEY` in the application environment before running an example.
 
 ## Next
 

--- a/apps/docs/v1/sdk-reference/java/agent-sdk-overview.mdx
+++ b/apps/docs/v1/sdk-reference/java/agent-sdk-overview.mdx
@@ -1,9 +1,13 @@
 ---
-title: "Overview"
-description: "Build local, tool-using Java agents on top of the Phaseo Responses API."
+title: "Java Agent SDK (work in progress)"
+description: "Review the work-in-progress Java Agent SDK runtime."
 ---
 
-The Java Agent SDK is a local runtime layered on `app.phaseo:phaseo-sdk`. It provides the same core contract as the TypeScript Agent SDK:
+<Note type="warning">
+  The Java Client SDK and Agent SDK are works in progress and are not yet available from Maven Central.
+</Note>
+
+The Java Agent SDK is a source-only runtime layered on the Java Client SDK. It provides the same core contract as the TypeScript Agent SDK:
 
 - bounded multi-step tool loops
 - concurrent tools with per-tool timeouts

--- a/apps/docs/v1/sdk-reference/java/images-edits.mdx
+++ b/apps/docs/v1/sdk-reference/java/images-edits.mdx
@@ -23,6 +23,6 @@ System.out.println(String.valueOf(response));
 ```
 
 <Note>
-The preview Java client sends JSON request bodies directly. For advanced multipart workflows,
+The work-in-progress Java client sends JSON request bodies directly. For advanced multipart workflows,
 use direct REST calls until higher-level helpers are added.
 </Note>

--- a/apps/docs/v1/sdk-reference/java/installation.mdx
+++ b/apps/docs/v1/sdk-reference/java/installation.mdx
@@ -1,13 +1,9 @@
 ---
-title: "Java SDK Installation"
-description: "How to build and use the preview Java SDK"
+title: "Java SDK Installation (work in progress)"
+description: "Build the work-in-progress Java SDK from source."
 ---
 
-<Note type="warning">
-  **SDKs are in very early alpha**: We're working as hard as we can to get them into a stable state. Please bear with us as we iterate rapidly.
-</Note>
-
-<Note type="warning">This package is not yet published to Maven Central.</Note>
+<Note type="warning">The Java SDK is a work in progress and is not yet published to Maven Central.</Note>
 
 ## Requirements
 

--- a/apps/docs/v1/sdk-reference/java/overview.mdx
+++ b/apps/docs/v1/sdk-reference/java/overview.mdx
@@ -1,10 +1,10 @@
 ---
-title: "Java SDK (preview)"
-description: "Experimental Java client for the Phaseo Gateway."
+title: "Java SDK (work in progress)"
+description: "Build the work-in-progress Java client from source."
 ---
 
 <Note type="warning">
-  **SDKs are in very early alpha**: We're working as hard as we can to get them into a stable state. Please bear with us as we iterate rapidly.
+  The Java SDK is a work in progress and is not yet published to Maven Central. Use the source build for evaluation only.
 </Note>
 
 The Java SDK now includes a lightweight handwritten wrapper on top of the generated client:
@@ -14,7 +14,7 @@ The Java SDK now includes a lightweight handwritten wrapper on top of the genera
 
 ## Current status
 
-- Preview only (not yet published to Maven Central).
+- Work in progress; not yet published to Maven Central.
 - Source lives in `packages/sdk/sdk-java`.
 - Generated low-level code lives in `packages/sdk/sdk-java/src/gen`.
 - Handwritten wrapper code lives in `packages/sdk/sdk-java/src/app/phaseo/sdk`.

--- a/apps/docs/v1/sdk-reference/php/agent-sdk-installation.mdx
+++ b/apps/docs/v1/sdk-reference/php/agent-sdk-installation.mdx
@@ -1,12 +1,18 @@
 ---
 title: "Installation"
-description: "Install the PHP Agent SDK and its core client dependency."
+description: "Evaluate the PHP Agent SDK from source while its Packagist package is prepared."
 ---
 
 ## Install
 
+<Note type="warning">
+  The PHP Agent SDK is implemented, but `phaseo/agent-sdk` is not yet published to Packagist. Use the repository source for evaluation; the core [`phaseo/sdk`](https://packagist.org/packages/phaseo/sdk) package is public.
+</Note>
+
 ```bash
-composer require phaseo/sdk phaseo/agent-sdk
+git clone https://github.com/phaseoteam/Phaseo.git
+cd Phaseo/packages/sdk/agent-sdk-php
+composer install
 ```
 
 ## Environment

--- a/apps/docs/v1/sdk-reference/php/agent-sdk.mdx
+++ b/apps/docs/v1/sdk-reference/php/agent-sdk.mdx
@@ -3,11 +3,9 @@ title: "Usage"
 description: "Run tool loops, human review, retries, and resumable agents with the PHP Agent SDK."
 ---
 
-## Install
+## Prepare the runtime
 
-```bash
-composer require phaseo/sdk phaseo/agent-sdk
-```
+The Agent SDK package is not yet on Packagist. Follow the [source installation instructions](./agent-sdk-installation).
 
 ## Quickstart
 

--- a/apps/docs/v1/sdk-reference/php/installation.mdx
+++ b/apps/docs/v1/sdk-reference/php/installation.mdx
@@ -1,45 +1,17 @@
 ---
 title: "PHP SDK Installation"
-description: "Set up the preview PHP SDK from source."
+description: "Install the Phaseo PHP SDK from Packagist."
 ---
 
-<Note type="warning">
-  The PHP SDK is not published on Packagist yet. Use it from source for now.
-</Note>
+The SDK is published as [`phaseo/sdk`](https://packagist.org/packages/phaseo/sdk) on Packagist.
 
 ## Requirements
 
-- PHP 8.1+
+- PHP 8.1 or newer
 - Composer
-- Access to this repository
 
-## Install from local source
-
-1. Regenerate generated files (optional but recommended after API changes):
+## Install
 
 ```bash
-pnpm openapi:gen:php
-```
-
-2. Add the SDK as a local Composer path repository:
-
-```json
-{
-  "repositories": [
-    {
-      "type": "path",
-      "url": "../phaseo/packages/sdk/sdk-php",
-      "options": { "symlink": true }
-    }
-  ],
-  "require": {
-    "phaseo/php-sdk": "*"
-  }
-}
-```
-
-3. Install dependencies:
-
-```bash
-composer install
+composer require phaseo/sdk
 ```

--- a/apps/docs/v1/sdk-reference/php/overview.mdx
+++ b/apps/docs/v1/sdk-reference/php/overview.mdx
@@ -1,11 +1,9 @@
 ---
-title: "PHP SDK (preview)"
-description: "Local-preview PHP wrapper for the Phaseo API."
+title: "PHP SDK"
+description: "Official PHP client for the Phaseo Gateway."
 ---
 
-<Note type="warning">
-  The PHP SDK is in preview and is not yet published to Packagist.
-</Note>
+Install the published [`phaseo/sdk`](https://packagist.org/packages/phaseo/sdk) package from Packagist.
 
 The local wrapper at `packages/sdk/sdk-php/src/index.php` currently exposes these methods:
 

--- a/apps/docs/v1/sdk-reference/php/usage.mdx
+++ b/apps/docs/v1/sdk-reference/php/usage.mdx
@@ -1,6 +1,6 @@
 ---
 title: "PHP SDK Usage"
-description: "Current wrapper methods supported by the preview PHP SDK."
+description: "Current wrapper methods supported by the PHP SDK."
 ---
 
 ## Setup

--- a/apps/docs/v1/sdk-reference/python/agent-sdk-installation.mdx
+++ b/apps/docs/v1/sdk-reference/python/agent-sdk-installation.mdx
@@ -1,12 +1,18 @@
 ---
 title: "Installation"
-description: "Install the Python Agent SDK and its core client dependency."
+description: "Evaluate the Python Agent SDK from source while its registry package is prepared."
 ---
 
 ## Install
 
+<Note type="warning">
+  The Python Agent SDK is implemented, but `phaseo-agent-sdk` is not yet published to PyPI. Use the repository source for evaluation; the core [`phaseo`](https://pypi.org/project/phaseo/) client is public.
+</Note>
+
 ```bash
-pip install phaseo phaseo-agent-sdk
+git clone https://github.com/phaseoteam/Phaseo.git
+cd Phaseo
+python -m pip install -e packages/sdk/sdk-py -e packages/sdk/agent-sdk-py
 ```
 
 ## Environment

--- a/apps/docs/v1/sdk-reference/python/agent-sdk.mdx
+++ b/apps/docs/v1/sdk-reference/python/agent-sdk.mdx
@@ -3,11 +3,9 @@ title: "Usage"
 description: "Run tool loops, human review, retries, and resumable agents with the Python Agent SDK."
 ---
 
-## Install
+## Prepare the runtime
 
-```bash
-pip install phaseo phaseo-agent-sdk
-```
+The independent package is not yet on PyPI. Follow the [source installation instructions](./agent-sdk-installation).
 
 ## Quickstart
 

--- a/apps/docs/v1/sdk-reference/python/installation.mdx
+++ b/apps/docs/v1/sdk-reference/python/installation.mdx
@@ -3,9 +3,7 @@ title: "Python SDK Installation"
 description: "How to install and set up the Phaseo Python SDK"
 ---
 
-<Note type="warning">
-  **SDKs are in very early alpha**: We're working as hard as we can to get them into a stable state. Please bear with us as we iterate rapidly.
-</Note>
+The SDK is published as [`phaseo`](https://pypi.org/project/phaseo/) on PyPI.
 
 ## Installation
 

--- a/apps/docs/v1/sdk-reference/python/overview.mdx
+++ b/apps/docs/v1/sdk-reference/python/overview.mdx
@@ -3,9 +3,7 @@ title: "Python SDK Overview"
 description: "Official Python client for the Phaseo Gateway API"
 ---
 
-<Note type="warning">
-  **SDKs are in very early alpha**: We're working as hard as we can to get them into a stable state. Please bear with us as we iterate rapidly.
-</Note>
+Install the published [`phaseo`](https://pypi.org/project/phaseo/) package from PyPI.
 
 The Phaseo Python SDK currently provides a synchronous client for the Phaseo Gateway API.
 

--- a/apps/docs/v1/sdk-reference/ruby/agent-sdk-installation.mdx
+++ b/apps/docs/v1/sdk-reference/ruby/agent-sdk-installation.mdx
@@ -1,12 +1,18 @@
 ---
 title: "Installation"
-description: "Install the Ruby Agent SDK and its core client dependency."
+description: "Evaluate the Ruby Agent SDK from source while its RubyGems package is prepared."
 ---
 
 ## Install
 
+<Note type="warning">
+  The Ruby Agent SDK is implemented, but `phaseo_agent_sdk` is not yet published to RubyGems. Use the repository source for evaluation; the core [`phaseo_sdk`](https://rubygems.org/gems/phaseo_sdk) gem is public.
+</Note>
+
 ```bash
-gem install phaseo_sdk phaseo_agent_sdk
+git clone https://github.com/phaseoteam/Phaseo.git
+cd Phaseo/packages/sdk/agent-sdk-ruby
+bundle install
 ```
 
 ## Environment

--- a/apps/docs/v1/sdk-reference/ruby/agent-sdk.mdx
+++ b/apps/docs/v1/sdk-reference/ruby/agent-sdk.mdx
@@ -3,11 +3,9 @@ title: "Usage"
 description: "Run tool loops, human review, retries, and resumable agents with the Ruby Agent SDK."
 ---
 
-## Install
+## Prepare the runtime
 
-```bash
-gem install phaseo_sdk phaseo_agent_sdk
-```
+The Agent SDK gem is not yet on RubyGems. Follow the [source installation instructions](./agent-sdk-installation).
 
 ## Quickstart
 

--- a/apps/docs/v1/sdk-reference/ruby/installation.mdx
+++ b/apps/docs/v1/sdk-reference/ruby/installation.mdx
@@ -1,29 +1,22 @@
 ---
 title: "Ruby SDK Installation"
-description: "Set up the preview Ruby SDK from source."
+description: "Install the Phaseo Ruby SDK from RubyGems."
 ---
 
-<Note type="warning">
-  The Ruby SDK is not published on RubyGems yet. Use it from source for now.
-</Note>
+The SDK is published as [`phaseo_sdk`](https://rubygems.org/gems/phaseo_sdk) on RubyGems.
 
 ## Requirements
 
-- Ruby 3.1+
-- Access to this repository
+- Ruby 3.1 or newer
 
-## Install from local source
-
-1. Regenerate generated files (optional but recommended after API changes):
+## Install
 
 ```bash
-pnpm openapi:gen:ruby
+gem install phaseo_sdk
 ```
 
-2. Load the SDK directly from the repository path:
+Or add it to your `Gemfile`:
 
 ```ruby
-require_relative '../phaseo/packages/sdk/sdk-ruby/lib/index'
+gem "phaseo_sdk"
 ```
-
-This loads the local preview wrapper and generated operations.

--- a/apps/docs/v1/sdk-reference/ruby/overview.mdx
+++ b/apps/docs/v1/sdk-reference/ruby/overview.mdx
@@ -1,11 +1,9 @@
 ---
-title: "Ruby SDK (preview)"
-description: "Local-preview Ruby wrapper for the Phaseo API."
+title: "Ruby SDK"
+description: "Official Ruby client for the Phaseo Gateway."
 ---
 
-<Note type="warning">
-  The Ruby SDK is in preview and is not yet published to RubyGems.
-</Note>
+Install the published [`phaseo_sdk`](https://rubygems.org/gems/phaseo_sdk) gem from RubyGems.
 
 The local wrapper at `packages/sdk/sdk-ruby/lib/index.rb` currently exposes these methods:
 

--- a/apps/docs/v1/sdk-reference/ruby/usage.mdx
+++ b/apps/docs/v1/sdk-reference/ruby/usage.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Ruby SDK Usage"
-description: "Current wrapper methods supported by the preview Ruby SDK."
+description: "Current wrapper methods supported by the Ruby SDK."
 ---
 
 ## Setup

--- a/apps/docs/v1/sdk-reference/rust/installation.mdx
+++ b/apps/docs/v1/sdk-reference/rust/installation.mdx
@@ -1,13 +1,9 @@
 ---
-title: "Rust SDK Installation"
-description: "How to build and use the preview Rust SDK"
+title: "Rust SDK Installation (work in progress)"
+description: "Build the work-in-progress Rust SDK from source."
 ---
 
-<Note type="warning">
-  **SDKs are in very early alpha**: We're working as hard as we can to get them into a stable state. Please bear with us as we iterate rapidly.
-</Note>
-
-<Note type="warning">This package is not yet published to crates.io.</Note>
+<Note type="warning">The Rust SDK is a work in progress and is not yet published to crates.io.</Note>
 
 ## Local build
 

--- a/apps/docs/v1/sdk-reference/rust/overview.mdx
+++ b/apps/docs/v1/sdk-reference/rust/overview.mdx
@@ -1,12 +1,12 @@
 ---
-title: "Rust SDK (preview)"
-description: "Experimental Rust client for the Phaseo Gateway."
+title: "Rust SDK (work in progress)"
+description: "Review the work-in-progress Rust client source."
 ---
 
 <Note type="warning">
-  **SDKs are in very early alpha**: We're working as hard as we can to get them into a stable state. Please bear with us as we iterate rapidly.
+  The Rust SDK is a work in progress and is not yet published to crates.io. Use the source build for evaluation only.
 </Note>
 
-- Status: Preview (not yet on crates.io).
+- Status: Work in progress (not yet on crates.io).
 - Source lives in `packages/sdk/sdk-rust`.
 - Generated code is in `packages/sdk/sdk-rust/src/gen`.

--- a/apps/docs/v1/sdk-reference/typescript/installation.mdx
+++ b/apps/docs/v1/sdk-reference/typescript/installation.mdx
@@ -3,9 +3,7 @@ title: "TypeScript SDK Installation"
 description: "How to install and set up the Phaseo TypeScript SDK"
 ---
 
-<Note type="warning">
-  **SDKs are in very early alpha**: We're working as hard as we can to get them into a stable state. Please bear with us as we iterate rapidly.
-</Note>
+The SDK is published as [`@phaseo/sdk`](https://www.npmjs.com/package/@phaseo/sdk) on npm.
 
 ## Installation
 

--- a/apps/docs/v1/sdk-reference/typescript/overview.mdx
+++ b/apps/docs/v1/sdk-reference/typescript/overview.mdx
@@ -3,9 +3,7 @@ title: "TypeScript SDK Overview"
 description: "Official TypeScript client for the Phaseo Gateway API"
 ---
 
-<Note type="warning">
-  **SDKs are in very early alpha**: We're working as hard as we can to get them into a stable state. Please bear with us as we iterate rapidly.
-</Note>
+Install the published [`@phaseo/sdk`](https://www.npmjs.com/package/@phaseo/sdk) package from npm.
 
 The Phaseo TypeScript SDK provides a type-safe, convenient way to interact with the Phaseo Gateway API. Built on top of the OpenAPI specification, it offers full TypeScript support with generated types and a simple client interface.
 


### PR DESCRIPTION
## Summary

- link each published Client SDK directly from its existing overview and installation pages
- remove Java, Rust, and C++ from the Client SDK navigation while keeping their work-in-progress source pages available by direct URL
- remove Java from quickstart examples and the visible Agent SDK navigation/capability table
- replace registry install commands for Agent SDK packages that are not public yet with source evaluation instructions

## Validation

- `pnpm docs:links`
- `pnpm docs:build`
- local Mintlify preview on port 3103

Created with Codex