### PR TITLE
Document Rust SDKs

### DIFF
--- a/apps/docs/docs.json
+++ b/apps/docs/docs.json
@@ -931,6 +931,36 @@
 										]
 									}
 								]
+							},
+							{
+								"item": "Rust SDK",
+								"icon": "/icons/languages/rust.svg",
+								"groups": [
+									{
+										"group": "Introduction",
+										"icon": "book-open",
+										"pages": [
+											"v1/sdk-reference/rust/overview",
+											"v1/sdk-reference/rust/installation",
+											"v1/sdk-reference/rust/usage"
+										]
+									},
+									{
+										"group": "Text",
+										"icon": "message-square-text",
+										"pages": [
+											"v1/sdk-reference/rust/responses",
+											"v1/sdk-reference/rust/chat-completions"
+										]
+									},
+									{
+										"group": "Reference",
+										"icon": "book-open",
+										"pages": [
+											"v1/sdk-reference/rust/api-reference"
+										]
+									}
+								]
 							}
 						]
 					},
@@ -1218,6 +1248,43 @@
 										"v1/sdk-reference/ruby/agent-sdk-examples",
 										"v1/sdk-reference/ruby/agent-sdk-observability"
 									]
+									}
+								]
+							},
+							{
+								"item": "Rust Agent SDK",
+								"icon": "/icons/languages/rust.svg",
+								"groups": [
+									{
+										"group": "Start Here",
+										"icon": "book-open",
+										"pages": [
+											"v1/sdk-reference/rust/agent-sdk-overview",
+											"v1/sdk-reference/rust/agent-sdk-installation"
+										]
+									},
+									{
+										"group": "Build",
+										"icon": "workflow",
+										"pages": [
+											"v1/sdk-reference/rust/agent-sdk",
+											"v1/sdk-reference/rust/agent-sdk-tools",
+											"v1/sdk-reference/rust/agent-sdk-state-and-approval"
+										]
+									},
+									{
+										"group": "Observe",
+										"icon": "activity",
+										"pages": [
+											"v1/sdk-reference/rust/agent-sdk-events-and-errors"
+										]
+									},
+									{
+										"group": "Reference",
+										"icon": "book-open",
+										"pages": [
+											"v1/sdk-reference/rust/agent-sdk-api-reference"
+										]
 									}
 								]
 							}

--- a/apps/docs/v1/guides/examples.mdx
+++ b/apps/docs/v1/guides/examples.mdx
@@ -137,6 +137,22 @@ response = client.generate_response(
 puts response
 ```
 
+```rust Rust SDK
+use phaseo::Phaseo;
+use serde_json::json;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let client = Phaseo::from_env()?;
+    let response = client.responses(&json!({
+        "model": "google/gemma-3-27b:free",
+        "input": "Summarize this article in 3 bullet points."
+    }))?;
+
+    println!("{}", response.body);
+    Ok(())
+}
+```
+
 </CodeGroup>
 
 ## Paid chat completion
@@ -193,4 +209,4 @@ If you want a coding agent to generate the first version for you, start here:
 
 ## More SDK examples
 
-Explore the [SDK Reference](../sdk-reference/typescript/overview) for language-specific examples.
+Explore the [SDK Reference](../sdk-reference/typescript/overview) or [Rust SDK guide](../sdk-reference/rust/overview) for language-specific examples.

--- a/apps/docs/v1/quickstart.mdx
+++ b/apps/docs/v1/quickstart.mdx
@@ -202,7 +202,7 @@ puts response
 
 ```rust Rust SDK
 use phaseo::Phaseo;
-use serde_json::json;
+use serde_json::{json, Value};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let client = Phaseo::from_env()?;
@@ -212,10 +212,23 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         "temperature": 0
     }))?;
 
-    let assistant_text = response
-        .body
-        .pointer("/output/0/content/0/text")
-        .and_then(|value| value.as_str())
+    let assistant_text = response.body
+        .get("output")
+        .and_then(Value::as_array)
+        .into_iter()
+        .flatten()
+        .filter(|item| item.get("type").and_then(Value::as_str) == Some("message"))
+        .flat_map(|item| {
+            item.get("content")
+                .and_then(Value::as_array)
+                .into_iter()
+                .flatten()
+        })
+        .find_map(|part| {
+            (part.get("type").and_then(Value::as_str) == Some("output_text"))
+                .then(|| part.get("text").and_then(Value::as_str))
+                .flatten()
+        })
         .unwrap_or("");
 
     println!("{assistant_text}");

--- a/apps/docs/v1/quickstart.mdx
+++ b/apps/docs/v1/quickstart.mdx
@@ -200,6 +200,29 @@ response = client.generate_response(
 puts response
 ```
 
+```rust Rust SDK
+use phaseo::Phaseo;
+use serde_json::json;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let client = Phaseo::from_env()?;
+    let response = client.responses(&json!({
+        "model": "openai/gpt-5.6-sol",
+        "input": "Reply with: quickstart works",
+        "temperature": 0
+    }))?;
+
+    let assistant_text = response
+        .body
+        .pointer("/output/0/content/0/text")
+        .and_then(|value| value.as_str())
+        .unwrap_or("");
+
+    println!("{assistant_text}");
+    Ok(())
+}
+```
+
 ```typescript Vercel AI SDK
 import { phaseo } from "@phaseo/ai-sdk-provider";
 import { generateText } from "ai";

