### PR TITLE
Automate Packagist refreshes

### DIFF
--- a/.github/workflows/publish-agent-sdks.yml
+++ b/.github/workflows/publish-agent-sdks.yml
@@ -258,18 +258,26 @@ jobs:
       - name: Notify Packagist
         env:
           PACKAGIST_USERNAME: ${{ secrets.PACKAGIST_USERNAME }}
-          PACKAGIST_MAIN_TOKEN: ${{ secrets.PACKAGIST_MAIN_TOKEN }}
+          PACKAGIST_SAFE_TOKEN: ${{ secrets.PACKAGIST_SAFE_TOKEN }}
           PACKAGIST_REPOSITORY_URL: ${{ steps.split.outputs.repo_url }}
         shell: bash
         run: |
           set -euo pipefail
-          if [ -z "${PACKAGIST_USERNAME:-}" ] || [ -z "${PACKAGIST_MAIN_TOKEN:-}" ]; then
-            echo "Packagist refresh credentials are not configured; relying on its GitHub webhook."
-            exit 0
+          if [ -z "${PACKAGIST_USERNAME:-}" ] || [ -z "${PACKAGIST_SAFE_TOKEN:-}" ]; then
+            echo "::error::Missing PACKAGIST_USERNAME or PACKAGIST_SAFE_TOKEN."
+            exit 1
           fi
-          curl -fsS -X POST "https://packagist.org/api/update-package?username=${PACKAGIST_USERNAME}&apiToken=${PACKAGIST_MAIN_TOKEN}" \
+          if [ -z "${PACKAGIST_REPOSITORY_URL:-}" ]; then
+            echo "::error::Missing split repository URL output."
+            exit 1
+          fi
+          response="$(curl --fail --silent --show-error --retry 3 --retry-all-errors \
+            -X POST "https://packagist.org/api/update-package" \
             -H "Content-Type: application/json" \
-            -d "{\"repository\":{\"url\":\"${PACKAGIST_REPOSITORY_URL}\"}}"
+            -H "Authorization: Bearer ${PACKAGIST_USERNAME}:${PACKAGIST_SAFE_TOKEN}" \
+            -d "{\"repository\":\"${PACKAGIST_REPOSITORY_URL}\"}")"
+          echo "$response" | jq -e '.status == "success"' >/dev/null
+          echo "Packagist refresh queued successfully."
 
   build-ruby:
     name: Build Ruby Agent SDK

--- a/.github/workflows/publish-sdk-php.yml
+++ b/.github/workflows/publish-sdk-php.yml
@@ -167,19 +167,23 @@ jobs:
       - name: Notify Packagist
         env:
           PACKAGIST_USERNAME: ${{ secrets.PACKAGIST_USERNAME }}
-          PACKAGIST_MAIN_TOKEN: ${{ secrets.PACKAGIST_MAIN_TOKEN }}
+          PACKAGIST_SAFE_TOKEN: ${{ secrets.PACKAGIST_SAFE_TOKEN }}
           PACKAGIST_REPOSITORY_URL: ${{ steps.split_repo.outputs.repo_url }}
         shell: bash
         run: |
           set -euo pipefail
-          if [ -z "${PACKAGIST_USERNAME:-}" ] || [ -z "${PACKAGIST_MAIN_TOKEN:-}" ]; then
-            echo "Packagist credentials are not configured; relying on the repository webhook."
-            exit 0
+          if [ -z "${PACKAGIST_USERNAME:-}" ] || [ -z "${PACKAGIST_SAFE_TOKEN:-}" ]; then
+            echo "::error::Missing PACKAGIST_USERNAME or PACKAGIST_SAFE_TOKEN."
+            exit 1
           fi
           if [ -z "${PACKAGIST_REPOSITORY_URL:-}" ]; then
             echo "::error::Missing split repository URL output."
             exit 1
           fi
-          curl -fsS -X POST "https://packagist.org/api/update-package?username=${PACKAGIST_USERNAME}&apiToken=${PACKAGIST_MAIN_TOKEN}" \
+          response="$(curl --fail --silent --show-error --retry 3 --retry-all-errors \
+            -X POST "https://packagist.org/api/update-package" \
             -H "Content-Type: application/json" \
-            -d "{\"repository\":{\"url\":\"${PACKAGIST_REPOSITORY_URL}\"}}"
+            -H "Authorization: Bearer ${PACKAGIST_USERNAME}:${PACKAGIST_SAFE_TOKEN}" \
+            -d "{\"repository\":\"${PACKAGIST_REPOSITORY_URL}\"}")"
+          echo "$response" | jq -e '.status == "success"' >/dev/null
+          echo "Packagist refresh queued successfully."

