### PR TITLE
Fix MCP OAuth scope negotiation

### DIFF
--- a/apps/api/src/routes/oauth.security.test.ts
+++ b/apps/api/src/routes/oauth.security.test.ts
@@ -650,6 +650,53 @@ describe("OAuth route security", () => {
 		expect(state.registeredClients).toEqual([]);
 	});
 
+	it("narrows full authorization-server scope catalogues to resource-bound MCP scopes", async () => {
+		const { oauthRouter } = await import("./oauth");
+		const response = await oauthRouter.request("https://example.com/register", {
+			method: "POST",
+			headers: { "content-type": "application/json" },
+			body: JSON.stringify({
+				client_name: "Codex",
+				redirect_uris: ["http://127.0.0.1:54709/callback/test"],
+				grant_types: ["authorization_code", "refresh_token"],
+				response_types: ["code"],
+				token_endpoint_auth_method: "none",
+				scope: [
+					"openid",
+					"profile",
+					"email",
+					"gateway:access",
+					"me:read",
+					"models:read",
+					"providers:read",
+					"pricing:read",
+					"credits:read",
+					"activity:read",
+					"analytics:read",
+					"generations:read",
+					"workspaces:read",
+					"workspaces:write",
+					"keys:read",
+					"keys:write",
+				].join(" "),
+			}),
+		});
+
+		expect(response.status).toBe(201);
+		expect(state.registeredClients[0]?.allowed_scopes).toEqual([
+			"models:read",
+			"providers:read",
+			"pricing:read",
+			"credits:read",
+			"activity:read",
+			"analytics:read",
+			"generations:read",
+		]);
+		expect(await response.json()).toMatchObject({
+			scope: "models:read providers:read pricing:read credits:read activity:read analytics:read generations:read",
+		});
+	});
+
 	it("defaults dynamic MCP registration to read-only scopes", async () => {
 		const { oauthRouter } = await import("./oauth");
 		const response = await oauthRouter.request("https://example.com/register", {

--- a/apps/api/src/routes/oauth.ts
+++ b/apps/api/src/routes/oauth.ts
@@ -91,6 +91,16 @@ const DYNAMIC_MCP_DEFAULT_SCOPES = [
 	"oauth_clients:read",
 ] as const;
 const DYNAMIC_MCP_SCOPE_SET = new Set<string>(DYNAMIC_MCP_SCOPES);
+const RESOURCE_BOUND_MCP_SCOPES = [
+	"models:read",
+	"providers:read",
+	"pricing:read",
+	"credits:read",
+	"activity:read",
+	"analytics:read",
+	"generations:read",
+] as const;
+const RESOURCE_BOUND_MCP_SCOPE_SET = new Set<string>(RESOURCE_BOUND_MCP_SCOPES);
 const MCP_RESOURCE_SERVER_CLIENT_ID = "phaseo_mcp_resource_server";
 
 class OAuthRequestBodyTooLarge extends Error {}
@@ -395,7 +405,16 @@ oauthRouter.post(
 		}
 
 		const requestedScopes = normalizeScopes(body.scope, DYNAMIC_MCP_DEFAULT_SCOPES);
-		if (requestedScopes.length === 0 || !requestedScopes.every((scope) => DYNAMIC_MCP_SCOPE_SET.has(scope))) {
+		const includesUnsupportedScopes = requestedScopes.some((scope) => !DYNAMIC_MCP_SCOPE_SET.has(scope));
+		// Some MCP clients register with the authorization server's complete
+		// advertised scope catalogue instead of the protected resource's narrower
+		// scope list. Never grant that broader request. When it also contains the
+		// canonical resource-bound MCP scopes, safely negotiate it down to that
+		// exact read-only set and return the narrowed scope in the response.
+		const grantedScopes = includesUnsupportedScopes
+			? requestedScopes.filter((scope) => RESOURCE_BOUND_MCP_SCOPE_SET.has(scope))
+			: requestedScopes;
+		if (grantedScopes.length === 0) {
 			return oauthError("invalid_scope", "Dynamically registered MCP clients are limited to read-only Phaseo scopes");
 		}
 		const clientId = crypto.randomUUID();
@@ -408,7 +427,7 @@ oauthRouter.post(
 			homepage_url: typeof body.client_uri === "string" ? body.client_uri : null,
 			client_type: "public",
 			redirect_uris: safeRedirectUris,
-			allowed_scopes: requestedScopes,
+			allowed_scopes: grantedScopes,
 			is_first_party: false,
 			beta_status: "public",
 			status: "active",
@@ -425,7 +444,7 @@ oauthRouter.post(
 			// than refresh-token families, so register only the grant we issue.
 			grant_types: ["authorization_code"],
 			token_endpoint_auth_method: "none",
-			scope: requestedScopes.join(" "),
+			scope: grantedScopes.join(" "),
 		}, 201, { "Cache-Control": "no-store" });
 	}),
 );


### PR DESCRIPTION
## Summary
- negotiate overly broad dynamic MCP registrations down to Phaseo's seven resource-bound read-only scopes
- keep privileged-only dynamic registrations rejected
- add a regression test matching the scope catalogue sent by Codex

## Why
Codex discovers the global Phaseo OAuth authorization server and includes its complete advertised scope catalogue during dynamic client registration. Phaseo correctly rejected that request because it contained write and gateway scopes, which prevented a fresh MCP install from reaching the consent screen. The server now returns only the safe MCP scope subset and stores only that subset.

## Validation
- `pnpm --filter @phaseo/gateway-api exec vitest run src/routes/oauth.security.test.ts` (28 passed)
- `pnpm --filter @phaseo/gateway-api typecheck`
- reproduced the production failure with `codex mcp add` and captured the exact dynamic-registration request against a local diagnostic authorization server

Created with Codex