--- a/apps/docs/v1/sdk-reference/agent-sdk/overview.mdx
+++ b/apps/docs/v1/sdk-reference/agent-sdk/overview.mdx
@@ -27,6 +27,7 @@ The current Agent SDK language set matches the primary client SDK set exposed in
 - [C#](../csharp/agent-sdk)
 - [PHP](../php/agent-sdk)
 - [Ruby](../ruby/agent-sdk)
+- [Rust](../rust/agent-sdk)
 
 ## Common model
 
@@ -39,24 +40,24 @@ Each Agent SDK keeps the same runtime model:
 - inspect lifecycle events or a Devtools trace
 - persist the returned run and resume after a human decision
 
-TypeScript is the reference API design. Python, Go, C#, PHP, and Ruby expose the same run states and core controls using language-native callbacks, concurrency, timeout, and cancellation primitives. Java remains a work in progress; Rust and C++ Agent SDKs are intentionally deferred.
+TypeScript is the reference API design. Python, Go, C#, PHP, and Ruby expose the broader cross-language contract using language-native callbacks, concurrency, timeout, and cancellation primitives. Rust is a supported synchronous runtime with local and external tools, exact-ID approvals, human review, model retries, serializable run state, lifecycle callbacks, and usage aggregation. Java and C++ remain work in progress.
 
 <Note>
-  Only the TypeScript Agent SDK is currently published to a package registry as [`@phaseo/agent-sdk`](https://www.npmjs.com/package/@phaseo/agent-sdk). Use the source installation pages for the other runtimes until their independent packages are released.
+  The Rust Agent SDK is published as [`phaseo-agent`](https://crates.io/crates/phaseo-agent). It does not yet include streaming, async execution, concurrent local tools, runtime schema validation, or Devtools capture.
 </Note>
 
 ## Cross-language capability contract
 
-| Capability | TypeScript | Python | Go | C# | PHP | Ruby |
-| --- | --- | --- | --- | --- | --- | --- |
-| Validated executable tools and recoverable errors | Yes | Yes | Yes | Yes | Yes | Yes |
-| Exact-ID approvals, HITL, and manual outputs | Yes | Yes | Yes | Yes | Yes | Yes |
-| Preliminary tool progress | Async generator | Iterator or callback | Callback | Callback | Callback | Callback |
-| Model streaming and replayable consumers | Async iterable | Iterator | Channel | Async enumerable | Iterable | Enumerator |
-| Composable step, token, cost, duration, tool, finish, and custom stops | Yes | Yes | Yes | Yes | Yes | Yes |
-| Dynamic turns, mutable context, and persisted next-turn overrides | Yes | Yes | Yes | Yes | Yes | Yes |
-| Application-owned state accessor | Yes | Yes | Yes | Yes | Yes | Yes |
-| Normalized usage and cost | Yes | Yes | Yes | Yes | Yes | Yes |
+| Capability | TypeScript | Python | Go | C# | PHP | Ruby | Rust |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| Executable tools and recoverable tool errors | Yes | Yes | Yes | Yes | Yes | Yes | Synchronous |
+| Exact-ID approvals, HITL, and manual outputs | Yes | Yes | Yes | Yes | Yes | Yes | Yes |
+| Preliminary tool progress | Async generator | Iterator or callback | Callback | Callback | Callback | Callback | Not yet |
+| Model streaming and replayable consumers | Async iterable | Iterator | Channel | Async enumerable | Iterable | Enumerator | Not yet |
+| Composable stop conditions | Yes | Yes | Yes | Yes | Yes | Yes | Step limit |
+| Dynamic turns and mutable context | Yes | Yes | Yes | Yes | Yes | Yes | Per-run model, step limit, and context |
+| Application-owned persisted run state | Yes | Yes | Yes | Yes | Yes | Yes | Serializable `RunResult` |
+| Normalized usage and cost | Yes | Yes | Yes | Yes | Yes | Yes | Yes |
 
 PHP and Ruby expose provider stream events through their normal synchronous iteration APIs. They do not require a hosted runtime or a background Phaseo service.
 
@@ -68,7 +69,7 @@ PHP and Ruby expose provider stream events through their normal synchronous iter
 | Tool-using, multi-step application logic | Agent SDK | Local loop, tools, checkpoints, review, events, and Devtools |
 | Custom transport or an unsupported language | Raw API | HTTP request and response handling |
 
-Agent SDK gateway adapters delegate model turns to the matching Client SDK. An `requestOptions` or language-equivalent configuration hook passes additional Responses API fields through while the Agent SDK continues to own `model`, `input`, `instructions`, and local function tools.
+Agent SDK gateway adapters delegate model turns to the matching Client SDK. Languages with a `requestOptions` or equivalent hook can pass additional Responses API fields through while the Agent SDK continues to own `model`, `input`, `instructions`, and local function tools. The Rust `0.1` adapter currently sends the normalized agent fields without an additional request-options hook.
 
 ## Recipes
 

--- a/apps/docs/v1/sdk-reference/agent-sdk/overview.mdx
+++ b/apps/docs/v1/sdk-reference/agent-sdk/overview.mdx
@@ -57,7 +57,7 @@ TypeScript is the reference API design. Python, Go, C#, PHP, and Ruby expose the
 | Composable stop conditions | Yes | Yes | Yes | Yes | Yes | Yes | Step limit |
 | Dynamic turns and mutable context | Yes | Yes | Yes | Yes | Yes | Yes | Per-run model, step limit, and context |
 | Application-owned persisted run state | Yes | Yes | Yes | Yes | Yes | Yes | Serializable `RunResult` |
-| Normalized usage and cost | Yes | Yes | Yes | Yes | Yes | Yes | Yes |
+| Normalized usage and cost | Yes | Yes | Yes | Yes | Yes | Yes | Tokens; custom-client cost only in `0.1` |
 
 PHP and Ruby expose provider stream events through their normal synchronous iteration APIs. They do not require a hosted runtime or a background Phaseo service.
 

--- a/apps/docs/v1/sdk-reference/rust/agent-sdk-api-reference.mdx
+++ b/apps/docs/v1/sdk-reference/rust/agent-sdk-api-reference.mdx
@@ -1,0 +1,171 @@
+---
+title: "Rust Agent SDK API Reference"
+description: "Public structs, traits, and methods in phaseo-agent 0.1."
+---
+
+This page describes the public API in [`phaseo-agent 0.1`](https://docs.rs/phaseo-agent/0.1.0/phaseo_agent/).
+
+## Agent definition
+
+| API | Purpose |
+| --- | --- |
+| `AgentDefinition::new(id, model)` | Create an agent definition with an eight-step default limit. |
+| `.instructions(text)` | Set the model instructions. |
+| `.tool(tool)` | Add one tool. |
+| `.max_steps(limit)` | Set the model-turn limit. Values are clamped to at least one. |
+| `.model_retries(count, backoff)` | Retry failed model requests with a fixed `Duration`. |
+| `.human_review(callback)` | Pause after a model response when the callback returns `Some(HumanReviewRequest)`. |
+| `create_agent(definition)` | Create an `Agent`. |
+
+## Running and continuing
+
+| Method | Purpose |
+| --- | --- |
+| `Agent::run(client, options)` | Run synchronously without an event callback. |
+| `Agent::run_with_events(client, options, callback)` | Run synchronously and emit `AgentEvent` values. |
+| `Agent::continue_run(client, options)` | Continue a paused run. |
+| `Agent::continue_with_events(client, options, callback)` | Continue and emit events. |
+
+`RunOptions` fields:
+
+- `input: Value`
+- `context: Value`
+- `model: Option<String>`
+- `max_steps: Option<usize>`
+
+Create defaults with `RunOptions::new(input)`.
+
+`ContinueOptions` fields:
+
+- `result: RunResult`
+- `human_input: Option<String>`
+- `approvals: Vec<ToolDecision>`
+- `tool_outputs: Vec<ToolOutput>`
+
+Create defaults with `ContinueOptions::new(result)`.
+
+## Tools
+
+| API | Purpose |
+| --- | --- |
+| `Tool::new(id, description, parameters, executor)` | Define a local synchronous tool. |
+| `Tool::external(id, description, parameters)` | Define a tool fulfilled by the application after a pause. |
+| `Tool::require_approval()` | Require an exact-ID approval before local execution. |
+| `define_tool(tool)` | Return the supplied `Tool` for a consistent definition style. |
+
+The executor signature is:
+
+```rust
+Fn(
+    serde_json::Value,
+    &RuntimeContext,
+) -> Result<serde_json::Value, AgentError>
+    + Send
+    + Sync
+    + 'static
+```
+
+`Tool` exposes `id`, `description`, `parameters`, `execute`, and `require_approval`. Prefer its constructors and builder method so executor types and defaults remain consistent.
+
+`RuntimeContext` passed to an executor contains:
+
+- `run_id`
+- `agent_id`
+- `step_index`
+- `context`
+- `tool_call`
+
+## Messages and tool calls
+
+`Message` contains `role`, `content`, `tool_calls`, optional `tool_call_id`, optional `name`, and `is_error`. Create ordinary messages with:
+
+- `Message::user(content)`
+- `Message::assistant(content)`
+
+`ToolCall` contains the call `id`, tool `name`, and JSON `input`.
+
+`ToolSpec` contains the tool `id`, `description`, and JSON Schema `parameters` sent to a model client.
+
+## Model clients
+
+Implement `ModelClient` to use another model transport:
+
+```rust
+pub trait ModelClient {
+    fn generate(
+        &mut self,
+        request: &ModelRequest,
+    ) -> Result<ModelResponse, AgentError>;
+}
+```
+
+The built-in Gateway adapter is available through:
+
+- `GatewayAgentClient::new(phaseo_client, model)`
+- `GatewayAgentClient::from_env(model)`
+- `create_gateway_agent_client(model)`
+
+It sends `ModelRequest` values to `POST /responses` and normalizes output text, function calls, request metadata, and usage.
+
+`ModelRequest` contains the agent ID, effective model, instructions, current messages, tool specifications, and application context.
+
+`ModelResponse` contains:
+
+- `message: Message`
+- `usage: UsageSummary`
+- `request_id: Option<String>`
+- `provider: Option<String>`
+- `model: Option<String>`
+- `finish_reason: Option<String>`
+
+## Review and pause types
+
+`HumanReviewContext` contains the run and agent IDs, step index, current messages, normalized model response, and application context.
+
+Return `HumanReviewRequest { reason, payload }` from the review callback to pause a run.
+
+`HumanPause` contains:
+
+- `reason`
+- JSON `payload`
+- `kind`
+- `pending_tool_calls`
+
+Each `PendingToolCall` contains the original `ToolCall`, its required input `kind`, and a human-readable `reason`.
+
+`ToolDecision` supplies an approved `tool_call_id` and optional reason. `ToolOutput` supplies a `tool_call_id` and JSON output.
+
+## Run records
+
+`RunResult` contains:
+
+- `run: RunRecord`
+- `steps: Vec<RunStep>`
+- `output: Value`
+- `messages: Vec<Message>`
+- `usage: UsageSummary`
+
+`RunRecord` contains the run and agent IDs, effective model and step limit, status, original input, application context, step count, optional pause, optional stop reason, and timestamps.
+
+`RunStep` contains its index, status, model-attempt count, tool calls, request ID, provider, model, finish reason, optional error, and usage.
+
+`UsageSummary` contains `input_tokens`, `output_tokens`, `cached_tokens`, `total_tokens`, and `cost`.
+
+`RunResult`, `RunRecord`, `RunStep`, `Message`, `ToolCall`, `HumanPause`, `PendingToolCall`, `ToolDecision`, `ToolOutput`, and `UsageSummary` support Serde serialization where their definitions derive `Serialize` and `Deserialize`.
+
+## Events and errors
+
+`AgentEvent` fields:
+
+- `event_type`
+- `run_id`
+- `agent_id`
+- `timestamp_ms`
+- `details`
+
+`AgentError` implements `std::error::Error` and `Display`. Use `AgentError::new(...)` to create one and `message()` to read its message.
+
+## External reference
+
+- [`phaseo-agent` on crates.io](https://crates.io/crates/phaseo-agent)
+- [`phaseo-agent` on docs.rs](https://docs.rs/phaseo-agent)

--- a/apps/docs/v1/sdk-reference/rust/agent-sdk-api-reference.mdx
+++ b/apps/docs/v1/sdk-reference/rust/agent-sdk-api-reference.mdx
@@ -151,6 +151,8 @@ Each `PendingToolCall` contains the original `ToolCall`, its required input `kin
 
 `UsageSummary` contains `input_tokens`, `output_tokens`, `cached_tokens`, `total_tokens`, and `cost`.
 
+`cost` is model-client supplied. The built-in `0.1` Gateway adapter does not currently map Gateway `cost_nanos` or `cost_cents` into this field.
+
 `RunResult`, `RunRecord`, `RunStep`, `Message`, `ToolCall`, `HumanPause`, `PendingToolCall`, `ToolDecision`, `ToolOutput`, and `UsageSummary` support Serde serialization where their definitions derive `Serialize` and `Deserialize`.
 
 ## Events and errors

--- a/apps/docs/v1/sdk-reference/rust/agent-sdk-events-and-errors.mdx
+++ b/apps/docs/v1/sdk-reference/rust/agent-sdk-events-and-errors.mdx
@@ -62,9 +62,11 @@ let definition = AgentDefinition::new(
 - `output_tokens`
 - `cached_tokens`
 - `total_tokens`
-- `cost`
+- `cost`, when the model client populates it
 
 Each `RunStep` also contains its own usage summary, request ID, provider, model, and finish reason.
+
+The built-in `0.1` Gateway adapter does not map Gateway `cost_nanos` or `cost_cents` into `UsageSummary.cost`. Read the Gateway response or generation record when exact spend is required.
 
 ## Errors
 

--- a/apps/docs/v1/sdk-reference/rust/agent-sdk-events-and-errors.mdx
+++ b/apps/docs/v1/sdk-reference/rust/agent-sdk-events-and-errors.mdx
@@ -1,0 +1,93 @@
+---
+title: "Events, Retries, and Errors"
+description: "Observe synchronous Rust agent runs and handle model or tool failures."
+---
+
+## Lifecycle events
+
+Use `run_with_events(...)` or `continue_with_events(...)` to receive events synchronously:
+
+```rust
+use phaseo_agent::{AgentEvent, RunOptions};
+
+let mut on_event = |event: &AgentEvent| {
+    println!(
+        "{} run={} details={}",
+        event.event_type,
+        event.run_id,
+        event.details
+    );
+};
+
+let result = agent.run_with_events(
+    &mut client,
+    RunOptions::new("Check project health"),
+    Some(&mut on_event),
+)?;
+```
+
+The runtime currently emits:
+
+- `run.started`
+- `model.request.started`
+- `model.response.completed`
+- `tool.started`
+- `tool.completed`
+- `run.paused`
+- `run.resumed`
+- `run.completed`
+- `run.stopped`
+
+Callbacks execute on the run's thread. Keep them fast or hand work to another component.
+
+## Model retries
+
+```rust
+use std::time::Duration;
+
+let definition = AgentDefinition::new(
+    "resilient-agent",
+    "openai/gpt-5.6-sol",
+)
+.model_retries(2, Duration::from_millis(250));
+```
+
+`max_retries` counts additional attempts after the first request. `RunStep.model_attempts` records how many attempts produced the successful model response.
+
+## Usage
+
+`RunResult.usage` aggregates:
+
+- `input_tokens`
+- `output_tokens`
+- `cached_tokens`
+- `total_tokens`
+- `cost`
+
+Each `RunStep` also contains its own usage summary, request ID, provider, model, and finish reason.
+
+## Errors
+
+All runtime failures use `AgentError`:
+
+```rust
+match agent.run(&mut client, options) {
+    Ok(result) => println!("{}", result.output),
+    Err(error) => eprintln!("Agent failed: {}", error.message()),
+}
+```
+
+Gateway `PhaseoError` values are converted into `AgentError`. If an application needs the original Gateway status and body, call the `phaseo` client directly or implement a custom `ModelClient` that preserves those fields in its own error handling.
+
+Local tool executor errors are returned to the model as tool results instead of ending the run immediately.
+
+## Step limits
+
+`AgentDefinition::max_steps(...)` sets the default model-turn limit. Override it for one run:
+
+```rust
+let mut options = RunOptions::new("Investigate this issue");
+options.max_steps = Some(4);
+```
+
+When the limit is reached, `run.status` is `stopped` and `run.stop_reason` is `max_steps:<limit>`.

--- a/apps/docs/v1/sdk-reference/rust/agent-sdk-installation.mdx
+++ b/apps/docs/v1/sdk-reference/rust/agent-sdk-installation.mdx
@@ -1,0 +1,55 @@
+---
+icon: "package"
+title: "Rust Agent SDK Installation"
+description: "Install phaseo-agent and configure its Phaseo Gateway client."
+---
+
+## Requirements
+
+- Rust 1.86 or newer
+- a Phaseo Gateway API key
+
+## Install
+
+```toml
+[dependencies]
+phaseo = "0.1"
+phaseo-agent = "0.1"
+serde_json = "1"
+```
+
+Or run:
+
+```bash
+cargo add phaseo@0.1 phaseo-agent@0.1 serde_json
+```
+
+## Configure authentication
+
+`create_gateway_agent_client(...)` and `GatewayAgentClient::from_env(...)` read `PHASEO_API_KEY`:
+
+```bash
+export PHASEO_API_KEY="phaseo_v1_sk_..."
+```
+
+The underlying `phaseo` client also accepts an optional `PHASEO_BASE_URL`.
+
+## Verify the installation
+
+```rust
+use phaseo_agent::{create_agent, AgentDefinition};
+
+fn main() {
+    let _agent = create_agent(AgentDefinition::new(
+        "verification-agent",
+        "openai/gpt-5.6-sol",
+    ));
+    println!("Phaseo Rust Agent SDK installed");
+}
+```
+
+## Next
+
+- [Build your first Rust agent](./agent-sdk)
+- [Tools and approvals](./agent-sdk-tools)
+- [Agent API reference](./agent-sdk-api-reference)

--- a/apps/docs/v1/sdk-reference/rust/agent-sdk-overview.mdx
+++ b/apps/docs/v1/sdk-reference/rust/agent-sdk-overview.mdx
@@ -1,0 +1,58 @@
+---
+icon: "bot"
+title: "Rust Agent SDK"
+description: "Build synchronous, tool-using agents with phaseo-agent."
+---
+
+Use the published [`phaseo-agent`](https://crates.io/crates/phaseo-agent) crate when a Rust application needs a bounded model loop, local tools, approvals, or resumable human review.
+
+The Rust Agent SDK builds on the `phaseo` client and runs model turns through the Phaseo Responses API.
+
+## Supported capabilities
+
+| Capability | Rust support |
+| --- | --- |
+| Local executable tools | Yes, executed synchronously in model-call order |
+| External tool outputs | Yes, through `Tool::external(...)` and `ContinueOptions` |
+| Tool approval | Yes, by exact tool-call ID |
+| Human review | Yes, with serializable paused run state |
+| Model retries | Yes, with fixed backoff |
+| Lifecycle events | Yes, through callback-based run methods |
+| Usage aggregation | Input, output, cached, total tokens, and cost |
+| Run limits | Maximum model steps |
+| Gateway adapter | Responses API through `GatewayAgentClient` |
+| Streaming | Not yet supported |
+| Async execution and cancellation | Not yet supported |
+| Concurrent local tools | Not yet supported |
+| Runtime schema validation | JSON Schema is sent to the model; local inputs and outputs are `serde_json::Value` |
+| Devtools capture | Not yet supported |
+
+<Note>
+  Rust is a supported synchronous runtime, not a feature-for-feature port of the TypeScript streaming runtime. The pages in this section document only APIs shipped in `phaseo-agent 0.1`.
+</Note>
+
+## Runtime model
+
+Each run:
+
+1. sends the current messages and tool definitions to a `ModelClient`
+2. executes available local tools
+3. pauses for approvals, external outputs, or human review when required
+4. appends results and continues until completion or the step limit
+
+The SDK does not store runs in a Phaseo-hosted service. Persist `RunResult` in your application when a run must survive a process restart.
+
+<Columns cols={2}>
+  <Card title="Install the Agent SDK" icon="package" href="./agent-sdk-installation">
+    Add both Rust crates and configure your API key.
+  </Card>
+  <Card title="Build your first agent" icon="play" href="./agent-sdk">
+    Run a local tool loop through Phaseo Gateway.
+  </Card>
+  <Card title="Tools and approvals" icon="wrench" href="./agent-sdk-tools">
+    Add local, external, and approval-gated tools.
+  </Card>
+  <Card title="Agent API reference" icon="book-open" href="./agent-sdk-api-reference">
+    Review the exact Rust structs, traits, and methods.
+  </Card>
+</Columns>

--- a/apps/docs/v1/sdk-reference/rust/agent-sdk-overview.mdx
+++ b/apps/docs/v1/sdk-reference/rust/agent-sdk-overview.mdx
@@ -18,7 +18,7 @@ The Rust Agent SDK builds on the `phaseo` client and runs model turns through th
 | Human review | Yes, with serializable paused run state |
 | Model retries | Yes, with fixed backoff |
 | Lifecycle events | Yes, through callback-based run methods |
-| Usage aggregation | Input, output, cached, total tokens, and cost |
+| Usage aggregation | Input, output, cached, and total tokens; cost when populated by a custom model client |
 | Run limits | Maximum model steps |
 | Gateway adapter | Responses API through `GatewayAgentClient` |
 | Streaming | Not yet supported |
@@ -41,6 +41,8 @@ Each run:
 4. appends results and continues until completion or the step limit
 
 The SDK does not store runs in a Phaseo-hosted service. Persist `RunResult` in your application when a run must survive a process restart.
+
+The `0.1` Gateway adapter does not currently map Gateway `cost_nanos` or `cost_cents` into `UsageSummary.cost`. Use the Gateway response or generation record for spend reporting rather than the Agent SDK cost field.
 
 <Columns cols={2}>
   <Card title="Install the Agent SDK" icon="package" href="./agent-sdk-installation">

--- a/apps/docs/v1/sdk-reference/rust/agent-sdk-state-and-approval.mdx
+++ b/apps/docs/v1/sdk-reference/rust/agent-sdk-state-and-approval.mdx
@@ -1,0 +1,88 @@
+---
+title: "Persist and Resume Runs"
+description: "Store Rust Agent SDK run state and continue after tools or human review."
+---
+
+`RunResult` is serializable with Serde. Store it in your own database, object store, or job record when a pause must survive a process restart.
+
+## Save paused state
+
+```rust
+let paused_json = serde_json::to_string_pretty(&paused)?;
+std::fs::write("paused-run.json", paused_json)?;
+```
+
+## Restore state
+
+```rust
+use phaseo_agent::RunResult;
+
+let saved = std::fs::read_to_string("paused-run.json")?;
+let paused: RunResult = serde_json::from_str(&saved)?;
+```
+
+Recreate the same agent definition and tools before continuing. Closures and `AgentDefinition` are not part of the serialized run.
+
+The effective model and maximum step count are stored in `RunRecord`, so per-run overrides remain active after continuation.
+
+## Human review
+
+Use `human_review(...)` to inspect a completed model turn and request human input:
+
+```rust
+use phaseo_agent::{AgentDefinition, HumanReviewRequest};
+use serde_json::json;
+
+let definition = AgentDefinition::new(
+    "review-agent",
+    "openai/gpt-5.6-sol",
+)
+.human_review(|context| {
+    if context.response.message.content.contains("needs approval") {
+        Some(HumanReviewRequest {
+            reason: "Review the proposed action".to_string(),
+            payload: json!({
+                "draft": context.response.message.content
+            }),
+        })
+    } else {
+        None
+    }
+});
+```
+
+Resume with human input:
+
+```rust
+use phaseo_agent::ContinueOptions;
+
+let mut options = ContinueOptions::new(paused);
+options.human_input = Some(
+    "Approved. Continue and return the final result.".to_string(),
+);
+
+let completed = agent.continue_run(&mut client, options)?;
+```
+
+## Pause kinds
+
+| `pause.kind` | Required continuation value |
+| --- | --- |
+| `human_review` | Non-empty `ContinueOptions.human_input` |
+| `tool_approval` | `ToolDecision` entries by tool-call ID |
+| `external_output` | `ToolOutput` entries by tool-call ID |
+| `tool_input` | A mixture of approvals and external outputs |
+
+## Application-owned persistence
+
+The Rust Agent SDK does not provide a hosted state backend or persistence adapter. Your application owns:
+
+- encryption and retention of stored runs
+- authorization for approvals and human input
+- recreation of tool executors
+- idempotency around resumed side effects
+
+## Related
+
+- [Tools and approvals](./agent-sdk-tools)
+- [Events, retries, and errors](./agent-sdk-events-and-errors)

--- a/apps/docs/v1/sdk-reference/rust/agent-sdk-tools.mdx
+++ b/apps/docs/v1/sdk-reference/rust/agent-sdk-tools.mdx
@@ -1,0 +1,128 @@
+---
+title: "Tools and Approvals"
+description: "Define local, external, and approval-gated tools in the Rust Agent SDK."
+---
+
+## Local tools
+
+Use `Tool::new(...)` when the Rust process can execute the operation:
+
+```rust
+use phaseo_agent::Tool;
+use serde_json::json;
+
+let get_status = Tool::new(
+    "get_status",
+    "Get the current service status",
+    json!({
+        "type": "object",
+        "properties": {
+            "service": { "type": "string" }
+        },
+        "required": ["service"]
+    }),
+    |input, _context| {
+        Ok(json!({
+            "service": input["service"],
+            "status": "healthy"
+        }))
+    },
+);
+```
+
+The parameters value is sent to the model as JSON Schema. Tool input and output are `serde_json::Value`; validate untrusted arguments inside the executor when stronger runtime guarantees are required.
+
+## Approval-gated tools
+
+Add `require_approval()` to pause before execution:
+
+```rust
+let deploy = Tool::new(
+    "deploy",
+    "Deploy an application environment",
+    json!({
+        "type": "object",
+        "properties": {
+            "environment": { "type": "string" }
+        },
+        "required": ["environment"]
+    }),
+    |input, _context| {
+        Ok(json!({
+            "environment": input["environment"],
+            "deployed": true
+        }))
+    },
+)
+.require_approval();
+```
+
+When the model calls this tool, the run returns with `run.status == "waiting_for_human"` and `run.pause.kind == "tool_approval"`.
+
+Resume by exact call ID:
+
+```rust
+use phaseo_agent::{ContinueOptions, ToolDecision};
+
+let call_id = paused.run.pause.as_ref().unwrap()
+    .pending_tool_calls[0].call.id.clone();
+
+let mut options = ContinueOptions::new(paused);
+options.approvals.push(ToolDecision {
+    tool_call_id: call_id,
+    reason: Some("Approved by the release operator".to_string()),
+});
+
+let completed = agent.continue_run(&mut client, options)?;
+```
+
+The Rust `0.1` API does not expose a separate rejection type. Leave an unapproved call paused or apply your application's rejection policy before resuming.
+
+## External tools
+
+Use `Tool::external(...)` when another process performs the operation:
+
+```rust
+let ticket_lookup = Tool::external(
+    "ticket_lookup",
+    "Load one support ticket",
+    json!({
+        "type": "object",
+        "properties": {
+            "ticket_id": { "type": "string" }
+        },
+        "required": ["ticket_id"]
+    }),
+);
+```
+
+The pause kind is `external_output` when every pending call needs an external result. Supply each result by call ID:
+
+```rust
+use phaseo_agent::{ContinueOptions, ToolOutput};
+
+let call_id = paused.run.pause.as_ref().unwrap()
+    .pending_tool_calls[0].call.id.clone();
+
+let mut options = ContinueOptions::new(paused);
+options.tool_outputs.push(ToolOutput {
+    tool_call_id: call_id,
+    output: json!({
+        "subject": "Provider latency increased",
+        "priority": "high"
+    }),
+});
+
+let completed = agent.continue_run(&mut client, options)?;
+```
+
+If one model turn mixes automatic and pending tools, the runtime executes the automatic tools before it returns the pause.
+
+## Tool errors
+
+An `AgentError` returned by a local executor becomes a structured tool error message and is sent back to the model. An unknown tool name or a missing approval/output fails continuation with `AgentError`.
+
+## Related
+
+- [Persist and resume runs](./agent-sdk-state-and-approval)
+- [Agent API reference](./agent-sdk-api-reference)

--- a/apps/docs/v1/sdk-reference/rust/agent-sdk-tools.mdx
+++ b/apps/docs/v1/sdk-reference/rust/agent-sdk-tools.mdx
@@ -64,14 +64,17 @@ Resume by exact call ID:
 ```rust
 use phaseo_agent::{ContinueOptions, ToolDecision};
 
-let call_id = paused.run.pause.as_ref().unwrap()
-    .pending_tool_calls[0].call.id.clone();
+let approvals = paused.run.pause.as_ref().unwrap()
+    .pending_tool_calls
+    .iter()
+    .map(|pending| ToolDecision {
+        tool_call_id: pending.call.id.clone(),
+        reason: Some("Approved by the release operator".to_string()),
+    })
+    .collect();
 
 let mut options = ContinueOptions::new(paused);
-options.approvals.push(ToolDecision {
-    tool_call_id: call_id,
-    reason: Some("Approved by the release operator".to_string()),
-});
+options.approvals = approvals;
 
 let completed = agent.continue_run(&mut client, options)?;
 ```
@@ -101,17 +104,20 @@ The pause kind is `external_output` when every pending call needs an external re
 ```rust
 use phaseo_agent::{ContinueOptions, ToolOutput};
 
-let call_id = paused.run.pause.as_ref().unwrap()
-    .pending_tool_calls[0].call.id.clone();
+let outputs = paused.run.pause.as_ref().unwrap()
+    .pending_tool_calls
+    .iter()
+    .map(|pending| ToolOutput {
+        tool_call_id: pending.call.id.clone(),
+        output: json!({
+            "subject": "Provider latency increased",
+            "priority": "high"
+        }),
+    })
+    .collect();
 
 let mut options = ContinueOptions::new(paused);
-options.tool_outputs.push(ToolOutput {
-    tool_call_id: call_id,
-    output: json!({
-        "subject": "Provider latency increased",
-        "priority": "high"
-    }),
-});
+options.tool_outputs = outputs;
 
 let completed = agent.continue_run(&mut client, options)?;
 ```

--- a/apps/docs/v1/sdk-reference/rust/agent-sdk.mdx
+++ b/apps/docs/v1/sdk-reference/rust/agent-sdk.mdx
@@ -1,0 +1,131 @@
+---
+title: "Build with the Rust Agent SDK"
+description: "Create a synchronous Rust agent that calls a local tool through Phaseo Gateway."
+---
+
+Use this guide to build a small tool-using agent and inspect its completed run.
+
+## Define a tool
+
+```rust
+use phaseo_agent::{define_tool, Tool};
+use serde_json::json;
+
+let lookup = define_tool(Tool::new(
+    "lookup_docs",
+    "Look up a Phaseo documentation topic",
+    json!({
+        "type": "object",
+        "properties": {
+            "topic": { "type": "string" }
+        },
+        "required": ["topic"]
+    }),
+    |input, context| {
+        Ok(json!({
+            "topic": input["topic"],
+            "run_id": context.run_id,
+            "found": true
+        }))
+    },
+));
+```
+
+The closure runs locally. Its `RuntimeContext` includes the run ID, agent ID, step index, application context, and original tool call.
+
+## Create the agent
+
+```rust
+use phaseo_agent::{create_agent, AgentDefinition};
+
+let agent = create_agent(
+    AgentDefinition::new("docs-agent", "openai/gpt-5.6-sol")
+        .instructions("Use lookup_docs when it helps. Finish with a concise answer.")
+        .max_steps(6)
+        .tool(lookup),
+);
+```
+
+## Run through Phaseo Gateway
+
+```rust
+use phaseo_agent::{create_gateway_agent_client, RunOptions};
+
+let mut client = create_gateway_agent_client("openai/gpt-5.6-sol")?;
+let mut options = RunOptions::new("Explain when to use routing presets.");
+options.context = serde_json::json!({
+    "workspace": "docs"
+});
+
+let result = agent.run(&mut client, options)?;
+println!("{}", result.output);
+```
+
+## Complete example
+
+```rust
+use phaseo_agent::{
+    create_agent, create_gateway_agent_client, define_tool, AgentDefinition,
+    RunOptions, Tool,
+};
+use serde_json::json;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let lookup = define_tool(Tool::new(
+        "lookup_docs",
+        "Look up a Phaseo documentation topic",
+        json!({
+            "type": "object",
+            "properties": {
+                "topic": { "type": "string" }
+            },
+            "required": ["topic"]
+        }),
+        |input, context| {
+            Ok(json!({
+                "topic": input["topic"],
+                "run_id": context.run_id,
+                "found": true
+            }))
+        },
+    ));
+
+    let agent = create_agent(
+        AgentDefinition::new("docs-agent", "openai/gpt-5.6-sol")
+            .instructions("Use lookup_docs when helpful. Answer concisely.")
+            .max_steps(6)
+            .tool(lookup),
+    );
+
+    let mut client = create_gateway_agent_client("openai/gpt-5.6-sol")?;
+    let result = agent.run(
+        &mut client,
+        RunOptions::new("Explain when to use routing presets."),
+    )?;
+
+    println!("{}", result.output);
+    println!("steps: {}", result.run.step_count);
+    println!("tokens: {}", result.usage.total_tokens);
+    Ok(())
+}
+```
+
+## Run state
+
+`RunResult` contains:
+
+- `run`: status, IDs, effective model, step limit, context, and pause state
+- `steps`: each model turn, request ID, provider, model, finish reason, tool calls, and usage
+- `messages`: the complete model and tool message history
+- `output`: the final output value
+- `usage`: aggregate token and cost values
+
+## Current execution model
+
+Rust Agent SDK runs are synchronous. Local tools execute one at a time. Use an application worker thread or task boundary when a run should not block a request handler.
+
+## Next
+
+- [Tools and approvals](./agent-sdk-tools)
+- [Persist and resume runs](./agent-sdk-state-and-approval)
+- [Events, retries, and errors](./agent-sdk-events-and-errors)

--- a/apps/docs/v1/sdk-reference/rust/agent-sdk.mdx
+++ b/apps/docs/v1/sdk-reference/rust/agent-sdk.mdx
@@ -118,7 +118,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 - `steps`: each model turn, request ID, provider, model, finish reason, tool calls, and usage
 - `messages`: the complete model and tool message history
 - `output`: the final output value
-- `usage`: aggregate token and cost values
+- `usage`: aggregate token values and any cost supplied by the model client
 
 ## Current execution model
 

--- a/apps/docs/v1/sdk-reference/rust/api-reference.mdx
+++ b/apps/docs/v1/sdk-reference/rust/api-reference.mdx
@@ -1,0 +1,59 @@
+---
+title: "Rust API Reference"
+description: "Public types and methods in phaseo 0.1."
+---
+
+This page describes the supported high-level API in [`phaseo 0.1`](https://docs.rs/phaseo/0.1.0/phaseo/).
+
+## `Phaseo`
+
+The synchronous authenticated Gateway client.
+
+| Method | Returns | Purpose |
+| --- | --- | --- |
+| `Phaseo::new(api_key)` | `Result<Phaseo, PhaseoError>` | Create a client with the production base URL. |
+| `Phaseo::from_env()` | `Result<Phaseo, PhaseoError>` | Read `PHASEO_API_KEY` and optional `PHASEO_BASE_URL`. |
+| `.with_base_url(url)` | `Result<Phaseo, PhaseoError>` | Replace the base URL. Remote URLs require HTTPS; exact loopback hosts may use HTTP. |
+| `.with_header(name, value)` | `Phaseo` | Add a header to subsequent requests. |
+| `.responses(request)` | `Result<PhaseoResponse, PhaseoError>` | POST JSON to `/responses`. |
+| `.chat_completions(request)` | `Result<PhaseoResponse, PhaseoError>` | POST JSON to `/chat/completions`. |
+| `.post(path, request)` | `Result<PhaseoResponse, PhaseoError>` | POST JSON to another path beneath the configured base URL. |
+
+All request bodies are `&serde_json::Value`.
+
+## `PhaseoResponse`
+
+| Field | Type | Meaning |
+| --- | --- | --- |
+| `status` | `u16` | HTTP status code. |
+| `body` | `serde_json::Value` | Parsed JSON response, or a JSON string when the response was not valid JSON. |
+| `request_id` | `Option<String>` | `x-request-id` response header when present. |
+
+## `PhaseoError`
+
+| Field | Type | Meaning |
+| --- | --- | --- |
+| `message` | `String` | Configuration, transport, or Gateway error message. |
+| `status` | `Option<u16>` | Gateway HTTP status when a response was received. |
+| `body` | `Option<serde_json::Value>` | Parsed Gateway error body when available. |
+
+`PhaseoError` implements `std::error::Error` and `Display`.
+
+## Generated modules
+
+The crate also exposes its generated OpenAPI client:
+
+| Module | Purpose |
+| --- | --- |
+| `phaseo::gen` | Complete generated client, models, and operations modules. |
+| `phaseo::client` | Re-export of `phaseo::gen::client`. |
+| `phaseo::models` | Re-export of `phaseo::gen::models`. |
+| `phaseo::operations` | Re-export of `phaseo::gen::operations`. |
+| `phaseo::model_ids` | Generated Phaseo model identifiers. |
+
+Generated operation names and types follow the OpenAPI output and may be lower-level than the `Phaseo` helpers. Prefer the high-level methods above for Responses and Chat Completions.
+
+## External reference
+
+- [`phaseo` on crates.io](https://crates.io/crates/phaseo)
+- [`phaseo` on docs.rs](https://docs.rs/phaseo)

--- a/apps/docs/v1/sdk-reference/rust/chat-completions.mdx
+++ b/apps/docs/v1/sdk-reference/rust/chat-completions.mdx
@@ -1,0 +1,44 @@
+---
+title: "Chat Completions"
+description: "Send OpenAI-compatible Chat Completions requests with the Rust SDK."
+---
+
+Use `chat_completions(...)` when an existing integration already uses message-based Chat Completions payloads.
+
+```rust
+use phaseo::Phaseo;
+use serde_json::json;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let client = Phaseo::from_env()?;
+    let response = client.chat_completions(&json!({
+        "model": "openai/gpt-5.6-sol",
+        "messages": [
+            {
+                "role": "system",
+                "content": "Answer concisely."
+            },
+            {
+                "role": "user",
+                "content": "What is provider fallback?"
+            }
+        ]
+    }))?;
+
+    let text = response
+        .body
+        .pointer("/choices/0/message/content")
+        .and_then(|value| value.as_str())
+        .unwrap_or("");
+
+    println!("{text}");
+    Ok(())
+}
+```
+
+For new integrations, prefer the [Responses API](./responses). It provides one request model for text, multimodal input, tools, and richer output items.
+
+## Related
+
+- [Chat Completions API reference](../../api-reference/endpoint/chat-completions)
+- [Rust API reference](./api-reference)

--- a/apps/docs/v1/sdk-reference/rust/installation.mdx
+++ b/apps/docs/v1/sdk-reference/rust/installation.mdx
@@ -1,17 +1,76 @@
 ---
-title: "Rust SDK Installation (work in progress)"
-description: "Build the work-in-progress Rust SDK from source."
+icon: "package"
+title: "Rust SDK Installation"
+description: "Install phaseo from crates.io and configure Phaseo Gateway authentication."
 ---
 
-<Note type="warning">The Rust SDK is a work in progress and is not yet published to crates.io.</Note>
+Use this guide to add the supported Rust client and make it available to your application.
 
-## Local build
+## Requirements
 
-- Requires a recent Rust toolchain (stable).
-- From the repo root, go to `packages/sdk/sdk-rust`.
-- Build with Cargo and use the crate as a path dependency.
+- Rust 1.86 or newer
+- a Phaseo Gateway API key
+
+## Install
+
+Add the client and JSON dependency:
+
+```toml
+[dependencies]
+phaseo = "0.1"
+serde_json = "1"
+```
+
+Or run:
 
 ```bash
-cd packages/sdk/sdk-rust
-cargo build
+cargo add phaseo@0.1 serde_json
 ```
+
+## Configure your API key
+
+`Phaseo::from_env()` reads `PHASEO_API_KEY`:
+
+```bash
+export PHASEO_API_KEY="phaseo_v1_sk_..."
+```
+
+PowerShell:
+
+```powershell
+$env:PHASEO_API_KEY = "phaseo_v1_sk_..."
+```
+
+Keep the key on the server. Do not compile it into a desktop, mobile, browser, or other distributed client.
+
+## Verify the installation
+
+```rust
+use phaseo::Phaseo;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let _client = Phaseo::from_env()?;
+    println!("Phaseo Rust client configured");
+    Ok(())
+}
+```
+
+```bash
+cargo run
+```
+
+## Custom endpoints
+
+Set `PHASEO_BASE_URL` when a development or proxy endpoint should replace `https://api.phaseo.app/v1`:
+
+```bash
+export PHASEO_BASE_URL="http://localhost:8787/v1"
+```
+
+Remote endpoints must use HTTPS. Plain HTTP is accepted only when the parsed host is exactly `localhost` or a loopback IP address.
+
+## Next
+
+- [Send requests](./usage)
+- [Responses API](./responses)
+- [Rust API reference](./api-reference)

--- a/apps/docs/v1/sdk-reference/rust/overview.mdx
+++ b/apps/docs/v1/sdk-reference/rust/overview.mdx
@@ -1,12 +1,57 @@
 ---
-title: "Rust SDK (work in progress)"
-description: "Review the work-in-progress Rust client source."
+icon: "compass"
+title: "Rust SDK"
+description: "Send Phaseo Gateway requests from Rust with the official phaseo crate."
 ---
 
-<Note type="warning">
-  The Rust SDK is a work in progress and is not yet published to crates.io. Use the source build for evaluation only.
+Use the published [`phaseo`](https://crates.io/crates/phaseo) crate to call Phaseo Gateway from a Rust application.
+
+The high-level client supports:
+
+- Responses API requests with `Phaseo::responses(...)`
+- Chat Completions requests with `Phaseo::chat_completions(...)`
+- other JSON endpoints with `Phaseo::post(...)`
+- environment-based configuration with `Phaseo::from_env()`
+- custom HTTPS endpoints and loopback development servers
+- structured status, JSON body, request ID, and error details
+
+```rust
+use phaseo::Phaseo;
+use serde_json::json;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let client = Phaseo::from_env()?;
+    let response = client.responses(&json!({
+        "model": "openai/gpt-5.6-sol",
+        "input": "Reply with exactly: Rust SDK works"
+    }))?;
+
+    println!("{}", response.body);
+    Ok(())
+}
+```
+
+<Note>
+  Version `0.1` is supported and published, but its Rust API can still evolve before `1.0`. Pin a compatible minor version in production.
 </Note>
 
-- Status: Work in progress (not yet on crates.io).
-- Source lives in `packages/sdk/sdk-rust`.
-- Generated code is in `packages/sdk/sdk-rust/src/gen`.
+## Current scope
+
+The ergonomic client is synchronous and accepts `serde_json::Value` request bodies. Generated low-level modules remain available under `phaseo::gen`, with convenience re-exports under `phaseo::client`, `phaseo::models`, and `phaseo::operations`.
+
+The Rust client does not currently provide an async transport or a high-level streaming helper. Use the raw HTTP API when an application needs streaming before those helpers are added.
+
+<Columns cols={2}>
+  <Card title="Install the Rust SDK" icon="package" href="./installation">
+    Add the crate and configure your API key.
+  </Card>
+  <Card title="Send requests" icon="play" href="./usage">
+    Call Responses, Chat Completions, and other JSON endpoints.
+  </Card>
+  <Card title="Rust API reference" icon="book-open" href="./api-reference">
+    Review the exact public types and methods in `phaseo 0.1`.
+  </Card>
+  <Card title="docs.rs" icon="arrow-up-right-from-square" href="https://docs.rs/phaseo">
+    Browse generated Rust API documentation.
+  </Card>
+</Columns>

--- a/apps/docs/v1/sdk-reference/rust/responses.mdx
+++ b/apps/docs/v1/sdk-reference/rust/responses.mdx
@@ -1,0 +1,66 @@
+---
+title: "Responses API"
+description: "Generate text and tool calls through the Phaseo Responses API from Rust."
+---
+
+Use `responses(...)` for new text-generation and tool-calling work.
+
+```rust
+use phaseo::Phaseo;
+use serde_json::json;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let client = Phaseo::from_env()?;
+    let response = client.responses(&json!({
+        "model": "openai/gpt-5.6-sol",
+        "input": "Give three concise benefits of model routing.",
+        "max_output_tokens": 200
+    }))?;
+
+    println!("status: {}", response.status);
+    println!("request ID: {:?}", response.request_id);
+    println!("{}", serde_json::to_string_pretty(&response.body)?);
+    Ok(())
+}
+```
+
+## Read the output text
+
+Responses API output is an array. For a simple text result:
+
+```rust
+let text = response
+    .body
+    .pointer("/output/0/content/0/text")
+    .and_then(|value| value.as_str());
+```
+
+Keep the full `body` when your request can return multiple messages, reasoning items, tool calls, or provider metadata.
+
+## Send function tools
+
+```rust
+let response = client.responses(&json!({
+    "model": "openai/gpt-5.6-sol",
+    "input": "Check the weather in London.",
+    "tools": [{
+        "type": "function",
+        "name": "get_weather",
+        "description": "Get the current weather for a city.",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "city": { "type": "string" }
+            },
+            "required": ["city"]
+        }
+    }]
+}))?;
+```
+
+For a local tool loop with approvals and resumable state, use the [Rust Agent SDK](./agent-sdk-overview).
+
+## Related
+
+- [Responses API reference](../../api-reference/endpoint/responses)
+- [Build with the Rust Agent SDK](./agent-sdk)

--- a/apps/docs/v1/sdk-reference/rust/responses.mdx
+++ b/apps/docs/v1/sdk-reference/rust/responses.mdx
@@ -29,10 +29,25 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 Responses API output is an array. For a simple text result:
 
 ```rust
-let text = response
-    .body
-    .pointer("/output/0/content/0/text")
-    .and_then(|value| value.as_str());
+use serde_json::Value;
+
+let text = response.body
+    .get("output")
+    .and_then(Value::as_array)
+    .into_iter()
+    .flatten()
+    .filter(|item| item.get("type").and_then(Value::as_str) == Some("message"))
+    .flat_map(|item| {
+        item.get("content")
+            .and_then(Value::as_array)
+            .into_iter()
+            .flatten()
+    })
+    .find_map(|part| {
+        (part.get("type").and_then(Value::as_str) == Some("output_text"))
+            .then(|| part.get("text").and_then(Value::as_str))
+            .flatten()
+    });
 ```
 
 Keep the full `body` when your request can return multiple messages, reasoning items, tool calls, or provider metadata.

--- a/apps/docs/v1/sdk-reference/rust/usage.mdx
+++ b/apps/docs/v1/sdk-reference/rust/usage.mdx
@@ -29,7 +29,7 @@ let client = Phaseo::new("phaseo_v1_sk_...")?;
 
 ```rust
 use phaseo::Phaseo;
-use serde_json::json;
+use serde_json::{json, Value};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let client = Phaseo::from_env()?;
@@ -38,10 +38,23 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         "input": "Summarize why provider fallbacks improve reliability."
     }))?;
 
-    let text = response
-        .body
-        .pointer("/output/0/content/0/text")
-        .and_then(|value| value.as_str())
+    let text = response.body
+        .get("output")
+        .and_then(Value::as_array)
+        .into_iter()
+        .flatten()
+        .filter(|item| item.get("type").and_then(Value::as_str) == Some("message"))
+        .flat_map(|item| {
+            item.get("content")
+                .and_then(Value::as_array)
+                .into_iter()
+                .flatten()
+        })
+        .find_map(|part| {
+            (part.get("type").and_then(Value::as_str) == Some("output_text"))
+                .then(|| part.get("text").and_then(Value::as_str))
+                .flatten()
+        })
         .unwrap_or("");
 
     println!("{text}");
@@ -88,6 +101,11 @@ let client = Phaseo::from_env()?
 ## Handle Gateway errors
 
 ```rust
+let request = serde_json::json!({
+    "model": "openai/gpt-5.6-sol",
+    "input": "Handle this request"
+});
+
 match client.responses(&request) {
     Ok(response) => println!("{}", response.body),
     Err(error) => {

--- a/apps/docs/v1/sdk-reference/rust/usage.mdx
+++ b/apps/docs/v1/sdk-reference/rust/usage.mdx
@@ -1,0 +1,107 @@
+---
+title: "Usage"
+description: "Create a Rust client, send Gateway requests, and handle responses and errors."
+---
+
+Use `Phaseo` when your Rust service needs a synchronous Phaseo Gateway client.
+
+## Create a client
+
+Load the API key and optional base URL from the environment:
+
+```rust
+use phaseo::Phaseo;
+
+let client = Phaseo::from_env()?;
+```
+
+Or pass the key directly:
+
+```rust
+use phaseo::Phaseo;
+
+let client = Phaseo::new("phaseo_v1_sk_...")?;
+```
+
+`Phaseo` redacts the API key and custom header values from its `Debug` output.
+
+## Send a Responses request
+
+```rust
+use phaseo::Phaseo;
+use serde_json::json;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let client = Phaseo::from_env()?;
+    let response = client.responses(&json!({
+        "model": "openai/gpt-5.6-sol",
+        "input": "Summarize why provider fallbacks improve reliability."
+    }))?;
+
+    let text = response
+        .body
+        .pointer("/output/0/content/0/text")
+        .and_then(|value| value.as_str())
+        .unwrap_or("");
+
+    println!("{text}");
+    Ok(())
+}
+```
+
+The complete JSON response remains available in `response.body`.
+
+## Send a Chat Completions request
+
+```rust
+let response = client.chat_completions(&json!({
+    "model": "openai/gpt-5.6-sol",
+    "messages": [{
+        "role": "user",
+        "content": "Reply with exactly: chat works"
+    }]
+}))?;
+
+println!("{}", response.body);
+```
+
+## Call another JSON endpoint
+
+Use `post(...)` for a Phaseo endpoint that does not yet have a high-level helper:
+
+```rust
+let response = client.post("/embeddings", &json!({
+    "model": "openai/text-embedding-3-small",
+    "input": "Phaseo routes across AI providers"
+}))?;
+```
+
+The path may include or omit its leading slash.
+
+## Add a request header
+
+```rust
+let client = Phaseo::from_env()?
+    .with_header("x-phaseo-workspace-id", "workspace_123");
+```
+
+## Handle Gateway errors
+
+```rust
+match client.responses(&request) {
+    Ok(response) => println!("{}", response.body),
+    Err(error) => {
+        eprintln!("message: {}", error.message);
+        eprintln!("status: {:?}", error.status);
+        eprintln!("body: {:?}", error.body);
+    }
+}
+```
+
+`PhaseoError` contains an HTTP status and parsed JSON body when the Gateway returned an error. Transport and configuration failures have no HTTP status.
+
+## Next
+
+- [Responses API](./responses)
+- [Chat Completions](./chat-completions)
+- [Rust API reference](./api-reference)


### PR DESCRIPTION
## Summary

- publish complete Rust client SDK documentation for the `phaseo` crate
- publish complete synchronous Rust Agent SDK documentation for `phaseo-agent`
- add Rust to the Client SDK and Agent SDK navigation, quickstart, and examples
- document current limitations explicitly, including no async runtime, streaming, concurrent local tools, runtime schema validation, or Devtools capture

## Validation

- `cargo check --all-targets` against exact crates.io versions `phaseo = 0.1.0` and `phaseo-agent = 0.1.0`
- `cargo +1.86.0 check --all-targets`
- `pnpm docs:links`
- `pnpm docs:build`
- `git diff --check`

Created with Codex

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added comprehensive documentation for the published Rust SDK, including installation, configuration, usage, Responses API, Chat Completions, and API reference guides.
  * Added Rust examples to the quickstart and free text generation guides.
  * Added documentation for the Rust Agent SDK, covering agents, tools, approvals, state persistence, events, retries, errors, and API reference.
  * Expanded documentation navigation to include Rust SDK and Rust Agent SDK sections.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->