--- a/.github/workflows/sdk-publish-readiness.yml
+++ b/.github/workflows/sdk-publish-readiness.yml
@@ -42,6 +42,24 @@ jobs:
           pnpm run test
           pnpm publish --dry-run --no-git-checks
 
+  packagist-credentials:
+    name: Packagist credentials
+    if: inputs.checkSecrets
+    runs-on: ubuntu-latest
+    environment: release
+    steps:
+      - name: Check required Packagist refresh credentials
+        env:
+          PACKAGIST_USERNAME: ${{ secrets.PACKAGIST_USERNAME }}
+          PACKAGIST_SAFE_TOKEN: ${{ secrets.PACKAGIST_SAFE_TOKEN }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ -z "${PACKAGIST_USERNAME:-}" ] || [ -z "${PACKAGIST_SAFE_TOKEN:-}" ]; then
+            echo "::error::Missing PACKAGIST_USERNAME or PACKAGIST_SAFE_TOKEN in the release environment."
+            exit 1
+          fi
+
   go:
     name: Go readiness
     runs-on: ubuntu-latest
@@ -147,18 +165,6 @@ jobs:
           composer validate --strict
           php tests/lifecycle_test.php
           (cd ../agent-sdk-php && composer validate --strict && php tests/agent_loop_test.php)
-      - name: Check optional Packagist refresh credentials
-        if: inputs.checkSecrets
-        env:
-          PACKAGIST_USERNAME: ${{ secrets.PACKAGIST_USERNAME }}
-          PACKAGIST_MAIN_TOKEN: ${{ secrets.PACKAGIST_MAIN_TOKEN }}
-        shell: bash
-        run: |
-          set -euo pipefail
-          if [ -z "${PACKAGIST_USERNAME:-}" ] || [ -z "${PACKAGIST_MAIN_TOKEN:-}" ]; then
-            echo "Packagist API refresh credentials are not set; publishing will rely on the repository webhook."
-          fi
-
   ruby:
     name: Ruby readiness
     runs-on: ubuntu-latest

--- a/packages/sdk/RELEASING.md
+++ b/packages/sdk/RELEASING.md
@@ -86,6 +86,7 @@ General policy:
   - Uses OIDC trusted publishing for PyPI and RubyGems
   - Trusted-publisher identity: repository owner `phaseoteam`, repository `Phaseo`, workflow `publish-agent-sdks.yml`, environment `release`
   - Uses the Phaseo GitHub App for Go tags and the PHP split repository
+  - Refreshes `phaseo/agent-sdk` on Packagist with the required `PACKAGIST_USERNAME` and `PACKAGIST_SAFE_TOKEN` release-environment secrets
   - Optional repo variable: `PHP_AGENT_SDK_SPLIT_REPO` (defaults to `phaseoteam/phaseo-php-agent-sdk`)
 
 - First npm publish / bootstrap: `.github/workflows/npm-bootstrap-publish.yml`
@@ -113,10 +114,10 @@ General policy:
   - Publishes by creating/pushing monorepo tag `sdk-php/vX.Y.Z`
   - Syncs `packages/sdk/sdk-php` to split repo main and pushes split tag `vX.Y.Z`
   - Uses the Phaseo GitHub App token to update the split repository
-  - Relies on the split repository's Packagist webhook by default
-  - Optional secrets for an immediate Packagist API refresh:
+  - Refreshes `phaseo/sdk` through the Packagist API after publishing the split tag
+  - Required `release` environment secrets:
     - `PACKAGIST_USERNAME`
-    - `PACKAGIST_MAIN_TOKEN`
+    - `PACKAGIST_SAFE_TOKEN`
   - Optional repo variable:
     - `PHP_SDK_SPLIT_REPO` (defaults to `phaseoteam/phaseo-php-sdk`)
 


### PR DESCRIPTION
## Summary

- use the Packagist safe API token for PHP package refreshes
- notify Packagist through its current bearer-auth API for both client and Agent SDKs
- fail releases when refresh credentials or repository metadata are missing
- retry transient API failures and validate Packagist acceptance

## Validation

- `git diff --check`
- parsed both edited workflow files with PyYAML
- installed `PACKAGIST_USERNAME` and `PACKAGIST_SAFE_TOKEN` in the protected `release` environment

Created with Codex