### PR TITLE
Fix model provider availability on pricing pages

### DIFF
--- a/apps/web-api/src/routes/public/models.test.ts
+++ b/apps/web-api/src/routes/public/models.test.ts
@@ -587,6 +587,63 @@ describe("public model routes", () => {
 		expect(fetchMock.mock.calls.some(([input]) => String(input).includes("get_v2_model_availability"))).toBe(true);
 	});
 
+	it("uses standard-tier availability without dropping alternate pricing plans", async () => {
+		const fetchMock = vi.fn(async (
+			input: RequestInfo | URL,
+			init?: RequestInit,
+		) => {
+			if (String(input).includes("/rpc/get_v2_model_pricing")) {
+				const body = JSON.parse(String(init?.body));
+				const isStandard = body.p_service_tier === "standard";
+				return new Response(JSON.stringify([{
+					provider: {
+						api_provider_id: "openai",
+						status: "active",
+						routing_status: isStandard ? "active" : "disabled",
+					},
+					provider_models: [{
+						id: "openai:openai/gpt-5.6-sol",
+						endpoint: "text.generate",
+						is_active_gateway: isStandard,
+						routing_status: "active",
+						capability_status: "active",
+					}],
+					pricing_rules: isStandard
+						? [{ id: "standard-price", pricing_plan: "standard" }]
+						: [
+							{ id: "standard-price", pricing_plan: "standard" },
+							{ id: "batch-price", pricing_plan: "batch" },
+						],
+				}]), { status: 200 });
+			}
+			return new Response(JSON.stringify([]), { status: 200 });
+		});
+		vi.stubGlobal("fetch", fetchMock);
+
+		const response = await app.request(
+			"https://phaseo.app/api/_web/models/openai%2Fgpt-5.6-sol/pricing",
+			{},
+			env,
+		);
+
+		expect(response.status).toBe(200);
+		await expect(response.json()).resolves.toMatchObject({
+			providers: [{
+				provider: { routing_status: "active" },
+				provider_models: [{ is_active_gateway: true }],
+				pricing_rules: [
+					{ id: "standard-price", pricing_plan: "standard" },
+					{ id: "batch-price", pricing_plan: "batch" },
+				],
+			}],
+		});
+		const pricingCalls = fetchMock.mock.calls.filter(([input]) =>
+			String(input).includes("/rpc/get_v2_model_pricing")
+		);
+		expect(pricingCalls.map((call) => JSON.parse(String(call[1]?.body)).p_service_tier))
+			.toEqual([null, "standard"]);
+	});
+
 	it("returns the overview shape used by the model page", async () => {
 		vi.stubGlobal("fetch", vi.fn(async (input: RequestInfo | URL) => {
 			const url = String(input);

--- a/apps/web-api/src/routes/public/models.ts
+++ b/apps/web-api/src/routes/public/models.ts
@@ -126,6 +126,56 @@ function normaliseGatewayStatus(value: unknown, isActive: unknown): string {
 	return isActive ? "active" : "inactive";
 }
 
+function mergeStandardPricingAvailability(
+	providers: Array<Record<string, unknown>>,
+	standardProviders: Array<Record<string, unknown>>,
+): Array<Record<string, unknown>> {
+	const standardByProviderId = new Map(
+		standardProviders.flatMap((entry) => {
+			const provider = entry.provider as Record<string, unknown> | null;
+			const providerId = String(provider?.api_provider_id ?? "").trim();
+			return providerId ? [[providerId, entry] as const] : [];
+		}),
+	);
+
+	return providers.map((entry) => {
+		const provider = entry.provider as Record<string, unknown> | null;
+		const providerId = String(provider?.api_provider_id ?? "").trim();
+		const standardEntry = standardByProviderId.get(providerId);
+		if (!standardEntry) return entry;
+		const standardProvider = standardEntry.provider as Record<string, unknown> | null;
+		const standardModels = Array.isArray(standardEntry.provider_models)
+			? standardEntry.provider_models as Array<Record<string, unknown>>
+			: [];
+		const standardModelByKey = new Map(standardModels.map((model) => [
+			`${String(model.id ?? "")}::${String(model.endpoint ?? "")}`,
+			model,
+		]));
+		const providerModels = Array.isArray(entry.provider_models)
+			? (entry.provider_models as Array<Record<string, unknown>>).map((model) => {
+				const standardModel = standardModelByKey.get(
+					`${String(model.id ?? "")}::${String(model.endpoint ?? "")}`,
+				);
+				return standardModel ? {
+					...model,
+					is_active_gateway: standardModel.is_active_gateway,
+					routing_status: standardModel.routing_status,
+					capability_status: standardModel.capability_status,
+				} : model;
+			})
+			: entry.provider_models;
+		return {
+			...entry,
+			provider: standardProvider ? {
+				...provider,
+				status: standardProvider.status,
+				routing_status: standardProvider.routing_status,
+			} : provider,
+			provider_models: providerModels,
+		};
+	});
+}
+
 function collectJsonTokens(value: unknown, tokens: string[] = []): string[] {
 	if (Array.isArray(value)) {
 		for (const item of value) collectJsonTokens(item, tokens);
@@ -1226,13 +1276,33 @@ publicModelsRouter.get("/:modelId/pricing", async (c) => {
 	const modelId = c.req.param("modelId");
 	try {
 		const client = getDataClient(c.env);
-		const v2Pricing = await client.rpc("get_v2_model_pricing", {
+		const requestedServiceTier = c.req.query("service_tier")?.trim().toLowerCase() || null;
+		const v2PricingPromise = client.rpc("get_v2_model_pricing", {
 			p_model_slug: modelId,
 			p_region: c.req.query("region")?.trim().toLowerCase() || null,
-			p_service_tier: c.req.query("service_tier")?.trim().toLowerCase() || null,
+			p_service_tier: requestedServiceTier,
 		});
+		const standardPricingPromise = requestedServiceTier === null
+			? client.rpc("get_v2_model_pricing", {
+				p_model_slug: modelId,
+				p_region: c.req.query("region")?.trim().toLowerCase() || null,
+				p_service_tier: "standard",
+			})
+			: Promise.resolve(null);
+		const [v2Pricing, standardPricing] = await Promise.all([
+			v2PricingPromise,
+			standardPricingPromise,
+		]);
 		if (!v2Pricing.error && Array.isArray(v2Pricing.data)) {
-			const providers = v2Pricing.data as Array<Record<string, unknown>>;
+			const providers = requestedServiceTier === null
+				&& standardPricing
+				&& !standardPricing.error
+				&& Array.isArray(standardPricing.data)
+				? mergeStandardPricingAvailability(
+					v2Pricing.data as Array<Record<string, unknown>>,
+					standardPricing.data as Array<Record<string, unknown>>,
+				)
+				: v2Pricing.data as Array<Record<string, unknown>>;
 			if (c.req.query("shape") === "source") {
 				return withPublicCache(c.json({
 					modelId,


### PR DESCRIPTION
## Summary

- use the standard service-tier projection as the authoritative provider availability state on model pricing pages
- retain the unfiltered pricing response so standard, batch, flex, and priority prices remain visible
- add regression coverage for the OpenAI GPT-5.6 Sol mismatch

## Root cause

The default V2 pricing projection aggregated all service tiers and could return a stale or inactive provider-routing state even when the standard gateway route was active. Filtering the entire response to `standard` fixed the status but removed alternate pricing plans. The route now merges standard-tier availability into the complete pricing response.

## Validation

- `pnpm --filter @phaseo/web-api test` (188 tests passed)
- `pnpm --filter @phaseo/web-api typecheck`
- `pnpm --filter @phaseo/web-api exec eslint src/routes/public/models.ts src/routes/public/models.test.ts` (no errors; existing max-lines warning only)
- `git diff --check`

Created with Codex