### PR TITLE
Publish truthful capability and guardrails status

### DIFF
--- a/apps/docs/docs.json
+++ b/apps/docs/docs.json
@@ -56,6 +56,7 @@
 									"v1/developers/introduction",
 									"v1/developers/authentication",
 									"v1/developers/integrating-with-the-gateway",
+									"v1/guides/capability-status",
 									"v1/guides/principles"
 								]
 							},

--- a/apps/docs/v1/api-reference/authentication.mdx
+++ b/apps/docs/v1/api-reference/authentication.mdx
@@ -36,7 +36,9 @@ curl https://api.phaseo.app/v1/responses \
 
 Management API keys are created and managed in the Phaseo dashboard, not through the public API.
 
-Use them for elevated administration endpoints such as [Credits](./endpoint/credits) and [Activity](./endpoint/activity), and for future control-plane APIs like guardrails, key management, and workspace management.
+Use them for elevated administration endpoints such as [Credits](./endpoint/credits), [Activity](./endpoint/activity), [Guardrails](./endpoint/guardrails), key management, and workspace management.
+
+The Guardrails REST API is available in beta. It is not yet included in the published OpenAPI-generated SDKs.
 
 ## Authentication failures
 

--- a/apps/docs/v1/api-reference/endpoint/guardrails.mdx
+++ b/apps/docs/v1/api-reference/endpoint/guardrails.mdx
@@ -1,12 +1,96 @@
 ---
 title: "Guardrails"
-badge: "Coming Soon"
-description: "Programmatic guardrails management for workspaces and keys."
+badge: "Beta"
+description: "Create workspace guardrails and assign them to API keys or workspace members."
 ---
 <Note>
 This API area requires a management API key. Standard Gateway API keys are not accepted.
 </Note>
 
-Guardrails APIs are coming soon.
+Use the Guardrails API to create reusable workspace policies, attach them to API keys or members, and enforce budgets, routing restrictions, prompt-injection checks, and sensitive-info actions.
 
-When released, guardrails will be part of the elevated control plane alongside credits, activity, key management, and workspace management.
+The REST API is in beta and is not yet included in the published OpenAPI-generated SDKs. Call these endpoints directly until the generated contract is available.
+
+## Permissions
+
+Management keys need the matching capability:
+
+- `guardrails:read` to list and retrieve guardrails and assignments
+- `guardrails:write` to create, update, and assign guardrails
+- `guardrails:delete` to delete guardrails
+
+Workspace members can read guardrails. Only workspace owners and admins can create, update, assign, or delete them.
+
+## Endpoints
+
+| Method | Path | Purpose |
+| --- | --- | --- |
+| `GET` | `/v1/guardrails` | List workspace guardrails. |
+| `POST` | `/v1/guardrails` | Create a guardrail. |
+| `GET` | `/v1/guardrails/{id}` | Retrieve a guardrail and its assigned key IDs. |
+| `PATCH` | `/v1/guardrails/{id}` | Update supported policy fields. |
+| `DELETE` | `/v1/guardrails/{id}` | Delete a guardrail and its assignments. |
+| `GET` | `/v1/guardrails/{id}/keys` | List assigned API keys. |
+| `POST` | `/v1/guardrails/{id}/keys/add` | Add API-key assignments. |
+| `POST` | `/v1/guardrails/{id}/keys/remove` | Remove API-key assignments. |
+| `PUT` | `/v1/guardrails/{id}/keys` | Replace all API-key assignments. |
+| `GET` | `/v1/guardrails/{id}/members` | List assigned workspace members. |
+| `POST` | `/v1/guardrails/{id}/members/add` | Add member assignments. |
+| `POST` | `/v1/guardrails/{id}/members/remove` | Remove member assignments. |
+
+## Create a guardrail
+
+```bash
+curl https://api.phaseo.app/v1/guardrails \
+  -H "Authorization: Bearer $PHASEO_MANAGEMENT_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "Production API policy",
+    "enabled": true,
+    "privacyZdrOnly": true,
+    "modelRestrictionMode": "allow",
+    "allowedApiModelIds": ["openai/gpt-5.4-mini"],
+    "promptInjectionEnabled": true,
+    "promptInjectionAction": "flag",
+    "budgets": {
+      "dailyRequests": 10000,
+      "monthlyCostNanos": 50000000000
+    }
+  }'
+```
+
+The response wraps the created guardrail in `data`.
+
+## Assign the guardrail to API keys
+
+```bash
+curl https://api.phaseo.app/v1/guardrails/GUARDRAIL_ID/keys/add \
+  -H "Authorization: Bearer $PHASEO_MANAGEMENT_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"key_ids":["KEY_ID"]}'
+```
+
+Key IDs must belong to the same workspace and must not be deleted.
+
+## Supported policy groups
+
+- privacy and ZDR requirements
+- provider allowlists or blocklists
+- model allowlists or blocklists
+- prompt-injection detection and `flag`, `redact`, or `block` actions
+- sensitive-info detection and custom rules
+- daily, weekly, and monthly request budgets
+- daily, weekly, and monthly cost budgets in nanos
+
+Use the dashboard preview before broad rollout, then verify blocks, redactions, and flags in Activity.
+
+## Current limitations
+
+- The REST routes are not yet represented in the public OpenAPI specification or generated SDKs.
+- Enterprise SSO enforcement and SCIM are separate capabilities and are not provided by guardrails.
+- Provider routing by data-collection policy, distillable-text policy, or quantization is not available until Phaseo has authoritative route metadata.
+
+## Related guides
+
+- [Roll out guardrails on API keys](../../cookbook/guardrails-for-api-keys)
+- [Capability status](../../guides/capability-status)

