### PR TITLE
Improve model migration and developer tool guides

### DIFF
--- a/apps/docs/docs.json
+++ b/apps/docs/docs.json
@@ -225,16 +225,17 @@
 										"expanded": false,
 										"pages": [
 											"v1/model-migrations/index",
+											"v1/model-migrations/anthropic-claude-opus-5",
+											"v1/model-migrations/openai-migrating-to-gpt-5-6",
 											"v1/model-migrations/anthropic-claude-opus-4-1-to-4-8",
 											"v1/model-migrations/anthropic-claude-opus-4-6-to-4-7",
-											"v1/model-migrations/anthropic-claude-opus-4-5-to-4-6",
-											"v1/model-migrations/anthropic-claude-sonnet-4-5-to-4-6",
-											"v1/model-migrations/openai-migrating-to-gpt-5-4",
-											"v1/model-migrations/openai-migrating-to-gpt-5-6",
-											"v1/model-migrations/google-migrating-to-gemini-3-and-3-1",
-											"v1/model-migrations/google-nano-banana-1-to-nano-banana-2",
 											"v1/model-migrations/mistral-small-3-2-to-mistral-small-4",
-											"v1/model-migrations/xai-grok-4-20"
+											"v1/model-migrations/openai-migrating-to-gpt-5-4",
+											"v1/model-migrations/google-nano-banana-1-to-nano-banana-2",
+											"v1/model-migrations/google-migrating-to-gemini-3-and-3-1",
+											"v1/model-migrations/anthropic-claude-sonnet-4-5-to-4-6",
+											"v1/model-migrations/xai-grok-4-20",
+											"v1/model-migrations/anthropic-claude-opus-4-5-to-4-6"
 										]
 									},
 									{

--- a/apps/docs/docs.json
+++ b/apps/docs/docs.json
@@ -46,6 +46,7 @@
 									"v1/guides/principles",
 									"v1/developers/authentication",
 									"v1/developers/integrating-with-the-gateway",
+									"v1/developers/cli-and-mcp",
 									"v1/community/faq"
 								]
 							},

--- a/apps/docs/v1/developers/cli-and-mcp.mdx
+++ b/apps/docs/v1/developers/cli-and-mcp.mdx
@@ -1,0 +1,103 @@
+---
+title: "CLI and MCP"
+description: "Use the Phaseo CLI for terminal automation or connect the authenticated MCP server to AI clients for live, read-only Phaseo data."
+icon: "terminal-square"
+---
+
+# CLI and MCP
+
+Use Phaseo from your terminal with the CLI, or connect an AI client through MCP. Both use Phaseo OAuth, but they are designed for different jobs.
+
+| Interface | Best for | Access |
+| --- | --- | --- |
+| Phaseo CLI | Terminal workflows, CI, administration, and automation | Read and write, limited by your scopes and workspace role |
+| Phaseo MCP | Live Phaseo data inside Codex, Claude, ChatGPT, and other MCP clients | Authenticated and read-only |
+| Docs MCP | Looking up current Phaseo documentation while coding | Documentation-only and read-only |
+
+## Phaseo CLI
+
+Use the CLI when you need to create or change Phaseo resources, script a workflow, or inspect account data from a shell.
+
+### Install and sign in
+
+```bash
+npm install -g @phaseo/cli
+phaseo login
+phaseo whoami
+```
+
+Interactive terminals use browser OAuth by default. For SSH, CI, and headless environments, use device authorization:
+
+```bash
+phaseo login --device-code
+```
+
+### Common workflows
+
+```bash
+phaseo models list --limit 20
+phaseo pricing models
+phaseo credits get
+phaseo workspaces list
+phaseo keys create --name "Local development"
+phaseo logs list --since 1h --status error --json
+```
+
+Use `--json` when another tool or script needs structured output. Secret values are displayed only by commands that explicitly create or reveal them.
+
+<Card title="Phaseo CLI guide" icon="terminal" href="../guides/integrations/phaseo-cli">
+	See authentication options, key management, workspaces, guardrails, and the complete command workflow.
+</Card>
+
+## Phaseo MCP
+
+Connect the Phaseo MCP server when you want an AI client to answer questions using live model, pricing, provider, usage, and workspace data.
+
+### Server URL
+
+`https://mcp.phaseo.app/mcp`
+
+### Connect from Codex
+
+```bash
+codex mcp add phaseo --url https://mcp.phaseo.app/mcp
+codex mcp login phaseo
+```
+
+The login command opens Phaseo OAuth. Choose a workspace and approve the requested read scopes, then confirm the connection:
+
+```bash
+codex mcp list
+```
+
+For another MCP client, add the same URL as a remote Streamable HTTP server. The client must support OAuth discovery, authorization code with S256 PKCE, and the MCP `resource` parameter.
+
+### What the MCP can read
+
+- models, providers, organisations, endpoint families, and pricing
+- credits, activity, analytics, request logs, and generation metadata
+- workspaces, members, presets, settings, and guardrails
+- API-key, management-key, OAuth-application, and webhook metadata without secret values
+
+The MCP does not run billable inference, return secret values, or mutate Phaseo resources. Use the dashboard, CLI, or Management API for those operations.
+
+## Docs MCP
+
+The Docs MCP is a separate endpoint for searching and reading Phaseo documentation. It does not access your account or workspace.
+
+```bash
+codex mcp add phaseoDocs --url https://phaseo.app/docs/mcp
+```
+
+Use it when a coding assistant needs current API examples, integration guidance, or feature documentation.
+
+<Card title="Docs MCP guide" icon="book-open" href="../guides/integrations/docs-mcp">
+	Connect the documentation server to Codex, Claude Code, Cursor, OpenCode, or VS Code.
+</Card>
+
+## Choose the right interface
+
+- Use the **CLI** to create keys, change settings, manage workspaces, or automate administrative workflows.
+- Use the **Phaseo MCP** to give an AI client safe access to live Phaseo data.
+- Use the **Docs MCP** to give a coding assistant current Phaseo documentation without account access.
+

--- a/apps/docs/v1/developers/cli-and-mcp.mdx
+++ b/apps/docs/v1/developers/cli-and-mcp.mdx
@@ -1,7 +1,7 @@
 ---
 title: "CLI and MCP"
 description: "Use the Phaseo CLI for terminal automation or connect the authenticated MCP server to AI clients for live, read-only Phaseo data."
