### PR TITLE
Persist upstream request attempts

### DIFF
--- a/apps/api/src/pipeline/audit/index.test.ts
+++ b/apps/api/src/pipeline/audit/index.test.ts
@@ -7,6 +7,7 @@ const ensureAppIdMock = vi.fn();
 const syncWorkspaceUsageRollupForRequestMock = vi.fn();
 const resolveGatewayIoLoggingPolicyMock = vi.fn();
 const persistGatewayIoLogMock = vi.fn();
+const persistGatewayUpstreamRequestsMock = vi.fn();
 
 vi.mock("@/runtime/env", () => ({
 	getSupabaseAdmin: (...args: any[]) => getSupabaseAdminMock(...args),
@@ -28,6 +29,10 @@ vi.mock("./io-logging", () => ({
 	persistGatewayIoLog: (...args: any[]) => persistGatewayIoLogMock(...args),
 }));
 
+vi.mock("./upstream-requests", () => ({
+	persistGatewayUpstreamRequests: (...args: any[]) => persistGatewayUpstreamRequestsMock(...args),
+}));
+
 import { auditFailure, auditSuccess } from "./index";
 
 describe("audit request detail persistence", () => {
@@ -39,6 +44,8 @@ describe("audit request detail persistence", () => {
 		syncWorkspaceUsageRollupForRequestMock.mockReset();
 		resolveGatewayIoLoggingPolicyMock.mockReset();
 		persistGatewayIoLogMock.mockReset();
+		persistGatewayUpstreamRequestsMock.mockReset();
+		persistGatewayUpstreamRequestsMock.mockResolvedValue(undefined);
 		ensureRuntimeForBackgroundMock.mockReturnValue(() => {});
 		isLocalTestingModeEnabledMock.mockReturnValue(false);
 		ensureAppIdMock.mockResolvedValue("app_resolved");
@@ -410,6 +417,12 @@ describe("audit request detail persistence", () => {
 
 		expect(fromMock).toHaveBeenCalledTimes(1);
 		expect(fromMock).toHaveBeenCalledWith("gateway_requests");
+		expect(persistGatewayUpstreamRequestsMock).toHaveBeenCalledWith(
+			expect.objectContaining({
+				requestId: "req_no_io",
+				provider: "openai",
+			}),
+		);
 		expect(rpcMock).toHaveBeenCalledOnce();
 		expect(rpcMock.mock.calls[0]?.[0]).toBe("ingest_v2_gateway_request_with_routing");
 		const event = rpcMock.mock.calls[0]?.[1]?.p_event;

--- a/apps/api/src/pipeline/audit/index.ts
+++ b/apps/api/src/pipeline/audit/index.ts
@@ -13,6 +13,7 @@ import {
 	stripGatewayRequestUsageColumns,
 } from "../usage-columns";
 import { persistGatewayIoLog, resolveGatewayIoLoggingPolicy } from "./io-logging";
+import { persistGatewayUpstreamRequests } from "./upstream-requests";
 
 function supaAdmin() {
     return getSupabaseAdmin();
@@ -782,6 +783,32 @@ export async function auditSuccess(args: {
                 "supabase_audit_success_insert",
             );
             await syncInsertedRequestRollup(insertedRow, "audit_success");
+            await persistGatewayUpstreamRequests({
+                insertedRow,
+                requestId: args.requestId,
+                workspaceId: args.workspaceId,
+                appId,
+                keyId: args.keyId ?? null,
+                endpoint: args.endpoint,
+                modelId: args.model,
+                provider: args.provider,
+                providerApiModelId: args.providerApiModelId ?? null,
+                providerModelSlug: args.providerModelSlug ?? null,
+                providerAttempts: args.providerAttempts ?? null,
+                statusCode: args.statusCode,
+                success: true,
+                nativeResponseId: args.nativeResponseId ?? null,
+                finishReason: args.finishReason ?? null,
+                usage: strippedUsage,
+                totalNanos: args.totalNanos ?? (
+                    Number.isFinite(args.totalCents) ? Math.round(args.totalCents * 1e7) : null
+                ),
+                currency: args.currency,
+                latencyMs: args.latencyMs ?? null,
+                generationMs: args.generationMs ?? null,
+                totalMs: args.endToEndMs ?? args.latencyMs ?? null,
+                context: "audit_success",
+            });
             let v2PersistenceError: Error | null = null;
             try {
                 await retryWithBackoff(() => upsertV2RequestFact({
@@ -1055,6 +1082,22 @@ export async function auditFailure(args: AuditFailureBefore | AuditFailureExecut
                         "supabase_audit_failure_before_insert",
                     );
                     await syncInsertedRequestRollup(insertedRow, "audit_failure_before");
+                    await persistGatewayUpstreamRequests({
+                        insertedRow,
+                        requestId: args.requestId,
+                        workspaceId: args.workspaceId,
+                        appId: resolvedAppId,
+                        keyId: args.keyId ?? null,
+                        endpoint: args.endpoint,
+                        modelId: args.requestedModel ?? args.model ?? "unknown",
+                        providerAttempts: args.providerAttempts ?? null,
+                        statusCode: args.statusCode,
+                        success: false,
+                        totalNanos: 0,
+                        latencyMs: args.latencyMs ?? null,
+                        totalMs: args.latencyMs ?? null,
+                        context: "audit_failure_before",
+                    });
                     let v2PersistenceError: Error | null = null;
                     try {
                         await retryWithBackoff(() => upsertV2RequestFact({
@@ -1203,6 +1246,28 @@ export async function auditFailure(args: AuditFailureBefore | AuditFailureExecut
                     "supabase_audit_failure_execute_insert",
                 );
                 await syncInsertedRequestRollup(insertedRow, "audit_failure_execute");
+                await persistGatewayUpstreamRequests({
+                    insertedRow,
+                    requestId: args.requestId,
+                    workspaceId: args.workspaceId,
+                    appId: resolvedAppId,
+                    keyId: args.keyId ?? null,
+                    endpoint: args.endpoint,
+                    modelId: args.model,
+                    provider: args.provider ?? null,
+                    providerApiModelId: args.providerApiModelId ?? null,
+                    providerModelSlug: args.providerModelSlug ?? null,
+                    providerAttempts: args.providerAttempts ?? null,
+                    statusCode: args.statusCode,
+                    success: false,
+                    usage: args.usage ?? {},
+                    totalNanos: 0,
+                    currency: args.currency ?? null,
+                    latencyMs: args.latencyMs ?? null,
+                    generationMs: args.generationMs ?? null,
+                    totalMs: args.latencyMs ?? null,
+                    context: "audit_failure_execute",
+                });
                 let v2PersistenceError: Error | null = null;
                 try {
                     await retryWithBackoff(() => upsertV2RequestFact({

--- a/apps/api/src/pipeline/audit/upstream-requests.test.ts
+++ b/apps/api/src/pipeline/audit/upstream-requests.test.ts
@@ -1,0 +1,130 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const fromMock = vi.fn();
+
+vi.mock("@/runtime/env", () => ({
+    getSupabaseAdmin: () => ({ from: fromMock }),
+}));
+
+import { persistGatewayUpstreamRequests } from "./upstream-requests";
+
+describe("persistGatewayUpstreamRequests", () => {
+    beforeEach(() => {
+        fromMock.mockReset();
+    });
+
+    it("persists ordered retry and failover rows with the parent total on the final success", async () => {
+        const insertMock = vi.fn().mockResolvedValue({ error: null });
+        fromMock.mockReturnValue({ insert: insertMock });
+
+        await persistGatewayUpstreamRequests({
+            insertedRow: {
+                id: "request-row-id",
+                created_at: "2026-07-26T12:00:00.000Z",
+                workspace_id: "workspace-id",
+            },
+            requestId: "request-id",
+            workspaceId: "workspace-id",
+            appId: "app-id",
+            keyId: "key-id",
+            endpoint: "responses",
+            modelId: "openai/gpt-5.4-mini",
+            provider: "openai",
+            providerApiModelId: "openai:gpt-5.4-mini",
+            providerModelSlug: "gpt-5.4-mini",
+            providerAttempts: [
+                {
+                    attempt_number: 1,
+                    provider: "provider-a",
+                    model: "openai/gpt-5.4-mini",
+                    outcome: "upstream_non_2xx",
+                    status: 429,
+                    duration_ms: 35,
+                    retryable: true,
+                    upstream_error_code: "rate_limit",
+                },
+                {
+                    attempt_number: 2,
+                    provider: "openai",
+                    model: "openai/gpt-5.4-mini",
+                    outcome: "success",
+                    status: 200,
+                    duration_ms: 42,
+                },
+            ],
+            statusCode: 200,
+            success: true,
+            nativeResponseId: "resp_123",
+            finishReason: "stop",
+            usage: { input_tokens: 20, output_tokens: 10, total_tokens: 30 },
+            totalNanos: 125_000,
+            currency: "USD",
+            latencyMs: 180,
+            generationMs: 150,
+            totalMs: 210,
+            context: "test",
+        });
+
+        expect(fromMock).toHaveBeenCalledWith("gateway_upstream_requests");
+        expect(insertMock).toHaveBeenCalledTimes(1);
+        const rows = insertMock.mock.calls[0][0];
+        expect(rows).toHaveLength(2);
+        expect(rows[0]).toMatchObject({
+            sequence: 1,
+            provider: "provider-a",
+            status_code: 429,
+            success: false,
+            cost_nanos: 0,
+            total_ms: 35,
+            error_code: "rate_limit",
+        });
+        expect(rows[1]).toMatchObject({
+            sequence: 2,
+            provider: "openai",
+            status_code: 200,
+            success: true,
+            native_response_id: "resp_123",
+            finish_reason: "stop",
+            duration_ms: 42,
+            latency_ms: 180,
+            generation_ms: 150,
+            total_ms: 210,
+            cost_nanos: 125_000,
+            usage: { input_tokens: 20, output_tokens: 10, total_tokens: 30 },
+        });
+    });
+
+    it("creates a synthetic final row when routing attempts are unavailable", async () => {
+        const insertMock = vi.fn().mockResolvedValue({ error: null });
+        fromMock.mockReturnValue({ insert: insertMock });
+
+        await persistGatewayUpstreamRequests({
+            insertedRow: {
+                id: "request-row-id",
+                created_at: "2026-07-26T12:00:00.000Z",
+                workspace_id: "workspace-id",
+            },
+            requestId: "request-id",
+            workspaceId: "workspace-id",
+            endpoint: "chat.completions",
+            modelId: "anthropic/claude-sonnet-4.5",
+            provider: "anthropic",
+            statusCode: 200,
+            success: true,
+            totalNanos: 50,
+            totalMs: 90,
+            context: "test",
+        });
+
+        expect(insertMock.mock.calls[0][0]).toEqual([
+            expect.objectContaining({
+                sequence: 1,
+                attempt_number: 1,
+                provider: "anthropic",
+                success: true,
+                cost_nanos: 50,
+                total_ms: 90,
+            }),
+        ]);
+    });
+});

--- a/apps/api/src/pipeline/audit/upstream-requests.test.ts
+++ b/apps/api/src/pipeline/audit/upstream-requests.test.ts
@@ -121,9 +121,54 @@ describe("persistGatewayUpstreamRequests", () => {
                 sequence: 1,
                 attempt_number: 1,
                 provider: "anthropic",
+                status_code: 200,
                 success: true,
                 cost_nanos: 50,
                 total_ms: 90,
+            }),
+        ]);
+    });
+
+    it("does not turn missing metrics or a gateway error status into upstream observations", async () => {
+        const insertMock = vi.fn().mockResolvedValue({ error: null });
+        fromMock.mockReturnValue({ insert: insertMock });
+
+        await persistGatewayUpstreamRequests({
+            insertedRow: {
+                id: "request-row-id",
+                created_at: "2026-07-26T12:00:00.000Z",
+                workspace_id: "workspace-id",
+            },
+            requestId: "request-id",
+            workspaceId: "workspace-id",
+            endpoint: "responses",
+            modelId: "openai/gpt-5.4-mini",
+            provider: "provider-a",
+            providerAttempts: [{
+                attempt_number: 1,
+                provider: "provider-a",
+                model: "openai/gpt-5.4-mini",
+                outcome: "blocked",
+                status: null,
+                duration_ms: "",
+                request_build_ms: null,
+            }],
+            statusCode: 503,
+            success: false,
+            latencyMs: null,
+            generationMs: null,
+            totalMs: null,
+            context: "test",
+        });
+
+        expect(insertMock.mock.calls[0][0]).toEqual([
+            expect.objectContaining({
+                status_code: null,
+                duration_ms: null,
+                latency_ms: null,
+                generation_ms: null,
+                total_ms: null,
+                request_build_ms: null,
             }),
         ]);
     });

--- a/apps/api/src/pipeline/audit/upstream-requests.ts
+++ b/apps/api/src/pipeline/audit/upstream-requests.ts
@@ -58,6 +58,7 @@ function isMissingTableError(error: unknown): boolean {
 }
 
 function finiteInteger(value: unknown): number | null {
+    if (value == null || (typeof value === "string" && value.trim() === "")) return null;
     const parsed = Number(value);
     return Number.isFinite(parsed) ? Math.round(parsed) : null;
 }
@@ -88,6 +89,8 @@ function buildAttempts(args: PersistGatewayUpstreamRequestsArgs): ProviderAttemp
 
 function buildRows(args: PersistGatewayUpstreamRequestsArgs) {
     const attempts = buildAttempts(args);
+    const hasRecordedAttempts = Array.isArray(args.providerAttempts)
+        && args.providerAttempts.some((attempt) => attempt && typeof attempt === "object");
     let finalAttemptIndex = -1;
     for (let index = attempts.length - 1; index >= 0; index -= 1) {
         if (isSuccessfulAttempt(attempts[index])) {
@@ -105,7 +108,7 @@ function buildRows(args: PersistGatewayUpstreamRequestsArgs) {
     return attempts.map((attempt, index) => {
         const isFinal = index === finalAttemptIndex;
         const statusCode = finiteInteger(attempt.status)
-            ?? (isFinal ? finiteInteger(args.statusCode) : null);
+            ?? (!hasRecordedAttempts && isFinal ? finiteInteger(args.statusCode) : null);
         const success = isSuccessfulAttempt(attempt)
             || (isFinal && args.success);
         const outcome = typeof attempt.outcome === "string"

--- a/apps/api/src/pipeline/audit/upstream-requests.ts
+++ b/apps/api/src/pipeline/audit/upstream-requests.ts
@@ -1,0 +1,237 @@
+// Purpose: Persist normalized provider interactions beneath one gateway request.
+// Why: Makes retries and failover queryable without inflating the parent request row.
+
+import type { Endpoint } from "@core/types";
+import { getSupabaseAdmin } from "@/runtime/env";
+
+let tableAvailable: boolean | null = null;
+let warnedMissingTable = false;
+
+type ProviderAttempt = Record<string, unknown>;
+
+export type PersistGatewayUpstreamRequestsArgs = {
+    insertedRow: { id: string; created_at: string; workspace_id: string };
+    requestId: string;
+    workspaceId: string;
+    appId?: string | null;
+    keyId?: string | null;
+    endpoint: Endpoint;
+    modelId: string;
+    provider?: string | null;
+    providerApiModelId?: string | null;
+    providerModelSlug?: string | null;
+    providerAttempts?: ProviderAttempt[] | null;
+    statusCode?: number | null;
+    success: boolean;
+    nativeResponseId?: string | null;
+    finishReason?: string | null;
+    usage?: unknown;
+    totalNanos?: number | null;
+    currency?: string | null;
+    latencyMs?: number | null;
+    generationMs?: number | null;
+    totalMs?: number | null;
+    context: string;
+};
+
+function normalizeJsonValue(value: unknown): unknown {
+    if (value == null) return null;
+    if (["string", "number", "boolean"].includes(typeof value)) return value;
+    try {
+        return JSON.parse(JSON.stringify(value));
+    } catch {
+        return null;
+    }
+}
+
+function isMissingTableError(error: unknown): boolean {
+    const candidate = error && typeof error === "object"
+        ? error as Record<string, unknown>
+        : null;
+    const cause = candidate?.cause && typeof candidate.cause === "object"
+        ? candidate.cause as Record<string, unknown>
+        : null;
+    const code = String(cause?.code ?? candidate?.code ?? "");
+    const message = String(cause?.message ?? candidate?.message ?? "").toLowerCase();
+    return (code === "PGRST205" || code === "42P01")
+        && message.includes("gateway_upstream_requests");
+}
+
+function finiteInteger(value: unknown): number | null {
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? Math.round(parsed) : null;
+}
+
+function isSuccessfulAttempt(attempt: ProviderAttempt): boolean {
+    const status = finiteInteger(attempt.status);
+    return attempt.outcome === "success"
+        || (status != null && status >= 200 && status < 300);
+}
+
+function buildAttempts(args: PersistGatewayUpstreamRequestsArgs): ProviderAttempt[] {
+    const attempts = Array.isArray(args.providerAttempts)
+        ? args.providerAttempts.filter((attempt) => attempt && typeof attempt === "object")
+        : [];
+    if (attempts.length > 0) return attempts;
+    if (!args.provider) return [];
+    return [{
+        attempt_number: 1,
+        provider: args.provider,
+        model: args.modelId,
+        api_model_id: args.providerApiModelId ?? null,
+        provider_model_slug: args.providerModelSlug ?? null,
+        outcome: args.success ? "success" : "error",
+        status: args.statusCode ?? null,
+        duration_ms: args.totalMs ?? args.latencyMs ?? null,
+    }];
+}
+
+function buildRows(args: PersistGatewayUpstreamRequestsArgs) {
+    const attempts = buildAttempts(args);
+    let finalAttemptIndex = -1;
+    for (let index = attempts.length - 1; index >= 0; index -= 1) {
+        if (isSuccessfulAttempt(attempts[index])) {
+            finalAttemptIndex = index;
+            break;
+        }
+    }
+    if (finalAttemptIndex < 0 && attempts.length > 0) {
+        finalAttemptIndex = attempts.length - 1;
+    }
+    const totalNanos = Number.isFinite(Number(args.totalNanos))
+        ? Math.max(0, Math.round(Number(args.totalNanos)))
+        : 0;
+
+    return attempts.map((attempt, index) => {
+        const isFinal = index === finalAttemptIndex;
+        const statusCode = finiteInteger(attempt.status)
+            ?? (isFinal ? finiteInteger(args.statusCode) : null);
+        const success = isSuccessfulAttempt(attempt)
+            || (isFinal && args.success);
+        const outcome = typeof attempt.outcome === "string"
+            ? attempt.outcome
+            : success ? "success" : "error";
+        const error = attempt.error && typeof attempt.error === "object"
+            ? attempt.error as Record<string, unknown>
+            : {};
+        const durationMs = finiteInteger(attempt.duration_ms);
+        const totalMs = isFinal
+            ? finiteInteger(args.totalMs) ?? finiteInteger(args.latencyMs) ?? durationMs
+            : durationMs;
+
+        return {
+            created_at: args.insertedRow.created_at,
+            gateway_request_id: args.insertedRow.id,
+            gateway_request_created_at: args.insertedRow.created_at,
+            request_id: args.requestId,
+            workspace_id: args.workspaceId,
+            app_id: args.appId ?? null,
+            key_id: args.keyId ?? null,
+            sequence: index + 1,
+            round_number: finiteInteger(attempt.round_number) ?? 1,
+            attempt_number: finiteInteger(attempt.attempt_number) ?? index + 1,
+            internal_attempt_number: finiteInteger(attempt.internal_attempt_number),
+            stage: ["blocked", "no_pricing", "unsupported_executor"].includes(outcome)
+                ? "routing"
+                : "upstream",
+            endpoint: args.endpoint,
+            model_id: typeof attempt.model === "string" ? attempt.model : args.modelId,
+            provider: typeof attempt.provider === "string" ? attempt.provider : args.provider ?? null,
+            api_model_id: typeof attempt.api_model_id === "string"
+                ? attempt.api_model_id
+                : isFinal ? args.providerApiModelId ?? null : null,
+            provider_model_slug: typeof attempt.provider_model_slug === "string"
+                ? attempt.provider_model_slug
+                : isFinal ? args.providerModelSlug ?? null : null,
+            upstream_route: typeof attempt.upstream_route === "string" ? attempt.upstream_route : null,
+            upstream_url: typeof attempt.upstream_url === "string" ? attempt.upstream_url : null,
+            status_code: statusCode,
+            status_text: typeof attempt.status_text === "string" ? attempt.status_text : null,
+            success,
+            outcome,
+            retryable: typeof attempt.retryable === "boolean" ? attempt.retryable : null,
+            fallback_attempted: attempt.fallback_attempted === true,
+            was_probe: attempt.was_probe === true,
+            key_source: attempt.key_source === "gateway" || attempt.key_source === "byok"
+                ? attempt.key_source
+                : null,
+            native_response_id: isFinal ? args.nativeResponseId ?? null : null,
+            provider_finish_reason: typeof attempt.provider_finish_reason === "string"
+                ? attempt.provider_finish_reason
+                : null,
+            finish_reason: isFinal ? args.finishReason ?? null : null,
+            duration_ms: durationMs,
+            latency_ms: isFinal ? finiteInteger(args.latencyMs) : null,
+            generation_ms: isFinal ? finiteInteger(args.generationMs) : null,
+            total_ms: totalMs,
+            request_build_ms: finiteInteger(attempt.request_build_ms),
+            upstream_headers_ms: finiteInteger(attempt.upstream_headers_ms),
+            retry_delay_ms: finiteInteger(attempt.retry_delay_ms),
+            usage: isFinal ? normalizeJsonValue(args.usage) ?? {} : {},
+            cost_nanos: isFinal && success ? totalNanos : 0,
+            currency: args.currency ?? null,
+            error_code: typeof attempt.upstream_error_code === "string"
+                ? attempt.upstream_error_code
+                : typeof error.code === "string" ? error.code : null,
+            error_type: typeof attempt.upstream_error_type === "string"
+                ? attempt.upstream_error_type
+                : typeof error.type === "string" ? error.type : null,
+            error_message: typeof attempt.upstream_error_message === "string"
+                ? attempt.upstream_error_message
+                : typeof error.message === "string" ? error.message : null,
+            error_description: typeof attempt.upstream_error_description === "string"
+                ? attempt.upstream_error_description
+                : typeof error.description === "string" ? error.description : null,
+            error_param: typeof attempt.upstream_error_param === "string"
+                ? attempt.upstream_error_param
+                : typeof error.param === "string" ? error.param : null,
+            request_payload: null,
+            response_payload: null,
+            metadata: normalizeJsonValue({
+                response_kind: attempt.response_kind ?? null,
+                upstream_request_count: attempt.upstream_request_count ?? null,
+                upstream_poll_count: attempt.upstream_poll_count ?? null,
+                upstream_auth_count: attempt.upstream_auth_count ?? null,
+                upstream_preflight_count: attempt.upstream_preflight_count ?? null,
+                upstream_media_count: attempt.upstream_media_count ?? null,
+            }) ?? {},
+        };
+    });
+}
+
+export async function persistGatewayUpstreamRequests(
+    args: PersistGatewayUpstreamRequestsArgs,
+): Promise<void> {
+    if (tableAvailable === false) return;
+    const rows = buildRows(args);
+    if (rows.length === 0) return;
+    try {
+        const { error } = await getSupabaseAdmin()
+            .from("gateway_upstream_requests")
+            .insert(rows);
+        if (error) {
+            const wrapped = new Error(
+                `[audit] insert gateway_upstream_requests error: ${error.message ?? "unknown"}`,
+            );
+            (wrapped as Error & { cause?: unknown }).cause = error;
+            throw wrapped;
+        }
+        tableAvailable = true;
+    } catch (error) {
+        if (isMissingTableError(error)) {
+            tableAvailable = false;
+            if (!warnedMissingTable) {
+                warnedMissingTable = true;
+                console.warn(
+                    "[audit] gateway_upstream_requests is unavailable; skipping normalized child rows.",
+                );
+            }
+            return;
+        }
+        console.error("[audit] failed to persist upstream requests", {
+            context: args.context,
+            requestId: args.requestId,
+            error: error instanceof Error ? error.message : String(error),
+        });
+    }
+}

--- a/apps/web-api/src/usage/actions.ts
+++ b/apps/web-api/src/usage/actions.ts
@@ -27,6 +27,16 @@ async function requireAuthenticatedUser() { return { supabase: current().account
 // Raw fallback can pull large request windows; keep it opt-in to protect DB egress.
 const rawFallbackEnabled = () => current().env.ENABLE_GATEWAY_USAGE_RAW_FALLBACK === "1";
 
+function numberOrNull(value: unknown): number | null {
+	if (value === null || value === undefined || value === "") return null;
+	const parsed = Number(value);
+	return Number.isFinite(parsed) ? parsed : null;
+}
+
+function stringOrNull(value: unknown): string | null {
+	return typeof value === "string" && value.trim().length > 0 ? value.trim() : null;
+}
+
 async function requireAuthedTeamContext(
 	supabase: Awaited<ReturnType<typeof createClient>>
 ) {
@@ -163,7 +173,10 @@ export interface RequestRow extends NormalizedRequestUsageColumns {
 	key_id: string | null;
 	pricing_lines: AsyncJobRequestPricingLine[];
 	provider_attempts: Array<{
+		sequence?: number | null;
 		attempt_number: number | null;
+		round_number?: number | null;
+		internal_attempt_number?: number | null;
 		provider: string | null;
 		api_model_id: string | null;
 		provider_model_slug: string | null;
@@ -171,6 +184,15 @@ export interface RequestRow extends NormalizedRequestUsageColumns {
 		status: number | null;
 		status_text: string | null;
 		duration_ms: number | null;
+		latency_ms?: number | null;
+		generation_ms?: number | null;
+		total_ms?: number | null;
+		cost_nanos?: number | null;
+		currency?: string | null;
+		finish_reason?: string | null;
+		provider_finish_reason?: string | null;
+		retryable?: boolean | null;
+		fallback_attempted?: boolean;
 		upstream_error_code: string | null;
 		upstream_error_message: string | null;
 		upstream_error_description: string | null;
@@ -200,6 +222,88 @@ export type GatewayIoLog = {
 	error: string | null;
 	payload: Record<string, unknown> | null;
 };
+
+async function fetchGatewayUpstreamRequests(
+	workspaceId: string,
+	requestId: string,
+): Promise<RequestRow["provider_attempts"]> {
+	const { data, error } = await createAdminClient()
+		.from("gateway_upstream_requests")
+		.select(`
+			sequence,
+			round_number,
+			attempt_number,
+			internal_attempt_number,
+			provider,
+			api_model_id,
+			provider_model_slug,
+			outcome,
+			status_code,
+			status_text,
+			duration_ms,
+			latency_ms,
+			generation_ms,
+			total_ms,
+			cost_nanos,
+			currency,
+			finish_reason,
+			provider_finish_reason,
+			retryable,
+			fallback_attempted,
+			error_code,
+			error_message,
+			error_description
+		`)
+		.eq("workspace_id", workspaceId)
+		.eq("request_id", requestId)
+		.order("sequence", { ascending: true });
+
+	if (error) {
+		const code = String(error.code ?? "");
+		const message = String(error.message ?? "").toLowerCase();
+		if ((code === "PGRST205" || code === "42P01")
+			&& message.includes("gateway_upstream_requests")) {
+			return [];
+		}
+		console.error("Error fetching upstream request rows:", error);
+		return [];
+	}
+
+	return normalizeGatewayUpstreamRows(data ?? []);
+}
+
+export function normalizeGatewayUpstreamRows(
+	rows: unknown[],
+): RequestRow["provider_attempts"] {
+	return rows.map((value) => {
+		const row = value && typeof value === "object" ? value as Record<string, unknown> : {};
+		return {
+		sequence: numberOrNull(row.sequence),
+		round_number: numberOrNull(row.round_number),
+		attempt_number: numberOrNull(row.attempt_number),
+		internal_attempt_number: numberOrNull(row.internal_attempt_number),
+		provider: stringOrNull(row.provider),
+		api_model_id: stringOrNull(row.api_model_id),
+		provider_model_slug: stringOrNull(row.provider_model_slug),
+		outcome: stringOrNull(row.outcome),
+		status: numberOrNull(row.status_code),
+		status_text: stringOrNull(row.status_text),
+		duration_ms: numberOrNull(row.duration_ms),
+		latency_ms: numberOrNull(row.latency_ms),
+		generation_ms: numberOrNull(row.generation_ms),
+		total_ms: numberOrNull(row.total_ms),
+		cost_nanos: numberOrNull(row.cost_nanos),
+		currency: stringOrNull(row.currency),
+		finish_reason: stringOrNull(row.finish_reason),
+		provider_finish_reason: stringOrNull(row.provider_finish_reason),
+		retryable: typeof row.retryable === "boolean" ? row.retryable : null,
+		fallback_attempted: row.fallback_attempted === true,
+		upstream_error_code: stringOrNull(row.error_code),
+		upstream_error_message: stringOrNull(row.error_message),
+		upstream_error_description: stringOrNull(row.error_description),
+		};
+	});
+}
 
 async function fetchGatewayIoLog(
 	workspaceId: string,
@@ -1604,6 +1708,11 @@ export async function investigateGeneration(
 		}
 
 		const request = toRequestRow(fallbackData);
+		const upstreamRequests = await fetchGatewayUpstreamRequests(
+			workspaceId,
+			trimmedRequestId,
+		);
+		if (upstreamRequests.length > 0) request.provider_attempts = upstreamRequests;
 		const providerIds = Array.from(
 			new Set(
 				[
@@ -1652,6 +1761,11 @@ export async function investigateGeneration(
 	}
 
 	const request = toRequestRow(data);
+	const upstreamRequests = await fetchGatewayUpstreamRequests(
+		workspaceId,
+		trimmedRequestId,
+	);
+	if (upstreamRequests.length > 0) request.provider_attempts = upstreamRequests;
 	const providerIds = Array.from(
 		new Set(
 			[

--- a/apps/web-api/src/usage/actions.upstream-requests.test.ts
+++ b/apps/web-api/src/usage/actions.upstream-requests.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+import { normalizeGatewayUpstreamRows } from "./actions";
+
+describe("normalizeGatewayUpstreamRows", () => {
+	it("maps child request rows into the existing provider timeline contract", () => {
+		expect(normalizeGatewayUpstreamRows([{
+			sequence: 2,
+			round_number: 1,
+			attempt_number: 2,
+			internal_attempt_number: null,
+			provider: "openai",
+			api_model_id: "openai:gpt-5.4-mini",
+			provider_model_slug: "gpt-5.4-mini",
+			outcome: "success",
+			status_code: 200,
+			status_text: "OK",
+			duration_ms: 42,
+			latency_ms: 180,
+			generation_ms: 150,
+			total_ms: 210,
+			cost_nanos: "125000",
+			currency: "USD",
+			finish_reason: "stop",
+			provider_finish_reason: "stop",
+			retryable: false,
+			fallback_attempted: true,
+			error_code: null,
+			error_message: null,
+			error_description: null,
+		}])).toEqual([{
+			sequence: 2,
+			round_number: 1,
+			attempt_number: 2,
+			internal_attempt_number: null,
+			provider: "openai",
+			api_model_id: "openai:gpt-5.4-mini",
+			provider_model_slug: "gpt-5.4-mini",
+			outcome: "success",
+			status: 200,
+			status_text: "OK",
+			duration_ms: 42,
+			latency_ms: 180,
+			generation_ms: 150,
+			total_ms: 210,
+			cost_nanos: 125000,
+			currency: "USD",
+			finish_reason: "stop",
+			provider_finish_reason: "stop",
+			retryable: false,
+			fallback_attempted: true,
+			upstream_error_code: null,
+			upstream_error_message: null,
+			upstream_error_description: null,
+		}]);
+	});
+});

--- a/apps/web/src/app/(dashboard)/gateway/usage/server-actions.ts
+++ b/apps/web/src/app/(dashboard)/gateway/usage/server-actions.ts
@@ -7,7 +7,16 @@ export interface RequestRow {
 	request_id: string; created_at: string; endpoint: string | null; model_id: string | null; provider: string | null;
 	app_id: string | null; session_id: string | null; success: boolean; status_code: number | null; error_code: string | null;
 	error_message: string | null; error_payload: Record<string, unknown> | null; usage: any; cost_nanos: number | null;
-	pricing_lines: AsyncJobRequestPricingLine[]; provider_attempts: Array<Record<string, any>>;
+	pricing_lines: AsyncJobRequestPricingLine[]; provider_attempts: Array<{
+		sequence?: number | null; attempt_number?: number | null; round_number?: number | null;
+		internal_attempt_number?: number | null; provider?: string | null; api_model_id?: string | null;
+		provider_model_slug?: string | null; outcome?: string | null; status?: number | null;
+		status_text?: string | null; duration_ms?: number | null; latency_ms?: number | null;
+		generation_ms?: number | null; total_ms?: number | null; cost_nanos?: number | null;
+		currency?: string | null; finish_reason?: string | null; provider_finish_reason?: string | null;
+		retryable?: boolean | null; fallback_attempted?: boolean; upstream_error_code?: string | null;
+		upstream_error_message?: string | null; upstream_error_description?: string | null;
+	}>;
 	usage_total_tokens?: number | null; usage_input_tokens?: number | null; usage_output_tokens?: number | null;
 	[key: string]: any;
 }

--- a/apps/web/src/components/(gateway)/usage/RequestDetailDialog.tsx
+++ b/apps/web/src/components/(gateway)/usage/RequestDetailDialog.tsx
@@ -879,7 +879,10 @@ export default function RequestDetailDialog({
 						`Attempt ${index + 1}`;
 					const statusTone = getAttemptStatusTone(attempt);
 					const statusDescription = getAttemptStatusDescription(attempt);
-					const durationMs = Number(attempt.duration_ms ?? 0) || 0;
+					const durationMs = Number(attempt.total_ms ?? attempt.duration_ms ?? 0) || 0;
+					const attemptFinishReason =
+						attempt.provider_finish_reason ?? attempt.finish_reason ?? null;
+					const attemptCostNanos = Number(attempt.cost_nanos ?? 0) || 0;
 					const attemptModelParts = getConcreteModelParts({
 						apiModelId: attempt.api_model_id,
 						providerModelSlug: attempt.provider_model_slug,
@@ -908,6 +911,16 @@ export default function RequestDetailDialog({
 													{value}
 												</code>
 											))}
+										</div>
+									) : null}
+									{attemptFinishReason || attemptCostNanos > 0 ? (
+										<div className="mt-0.5 flex flex-wrap gap-x-2 text-[10px] text-muted-foreground">
+											{attemptFinishReason ? (
+												<span>finish: {attemptFinishReason}</span>
+											) : null}
+											{attemptCostNanos > 0 ? (
+												<span>cost: {formatCost(attemptCostNanos)}</span>
+											) : null}
 										</div>
 									) : null}
 								</div>


### PR DESCRIPTION
## Summary

- persist ordered provider retries and failover attempts into the existing `gateway_upstream_requests` child table
- retain the parent `provider_attempts` field for backward-compatible analytics
- allocate the request cost to the final successful upstream row and use completed-call timing for its total duration
- keep child persistence isolated so failures cannot block the parent request log
- keep request and response bodies out of the child table; payloads remain governed by the existing opt-in I/O logging policy
- load child rows lazily when request details are opened and reuse the current provider timeline
- show finish reason and allocated cost for normalized upstream rows

Supersedes #1043 with a current-main implementation. The migration from #1043 is already present on `main`.

## Validation

- `pnpm --filter @phaseo/gateway-api lint` (passes; existing max-lines warnings)
- gateway API typecheck
- 8 focused gateway audit tests
- `pnpm --filter @phaseo/web-api lint` (passes; existing max-lines warnings)
- web API typecheck
- web API upstream-row normalization test
- focused web ESLint (0 errors; existing warnings in the request dialog)
- `git diff --check`

The full web typecheck currently has four unrelated branch-point failures: three missing generated `LayoutProps` globals and one existing `ProcessEnv` test cast. The touched web files pass focused ESLint, and the web API contract typechecks cleanly.

Created with Codex