--- a/apps/docs/v1/guides/capability-status.mdx
+++ b/apps/docs/v1/guides/capability-status.mdx
@@ -1,0 +1,80 @@
+---
+title: "Capability status"
+description: "Check which Phaseo features are available today, which are in beta, and which still have limitations."
+---
+
+Use this page before committing a production integration to a Phaseo feature. It records the supported product state, not just whether implementation code exists.
+
+Last verified against `main` commit `dbb4520e` on July 26, 2026.
+
+## Status definitions
+
+| Status | Meaning |
+| --- | --- |
+| Available | Publicly supported and suitable for production use within the documented limits. |
+| Beta | Public and usable, but the contract or operational limits may still change. |
+| Partial | A supported path exists, with an important limitation listed here. |
+| Planned | Tracked or implemented in unmerged work, but not part of the supported `main` contract. |
+| Unavailable | No supported Phaseo product path exists yet. |
+
+## Gateway APIs
+
+| Capability | Status | Current contract |
+| --- | --- | --- |
+| Chat Completions, Responses, and Anthropic Messages | Available | Public gateway endpoints with streaming, tools, and structured output support. |
+| Embeddings and reranking | Beta | Public endpoints; model and provider availability varies. |
+| Images, video, speech, transcription, and audio | Beta | Public endpoints; supported operations vary by model and provider. |
+| Files and PDF inputs | Beta | File ownership and retrieval are supported; provider-specific file behavior can differ. |
+| Batch processing | Beta | Create, retrieve, list, and cancel flows are public. |
+| OCR, music, moderation, and realtime sessions | Beta | Dedicated endpoints are available with provider-specific coverage. |
+
+## Routing and model discovery
+
+| Capability | Status | Current contract |
+| --- | --- | --- |
+| Provider order, allow, ignore, and fallback | Available | Supported through the documented provider-routing fields. |
+| Price, latency, throughput, region, and ZDR routing | Beta | Applied when Phaseo has authoritative metadata for the candidate routes. |
+| `data_collection` routing | Unavailable | Requests using this filter are rejected because provider policy metadata is not authoritative yet. |
+| `enforce_distillable_text` routing | Unavailable | Requests using this filter are rejected because provider policy metadata is not authoritative yet. |
+| `quantizations` routing | Unavailable | Requests using this filter are rejected because route-level quantization metadata is not authoritative yet. |
+| Phaseo Free Router | Beta | Available when the workspace has a matching free provider route. |
+| Per-model endpoint and parameter discovery | Planned | Tracked in issue #835 and draft PR #836; do not build against the unmerged route contract. |
+| Private-model lifecycle | Unavailable | Internal discovery support is not a public private-model onboarding and lifecycle product. |
+
+## Controls and enterprise access
+
+| Capability | Status | Current contract |
+| --- | --- | --- |
+| Guardrail creation and enforcement | Beta | Dashboard and management API paths support budgets, routing restrictions, prompt-injection checks, and sensitive-info actions. |
+| Guardrail assignment to keys and members | Beta | Management API and dashboard assignment paths are available. |
+| Guardrails in generated SDKs | Planned | Guardrail routes are not yet part of the published OpenAPI-generated SDK contract. Use the documented REST endpoints. |
+| Workspaces, management keys, and OAuth | Beta | Public control-plane routes are available with capability and workspace-role checks. |
+| Enterprise SAML or custom OIDC sign-in | Partial | Configuration and sign-in paths exist, but team-wide enforcement is not active. |
+| Mandatory SSO enforcement | Planned | The current enforcement hook is intentionally non-blocking. Do not treat the `sso_enforced` setting as an access-control guarantee. |
+| SCIM provisioning | Unavailable | Automated user and group provisioning is not implemented. |
+
+## Observability and tools
+
+| Capability | Status | Current contract |
+| --- | --- | --- |
+| Request, usage, cost, and generation history | Available | Workspace activity and request-detail views are supported. |
+| Per-attempt upstream request records | Partial | Aggregate request and failure details are available on `main`; the separate child-record implementation remains in PR #1043. |
+| Preset feedback analytics | Planned | The consolidated implementation remains in PR #1033. |
+| Hosted datetime, web search, web fetch, advisor, subagent, Fusion, image generation, and apply-patch tools | Beta | Available through the documented server-tool flow where the selected model supports tools. |
+| Hosted shell and model-catalog search tools | Unavailable | These are not supported server tools today. |
+
+## How to use this page
+
+- Build production integrations against **Available** capabilities.
+- Use **Beta** capabilities behind a rollout flag and monitor errors and costs.
+- Read the stated limitation before adopting a **Partial** capability.
+- Do not depend on **Planned** or **Unavailable** capabilities until this page changes.
+
+If runtime behavior contradicts this page, treat that as a documentation defect and report it with the endpoint, request ID, and observed response.
+
+## Related guides
+
+- [Routing and fallbacks](./routing-and-fallbacks)
+- [Guardrails API](../api-reference/endpoint/guardrails)
+- [Feature parity matrix](../migration-guides/feature-parity-matrix)
+

