### PR TITLE
Hide external providers from models

### DIFF
--- a/apps/web-api/src/routes/public/models.test.ts
+++ b/apps/web-api/src/routes/public/models.test.ts
@@ -374,7 +374,7 @@ describe("public model routes", () => {
 		});
 	});
 
-	it("preserves external provider status in gateway monitor rows", async () => {
+	it("excludes external providers from models-page monitor rows", async () => {
 		vi.stubGlobal("fetch", vi.fn(async (input: RequestInfo | URL) => {
 			const url = String(input);
 			if (url.includes("get_monitor_model_rows")) {
@@ -413,9 +413,7 @@ describe("public model routes", () => {
 			models: [
 				{
 					model_id: "google/gemini-3.5-flash",
-					gateway_monitor_rows: [
-						{ provider: { id: "openrouter" }, gatewayStatus: "external" },
-					],
+					gateway_monitor_rows: [],
 				},
 			],
 		});

--- a/apps/web-api/src/routes/public/models.ts
+++ b/apps/web-api/src/routes/public/models.ts
@@ -301,7 +301,7 @@ async function fetchProviderStatuses(env: Env, providerIds: string[]) {
 
 export async function fetchGatewayMonitorRows(
 	env: Env,
-	_catalogueVersion: ModelsCatalogueVersion = "v1",
+	_catalogueVersion: ModelsCatalogueVersion = "v2",
 ): Promise<Map<string, Record<string, unknown>[]>> {
 	const client = getDataClient(env);
 	const rows: Record<string, unknown>[] = [];
@@ -338,6 +338,10 @@ export async function fetchGatewayMonitorRows(
 			? `${baseModelId}:free`
 			: baseModelId;
 		const providerId = String(row.provider_id ?? "").trim();
+		// The /models catalogue describes Phaseo availability. External catalogue
+		// providers remain available on model detail pages, but must not inflate
+		// this page's provider counts or hover lists.
+		if (providerStatusesById.get(providerId) === "external") continue;
 		const apiModelId = String(row.api_model_id ?? "").trim();
 		const providerModelId = String(
 			row.provider_api_model_id ?? row.provider_model_slug ?? apiModelId,
@@ -374,9 +378,7 @@ export async function fetchGatewayMonitorRows(
 				executionRegions: providerRegionsById.get(providerId) ?? [],
 			},
 			endpoint: capabilityId,
-			gatewayStatus: providerStatusesById.get(providerId) === "external"
-				? "external"
-				: normaliseGatewayStatus(row.capability_status, row.is_active_gateway),
+			gatewayStatus: normaliseGatewayStatus(row.capability_status, row.is_active_gateway),
 			inputModalities: toStringList(row.input_modalities).length ? toStringList(row.input_modalities) : toStringList(row.model_input_types),
 			outputModalities: toStringList(row.output_modalities).length ? toStringList(row.output_modalities) : toStringList(row.model_output_types),
 			context: numberOrNull(row.context_length) ?? numberOrNull(row.capability_max_input_tokens) ?? 0,


### PR DESCRIPTION
## Summary

- exclude external catalogue providers from `/models` monitor rows
- keep external providers available on model-detail provider/pricing surfaces
- default the V2 monitor-row fetcher to the V2 catalogue contract
- add regression coverage for the provider hover/count data source

## Validation

- `pnpm --filter @phaseo/web-api test -- src/routes/public/models.test.ts`
- `pnpm --filter @phaseo/web-api typecheck`

Created with Codex