-icon: "terminal-square"
+icon: "square-terminal"
 ---
 
 # CLI and MCP

--- a/apps/docs/v1/migration-guides/index.mdx
+++ b/apps/docs/v1/migration-guides/index.mdx
@@ -33,15 +33,17 @@ These guides focus on:
 
 Current model migration guides:
 
-- [Anthropic: Claude Opus 4.1 to 4.8](../model-migrations/anthropic-claude-opus-4-1-to-4-8)
-- [Anthropic: Claude Opus 4.6 to 4.7](../model-migrations/anthropic-claude-opus-4-6-to-4-7)
-- [Anthropic: Claude Opus 4.5 to 4.6](../model-migrations/anthropic-claude-opus-4-5-to-4-6)
-- [Anthropic: Claude Sonnet 4.5 to 4.6](../model-migrations/anthropic-claude-sonnet-4-5-to-4-6)
-- [OpenAI: Migrating to GPT-5.6](../model-migrations/openai-migrating-to-gpt-5-6)
-- [OpenAI: Migrating to GPT-5.4](../model-migrations/openai-migrating-to-gpt-5-4)
-- [Google: Migrating to Gemini 3 and 3.1](../model-migrations/google-migrating-to-gemini-3-and-3-1)
-- [Google: Nano Banana 1 to Nano Banana 2](../model-migrations/google-nano-banana-1-to-nano-banana-2)
-- [SpaceXAI: Grok 4.20](../model-migrations/xai-grok-4-20)
+- [Anthropic Claude Opus 5](../model-migrations/anthropic-claude-opus-5)
+- [OpenAI GPT-5.6](../model-migrations/openai-migrating-to-gpt-5-6)
+- [Anthropic Claude Opus 4.8](../model-migrations/anthropic-claude-opus-4-1-to-4-8)
+- [Anthropic Claude Opus 4.7](../model-migrations/anthropic-claude-opus-4-6-to-4-7)
+- [Mistral Small 4](../model-migrations/mistral-small-3-2-to-mistral-small-4)
+- [OpenAI GPT-5.4](../model-migrations/openai-migrating-to-gpt-5-4)
+- [Google Nano Banana 2](../model-migrations/google-nano-banana-1-to-nano-banana-2)
+- [Google Gemini 3.1](../model-migrations/google-migrating-to-gemini-3-and-3-1)
+- [Anthropic Claude Sonnet 4.6](../model-migrations/anthropic-claude-sonnet-4-5-to-4-6)
+- [SpaceXAI Grok 4.20](../model-migrations/xai-grok-4-20)
+- [Anthropic Claude Opus 4.6](../model-migrations/anthropic-claude-opus-4-5-to-4-6)
 
 ## Platform migrations
 

--- a/apps/docs/v1/migration-guides/index.mdx
+++ b/apps/docs/v1/migration-guides/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Migration Guides"
-description: "Guides for moving between platforms or upgrading from one model to a newer model."
+description: "Guides for moving between platforms or adopting a specific model release."
 icon: "compass"
 ---
 
@@ -9,7 +9,7 @@ icon: "compass"
 Phaseo migration guides cover two different upgrade problems:
 
 - moving from one platform or gateway to Phaseo
-- moving from an older model release to a newer model on the same platform
+- adopting a specific model release on the same platform
 
 <Columns cols={2}>
 	<Card title="Model migrations" icon="brain-circuit" href="../model-migrations">

--- a/apps/docs/v1/model-migrations/anthropic-claude-opus-4-1-to-4-8.mdx
+++ b/apps/docs/v1/model-migrations/anthropic-claude-opus-4-1-to-4-8.mdx
@@ -1,10 +1,10 @@
 ---
-title: "Anthropic: Claude Opus 4.1 to 4.8"
+title: "Anthropic Claude Opus 4.8"
 description: "The concrete migration steps to move deprecated Claude Opus 4.1 traffic onto Claude Opus 4.8."
 icon: "/icons/brands/anthropic.svg"
 ---
 
-# Anthropic: Claude Opus 4.1 to 4.8
+# Anthropic Claude Opus 4.8
 
 Use this guide when you are moving from `anthropic/claude-opus-4.1` to `anthropic/claude-opus-4.8`.
 
@@ -19,7 +19,7 @@ Anthropic deprecated Claude Opus 4.1 on June 5, 2026 and scheduled retirement fo
 - Opus 4.8 adds mid-conversation system messages
 - Opus 4.8 raises the baseline context/output ceilings to 1M context and 128K max output on the Claude API, Claude Platform on AWS, Amazon Bedrock, and Vertex AI
 
-## What to change in your integration
+## Migration quickstart
 
 ### 1. Update the model ID
 

--- a/apps/docs/v1/model-migrations/anthropic-claude-opus-4-1-to-4-8.mdx
+++ b/apps/docs/v1/model-migrations/anthropic-claude-opus-4-1-to-4-8.mdx
@@ -1,18 +1,18 @@
 ---
 title: "Anthropic Claude Opus 4.8"
-description: "The concrete migration steps to move deprecated Claude Opus 4.1 traffic onto Claude Opus 4.8."
+description: "What to know when adopting Claude Opus 4.8, including adaptive thinking, sampling controls, and long context."
 icon: "/icons/brands/anthropic.svg"
 ---
 
 # Anthropic Claude Opus 4.8
 
-Use this guide when you are moving from `anthropic/claude-opus-4.1` to `anthropic/claude-opus-4.8`.
+Use this guide to adopt `anthropic/claude-opus-4.8` safely in production.
 
 Anthropic deprecated Claude Opus 4.1 on June 5, 2026 and scheduled retirement for August 5, 2026. Their migration guidance for Opus 4.1 is cumulative: first apply the Claude Opus 4.7 request-shape changes, then review the Claude Opus 4.8 behavior changes.
 
-## What changed
+## What's new
 
-- the target model becomes `claude-opus-4-8`
+- the Phaseo model ID is `anthropic/claude-opus-4.8`
 - Opus 4.7 and later reject non-default sampling params like `temperature`, `top_p`, and `top_k`
 - Opus 4.7 and later reject manual extended-thinking budgets; use adaptive thinking instead
 - Opus 4.8 defaults `output_config.effort` to `high`