--- a/apps/docs/v1/migration-guides/feature-parity-matrix.mdx
+++ b/apps/docs/v1/migration-guides/feature-parity-matrix.mdx
@@ -7,7 +7,7 @@ description: "See what you can migrate to Phaseo confidently today, and which ar
 
 Use this page to see what you can migrate to Phaseo confidently today, and which areas still need extra care.
 
-This summary is based on the code, tests, SDKs, and docs currently shipped in this repo.
+This summary is based on the code, tests, SDKs, and docs currently shipped in this repo. For production availability and explicit limitations, use the [Capability status](../guides/capability-status) page as the controlling reference.
 
 ## Platform migration matrix
 
@@ -33,7 +33,10 @@ This summary is based on the code, tests, SDKs, and docs currently shipped in th
 | Fallback controls for migrations | Public docs now point to preset constraints, routing mode, preview-channel toggles, and BYOK fallback controls as the supported migration knobs | Strong |
 | Replay and retry ergonomics | `GET /v1/generations?id=<request_id>` now returns `replay_supported` plus a `replay_request` payload that can be resent to the original endpoint | Strong |
 | Request transforms and defaults | Presets guide now defines the supported public controls for prompt injection, parameter defaults, reasoning defaults, and provider constraints | Strong |
-| Broader competitor benchmarking | Operational compare flow now covers OpenRouter, LLMGateway, and Vercel AI Gateway; the remaining work is keeping that evidence aligned as contracts evolve | Strong |
+| Broader competitor benchmarking | Operational compare flow covers OpenRouter, LLMGateway, and Vercel AI Gateway; the evidence still needs ongoing contract validation | Partial |
+| Provider policy routing | ZDR and region controls are supported; data-collection, distillable-text, and quantization filters are rejected until metadata is authoritative | Partial |
+| Enterprise identity | SAML/custom OIDC configuration and sign-in paths exist; mandatory enforcement is not active and SCIM is unavailable | Partial |
+| Per-model endpoint discovery | Existing model filters do not expose the complete route-level parameter and modality contract | Planned |
 
 ## What is already strong
 
@@ -44,7 +47,10 @@ This summary is based on the code, tests, SDKs, and docs currently shipped in th
 
 ## What still needs attention
 
-1. Keep the migration docs and comparison notes current as the product changes.
+1. Add authoritative provider metadata for data-collection, distillation, and quantization routing policies.
+2. Ship per-model endpoint and parameter discovery from issue #835 and PR #836.
+3. Replace the non-blocking SSO enforcement scaffold and add SCIM before claiming enterprise identity parity.
+4. Keep the migration docs and comparison evidence current as the product changes.
 
 ## Related guides
 

--- a/apps/docs/v1/migration-guides/gateway-parity-review.mdx
+++ b/apps/docs/v1/migration-guides/gateway-parity-review.mdx
@@ -5,7 +5,7 @@ description: "Understand how ready Phaseo is for migrations from OpenRouter, Ver
 
 Use this page to understand how ready Phaseo is for migrations from OpenRouter, Vercel AI Gateway, and LLMGateway.
 
-This review is based on the current codebase, tests, SDKs, and docs in this repo.
+This review is based on the current codebase, tests, SDKs, and docs in this repo. The [Capability status](../guides/capability-status) page is the controlling reference when a migration depends on a beta, partial, planned, or unavailable feature.
 
 ## Scope reviewed
 
