### PR TITLE
Publish Agent SDK core dependency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -939,8 +939,37 @@ jobs:
               env:
                   GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
 
-            - name: Restore committed TypeScript Agent SDK release state
-              run: git restore --source=HEAD --staged --worktree -- packages/sdk/agent-sdk-ts
+            - name: Restore committed TypeScript SDK release state
+              run: git restore --source=HEAD --staged --worktree -- packages/sdk/sdk-ts packages/sdk/agent-sdk-ts
+
+            - name: Check TypeScript core SDK release status
+              id: sdk-npm-release
+              run: |
+                  node --input-type=module <<'NODE'
+                  import fs from "node:fs";
+                  import packageJson from "./packages/sdk/sdk-ts/package.json" with { type: "json" };
+
+                  const packagePath = encodeURIComponent(packageJson.name);
+                  const versionPath = encodeURIComponent(packageJson.version);
+                  const response = await fetch(`https://registry.npmjs.org/${packagePath}/${versionPath}`);
+
+                  if (response.status !== 200 && response.status !== 404) {
+                    throw new Error(`npm registry returned ${response.status} while checking ${packageJson.name}@${packageJson.version}`);
+                  }
+
+                  const shouldPublish = response.status === 404;
+                  fs.appendFileSync(
+                    process.env.GITHUB_OUTPUT,
+                    `package=${packageJson.name}\nversion=${packageJson.version}\nshould_publish=${shouldPublish}\n`,
+                  );
+
+                  const status = shouldPublish ? "is missing from" : "already exists on";
+                  console.log(`${packageJson.name}@${packageJson.version} ${status} npm`);
+                  NODE
+
+            - name: Publish TypeScript core SDK to npm
+              if: steps.sdk-npm-release.outputs.should_publish == 'true'
+              run: pnpm --filter @phaseo/sdk publish --access public --no-git-checks
 
             - name: Check TypeScript Agent SDK release status
               id: agent-sdk-npm-release

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -853,6 +853,9 @@ jobs:
     publish:
         name: Handle Versions
         runs-on: ubuntu-latest
+        concurrency:
+            group: sdk-release-publish
+            cancel-in-progress: false
         needs:
             - sdk-gen
             - packages


### PR DESCRIPTION
Publish the committed TypeScript core SDK version before the Agent SDK exact-version guard so clean Agent installations can resolve their required dependency.

- restore both core and Agent SDK package state from committed `HEAD` after Changesets mutates the workspace
- check `@phaseo/sdk` exact version against npm and publish only on 404
- publish core before checking Agent
- retain fail-closed registry handling and trusted OIDC provenance

Current registry state:
- `@phaseo/sdk@2.2.0`: missing (404)
- `@phaseo/agent-sdk@0.2.0`: published (200), so it will be skipped

Validation:
- exact npm registry status checks above
- `git diff --check`
- prior protected CI successfully built both packages from the same committed release state

Created with Codex