@@ -23,13 +23,7 @@ Anthropic deprecated Claude Opus 4.1 on June 5, 2026 and scheduled retirement fo
 
 ### 1. Update the model ID
 
-Move from:
-
-- `anthropic/claude-opus-4.1`
-
-to:
-
-- `anthropic/claude-opus-4.8`
+Set the model ID to `anthropic/claude-opus-4.8`.
 
 ### 2. Remove non-default sampling parameters
 

--- a/apps/docs/v1/model-migrations/anthropic-claude-opus-4-5-to-4-6.mdx
+++ b/apps/docs/v1/model-migrations/anthropic-claude-opus-4-5-to-4-6.mdx
@@ -1,10 +1,10 @@
 ---
-title: "Anthropic: Claude Opus 4.5 to 4.6"
+title: "Anthropic Claude Opus 4.6"
 description: "The concrete API and behavior changes to review when upgrading from Claude Opus 4.5 to Claude Opus 4.6."
 icon: "/icons/brands/anthropic.svg"
 ---
 
-# Anthropic: Claude Opus 4.5 to 4.6
+# Anthropic Claude Opus 4.6
 
 Use this guide when you are moving from `anthropic/claude-opus-4.5` to `anthropic/claude-opus-4.6`.
 
@@ -19,7 +19,7 @@ Claude Opus 4.6 is not just a model-ID swap. Anthropic's migration guidance incl
 - Opus 4.6 specifically no longer needs the `interleaved-thinking-2025-05-14` beta header
 - Opus 4.6 adds a 1M-token context window in beta and improves long-running coding and agentic tasks
 
-## What to change in your integration
+## Migration quickstart
 
 ### 1. Remove assistant prefills
 

--- a/apps/docs/v1/model-migrations/anthropic-claude-opus-4-5-to-4-6.mdx
+++ b/apps/docs/v1/model-migrations/anthropic-claude-opus-4-5-to-4-6.mdx
@@ -1,16 +1,16 @@
 ---
 title: "Anthropic Claude Opus 4.6"
-description: "The concrete API and behavior changes to review when upgrading from Claude Opus 4.5 to Claude Opus 4.6."
+description: "What to know when adopting Claude Opus 4.6, including structured output, adaptive thinking, and prefills."
 icon: "/icons/brands/anthropic.svg"
 ---
 
 # Anthropic Claude Opus 4.6
 
-Use this guide when you are moving from `anthropic/claude-opus-4.5` to `anthropic/claude-opus-4.6`.
+Use this guide to adopt `anthropic/claude-opus-4.6` safely in production.
 
 Claude Opus 4.6 is not just a model-ID swap. Anthropic's migration guidance includes request-shape changes, removed beta flags, and stricter behavior around prefills.
 
-## What changed
+## What's new
 
 - assistant prefills are no longer supported on Claude 4.6 models and now return `400`
 - structured output moved from `output_format` to `output_config.format`

--- a/apps/docs/v1/model-migrations/anthropic-claude-opus-4-6-to-4-7.mdx
+++ b/apps/docs/v1/model-migrations/anthropic-claude-opus-4-6-to-4-7.mdx
@@ -1,16 +1,16 @@
 ---
 title: "Anthropic Claude Opus 4.7"
-description: "Model migration notes for upgrading Anthropic Claude Opus 4.6 traffic to Claude Opus 4.7."
+description: "What to know when adopting Claude Opus 4.7, including adaptive thinking, sampling controls, and token usage."
 icon: "/icons/brands/anthropic.svg"
 ---
 
 # Anthropic Claude Opus 4.7
 
-Use this guide when moving from `anthropic/claude-opus-4.6` to `anthropic/claude-opus-4.7`.
+Use this guide to adopt `anthropic/claude-opus-4.7` safely in production.
 
 Claude Opus 4.7 introduces request-shape changes that can hard-fail old 4.6 patterns if left unchanged.
 
-## What changed
+## What's new
 
 - New effort level: `xhigh` (Messages API)
 - Extended thinking budgets were removed for Opus 4.7 (`thinking: { type: "enabled", budget_tokens: ... }` now fails)
@@ -31,13 +31,7 @@ To reduce migration breakage, Phaseo accepts legacy Opus 4.6 fields for Opus 4.7
 
 ### 1. Update model ID
 
-Move from:
-
-- `anthropic/claude-opus-4.6`
-
-to:
-
-- `anthropic/claude-opus-4.7`
+Set the model ID to `anthropic/claude-opus-4.7`.
 
 ### 2. Move to adaptive thinking with summarized display
 

--- a/apps/docs/v1/model-migrations/anthropic-claude-opus-4-6-to-4-7.mdx
+++ b/apps/docs/v1/model-migrations/anthropic-claude-opus-4-6-to-4-7.mdx
@@ -1,10 +1,10 @@
 ---
-title: "Anthropic: Claude Opus 4.6 to 4.7"
+title: "Anthropic Claude Opus 4.7"
 description: "Model migration notes for upgrading Anthropic Claude Opus 4.6 traffic to Claude Opus 4.7."
 icon: "/icons/brands/anthropic.svg"
 ---
 
-# Anthropic: Claude Opus 4.6 to 4.7
+# Anthropic Claude Opus 4.7
 
 Use this guide when moving from `anthropic/claude-opus-4.6` to `anthropic/claude-opus-4.7`.
 
@@ -27,7 +27,7 @@ To reduce migration breakage, Phaseo accepts legacy Opus 4.6 fields for Opus 4.7
 - Opus 4.7 thinking is always sent as `thinking: { "type": "adaptive", "display": "summarized" }`
 - `reasoning.effort` is still honored and mapped to `output_config.effort` (`xhigh` supported)
 
-## What to change in your integration
+## Migration quickstart
 
 ### 1. Update model ID
 

--- a/apps/docs/v1/model-migrations/anthropic-claude-opus-5.mdx
+++ b/apps/docs/v1/model-migrations/anthropic-claude-opus-5.mdx
@@ -1,12 +1,12 @@
 ---
 title: "Anthropic Claude Opus 5"
