### PR TITLE
Publish versioned Agent SDK once

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -939,6 +939,35 @@ jobs:
               env:
                   GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
 
+            - name: Check TypeScript Agent SDK release status
+              id: agent-sdk-npm-release
+              run: |
+                  node --input-type=module <<'NODE'
+                  import fs from "node:fs";
+                  import packageJson from "./packages/sdk/agent-sdk-ts/package.json" with { type: "json" };
+
+                  const packagePath = encodeURIComponent(packageJson.name);
+                  const versionPath = encodeURIComponent(packageJson.version);
+                  const response = await fetch(`https://registry.npmjs.org/${packagePath}/${versionPath}`);
+
+                  if (response.status !== 200 && response.status !== 404) {
+                    throw new Error(`npm registry returned ${response.status} while checking ${packageJson.name}@${packageJson.version}`);
+                  }
+
+                  const shouldPublish = response.status === 404;
+                  fs.appendFileSync(
+                    process.env.GITHUB_OUTPUT,
+                    `package=${packageJson.name}\nversion=${packageJson.version}\nshould_publish=${shouldPublish}\n`,
+                  );
+
+                  const status = shouldPublish ? "is missing from" : "already exists on";
+                  console.log(`${packageJson.name}@${packageJson.version} ${status} npm`);
+                  NODE
+
+            - name: Publish TypeScript Agent SDK to npm
+              if: steps.agent-sdk-npm-release.outputs.should_publish == 'true'
+              run: pnpm --filter @phaseo/agent-sdk publish --access public --no-git-checks
+
             - name: Set up Python (for PyPI publish)
               uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97
               with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -939,6 +939,9 @@ jobs:
               env:
                   GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
 
+            - name: Restore committed TypeScript Agent SDK release state
+              run: git restore --source=HEAD --staged --worktree -- packages/sdk/agent-sdk-ts
+
             - name: Check TypeScript Agent SDK release status
               id: agent-sdk-npm-release
               run: |


### PR DESCRIPTION
Ensure an already-versioned TypeScript Agent SDK is published even when a newer unrelated changeset causes Changesets to open the next release PR instead of entering publish mode.

- check the exact local Agent SDK version against the npm registry after the Changesets action
- publish only when that exact version returns 404
- fail closed on unexpected registry responses
- retain OIDC/provenance through the existing trusted `ci.yml` release job

This resolves the `@phaseo/agent-sdk@0.2.0` release race without allowing duplicate publication.

Validation:
- npm registry exact-version check returns 404 for `@phaseo/agent-sdk@0.2.0`
- Agent SDK build passed in the immediately preceding protected release and main CI runs; this worktree has no installed dependencies
- `git diff --check`

Created with Codex