@@ -54,7 +54,7 @@ OpenRouter currently has the deepest repo support among the reviewed competitors
 - OpenRouter-specific compatibility headers in the benchmark flow
 - existing product copy and internal compare UI built around the OpenRouter comparison path
 
-This does not mean every OpenRouter feature is matched. It means Phaseo currently gives you the clearest migration and validation path for that competitor.
+This does not mean every OpenRouter feature is matched. Provider-policy filters, private-model lifecycle, per-model endpoint discovery, mandatory SSO enforcement, and SCIM remain material gaps.
 
 ### 3) Batch and async support is much stronger now
 
@@ -81,7 +81,19 @@ This means the migration story is no longer only "change the base URL." The loca
 
 ## What still needs work
 
-### 1) Competitor comparison tooling is now mostly aligned
+### 1) Provider-policy routing is incomplete
+
+Phaseo supports provider ordering, allow/ignore lists, fallbacks, price, latency, throughput, region, and ZDR controls. It does not currently support routing by data-collection policy, distillable-text policy, or quantization because the route metadata is not authoritative enough.
+
+### 2) Enterprise identity is not at parity
+
+SAML and custom OIDC configuration and sign-in paths exist, but mandatory workspace SSO enforcement is intentionally non-blocking. SCIM provisioning is not implemented.
+
+### 3) Per-model endpoint discovery remains planned
+
+The public model catalogue supports useful filters, but it does not yet expose the complete route-level endpoint, parameter, modality, policy, and quantization contract tracked by issue #835 and draft PR #836.
+
+### 4) Competitor comparison tooling is mostly aligned
 
 The internal benchmark and compare tooling now supports:
 
@@ -92,7 +104,7 @@ The internal benchmark and compare tooling now supports:
 
 That closes the earlier benchmarking gap for Vercel AI Gateway and makes the internal comparison flow more consistent across all three reviewed gateways.
 
-### 2) The parity matrix exists, but not every related capability has a dedicated doc page yet
+### 5) The parity matrix exists, but not every related capability has a dedicated doc page yet
 
 The migration guides now have a dedicated [Feature Parity Matrix](./feature-parity-matrix), but the wider docs still do not give every capability the same level of visibility. The matrix currently tracks:
 
@@ -104,7 +116,7 @@ The migration guides now have a dedicated [Feature Parity Matrix](./feature-pari
 
 The matrix closes the original documentation gap, but the wider docs still need more direct capability pages in a few places.
 
-### 3) Some gaps are still proof gaps, not confirmed product gaps
+### 6) Some gaps are proof gaps rather than confirmed product gaps
 
 For several backlog items, the current weakness is not necessarily "feature absent," but "not strongly documented or validated yet":
 
@@ -126,8 +138,10 @@ Phaseo already has strong evidence for:
 
 The highest-value next work is:
 
-1. Keep the parity matrix current as routing, pricing, async jobs, and replay/retry support evolve.
-2. Keep the competitor comparison flow current as request contracts change.
+1. Ship authoritative provider-policy metadata and per-model endpoint discovery.
+2. Implement mandatory SSO enforcement and SCIM before claiming enterprise identity parity.
+3. Keep the parity matrix current as routing, pricing, async jobs, and replay/retry support evolve.
+4. Keep the competitor comparison flow current as request contracts change.
 
 ## Recommended next steps
 


### PR DESCRIPTION
## Summary

- add one controlling capability-status page with explicit Available, Beta, Partial, Planned, and Unavailable states
- replace the stale Guardrails “Coming Soon” page with the working beta REST contract, permissions, examples, assignments, and limitations
- correct management-key authentication guidance
- publish one vendor-neutral status contract that names the remaining policy-routing, endpoint-discovery, SSO-enforcement, and SCIM gaps

## Why

The runtime, dashboard, cookbook, and API reference disagreed about Guardrails, while existing parity pages did not name several material limitations. Buyers and developers need a product-status contract based on supported behavior rather than the presence of implementation code.

## User impact

Developers can now distinguish production-ready features from beta, partial, planned, and unavailable capabilities before committing an integration. Guardrails users have actionable REST documentation, and enterprise identity limitations are stated explicitly.

## Validation

- `pnpm docs:links`
- `pnpm docs:build`
- `git diff --check`

## Follow-up

- add Guardrails to the public OpenAPI and generated SDK contract
- replace the non-blocking SSO enforcement scaffold and add SCIM
- ship per-model endpoint and parameter discovery from #835 / #836
- add authoritative metadata for data-collection, distillation, and quantization routing filters