-description: "Upgrade Claude Opus 4.8 workloads to Claude Opus 5 and validate the larger context, output, and agentic behavior."
+description: "What to know when adopting Claude Opus 5 for long-context reasoning, coding, and agentic workloads."
 icon: "/icons/brands/anthropic.svg"
 ---
 
 # Anthropic Claude Opus 5
 
-Use this guide when you are moving from `anthropic/claude-opus-4.8` to `anthropic/claude-opus-5`.
+Use this guide to adopt `anthropic/claude-opus-5` safely in production.
 
 Claude Opus 5 is the current Opus model for complex reasoning, long-horizon agentic coding, and high-autonomy workflows. It keeps the same price as Opus 4.8 while supporting a 1M-token context window and up to 128K output tokens.
 
@@ -29,9 +29,9 @@ Claude Opus 5 is the current Opus model for complex reasoning, long-horizon agen
 }
 ```
 
-## What changed
+## What's new
 
-- the target model becomes `anthropic/claude-opus-5`
+- the Phaseo model ID is `anthropic/claude-opus-5`
 - the context window is 1M tokens
 - the maximum output is 128K tokens
 - the model is positioned for longer-running reasoning, coding, and autonomous tool workflows

--- a/apps/docs/v1/model-migrations/anthropic-claude-opus-5.mdx
+++ b/apps/docs/v1/model-migrations/anthropic-claude-opus-5.mdx
@@ -1,0 +1,74 @@
+---
+title: "Anthropic Claude Opus 5"
+description: "Upgrade Claude Opus 4.8 workloads to Claude Opus 5 and validate the larger context, output, and agentic behavior."
+icon: "/icons/brands/anthropic.svg"
+---
+
+# Anthropic Claude Opus 5
+
+Use this guide when you are moving from `anthropic/claude-opus-4.8` to `anthropic/claude-opus-5`.
+
+Claude Opus 5 is the current Opus model for complex reasoning, long-horizon agentic coding, and high-autonomy workflows. It keeps the same price as Opus 4.8 while supporting a 1M-token context window and up to 128K output tokens.
+
+## Migration quickstart
+
+1. Change the model ID to `anthropic/claude-opus-5` without changing the rest of the request.
+2. Re-run your production prompt, tool, and structured-output evaluations.
+3. Rebaseline latency, token use, and task cost for long-context and high-effort workloads.
+4. Canary the model behind a fallback to Claude Opus 4.8 before changing your default route.
+
+```json
+{
+  "model": "anthropic/claude-opus-5",
+  "messages": [
+    {
+      "role": "user",
+      "content": "Review this implementation plan and identify the highest-risk assumptions."
+    }
+  ]
+}
+```
+
+## What changed
+
+- the target model becomes `anthropic/claude-opus-5`
+- the context window is 1M tokens
+- the maximum output is 128K tokens
+- the model is positioned for longer-running reasoning, coding, and autonomous tool workflows
+- pricing remains aligned with Claude Opus 4.8
+
+## What to test
+
+### Prompts and outputs
+
+- instruction following on your longest system prompts
+- structured-output and schema pass rates
+- response length and stopping behavior
+- regressions in prompts tuned specifically for Claude Opus 4.8
+
+### Tools and agents
+
+- tool selection and argument quality
+- recovery after tool errors or partial results
+- long-horizon completion rate
+- permission and approval boundaries in high-autonomy workflows
+
+### Operations
+
+- latency and token use at each effort level you expose
+- context-window usage on long documents and agent traces
+- cost per successful task
+- fallback behavior when the primary route times out or fails
+
+## Safe rollout
+
+1. Keep Claude Opus 4.8 available as a fallback during evaluation.
+2. Shadow representative production traffic before serving user requests.
+3. Canary by workload rather than moving every Opus route at once.
+4. Promote only after quality, latency, cost, and tool-safety checks meet your targets.
+
+## Sources
+
+- [Claude Opus 5 announcement](https://www.anthropic.com/news/claude-opus-5)
+- [Claude Opus 5 system card](https://www.anthropic.com/claude-opus-5-system-card)
+

--- a/apps/docs/v1/model-migrations/anthropic-claude-sonnet-4-5-to-4-6.mdx
+++ b/apps/docs/v1/model-migrations/anthropic-claude-sonnet-4-5-to-4-6.mdx
@@ -1,10 +1,10 @@
 ---
-title: "Anthropic: Claude Sonnet 4.5 to 4.6"
+title: "Anthropic Claude Sonnet 4.6"
 description: "The concrete API and behavior changes to review when upgrading from Claude Sonnet 4.5 to Claude Sonnet 4.6."
 icon: "/icons/brands/anthropic.svg"
 ---
 
-# Anthropic: Claude Sonnet 4.5 to 4.6
+# Anthropic Claude Sonnet 4.6
 
 Use this guide when you are moving from `anthropic/claude-sonnet-4.5` to `anthropic/claude-sonnet-4.6`.
 
@@ -19,7 +19,7 @@ Sonnet 4.6 shares the same migration mechanics as the broader Claude 4.6 line, b
 - Sonnet 4.6 is a full upgrade across coding, computer use, long-context reasoning, agent planning, and instruction following
 - Sonnet 4.6 adds a 1M-token context window in beta
 
-## What to change in your integration
+## Migration quickstart
 
 ### 1. Stop using assistant prefills
 

--- a/apps/docs/v1/model-migrations/anthropic-claude-sonnet-4-5-to-4-6.mdx
+++ b/apps/docs/v1/model-migrations/anthropic-claude-sonnet-4-5-to-4-6.mdx
@@ -1,16 +1,16 @@
 ---
 title: "Anthropic Claude Sonnet 4.6"
-description: "The concrete API and behavior changes to review when upgrading from Claude Sonnet 4.5 to Claude Sonnet 4.6."
+description: "What to know when adopting Claude Sonnet 4.6 for coding, computer use, and agent planning."
 icon: "/icons/brands/anthropic.svg"
 ---
 
 # Anthropic Claude Sonnet 4.6
 
-Use this guide when you are moving from `anthropic/claude-sonnet-4.5` to `anthropic/claude-sonnet-4.6`.
+Use this guide to adopt `anthropic/claude-sonnet-4.6` safely in production.
 
 Sonnet 4.6 shares the same migration mechanics as the broader Claude 4.6 line, but it also changes the performance profile enough that prompt and routing assumptions should be revalidated.
 
-## What changed
+## What's new
 
 - assistant prefills are no longer supported on Claude 4.6 models and return `400`
 - structured output moved from `output_format` to `output_config.format`

--- a/apps/docs/v1/model-migrations/google-migrating-to-gemini-3-and-3-1.mdx
+++ b/apps/docs/v1/model-migrations/google-migrating-to-gemini-3-and-3-1.mdx
@@ -1,12 +1,12 @@
 ---
 title: "Google Gemini 3.1"
-description: "The API and behavior changes to review when upgrading existing Gemini integrations to Gemini 3 or Gemini 3.1."
+description: "What to know when adopting Gemini 3.1, including reasoning controls, multimodal handling, and thought signatures."
 icon: "/icons/brands/google.svg"
 ---
 
 # Google Gemini 3.1
 
-Use this guide when you are moving older Gemini traffic onto:
+Use this guide to adopt the Gemini 3.1 family safely in production:
 
 - `google/gemini-3-pro-preview`
 - `google/gemini-3-flash-preview`
@@ -15,7 +15,7 @@ Use this guide when you are moving older Gemini traffic onto:
 
 Gemini 3 introduced real API-level changes around reasoning control and multimodal handling. Gemini 3.1 then raised the baseline again, especially for more complex reasoning-heavy tasks.
 
-## What changed
+## What's new
 
 - Gemini 3 introduced `thinking_level` as the main control for reasoning depth
 - Gemini 3 added `media_resolution` for multimodal vision handling

--- a/apps/docs/v1/model-migrations/google-migrating-to-gemini-3-and-3-1.mdx
+++ b/apps/docs/v1/model-migrations/google-migrating-to-gemini-3-and-3-1.mdx
@@ -1,10 +1,10 @@
 ---
-title: "Google: Migrating to Gemini 3 and 3.1"
+title: "Google Gemini 3.1"
 description: "The API and behavior changes to review when upgrading existing Gemini integrations to Gemini 3 or Gemini 3.1."
 icon: "/icons/brands/google.svg"
 ---
 
-# Google: Migrating to Gemini 3 and 3.1
+# Google Gemini 3.1
 
 Use this guide when you are moving older Gemini traffic onto:
 
@@ -23,7 +23,7 @@ Gemini 3 introduced real API-level changes around reasoning control and multimod
 - in stricter workflows, missing Thought Signatures can produce degraded quality or `400` errors
 - Gemini 3.1 Pro is positioned as the stronger reasoning upgrade for complex tasks and agentic workflows
 
-## What to change in your integration
+## Migration quickstart
 
 ### 1. Re-map reasoning controls
 

--- a/apps/docs/v1/model-migrations/google-nano-banana-1-to-nano-banana-2.mdx
+++ b/apps/docs/v1/model-migrations/google-nano-banana-1-to-nano-banana-2.mdx
@@ -1,16 +1,16 @@
 ---
 title: "Google Nano Banana 2"
-description: "What actually changes when image workflows move from Nano Banana 1 to Nano Banana 2."
+description: "What to know when adopting Nano Banana 2 for production image generation and editing."
 icon: "/icons/brands/google.svg"
 ---
 
 # Google Nano Banana 2
 
-Use this guide when you are replacing an older Nano Banana workflow with Nano Banana 2.
+Use this guide to adopt Nano Banana 2 safely in production image workflows.
 
 Nano Banana 2 is not only a quality upgrade. Google positions it as a production-ready image model with broader control over output format, resolution, and fidelity.
 
-## What changed
+## What's new
 
 - Nano Banana 2 adds explicit control over aspect ratios
 - output resolutions now range from `512px` to `4K`

--- a/apps/docs/v1/model-migrations/google-nano-banana-1-to-nano-banana-2.mdx
+++ b/apps/docs/v1/model-migrations/google-nano-banana-1-to-nano-banana-2.mdx
@@ -1,10 +1,10 @@
 ---
-title: "Google: Nano Banana 1 to Nano Banana 2"
+title: "Google Nano Banana 2"
 description: "What actually changes when image workflows move from Nano Banana 1 to Nano Banana 2."
 icon: "/icons/brands/google.svg"
 ---
 
-# Google: Nano Banana 1 to Nano Banana 2
+# Google Nano Banana 2
 
 Use this guide when you are replacing an older Nano Banana workflow with Nano Banana 2.
 
@@ -19,7 +19,7 @@ Nano Banana 2 is not only a quality upgrade. Google positions it as a production
 - text rendering and translation inside images are better
 - visual fidelity is higher while generation remains fast
 
-## What to change in your integration
+## Migration quickstart
 
 ### 1. Re-check output assumptions
 

--- a/apps/docs/v1/model-migrations/index.mdx
+++ b/apps/docs/v1/model-migrations/index.mdx
@@ -15,33 +15,23 @@ These pages focus on the changes that usually break real integrations first:
 - structured output and tool-calling regressions
 - rollout, fallback, and rollback strategy
 
-## Available guides
+## Model guides
 
-- [Anthropic: Claude Opus 4.1 to 4.8](./anthropic-claude-opus-4-1-to-4-8)
-- [Anthropic: Claude Opus 4.6 to 4.7](./anthropic-claude-opus-4-6-to-4-7)
-- [Anthropic: Claude Opus 4.5 to 4.6](./anthropic-claude-opus-4-5-to-4-6)
-- [Anthropic: Claude Sonnet 4.5 to 4.6](./anthropic-claude-sonnet-4-5-to-4-6)
-- [OpenAI: Migrating to GPT-5.6](./openai-migrating-to-gpt-5-6)
-- [OpenAI: Migrating to GPT-5.4](./openai-migrating-to-gpt-5-4)
-- [Google: Migrating to Gemini 3 and 3.1](./google-migrating-to-gemini-3-and-3-1)
-- [Google: Nano Banana 1 to Nano Banana 2](./google-nano-banana-1-to-nano-banana-2)
-- [Mistral: Mistral Small 3.2 to Mistral Small 4](./mistral-small-3-2-to-mistral-small-4)
-- [SpaceXAI: Grok 4.20](./xai-grok-4-20)
+Guides are ordered by the target model's release date, with the newest first.
 
-## Release timeline
-
-| Guide | Model release date |
-| --- | --- |
-| [Anthropic: Claude Opus 4.1 to 4.8](./anthropic-claude-opus-4-1-to-4-8) | May 28, 2026 |
-| [Anthropic: Claude Opus 4.6 to 4.7](./anthropic-claude-opus-4-6-to-4-7) | April 16, 2026 |
-| [Anthropic: Claude Opus 4.5 to 4.6](./anthropic-claude-opus-4-5-to-4-6) | February 5, 2026 |
-| [Anthropic: Claude Sonnet 4.5 to 4.6](./anthropic-claude-sonnet-4-5-to-4-6) | February 17, 2026 |
-| [OpenAI: Migrating to GPT-5.6](./openai-migrating-to-gpt-5-6) | Current OpenAI GPT family |
-| [OpenAI: Migrating to GPT-5.4](./openai-migrating-to-gpt-5-4) | March 5, 2026 |
-| [Google: Migrating to Gemini 3 and 3.1](./google-migrating-to-gemini-3-and-3-1) | Gemini 3: November 25, 2025; Gemini 3.1 Pro: February 19, 2026 |
-| [Google: Nano Banana 1 to Nano Banana 2](./google-nano-banana-1-to-nano-banana-2) | February 26, 2026 |
-| [Mistral: Mistral Small 3.2 to Mistral Small 4](./mistral-small-3-2-to-mistral-small-4) | March 16, 2026 |
-| [SpaceXAI: Grok 4.20](./xai-grok-4-20) | February 17, 2026 |
+| Model | Released | Upgrade from |
+| --- | --- | --- |
+| [Anthropic Claude Opus 5](./anthropic-claude-opus-5) | July 24, 2026 | Claude Opus 4.8 |
+| [OpenAI GPT-5.6](./openai-migrating-to-gpt-5-6) | July 9, 2026 | Earlier GPT-5 models |
+| [Anthropic Claude Opus 4.8](./anthropic-claude-opus-4-1-to-4-8) | May 28, 2026 | Claude Opus 4.1 |
+| [Anthropic Claude Opus 4.7](./anthropic-claude-opus-4-6-to-4-7) | April 16, 2026 | Claude Opus 4.6 |
+| [Mistral Small 4](./mistral-small-3-2-to-mistral-small-4) | March 16, 2026 | Mistral Small 3.2 |
+| [OpenAI GPT-5.4](./openai-migrating-to-gpt-5-4) | March 5, 2026 | GPT-4.1 and earlier GPT-5 models |
+| [Google Nano Banana 2](./google-nano-banana-1-to-nano-banana-2) | February 26, 2026 | Nano Banana 1 |
+| [Google Gemini 3.1](./google-migrating-to-gemini-3-and-3-1) | February 19, 2026 | Earlier Gemini models |
+| [Anthropic Claude Sonnet 4.6](./anthropic-claude-sonnet-4-5-to-4-6) | February 17, 2026 | Claude Sonnet 4.5 |
+| [SpaceXAI Grok 4.20](./xai-grok-4-20) | February 17, 2026 | Earlier Grok 4 models |
+| [Anthropic Claude Opus 4.6](./anthropic-claude-opus-4-5-to-4-6) | February 5, 2026 | Claude Opus 4.5 |
 
 ## How to use this section
 

--- a/apps/docs/v1/model-migrations/index.mdx
+++ b/apps/docs/v1/model-migrations/index.mdx
@@ -1,7 +1,7 @@
 ---
 icon: "compass"
 title: "Model Migrations"
-description: "Model-specific upgrade guides for moving production traffic from an older model release to a newer one."
+description: "Model-specific guidance for adopting new model releases safely in production."
 ---
 
 # Model Migrations
@@ -19,19 +19,19 @@ These pages focus on the changes that usually break real integrations first:
 
 Guides are ordered by the target model's release date, with the newest first.
 
-| Model | Released | Upgrade from |
+| Model | Released | Useful for |
 | --- | --- | --- |
-| [Anthropic Claude Opus 5](./anthropic-claude-opus-5) | July 24, 2026 | Claude Opus 4.8 |
-| [OpenAI GPT-5.6](./openai-migrating-to-gpt-5-6) | July 9, 2026 | Earlier GPT-5 models |
-| [Anthropic Claude Opus 4.8](./anthropic-claude-opus-4-1-to-4-8) | May 28, 2026 | Claude Opus 4.1 |
-| [Anthropic Claude Opus 4.7](./anthropic-claude-opus-4-6-to-4-7) | April 16, 2026 | Claude Opus 4.6 |
-| [Mistral Small 4](./mistral-small-3-2-to-mistral-small-4) | March 16, 2026 | Mistral Small 3.2 |
-| [OpenAI GPT-5.4](./openai-migrating-to-gpt-5-4) | March 5, 2026 | GPT-4.1 and earlier GPT-5 models |
-| [Google Nano Banana 2](./google-nano-banana-1-to-nano-banana-2) | February 26, 2026 | Nano Banana 1 |
-| [Google Gemini 3.1](./google-migrating-to-gemini-3-and-3-1) | February 19, 2026 | Earlier Gemini models |
-| [Anthropic Claude Sonnet 4.6](./anthropic-claude-sonnet-4-5-to-4-6) | February 17, 2026 | Claude Sonnet 4.5 |
-| [SpaceXAI Grok 4.20](./xai-grok-4-20) | February 17, 2026 | Earlier Grok 4 models |
-| [Anthropic Claude Opus 4.6](./anthropic-claude-opus-4-5-to-4-6) | February 5, 2026 | Claude Opus 4.5 |
+| [Anthropic Claude Opus 5](./anthropic-claude-opus-5) | July 24, 2026 | Complex reasoning and long-horizon agents |
+| [OpenAI GPT-5.6](./openai-migrating-to-gpt-5-6) | July 9, 2026 | Tiered reasoning, coding, and professional work |
+| [Anthropic Claude Opus 4.8](./anthropic-claude-opus-4-1-to-4-8) | May 28, 2026 | Long context and adaptive thinking |
+| [Anthropic Claude Opus 4.7](./anthropic-claude-opus-4-6-to-4-7) | April 16, 2026 | High-effort reasoning with stricter request controls |
+| [Mistral Small 4](./mistral-small-3-2-to-mistral-small-4) | March 16, 2026 | Efficient workloads with optional reasoning |
+| [OpenAI GPT-5.4](./openai-migrating-to-gpt-5-4) | March 5, 2026 | Reasoning, vision, and computer use |
+| [Google Nano Banana 2](./google-nano-banana-1-to-nano-banana-2) | February 26, 2026 | Production image generation and editing |
+| [Google Gemini 3.1](./google-migrating-to-gemini-3-and-3-1) | February 19, 2026 | Multimodal and reasoning-heavy workloads |
+| [Anthropic Claude Sonnet 4.6](./anthropic-claude-sonnet-4-5-to-4-6) | February 17, 2026 | Coding, computer use, and agent planning |
+| [SpaceXAI Grok 4.20](./xai-grok-4-20) | February 17, 2026 | Reasoning and multi-agent workloads |
+| [Anthropic Claude Opus 4.6](./anthropic-claude-opus-4-5-to-4-6) | February 5, 2026 | Long-running coding and agentic tasks |
 
 ## How to use this section
 

--- a/apps/docs/v1/model-migrations/mistral-small-3-2-to-mistral-small-4.mdx
+++ b/apps/docs/v1/model-migrations/mistral-small-3-2-to-mistral-small-4.mdx
@@ -1,10 +1,10 @@
 ---
-title: "Mistral: Mistral Small 3.2 to Mistral Small 4"
+title: "Mistral Small 4"
 description: "Gateway migration notes for upgrading Mistral Small traffic to Mistral Small 4, including reasoning_effort behavior."
 icon: "/icons/brands/mistral.svg"
 ---
 
-# Mistral: Mistral Small 3.2 to Mistral Small 4
+# Mistral Small 4
 
 Use this guide when migrating Mistral Small routes to:
 
@@ -24,7 +24,7 @@ Previous common route:
   - `message.content` for assistant-visible text
   - `message.reasoning_content` and `message.reasoning_details` for reasoning text
 
-## Required request changes
+## Migration quickstart
 
 Reasoning defaults to off for this route.
 

--- a/apps/docs/v1/model-migrations/mistral-small-3-2-to-mistral-small-4.mdx
+++ b/apps/docs/v1/model-migrations/mistral-small-3-2-to-mistral-small-4.mdx
@@ -1,20 +1,16 @@
 ---
 title: "Mistral Small 4"
-description: "Gateway migration notes for upgrading Mistral Small traffic to Mistral Small 4, including reasoning_effort behavior."
+description: "What to know when adopting Mistral Small 4, including reasoning controls and normalized response fields."
 icon: "/icons/brands/mistral.svg"
 ---
 
 # Mistral Small 4
 
-Use this guide when migrating Mistral Small routes to:
+Use this guide to adopt Mistral Small 4 safely through the Phaseo Gateway:
 
 - `mistral/mistral-small-4-2026-03-16`
 
-Previous common route:
-
-- `mistral/mistral-small-3-2-2025-06-20`
-
-## What changed
+## What's new
 
 - Mistral Small 4 exposes a reasoning mode control via `reasoning_effort`.
 - Gateway sends only two upstream values for this model route:

--- a/apps/docs/v1/model-migrations/openai-migrating-to-gpt-5-4.mdx
+++ b/apps/docs/v1/model-migrations/openai-migrating-to-gpt-5-4.mdx
@@ -1,14 +1,12 @@
 ---
 title: "OpenAI GPT-5.4"
-description: "What materially changes when you move existing OpenAI traffic onto GPT-5.4."
+description: "What to know when adopting GPT-5.4, including reasoning controls, vision, and computer use."
 icon: "/icons/brands/openai.svg"
 ---
 
 # OpenAI GPT-5.4
 
-Use this guide when you are moving existing traffic onto `openai/gpt-5.4`.
-
-This usually means replacing older OpenAI routes such as GPT-4.1, GPT-5, or an earlier GPT-5.x release.
+Use this guide to adopt `openai/gpt-5.4` safely in production.
 
 GPT-5.4 is less about a brand-new request shape and more about updated reasoning controls, vision handling, and tool use. As of March 10, 2026, OpenAI's official GPT-5.4 docs emphasize `reasoning.effort`, improved computer use, and higher-fidelity image input. They do not document a GPT-5.4-specific `phase` parameter.
 
@@ -19,7 +17,7 @@ GPT-5.4 is less about a brand-new request shape and more about updated reasoning
 3. Re-test vision, structured outputs, and computer-use workflows where applicable.
 4. Canary GPT-5.4 with the previous route available as a fallback.
 
-## What changed
+## What's new
 
 - `reasoning.effort` supports `none`, `low`, `medium`, `high`, and `xhigh`
 - GPT-5.4 introduces `original` image input detail for full-fidelity visual perception

--- a/apps/docs/v1/model-migrations/openai-migrating-to-gpt-5-4.mdx
+++ b/apps/docs/v1/model-migrations/openai-migrating-to-gpt-5-4.mdx
@@ -1,16 +1,23 @@
 ---
-title: "OpenAI: Migrating to GPT-5.4"
+title: "OpenAI GPT-5.4"
 description: "What materially changes when you move existing OpenAI traffic onto GPT-5.4."
 icon: "/icons/brands/openai.svg"
 ---
 
-# OpenAI: Migrating to GPT-5.4
+# OpenAI GPT-5.4
 
 Use this guide when you are moving existing traffic onto `openai/gpt-5.4`.
 
 This usually means replacing older OpenAI routes such as GPT-4.1, GPT-5, or an earlier GPT-5.x release.
 
 GPT-5.4 is less about a brand-new request shape and more about updated reasoning controls, vision handling, and tool use. As of March 10, 2026, OpenAI's official GPT-5.4 docs emphasize `reasoning.effort`, improved computer use, and higher-fidelity image input. They do not document a GPT-5.4-specific `phase` parameter.
+
+## Migration quickstart
+
+1. Change the model ID to `openai/gpt-5.4` without changing the rest of the request.
+2. Choose and test the reasoning effort that matches the route's latency budget.
+3. Re-test vision, structured outputs, and computer-use workflows where applicable.
+4. Canary GPT-5.4 with the previous route available as a fallback.
 
 ## What changed
 

--- a/apps/docs/v1/model-migrations/openai-migrating-to-gpt-5-6.mdx
+++ b/apps/docs/v1/model-migrations/openai-migrating-to-gpt-5-6.mdx
@@ -1,12 +1,12 @@
 ---
 title: "OpenAI GPT-5.6"
-description: "What to review before moving GPT-5.x traffic to GPT-5.6 Sol, Terra, or Luna."
+description: "What to know when adopting GPT-5.6 Sol, Terra, or Luna for production workloads."
 icon: "/icons/brands/openai.svg"
 ---
 
 # OpenAI GPT-5.6
 
-Use this guide when you are preparing existing OpenAI traffic for GPT-5.6.
+Use this guide to adopt the GPT-5.6 family safely in production.
 
 GPT-5.6 is the current OpenAI GPT family for complex production workflows. In AI Stats, the fixed tier IDs map to the OpenAI model IDs `gpt-5.6-sol`, `gpt-5.6-terra`, and `gpt-5.6-luna`.
 
@@ -29,7 +29,7 @@ OpenAI's `gpt-5.6` alias routes to `gpt-5.6-sol`. In AI Stats, use `openai/gpt-5
 
 AI Stats also tracks tier aliases for the latest model in each tier: `openai/gpt-sol-latest`, `openai/gpt-terra-latest`, and `openai/gpt-luna-latest`. Use the fixed GPT-5.6 IDs for controlled migrations, and use the tier aliases only when you deliberately want future Sol, Terra, or Luna releases to roll forward through the same route.
 
