### PR TITLE
Fix PHP Agent SDK split publish

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -832,8 +832,19 @@ jobs:
                   ruby-version: "3.2"
             - name: Run Agent SDK tests
               run: pnpm run test:agent-sdk-${{ matrix.sdk }}
-            - name: Run live GPT 5.6 Luna Agent SDK smoke
+            - name: Check live smoke credentials
+              id: live-smoke-credentials
               if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+              env:
+                  PHASEO_API_KEY: ${{ secrets.PHASEO_API_KEY }}
+              run: |
+                  if [ -n "$PHASEO_API_KEY" ]; then
+                    echo "available=true" >> "$GITHUB_OUTPUT"
+                  else
+                    echo "available=false" >> "$GITHUB_OUTPUT"
+                  fi
+            - name: Run live GPT 5.6 Luna Agent SDK smoke
+              if: github.event_name == 'push' && github.ref == 'refs/heads/main' && steps.live-smoke-credentials.outputs.available == 'true'
               env:
                   PHASEO_AGENT_LIVE_SMOKE: "true"
                   PHASEO_API_KEY: ${{ secrets.PHASEO_API_KEY }}

--- a/.github/workflows/publish-agent-sdks.yml
+++ b/.github/workflows/publish-agent-sdks.yml
@@ -250,7 +250,7 @@ jobs:
           split_url="https://github.com/${split_repo}"
           git remote add split "https://x-access-token:${GH_APP_TOKEN}@github.com/${split_repo}.git"
           split_commit="$(git subtree split --prefix=packages/sdk/agent-sdk-php HEAD)"
-          git push --force split "${split_commit}:main"
+          git push --force split "${split_commit}:refs/heads/main"
           if ! git ls-remote --exit-code --tags split "refs/tags/v${version}" >/dev/null 2>&1; then
             git push split "${split_commit}:refs/tags/v${version}"
           fi


### PR DESCRIPTION
Fix two release-path failures exposed by the first Agent SDK publication run.

- push the PHP subtree commit to the fully qualified `refs/heads/main` destination required when creating an empty split repository
- skip optional live Agent SDK smoke tests when the Phaseo API-key secret is absent, without exposing the secret to unrelated setup steps
- retain exact-version/tag checks so rerunning skips Python, Ruby, Go, NuGet, and the already-created PHP monorepo tag

Validation:
- `git diff --check`
- PHP failure reproduced from release run 30199423102 and corrected using Git's explicit suggested refspec
- public clean installs verified for PyPI, NuGet, RubyGems, and Go at `0.2.0`
- original main CI failure traced to an empty `PHASEO_API_KEY` with live-smoke opt-in enabled

Created with Codex

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Live GPT 5.6 Luna Agent SDK smoke tests now run only when the required API credentials are available.
  - Updated PHP Agent SDK publishing to target the main branch explicitly, improving release workflow reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->