### PR TITLE
Fix gateway context compatibility

### DIFF
--- a/apps/api/src/core/types.ts
+++ b/apps/api/src/core/types.ts
@@ -96,9 +96,10 @@ export type RequestMeta = {
     streamDisconnectAction?: "cancel_upstream" | "drain_upstream";
     before_ms?: number;           // Gateway preflight ("before" stage) latency
     beforeContextMs?: number;     // Context fetch + enrichment latency inside before
-    beforeContextCacheStatus?: "hit" | "miss" | "bypass";
+    beforeContextCacheStatus?: "hit" | "miss" | "bypass" | "credit_refresh";
     beforeContextKeyVersionMs?: number;
     beforeContextCacheReadMs?: number;
+    beforeContextCreditRefreshMs?: number;
     beforeContextRpcMs?: number;
     beforeContextEnrichMs?: number;
     beforeContextCacheWriteMs?: number;

--- a/apps/api/src/observability/events.ts
+++ b/apps/api/src/observability/events.ts
@@ -1340,6 +1340,7 @@ export async function emitGatewayRequestEvent(args: EventArgs) {
             before_context_cache_status: ctx?.meta?.beforeContextCacheStatus ?? null,
             before_context_key_version_ms: toNum(ctx?.meta?.beforeContextKeyVersionMs),
             before_context_cache_read_ms: toNum(ctx?.meta?.beforeContextCacheReadMs),
+            before_context_credit_refresh_ms: toNum(ctx?.meta?.beforeContextCreditRefreshMs),
             before_context_rpc_ms: toNum(ctx?.meta?.beforeContextRpcMs),
             before_context_enrich_ms: toNum(ctx?.meta?.beforeContextEnrichMs),
             before_context_cache_write_ms: toNum(ctx?.meta?.beforeContextCacheWriteMs),

--- a/apps/api/src/pipeline/before/context.credit-refresh.test.ts
+++ b/apps/api/src/pipeline/before/context.credit-refresh.test.ts
@@ -1,0 +1,303 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const runtime = vi.hoisted(() => {
+	const store = new Map<string, string>();
+	const background: Promise<unknown>[] = [];
+	const pendingWriteResolvers: Array<() => void> = [];
+	let deferWrites = false;
+	let walletResult: {
+		data: { balance_nanos: number; reserved_nanos: number } | null;
+		error: { message: string } | null;
+	} = {
+		data: { balance_nanos: 5_000_000_000, reserved_nanos: 1_000_000_000 },
+		error: null,
+	};
+
+	const cache = {
+		get: vi.fn(async (key: string | string[]) => {
+			if (Array.isArray(key)) {
+				return new Map(key.flatMap((entry) => {
+					const value = store.get(entry);
+					return value == null ? [] : [[entry, value] as const];
+				}));
+			}
+			return store.get(key) ?? null;
+		}),
+		put: vi.fn(async (key: string, value: string) => {
+			if (deferWrites) {
+				await new Promise<void>((resolve) => pendingWriteResolvers.push(resolve));
+			}
+			store.set(key, value);
+		}),
+		delete: vi.fn(async (key: string) => {
+			store.delete(key);
+		}),
+	};
+
+	const contextPayload = {
+		workspace_id: "workspace_credit",
+		resolved_model: "resolved/openai-gpt-5.4-nano",
+		key_ok: { ok: true, reason: null },
+		key_limit_ok: { ok: true, reason: null },
+		credit_ok: { ok: true, reason: null, balance_nanos: 4_000_000_000 },
+		providers: [],
+		pricing: {},
+	};
+	const rpc = vi.fn(async () => ({ data: [contextPayload], error: null }));
+	const from = vi.fn((table: string) => {
+		if (table === "wallets") {
+			return {
+				select: () => ({
+					eq: () => ({
+						maybeSingle: async () => walletResult,
+					}),
+				}),
+			};
+		}
+		if (table === "workspace_settings") {
+			return {
+				select: () => ({
+					eq: () => ({
+						maybeSingle: async () => ({
+							data: {
+								routing_mode: null,
+								byok_fallback_enabled: false,
+								beta_channel_enabled: false,
+								alpha_channel_enabled: false,
+								cache_aware_routing_enabled: true,
+							},
+							error: null,
+						}),
+					}),
+				}),
+			};
+		}
+		if (table === "workspaces") {
+			return {
+				select: () => ({
+					eq: () => ({
+						maybeSingle: async () => ({
+							data: { billing_mode: "wallet" },
+							error: null,
+						}),
+					}),
+				}),
+			};
+		}
+		throw new Error(`Unexpected table: ${table}`);
+	});
+
+	return {
+		store,
+		background,
+		pendingWriteResolvers,
+		cache,
+		supabase: { rpc, from },
+		get deferWrites() {
+			return deferWrites;
+		},
+		set deferWrites(value: boolean) {
+			deferWrites = value;
+		},
+		get walletResult() {
+			return walletResult;
+		},
+		set walletResult(value) {
+			walletResult = value;
+		},
+	};
+});
+
+vi.mock("@/runtime/env", () => ({
+	getCache: () => runtime.cache as unknown as KVNamespace,
+	getSupabaseAdmin: () => runtime.supabase,
+	dispatchBackground: (promise: Promise<unknown>) => {
+		runtime.background.push(promise);
+	},
+}));
+
+const workspaceId = "workspace_credit";
+const apiKeyId = "key_credit";
+const model = "openai/gpt-5.4-nano";
+const endpoint = "chat.completions";
+
+const teamEnrichment = {
+	tier: "basic",
+	created_at: "2026-01-01T00:00:00.000Z",
+	account_age_days: 1,
+	balance_nanos: 9_000_000_000,
+	balance_usd: 9,
+	balance_is_low: false,
+	total_requests: 10,
+	total_spend_nanos: 1,
+	total_spend_usd: 0,
+	spend_24h_nanos: 1,
+	spend_24h_usd: 0,
+	spend_7d_nanos: 1,
+	spend_7d_usd: 0,
+	spend_30d_nanos: 1,
+	spend_30d_usd: 0,
+	requests_1h: 1,
+	requests_24h: 1,
+};
+
+function seedContextCache(options: { legacyCredit?: boolean; credit?: unknown } = {}): void {
+	runtime.store.set(`gateway:keyver:id:${apiKeyId}`, "1");
+	runtime.store.set(
+		`gateway:dynamic:default:${workspaceId}:${apiKeyId}:v1`,
+		JSON.stringify({
+			workspaceId,
+			key: { ok: true, reason: null, resetAt: null },
+			keyLimit: { ok: true, reason: null, resetAt: null, buckets: null },
+			teamEnrichment,
+			teamSettings: { billingMode: "wallet" },
+			...(options.legacyCredit
+				? { credit: { ok: true, reason: null, resetAt: null, balanceNanos: 9_000_000_000 } }
+				: {}),
+		}),
+	);
+	runtime.store.set(
+		`gateway:static:v2:default:${workspaceId}:${endpoint}:${model}`,
+		JSON.stringify({
+			workspaceId,
+			resolvedModel: model,
+			preset: null,
+			providers: [],
+			pricing: {},
+			testingMode: false,
+		}),
+	);
+	if (options.credit) {
+		runtime.store.set(`gateway:credit:${workspaceId}`, JSON.stringify(options.credit));
+	}
+}
+
+describe("fetchGatewayContext credit-only cache refresh", () => {
+	beforeEach(() => {
+		runtime.store.clear();
+		runtime.background.length = 0;
+		runtime.pendingWriteResolvers.length = 0;
+		runtime.deferWrites = false;
+		runtime.walletResult = {
+			data: { balance_nanos: 5_000_000_000, reserved_nanos: 1_000_000_000 },
+			error: null,
+		};
+		runtime.cache.get.mockClear();
+		runtime.cache.put.mockClear();
+		runtime.cache.delete.mockClear();
+		runtime.supabase.rpc.mockClear();
+		runtime.supabase.from.mockClear();
+		vi.resetModules();
+	});
+
+	it("refreshes only wallet credit and preserves the cached gateway context", async () => {
+		seedContextCache();
+		const { fetchGatewayContext } = await import("./context");
+
+		const context = await fetchGatewayContext({
+			workspaceId,
+			model,
+			endpoint,
+			apiKeyId,
+			disableCache: false,
+		});
+
+		expect(context.credit).toMatchObject({ ok: true, balanceNanos: 4_000_000_000 });
+		expect(context.teamEnrichment).toMatchObject({
+			balance_nanos: 4_000_000_000,
+			balance_usd: 4,
+			balance_is_low: false,
+		});
+		expect(context.contextTelemetry).toMatchObject({
+			cacheStatus: "credit_refresh",
+			rpcMs: null,
+			enrichMs: null,
+		});
+		expect(context.contextTelemetry?.creditRefreshMs).toEqual(expect.any(Number));
+		expect(runtime.supabase.rpc).not.toHaveBeenCalled();
+		expect(runtime.supabase.from).toHaveBeenCalledTimes(1);
+		expect(runtime.supabase.from).toHaveBeenCalledWith("wallets");
+		expect(runtime.background).toHaveLength(1);
+		await Promise.all(runtime.background);
+		expect(JSON.parse(runtime.store.get(`gateway:credit:${workspaceId}`) ?? "null")).toMatchObject({
+			credit: { ok: true, balanceNanos: 4_000_000_000 },
+		});
+	});
+
+	it("ignores stale legacy credit and fails closed using reserved funds", async () => {
+		seedContextCache({ legacyCredit: true });
+		runtime.walletResult = {
+			data: { balance_nanos: 1_500_000_000, reserved_nanos: 750_000_001 },
+			error: null,
+		};
+		const { fetchGatewayContext } = await import("./context");
+
+		const context = await fetchGatewayContext({
+			workspaceId,
+			model,
+			endpoint,
+			apiKeyId,
+			disableCache: false,
+		});
+
+		expect(context.credit).toMatchObject({
+			ok: false,
+			reason: "insufficient_funds",
+			balanceNanos: 749_999_999,
+		});
+		expect(context.contextTelemetry?.cacheStatus).toBe("credit_refresh");
+		expect(runtime.supabase.rpc).not.toHaveBeenCalled();
+	});
+
+	it("uses a valid separate credit snapshot without querying the wallet", async () => {
+		seedContextCache({
+			credit: {
+				workspaceId,
+				credit: { ok: true, reason: null, resetAt: null, balanceNanos: 3_000_000_000 },
+				teamEnrichment,
+			},
+		});
+		const { fetchGatewayContext } = await import("./context");
+
+		const context = await fetchGatewayContext({
+			workspaceId,
+			model,
+			endpoint,
+			apiKeyId,
+			disableCache: false,
+		});
+
+		expect(context.credit.balanceNanos).toBe(3_000_000_000);
+		expect(context.contextTelemetry).toMatchObject({
+			cacheStatus: "hit",
+			creditRefreshMs: null,
+		});
+		expect(runtime.supabase.from).not.toHaveBeenCalled();
+	});
+
+	it("does not await full-context KV writes", async () => {
+		runtime.store.set(`gateway:keyver:id:${apiKeyId}`, "1");
+		runtime.deferWrites = true;
+		const { fetchGatewayContext } = await import("./context");
+		let settled = false;
+		const fetchPromise = fetchGatewayContext({
+			workspaceId,
+			model,
+			endpoint,
+			apiKeyId,
+			disableCache: false,
+		}).then((context) => {
+			settled = true;
+			return context;
+		});
+
+		await vi.waitFor(() => expect(runtime.cache.put).toHaveBeenCalledTimes(3));
+		await Promise.resolve();
+		expect(settled).toBe(true);
+		expect(runtime.background).toHaveLength(1);
+
+		for (const resolve of runtime.pendingWriteResolvers.splice(0)) resolve();
+		await Promise.all(runtime.background);
+		await fetchPromise;
+	});
+});

--- a/apps/api/src/pipeline/before/context.shared.test.ts
+++ b/apps/api/src/pipeline/before/context.shared.test.ts
@@ -3,11 +3,70 @@ import {
 	computeAdaptiveTtlForDynamic,
 	computeStaticTtl,
 	hasConfiguredKeyLimits,
+	mergeCachedContext,
 	normalizeCapabilityStatus,
 	normalizeProviderStatus,
 	normalizeRoutingStatus,
+	splitContextForCache,
 	supportsEndpointViaModalities,
 } from "./context.shared";
+
+describe("credit cache composition", () => {
+	const teamEnrichment = {
+		tier: "basic",
+		created_at: "2026-01-01T00:00:00.000Z",
+		account_age_days: 1,
+		balance_nanos: 5_000_000_000,
+		balance_usd: 5,
+		balance_is_low: false,
+		total_requests: 1,
+		total_spend_nanos: 1,
+		total_spend_usd: 0,
+		spend_24h_nanos: 1,
+		spend_24h_usd: 0,
+		spend_7d_nanos: 1,
+		spend_7d_usd: 0,
+		spend_30d_nanos: 1,
+		spend_30d_usd: 0,
+		requests_1h: 1,
+		requests_24h: 1,
+	};
+
+	it("keeps observational team enrichment in dynamic context", () => {
+		const split = splitContextForCache({
+			workspaceId: "workspace_123",
+			key: { ok: true, reason: null, resetAt: null },
+			keyLimit: { ok: true, reason: null, resetAt: null },
+			credit: { ok: true, reason: null, resetAt: null, balanceNanos: 5_000_000_000 },
+			providers: [],
+			pricing: {},
+			teamEnrichment,
+		} as any);
+
+		expect(split.dynamic.teamEnrichment).toEqual(teamEnrichment);
+	});
+
+	it("does not fall back to stale credit embedded in a legacy dynamic entry", () => {
+		expect(() => mergeCachedContext({
+			dynamic: {
+				workspaceId: "workspace_123",
+				key: { ok: true, reason: null, resetAt: null },
+				keyLimit: { ok: true, reason: null, resetAt: null },
+				credit: { ok: true, reason: null, resetAt: null, balanceNanos: 5_000_000_000 },
+			},
+			static: {
+				workspaceId: "workspace_123",
+				resolvedModel: "openai/gpt-5.4-nano",
+				preset: null,
+				providers: [],
+				pricing: {},
+				testingMode: false,
+			},
+			credit: null,
+			endpoint: "chat.completions",
+		})).toThrow("gateway_context_credit_cache_missing");
+	});
+});
 
 describe("key limit cache policy", () => {
 	it("detects request and spend caps across every supported window", () => {

--- a/apps/api/src/pipeline/before/context.shared.ts
+++ b/apps/api/src/pipeline/before/context.shared.ts
@@ -257,7 +257,10 @@ export function mergeCachedContext(args: {
 	credit?: CreditContextCacheEntry | null;
 	endpoint: string;
 }): GatewayContextData {
-	const credit = args.credit?.credit ?? args.dynamic.credit;
+	// Credit is invalidated independently after every wallet mutation. Never
+	// fall back to a legacy credit value embedded in the dynamic entry: that can
+	// re-admit a request using a pre-charge balance after the credit key is gone.
+	const credit = args.credit?.credit;
 	if (!credit) {
 		throw new Error("gateway_context_credit_cache_missing");
 	}
@@ -290,6 +293,10 @@ export function splitContextForCache(value: GatewayContextData): {
 			keyLimit: value.keyLimit,
 			keyEnrichment: value.keyEnrichment ?? null,
 			teamSettings: value.teamSettings ?? null,
+			// Aggregate enrichment is observational rather than an authorization
+			// input. Keep it with the dynamic context so a credit-only refresh can
+			// preserve it while replacing its balance fields authoritatively.
+			teamEnrichment: value.teamEnrichment ?? null,
 		},
 		static: {
 			workspaceId: value.workspaceId,

--- a/apps/api/src/pipeline/before/context.ts
+++ b/apps/api/src/pipeline/before/context.ts
@@ -3,7 +3,7 @@
 // Why: Keeps pre-execution logic centralized and consistent.
 // How: Calls RPC/SQL to fetch provider, pricing, and gating context.
 
-import { getSupabaseAdmin, getCache } from "@/runtime/env";
+import { dispatchBackground, getSupabaseAdmin, getCache } from "@/runtime/env";
 import { getProviderResidencyMetadata } from "@/lib/config/providerResidency";
 import { getTextMany, keyVersionToken } from "@/core/kv";
 import { gatewayCreditCacheKey } from "@/core/gateway-credit-cache";
@@ -69,8 +69,70 @@ const PRESET_TTL = 120;      // 2 minutes
 const CONTEXT_INFLIGHT_MAX_ENTRIES = 512;
 const CONTEXT_KEY_VERSION_L1_TTL_MS = 5_000;
 const FREE_ROUTER_MODEL_ID = "phaseo/free";
+const MIN_GATEWAY_CREDIT_NANOS = 1_000_000_000;
 
 const contextInflight = new Map<string, Promise<GatewayContextData>>();
+
+type CreditContextSnapshot = Pick<
+	GatewayContextData,
+	"workspaceId" | "credit" | "teamEnrichment"
+>;
+
+function finiteNonNegativeNanos(value: unknown): number {
+	const parsed = Number(value);
+	return Number.isFinite(parsed) ? Math.max(0, parsed) : 0;
+}
+
+async function fetchFreshCreditContext(args: {
+	workspaceId: string;
+	teamEnrichment?: GatewayContextData["teamEnrichment"];
+}): Promise<CreditContextSnapshot> {
+	const { data, error } = await getSupabaseAdmin()
+		.from("wallets")
+		.select("balance_nanos,reserved_nanos")
+		.eq("workspace_id", args.workspaceId)
+		.maybeSingle();
+	if (error) {
+		throw new Error(`gateway_credit_refresh_failed:${error.message ?? "unknown"}`);
+	}
+
+	if (!data) {
+		return {
+			workspaceId: args.workspaceId,
+			credit: {
+				ok: false,
+				reason: "wallet_missing",
+				resetAt: null,
+				balanceNanos: 0,
+			},
+			teamEnrichment: args.teamEnrichment ?? null,
+		};
+	}
+
+	const rawBalanceNanos = finiteNonNegativeNanos(data.balance_nanos);
+	const reservedNanos = finiteNonNegativeNanos(data.reserved_nanos);
+	const availableNanos = Math.max(rawBalanceNanos - reservedNanos, 0);
+	const hasMinimumCredit = availableNanos >= MIN_GATEWAY_CREDIT_NANOS;
+	const teamEnrichment = args.teamEnrichment
+		? {
+			...args.teamEnrichment,
+			balance_nanos: availableNanos,
+			balance_usd: Math.round((availableNanos / 1_000_000_000) * 100) / 100,
+			balance_is_low: !hasMinimumCredit,
+		}
+		: null;
+
+	return {
+		workspaceId: args.workspaceId,
+		credit: {
+			ok: hasMinimumCredit,
+			reason: hasMinimumCredit ? null : "insufficient_funds",
+			resetAt: null,
+			balanceNanos: availableNanos,
+		},
+		teamEnrichment,
+	};
+}
 
 async function hydrateByokKeys(
 	context: GatewayContextData,
@@ -827,6 +889,7 @@ export async function fetchGatewayContext(args: {
         totalMs: 0,
         keyVersionMs: null,
         cacheReadMs: null,
+        creditRefreshMs: null,
         rpcMs: null,
         enrichMs: null,
         cacheWriteMs: null,
@@ -877,9 +940,44 @@ export async function fetchGatewayContext(args: {
 					// Request/cost usage changes after every completion. A cached
 					// snapshot can admit subsequent requests past a configured cap,
 					// so only uncapped keys may use the dynamic context snapshot.
-                    const creditParsed = creditCachedRaw ? JSON.parse(creditCachedRaw) : null;
-                    const creditContext = isCreditContextLike(creditParsed) ? creditParsed : null;
-                    const merged = mergeCachedContext({
+					let cacheStatus: ContextFetchTelemetry["cacheStatus"] = "hit";
+					let creditContext: CreditContextSnapshot | null = null;
+					if (creditCachedRaw) {
+						try {
+							const creditParsed = JSON.parse(creditCachedRaw);
+							creditContext = isCreditContextLike(creditParsed) ? creditParsed : null;
+						} catch {
+							creditContext = null;
+						}
+					}
+					if (!creditContext) {
+						const creditRefreshStartedAt = performance.now();
+						creditContext = await fetchFreshCreditContext({
+							workspaceId: args.workspaceId,
+							teamEnrichment: dynamicParsed.teamEnrichment ?? null,
+						});
+						telemetry.creditRefreshMs = round3(
+							performance.now() - creditRefreshStartedAt,
+						);
+						cacheStatus = "credit_refresh";
+						const creditOnlyContext = mergeCachedContext({
+							dynamic: dynamicParsed,
+							static: staticParsed,
+							credit: creditContext,
+							endpoint: args.endpoint,
+						});
+						const creditTtl = clampTtl(
+							computeCreditSnapshotTtlForContext(creditOnlyContext),
+						);
+						dispatchBackground(
+							cache.put(
+								creditCacheKey,
+								JSON.stringify(creditContext),
+								{ expirationTtl: creditTtl },
+							).catch(() => undefined),
+						);
+					}
+					const merged = mergeCachedContext({
                         dynamic: dynamicParsed,
                         static: staticParsed,
                         credit: creditContext,
@@ -889,7 +987,7 @@ export async function fetchGatewayContext(args: {
                         ...merged,
                         contextTelemetry: {
                             ...telemetry,
-                            cacheStatus: "hit",
+                            cacheStatus,
                             totalMs: round3(performance.now() - fetchStartedAt),
                         },
 					}, args.workspaceId);
@@ -1554,7 +1652,11 @@ export async function fetchGatewayContext(args: {
                         cache.put(staticCacheKey, JSON.stringify(split.static), { expirationTtl: staticTtl }),
                     );
                 }
-                await Promise.all(cacheWrites);
+				dispatchBackground(
+					Promise.all(cacheWrites)
+						.then(() => undefined)
+						.catch(() => undefined),
+				);
             } catch {
                 // ignore cache write failures
             } finally {

--- a/apps/api/src/pipeline/before/guards.ts
+++ b/apps/api/src/pipeline/before/guards.ts
@@ -574,9 +574,10 @@ export function makeMeta(input: {
     providerCapabilitiesBeta?: boolean;
     beta?: RequestBetaOptions;
     beforeContextMs?: number | null;
-    beforeContextCacheStatus?: "hit" | "miss" | "bypass" | null;
+    beforeContextCacheStatus?: "hit" | "miss" | "bypass" | "credit_refresh" | null;
     beforeContextKeyVersionMs?: number | null;
     beforeContextCacheReadMs?: number | null;
+    beforeContextCreditRefreshMs?: number | null;
     beforeContextRpcMs?: number | null;
     beforeContextEnrichMs?: number | null;
     beforeContextCacheWriteMs?: number | null;
@@ -652,6 +653,7 @@ export function makeMeta(input: {
         beforeContextCacheStatus: input.beforeContextCacheStatus ?? undefined,
         beforeContextKeyVersionMs: input.beforeContextKeyVersionMs ?? undefined,
         beforeContextCacheReadMs: input.beforeContextCacheReadMs ?? undefined,
+        beforeContextCreditRefreshMs: input.beforeContextCreditRefreshMs ?? undefined,
         beforeContextRpcMs: input.beforeContextRpcMs ?? undefined,
         beforeContextEnrichMs: input.beforeContextEnrichMs ?? undefined,
         beforeContextCacheWriteMs: input.beforeContextCacheWriteMs ?? undefined,

--- a/apps/api/src/pipeline/before/index.ts
+++ b/apps/api/src/pipeline/before/index.ts
@@ -726,6 +726,7 @@ export async function beforeRequest(
         beforeContextCacheStatus: contextTelemetry?.cacheStatus ?? null,
         beforeContextKeyVersionMs: contextTelemetry?.keyVersionMs ?? null,
         beforeContextCacheReadMs: contextTelemetry?.cacheReadMs ?? null,
+        beforeContextCreditRefreshMs: contextTelemetry?.creditRefreshMs ?? null,
         beforeContextRpcMs: contextTelemetry?.rpcMs ?? null,
         beforeContextEnrichMs: contextTelemetry?.enrichMs ?? null,
         beforeContextCacheWriteMs: contextTelemetry?.cacheWriteMs ?? null,

--- a/apps/api/src/pipeline/before/schemas.capability-params.test.ts
+++ b/apps/api/src/pipeline/before/schemas.capability-params.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+import { providerSchema } from "./schemas";
+
+describe("providerSchema capability params", () => {
+    it("preserves the legacy object representation", () => {
+        const parsed = providerSchema.parse({
+            provider_id: "openai",
+            capability_params: {
+                temperature: {},
+                reasoning: { style: "effort" },
+            },
+        });
+
+        expect(parsed.capabilityParams).toEqual({
+            temperature: {},
+            reasoning: { style: "effort" },
+        });
+    });
+
+    it("normalizes descriptor arrays returned by generic text capabilities", () => {
+        const parsed = providerSchema.parse({
+            provider_id: "openai",
+            capability_params: [
+                {
+                    param_id: "max_tokens",
+                    provider_min: null,
+                    provider_max: 128_000,
+                },
+                {
+                    param_id: "reasoning.mode",
+                    values: ["standard", "pro"],
+                    provider_default: "standard",
+                },
+            ],
+        });
+
+        expect(parsed.capabilityParams).toEqual({
+            max_tokens: {
+                provider_min: null,
+                provider_max: 128_000,
+            },
+            "reasoning.mode": {
+                values: ["standard", "pro"],
+                provider_default: "standard",
+            },
+        });
+    });
+
+    it("ignores descriptor entries without a parameter id", () => {
+        const parsed = providerSchema.parse({
+            provider_id: "openai",
+            capability_params: [{ provider_default: null }],
+        });
+
+        expect(parsed.capabilityParams).toEqual({});
+    });
+});

--- a/apps/api/src/pipeline/before/schemas.ts
+++ b/apps/api/src/pipeline/before/schemas.ts
@@ -189,6 +189,28 @@ function toModalityList(value: unknown): string[] | null {
     return null;
 }
 
+function normalizeCapabilityParams(
+    value: Record<string, unknown> | Array<Record<string, unknown>>,
+): Record<string, unknown> {
+    if (!Array.isArray(value)) return value;
+
+    const normalized: Record<string, unknown> = {};
+    for (const descriptor of value) {
+        const paramId = String(descriptor.param_id ?? "").trim();
+        if (!paramId) continue;
+        const { param_id: _paramId, ...metadata } = descriptor;
+        normalized[paramId] = metadata;
+    }
+    return normalized;
+}
+
+const capabilityParamsSchema = z
+    .union([
+        z.record(z.string(), z.any()),
+        z.array(z.record(z.string(), z.any())),
+    ])
+    .transform(normalizeCapabilityParams);
+
 const providerSchema = z
     .object({
         provider_id: z.string(),
@@ -239,7 +261,7 @@ const providerSchema = z
         supports_endpoint: z.boolean().optional().default(true),
         base_weight: z.coerce.number().optional().default(1),
         byok_meta: z.array(byokMetaSchema).optional().default([]),
-        capability_params: z.record(z.string(), z.any()).optional().default({}),
+        capability_params: capabilityParamsSchema.optional().default({}),
         max_input_tokens: z.coerce.number().nullable().optional(),
         max_output_tokens: z.coerce.number().nullable().optional(),
     })

--- a/apps/api/src/pipeline/before/textParamPolicy.test.ts
+++ b/apps/api/src/pipeline/before/textParamPolicy.test.ts
@@ -52,6 +52,17 @@ describe("textParamPolicy", () => {
 		]);
 	});
 
+	it("accepts standard OpenAI chat stream options", () => {
+		const body = {
+			model: "openai/gpt-5.4-nano",
+			messages: [{ role: "user", content: "Hello" }],
+			stream: true,
+			stream_options: { include_usage: true },
+		};
+
+		expect(getUnknownTopLevelParams("chat.completions", body)).toEqual([]);
+	});
+
 	it("extracts documented AION responses parameters", () => {
 		const body = {
 			model: "aion-labs/aion-3.0",

--- a/apps/api/src/pipeline/before/textParamPolicy.ts
+++ b/apps/api/src/pipeline/before/textParamPolicy.ts
@@ -33,6 +33,7 @@ const TEXT_ENDPOINT_REGISTRY: Record<TextEndpoint, EndpointParamRegistry> = {
 			"presence_penalty",
 			"seed",
 			"stream",
+			"stream_options",
 			"temperature",
 			"tools",
 			"max_tool_calls",

--- a/apps/api/src/pipeline/before/types.ts
+++ b/apps/api/src/pipeline/before/types.ts
@@ -279,10 +279,11 @@ export type KeyEnrichment = {
 };
 
 export type ContextFetchTelemetry = {
-    cacheStatus: "hit" | "miss" | "bypass";
+    cacheStatus: "hit" | "miss" | "bypass" | "credit_refresh";
     totalMs: number;
     keyVersionMs?: number | null;
     cacheReadMs?: number | null;
+    creditRefreshMs?: number | null;
     rpcMs?: number | null;
     enrichMs?: number | null;
     cacheWriteMs?: number | null;


### PR DESCRIPTION
## Summary

- normalize descriptor-array capability parameters returned by generic text capability rows
- preserve the legacy capability-parameter object representation
- accept standard OpenAI `stream_options` on Chat Completions requests
- refresh a missing gateway credit snapshot with one authoritative wallet read while reusing cached model/provider context
- subtract reserved funds and ignore stale legacy credit embedded in dynamic cache entries
- move context KV writes off the generation critical path
- add `credit_refresh` timing and cache-status fields to gateway observability

## Root cause

Successful generation billing invalidates the separate workspace credit cache. The next request previously treated that one missing segment as a complete context-cache miss, rerunning two context RPCs, workspace/provider enrichment, and synchronous KV writes even though the dynamic and static context remained valid.

## Validation

- `pnpm --filter @phaseo/gateway-api exec vitest run src/pipeline/before/context.credit-refresh.test.ts src/pipeline/before/context.shared.test.ts src/pipeline/pricing/persist.test.ts` (18 passed)
- `pnpm --filter @phaseo/gateway-api typecheck`
- `pnpm --filter @phaseo/gateway-api build` (Wrangler production dry run; 5,840.12 KiB upload / 992.62 KiB gzip)
- deployed Worker version `cc9e3eb1-71db-4266-b293-9025d89cbb41` with an 89 ms reported startup time
- completed a GPT-5.4 Nano smoke request successfully
- completed a Phaseo-only 10 cold + 10 warm benchmark with 20/20 measured requests successful
- production logs for all 30 generated calls showed 20 credit-only refreshes and 10 context hits, with zero full context misses, context RPCs, enrichments, retries, or failovers

Created with Codex