-## What changed
+## What's new
 
 - GPT-5.6 adds the new Sol/Terra/Luna split instead of one default GPT route.
 - All three GPT-5.6 tiers support `reasoning.effort: "max"` for the highest reasoning budget.
@@ -141,7 +141,7 @@ Use `cache_control` when you want provider-neutral cache hints or explicit cache
 ### Cost and latency
 
 - latency at each reasoning effort
-- output token growth when moving from older GPT-5.x models
+- output token growth relative to your current production baseline
 - cache read/write mix on repeated prompts
 - cost per successful task, not just price per token
 

--- a/apps/docs/v1/model-migrations/openai-migrating-to-gpt-5-6.mdx
+++ b/apps/docs/v1/model-migrations/openai-migrating-to-gpt-5-6.mdx
@@ -1,16 +1,23 @@
 ---
-title: "OpenAI: Migrating to GPT-5.6"
+title: "OpenAI GPT-5.6"
 description: "What to review before moving GPT-5.x traffic to GPT-5.6 Sol, Terra, or Luna."
 icon: "/icons/brands/openai.svg"
 ---
 
-# OpenAI: Migrating to GPT-5.6
+# OpenAI GPT-5.6
 
 Use this guide when you are preparing existing OpenAI traffic for GPT-5.6.
 
 GPT-5.6 is the current OpenAI GPT family for complex production workflows. In AI Stats, the fixed tier IDs map to the OpenAI model IDs `gpt-5.6-sol`, `gpt-5.6-terra`, and `gpt-5.6-luna`.
 
-## Choose the right GPT-5.6 model
+## Migration quickstart
+
+1. Choose the fixed Sol, Terra, or Luna model that matches the workload.
+2. Swap only the model ID and keep the rest of the request stable.
+3. Re-test reasoning effort, structured outputs, tools, latency, and task cost.
+4. Canary the new route with your previous GPT-5 model available as a fallback.
+
+## Choose a model
 
 | Model | Use it for | Reasoning effort |
 | --- | --- | --- |

--- a/apps/docs/v1/model-migrations/xai-grok-4-20.mdx
+++ b/apps/docs/v1/model-migrations/xai-grok-4-20.mdx
@@ -1,10 +1,10 @@
 ---
-title: "SpaceXAI: Grok 4.20"
+title: "SpaceXAI Grok 4.20"
 description: "Gateway-focused migration notes for Grok 4.20, including reasoning toggle and multi-agent effort controls."
 icon: "/icons/brands/grok.svg"
 ---
 
-# SpaceXAI: Grok 4.20
+# SpaceXAI Grok 4.20
 
 Use this guide when you are moving traffic onto Grok 4.20 through the Phaseo Gateway.
 
@@ -16,7 +16,7 @@ Optional multi-agent route exposed by provider model ID:
 
 - `spacex-ai/grok-4.20-multi-agent-beta-0309`
 
-## Migration requirement
+## Migration quickstart
 
 For most integrations, there is no required migration work beyond updating the model ID and re-running your normal validation set.
 

--- a/apps/docs/v1/model-migrations/xai-grok-4-20.mdx
+++ b/apps/docs/v1/model-migrations/xai-grok-4-20.mdx
@@ -1,12 +1,12 @@
 ---
 title: "SpaceXAI Grok 4.20"
-description: "Gateway-focused migration notes for Grok 4.20, including reasoning toggle and multi-agent effort controls."
+description: "What to know when adopting Grok 4.20, including reasoning and multi-agent effort controls."
 icon: "/icons/brands/grok.svg"
 ---
 
 # SpaceXAI Grok 4.20
 
-Use this guide when you are moving traffic onto Grok 4.20 through the Phaseo Gateway.
+Use this guide to adopt Grok 4.20 safely through the Phaseo Gateway.
 
 Primary route in our catalog:
 
@@ -22,7 +22,7 @@ For most integrations, there is no required migration work beyond updating the m
 
 Existing request and response patterns can remain the same.
 
-## What changed
+## What's new
 
 For the base Grok 4.20 route, there is no behavior change you need to migrate for in Phaseo Gateway.
 


### PR DESCRIPTION
## Summary

- add an Overview guide that explains when to use the Phaseo CLI, authenticated Phaseo MCP, or Docs MCP
- rename model migration guides around their destination model
- order the model migration index and sidebar by release date, newest first
- frame each guide around adopting the target model without assuming a fixed source model
- add a Claude Opus 5 guide and concise migration quickstarts
- surface the most useful capability and compatibility details for each model

## Validation

- `pnpm docs:links`
- `pnpm docs:build`
- `git diff --check`

Created with Codex