### PR TITLE
Improve pricing transparency and calculator

### DIFF
--- a/.changeset/calm-byok-pricing.md
+++ b/.changeset/calm-byok-pricing.md
@@ -1,0 +1,6 @@
+---
+"@phaseo/gateway-api": patch
+"@phaseo/web": patch
+---
+
+Increase the monthly BYOK allowance to one million requests and reduce the service fee after the allowance to 2.5%.

--- a/apps/api/src/pipeline/pricing/byok-fee.test.ts
+++ b/apps/api/src/pipeline/pricing/byok-fee.test.ts
@@ -94,7 +94,7 @@ describe("applyByokServiceFee", () => {
 		expect(result.pricedUsage.pricing.lines).toEqual([]);
 	});
 
-	it("charges 3.5% fee after free-tier threshold", async () => {
+	it("charges 2.5% fee after the one-million-request threshold", async () => {
 		rpcMock.mockResolvedValue({
 			data: [{ month_start: "2026-02-01T00:00:00+00:00", request_count: BYOK_MONTHLY_FREE_REQUESTS + 1 }],
 			error: null,
@@ -120,7 +120,7 @@ describe("applyByokServiceFee", () => {
 
 		expect(result.byokFeeNanos).toBe(expectedFeeNanos);
 		expect(result.totalNanos).toBe(expectedFeeNanos);
-		expect(result.totalCents).toBe(7);
+		expect(result.totalCents).toBe(5);
 		expect(result.pricedUsage.pricing.byok_fee_applied).toBe(true);
 		expect(result.pricedUsage.pricing.lines).toHaveLength(1);
 		expect(result.pricedUsage.pricing.lines[0].meter).toBe("byok_service_fee");
@@ -152,7 +152,7 @@ describe("applyByokServiceFee", () => {
 		});
 
 		expect(result.byokMonthlyRequestCount).toBe(BYOK_MONTHLY_FREE_REQUESTS + 1);
-		expect(result.totalNanos).toBe(105_000_000); // $3 * 3.5%
+		expect(result.totalNanos).toBe(75_000_000); // $3 * 2.5%
 		expect(result.pricedUsage.byok_billing.counter_source).toBe("fallback_read");
 	});
 
@@ -180,8 +180,8 @@ describe("applyByokServiceFee", () => {
 			},
 		});
 
-		expect(result.totalNanos).toBe(105_000_000);
-		expect(result.totalCents).toBe(10);
+		expect(result.totalNanos).toBe(75_000_000);
+		expect(result.totalCents).toBe(7);
 		expect(result.byokMonthlyRequestCount).toBeNull();
 		expect(result.pricedUsage.pricing.byok_fee_applied).toBe(true);
 		expect(result.pricedUsage.byok_billing.counter_source).toBe("unavailable");

--- a/apps/api/src/pipeline/pricing/byok-fee.ts
+++ b/apps/api/src/pipeline/pricing/byok-fee.ts
@@ -5,8 +5,8 @@ const NANOS_PER_CENT = 10_000_000;
 const COUNTER_RPC_MAX_ATTEMPTS = 3;
 const COUNTER_RPC_RETRY_BASE_MS = 25;
 
-export const BYOK_MONTHLY_FREE_REQUESTS = 100_000;
-export const BYOK_SERVICE_FEE_RATE = 0.035;
+export const BYOK_MONTHLY_FREE_REQUESTS = 1_000_000;
+export const BYOK_SERVICE_FEE_RATE = 0.025;
 
 type ByokCounterRow = {
 	month_start?: string | null;

--- a/apps/web-api/src/routes/public/pricing.test.ts
+++ b/apps/web-api/src/routes/public/pricing.test.ts
@@ -7,6 +7,45 @@ const env = {
 	SUPABASE_SERVICE_ROLE_KEY: "service-role-key",
 };
 
+const targetRoute = {
+	provider_model_id: "00000000-0000-4000-8000-999999999999",
+	provider_slug: "openai",
+	provider_model_slug: "gpt-5.6-sol",
+	model_slug: "openai/gpt-5.6-sol",
+	routing_enabled: true,
+	status: "active",
+	effective_from: null,
+	effective_to: null,
+};
+
+const targetModel = {
+	model_slug: "openai/gpt-5.6-sol",
+	name: "GPT 5.6 Sol",
+	released_at: "2026-07-09T00:00:00Z",
+	announced_at: null,
+};
+
+const targetSku = {
+	sku_id: "sku-sol",
+	provider_model_id: targetRoute.provider_model_id,
+	operation: "text.generate",
+	service_tier_slug: "standard",
+	currency: "USD",
+	status: "active",
+	effective_from: null,
+	effective_to: null,
+	metadata: {},
+};
+
+const targetMeter = {
+	sku_id: targetSku.sku_id,
+	meter_key: "input_text_tokens",
+	unit: "token",
+	unit_quantity: 1_000_000,
+	price_nanos: 5_000_000_000,
+	metadata: {},
+};
+
 afterEach(() => {
 	vi.unstubAllGlobals();
 });
@@ -52,5 +91,65 @@ describe("public pricing routes", () => {
 		expect(response.status).toBe(200);
 		expect(skuQueryCount).toBe(3);
 		expect(payload.models).toHaveLength(1);
+	});
+
+	it("paginates V2 provider routes so records beyond the first 1,000 are included", async () => {
+		let providerPage = 0;
+		const firstPage = Array.from({ length: 1_000 }, (_, index) => ({
+			...targetRoute,
+			provider_model_id: `00000000-0000-4000-8001-${String(index).padStart(12, "0")}`,
+			provider_model_slug: `model-${index}`,
+			model_slug: `organisation/model-${index}`,
+		}));
+		const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+			const url = String(input);
+			if (url.includes("v2_model_provider_routes")) {
+				providerPage += 1;
+				return new Response(JSON.stringify(providerPage === 1 ? firstPage : [targetRoute]), { status: 200 });
+			}
+			if (url.includes("v2_models")) return new Response(JSON.stringify([targetModel]), { status: 200 });
+			if (url.includes("v2_pricing_skus")) return new Response(JSON.stringify([targetSku]), { status: 200 });
+			if (url.includes("v2_pricing_sku_meters")) return new Response(JSON.stringify([targetMeter]), { status: 200 });
+			return new Response("[]", { status: 200 });
+		});
+		vi.stubGlobal("fetch", fetchMock);
+
+		const response = await app.request("https://phaseo.app/api/_web/pricing/models", {}, env);
+
+		expect(response.status).toBe(200);
+		await expect(response.json()).resolves.toMatchObject({
+			models: [{
+				model: "openai/gpt-5.6-sol",
+				display_name: "GPT 5.6 Sol",
+				provider: "openai",
+				endpoint: "text.generate",
+				meters: [{ meter: "input_text_tokens", price_per_unit: "5" }],
+			}],
+		});
+		const providerRequests = fetchMock.mock.calls.filter(([input]) =>
+			String(input).includes("v2_model_provider_routes")
+		);
+		expect(providerRequests).toHaveLength(2);
+	});
+
+	it("filters V2 provider routes when model IDs are supplied", async () => {
+		const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+			const url = String(input);
+			if (url.includes("v2_model_provider_routes")) return new Response("[]", { status: 200 });
+			return new Response("[]", { status: 200 });
+		});
+		vi.stubGlobal("fetch", fetchMock);
+
+		const response = await app.request(
+			"https://phaseo.app/api/_web/pricing/models?model_ids=openai%2Fgpt-5.6-sol",
+			{},
+			env,
+		);
+
+		expect(response.status).toBe(200);
+		const providerUrl = String(fetchMock.mock.calls.find(([input]) =>
+			String(input).includes("v2_model_provider_routes")
+		)?.[0]);
+		expect(decodeURIComponent(providerUrl)).toContain("model_slug=in.(openai/gpt-5.6-sol)");
 	});
 });

--- a/apps/web-api/src/routes/public/pricing.ts
+++ b/apps/web-api/src/routes/public/pricing.ts
@@ -26,10 +26,29 @@ function rowsOrThrow<T extends Record<string, unknown>>(
 publicPricingRouter.get("/pricing/models", async (c) => {
 	try {
 		const client = getDataClient(c.env); const now = Date.now();
+		const requestedModelIds = [...new Set(
+			(c.req.query("model_ids") ?? "")
+				.split(",")
+				.map((value) => value.trim())
+				.filter(Boolean),
+		)].slice(0, 100);
 		const active = (row: Record<string, unknown>) => { const from = row.effective_from ? Date.parse(String(row.effective_from)) : Number.NEGATIVE_INFINITY; const to = row.effective_to ? Date.parse(String(row.effective_to)) : Number.POSITIVE_INFINITY; return now >= from && now < to; };
-		const providerResult = await client.from("v2_model_provider_routes").select("provider_model_id,provider_slug,provider_model_slug,model_slug,routing_enabled,status,effective_from,effective_to").eq("routing_enabled", true).in("status", ["active", "degraded"]);
-		if (providerResult.error) throw providerResult.error;
-		const providerRows = ((providerResult.data ?? []) as Array<Record<string, unknown>>).filter(active);
+		const providerRows: Array<Record<string, unknown>> = [];
+		for (let offset = 0; ; offset += 1_000) {
+			let query = client
+				.from("v2_model_provider_routes")
+				.select("provider_model_id,provider_slug,provider_model_slug,model_slug,routing_enabled,status,effective_from,effective_to")
+				.eq("routing_enabled", true)
+				.in("status", ["active", "degraded"]);
+			if (requestedModelIds.length > 0) query = query.in("model_slug", requestedModelIds);
+			const providerResult = await query
+				.order("provider_model_id", { ascending: true })
+				.range(offset, offset + 999);
+			if (providerResult.error) throw providerResult.error;
+			const page = (providerResult.data ?? []) as Array<Record<string, unknown>>;
+			providerRows.push(...page.filter(active));
+			if (page.length < 1_000) break;
+		}
 		const routeIds = providerRows.map((row) => String(row.provider_model_id ?? "")).filter(Boolean);
 		const modelIds = [...new Set(providerRows.map((row) => String(row.model_slug ?? "")).filter(Boolean))];
 		const [modelResults, skuResults] = await Promise.all([

--- a/apps/web/src/app/(dashboard)/page.tsx
+++ b/apps/web/src/app/(dashboard)/page.tsx
@@ -2,9 +2,9 @@ import Link from "next/link";
 import { Suspense } from "react";
 import {
 	ArrowRight,
-	Boxes,
+	CalendarOff,
 	Coins,
-	LockOpen,
+	KeyRound,
 	type LucideIcon,
 } from "lucide-react";
 import type { Metadata } from "next";
@@ -64,19 +64,19 @@ const PRICING_POINTS: Array<{
 	icon: LucideIcon;
 }> = [
 	{
-		title: "Official API rates underneath",
-		body: "Usage pricing follows the official provider rates you would expect if you were calling them directly.",
+		title: "Pay as you go, full stop",
+		body: "No enterprise plan, contract, subscription, minimum spend, or monthly or annual commitment.",
+		icon: CalendarOff,
+	},
+	{
+		title: `${standardFeeText}% credit purchase fee`,
+		body: "Applied when you purchase credits, with a $1 minimum. Usage follows the model prices shown in the catalog.",
 		icon: Coins,
 	},
 	{
-		title: `Flat ${standardFeeText}% gateway fee`,
-		body: "No mandatory seat pricing and no separate plan unlock just to use the core gateway surface.",
-		icon: Boxes,
-	},
-	{
 		title: "Managed credits or BYOK",
-		body: "Start with Phaseo credits, or keep provider relationships intact and route through your own keys when you need to.",
-		icon: LockOpen,
+		body: "BYOK includes one million fee-free requests each month, then a 2.5% service fee on provider-equivalent cost.",
+		icon: KeyRound,
 	},
 ] as const;
 

--- a/apps/web/src/app/(dashboard)/pricing/PricingComparisonShell.tsx
+++ b/apps/web/src/app/(dashboard)/pricing/PricingComparisonShell.tsx
@@ -1,0 +1,68 @@
+"use client";
+
+import type { ReactNode } from "react";
+import Link from "next/link";
+import { parseAsBoolean, useQueryState } from "nuqs";
+import { Scale } from "lucide-react";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import { cn } from "@/lib/utils";
+
+const compareParser = parseAsBoolean.withDefault(false).withOptions({
+	history: "push",
+});
+
+export function PricingComparisonShell({ children }: { children: ReactNode }) {
+	const [compare, setCompare] = useQueryState("compare", compareParser);
+
+	return (
+		<div>
+			<div className="mb-5 flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
+				<div className="max-w-3xl">
+					<h2 className="text-2xl font-semibold tracking-tight text-foreground sm:text-3xl">
+						Everything included
+					</h2>
+					<p className="mt-2 text-sm leading-6 text-muted-foreground">
+						Explore the model catalog, rankings, SDKs, and free model chat before spending anything. Add credits when you need paid model usage without changing plans.
+					</p>
+					<p className="mt-3 text-xs font-medium text-foreground sm:hidden">
+						Swipe horizontally to compare providers.
+					</p>
+				</div>
+				<Link
+					href={compare ? "/pricing" : "/pricing?compare=true"}
+					role="button"
+					aria-pressed={compare}
+					onClick={async (event) => {
+						event.preventDefault();
+						await setCompare(compare ? null : true);
+					}}
+					className={cn(
+						"inline-flex h-9 shrink-0 items-center gap-2 rounded-md border border-border bg-background px-3 text-sm font-medium transition-colors hover:bg-muted",
+						compare && "bg-muted",
+					)}
+				>
+					<Scale className="h-4 w-4" aria-hidden="true" />
+					{compare ? "Show free access" : "Compare competitors"}
+				</Link>
+			</div>
+
+			<ScrollArea
+				scrollBarOrientation="horizontal"
+				keepScrollbarMounted
+				viewportClassName="pb-2"
+				className={cn(
+					"w-full rounded-xl border border-zinc-200/70 bg-white/75 [&>[data-orientation=horizontal]]:opacity-100 [&>[data-orientation=horizontal]]:transition-none dark:border-zinc-800/70 dark:bg-zinc-950/60",
+					compare && "[&_.best-cell]:bg-zinc-50/45 [&_.competitor-cell]:table-cell [&_.competitor-col]:table-column [&_.feature-column]:w-[20%] [&_.free-column]:hidden [&_.phaseo-column]:w-[16%] [&_.phaseo-default]:hidden [&_.phaseo-compare]:inline [&_table]:min-w-[1480px] dark:[&_.best-cell]:bg-white/[0.012]",
+				)}
+			>
+				{children}
+			</ScrollArea>
+
+			{compare ? (
+				<p className="mt-3 text-xs leading-5 text-muted-foreground">
+					Competitor details reflect published documentation checked 26 July 2026. &quot;Not advertised&quot; means the feature could not be verified in public product or pricing documentation. Subtle highlights indicate the strongest documented support or pricing in each row; ties are shown where offerings are equivalent.
+				</p>
+			) : null}
+		</div>
+	);
+}

--- a/apps/web/src/app/(dashboard)/pricing/page.tsx
+++ b/apps/web/src/app/(dashboard)/pricing/page.tsx
@@ -1,7 +1,22 @@
+/* eslint-disable max-lines -- pricing, comparison, and FAQ copy are intentionally reviewed together */
 import Link from "next/link";
+import Image from "next/image";
 import type { Metadata } from "next";
 import { Fragment } from "react";
-import { ArrowRight, BadgeDollarSign, Calculator, Check, Minus, X } from "lucide-react";
+import {
+	ArrowRight,
+	Calculator,
+	CalendarOff,
+	Check,
+	Coins,
+	ExternalLink,
+	FileX2,
+	KeyRound,
+	Minus,
+	ReceiptText,
+	WalletCards,
+	X,
+} from "lucide-react";
 import { buildMetadata } from "@/lib/seo";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
@@ -14,18 +29,19 @@ import {
 	AccordionTrigger,
 } from "@/components/ui/accordion";
 import { GATEWAY_TIERS } from "@/components/(gateway)/credits/tiers";
+import { PricingComparisonShell } from "./PricingComparisonShell";
 
 export const metadata: Metadata = buildMetadata({
 	title: "Pricing",
 	description:
-		"See gateway pricing, credit fees, BYOK support and plan differences for Free and Pay As You Go.",
+		"Simple pay-as-you-go AI gateway pricing with no enterprise plan, contracts, subscriptions, or monthly commitments.",
 	path: "/pricing",
 	keywords: [
 		"AI gateway pricing",
 		"API credit fees",
 		"BYOK pricing",
 		"pay as you go AI API",
-		"AI gateway plans",
+		"AI gateway without contracts",
 	],
 });
 
@@ -40,7 +56,6 @@ type MatrixRow = {
 	featureHref?: string;
 	free: Cell;
 	payg: Cell;
-	enterprise: Cell;
 };
 
 type MatrixSection = {
@@ -48,6 +63,18 @@ type MatrixSection = {
 	title: string;
 	rows: MatrixRow[];
 };
+
+type CompetitorKey = "openrouter" | "vercel" | "cloudflare" | "llmgateway";
+
+type Competitor = {
+	key: CompetitorKey;
+	name: string;
+	href: string;
+	logoLight: string;
+	logoDark?: string;
+};
+
+type ComparisonOption = "phaseo" | CompetitorKey;
 
 type FAQItem = {
 	id: string;
@@ -61,26 +88,35 @@ type FAQSection = {
 	items: FAQItem[];
 };
 
-function getTierByKey(key: "basic" | "enterprise") {
+function getTierByKey(key: "basic") {
 	const tier = GATEWAY_TIERS.find((entry) => entry.key === key);
 	if (!tier) throw new Error(`Missing required gateway tier: ${key}`);
 	return tier;
 }
 
-function PlanCell({ cell }: { cell: Cell }) {
+function PlanCell({ cell, label }: { cell: Cell; label: string }) {
 	if (cell.type === "text") {
-		return <span className="text-xs text-muted-foreground">{cell.value}</span>;
+		return (
+			<div className="flex flex-col items-center justify-center gap-1.5 text-center">
+				<span className="text-xs leading-4 text-muted-foreground">{cell.value}</span>
+			</div>
+		);
 	}
 
 	const included = cell.type === "included";
 	const notApplicable = cell.type === "not_applicable";
+	const statusLabel = included
+		? "Included"
+		: notApplicable
+			? "Not applicable"
+			: "Not included";
 	const iconClass = included
 		? "inline-flex h-5 w-5 items-center justify-center rounded-full border border-emerald-300 bg-emerald-50 text-emerald-700 dark:border-emerald-700/60 dark:bg-emerald-950/30 dark:text-emerald-300"
 		: notApplicable
 			? "inline-flex h-5 w-5 items-center justify-center rounded-full border border-zinc-300 bg-zinc-100 text-zinc-500 dark:border-zinc-700 dark:bg-zinc-900 dark:text-zinc-400"
 			: "inline-flex h-5 w-5 items-center justify-center rounded-full border border-rose-300 bg-rose-50 text-rose-700 dark:border-rose-700/60 dark:bg-rose-950/30 dark:text-rose-300";
 	const iconNode = (
-		<span className={iconClass}>
+		<span className={iconClass} aria-hidden="true">
 			{included ? (
 				<Check className="h-3.5 w-3.5" />
 			) : notApplicable ? (
@@ -92,7 +128,7 @@ function PlanCell({ cell }: { cell: Cell }) {
 	);
 
 	const inlineText = cell.inlineText ? (
-		<span className="max-w-28 text-[11px] leading-4 text-muted-foreground">
+		<span className="max-w-44 text-[11px] leading-4 text-muted-foreground">
 			{cell.inlineText}
 		</span>
 	) : null;
@@ -101,6 +137,7 @@ function PlanCell({ cell }: { cell: Cell }) {
 		return (
 			<div className="flex flex-col items-center justify-center gap-1 text-center">
 				{iconNode}
+				<span className="sr-only">{`${label}: ${statusLabel}`}</span>
 				{inlineText}
 			</div>
 		);
@@ -113,7 +150,7 @@ function PlanCell({ cell }: { cell: Cell }) {
 					<button
 						type="button"
 						className="rounded-full"
-						aria-label="View plan details"
+						aria-label={`${label}: ${statusLabel}. View details`}
 					>
 						{iconNode}
 					</button>
@@ -126,100 +163,379 @@ function PlanCell({ cell }: { cell: Cell }) {
 }
 
 const basicTier = getTierByKey("basic");
-const enterpriseTier = getTierByKey("enterprise");
-const HIDE_ENTERPRISE_REFERENCES = true;
-const SHOW_ENTERPRISE_PLAN = !HIDE_ENTERPRISE_REFERENCES;
-const SHOW_ENTERPRISE_PREVIEW_ROWS = false;
-const ENTERPRISE_PREVIEW_ROWS: MatrixRow[] = [
-	{
-		feature: "Data policy routing",
-		free: { type: "excluded" },
-		payg: { type: "excluded" },
-		enterprise: { type: "included" },
-	},
-	{
-		feature: "Management policy enforcement",
-		free: { type: "excluded" },
-		payg: { type: "excluded" },
-		enterprise: { type: "included" },
-	},
-	{
-		feature: "SSO / SAML",
-		free: { type: "included" },
-		payg: { type: "included" },
-		enterprise: { type: "included" },
-	},
-	{
-		feature: "Contractual SLAs",
-		free: { type: "excluded" },
-		payg: { type: "excluded" },
-		enterprise: { type: "included" },
-	},
+const BYOK_MONTHLY_FREE_REQUESTS = 1_000_000;
+const BYOK_SERVICE_FEE_PERCENT = 2.5;
+
+const COMPETITORS: Competitor[] = [
+	{ key: "openrouter", name: "OpenRouter", href: "https://openrouter.ai/pricing", logoLight: "/logos/openrouter_light.svg", logoDark: "/logos/openrouter_dark.svg" },
+	{ key: "vercel", name: "Vercel", href: "https://vercel.com/docs/ai-gateway/pricing", logoLight: "/logos/vercel_light.svg", logoDark: "/logos/vercel_dark.svg" },
+	{ key: "cloudflare", name: "Cloudflare", href: "https://developers.cloudflare.com/ai-gateway/reference/pricing/", logoLight: "/logos/cloudflare.svg" },
+	{ key: "llmgateway", name: "LLM Gateway", href: "https://llmgateway.io/pricing", logoLight: "/logos/llmgateway-light.svg", logoDark: "/logos/llmgateway-dark.svg" },
 ];
+
+function ProviderLogo({ competitor }: { competitor: Competitor }) {
+	return (
+		<span className="relative inline-flex h-5 w-5 shrink-0 items-center justify-center">
+			<Image src={competitor.logoLight} alt="" width={20} height={20} className={competitor.logoDark ? "h-5 w-5 object-contain dark:hidden" : "h-5 w-5 object-contain"} />
+			{competitor.logoDark ? <Image src={competitor.logoDark} alt="" width={20} height={20} className="hidden h-5 w-5 object-contain dark:block" /> : null}
+		</span>
+	);
+}
+
+const included = (note?: string, inlineText?: string): Cell => ({ type: "included", note, inlineText });
+const excluded = (inlineText = "Not advertised"): Cell => ({ type: "not_applicable", inlineText });
+const textCell = (value: string): Cell => ({ type: "text", value });
+
+const COMPETITOR_FEATURES: Record<string, Record<CompetitorKey, Cell>> = {
+	"Gateway usage": {
+		openrouter: included(), vercel: included(), cloudflare: included(), llmgateway: included(),
+	},
+	"Credit purchase fee": {
+		openrouter: textCell("5.5% ($0.80 minimum)"),
+		vercel: textCell("0% gateway markup; payment processing fees may apply"),
+		cloudflare: textCell("5% with Unified Billing"),
+		llmgateway: textCell("5% (+1.5% non-US cards)"),
+	},
+	Models: {
+		openrouter: included(), vercel: included(), cloudflare: included(), llmgateway: included(),
+	},
+	Providers: {
+		openrouter: included(), vercel: included(), cloudflare: included(), llmgateway: included(),
+	},
+	"Gateway API access": {
+		openrouter: included(), vercel: included(), cloudflare: included(), llmgateway: included(),
+	},
+	"Responses API": {
+		openrouter: included("OpenRouter documents a beta Responses API."),
+		vercel: included("Vercel documents a dedicated Responses API."),
+		cloudflare: included("Available through Cloudflare's OpenAI-compatible REST API."),
+		llmgateway: included("Available at the OpenAI-compatible /v1/responses endpoint."),
+	},
+	"Chat Completions API": {
+		openrouter: included(), vercel: included(), cloudflare: included(), llmgateway: included(),
+	},
+	"Anthropic Messages API": {
+		openrouter: included(), vercel: included(), cloudflare: included(), llmgateway: included(),
+	},
+	"Text generation": {
+		openrouter: included(), vercel: included(), cloudflare: included(), llmgateway: included(),
+	},
+	"Image generation": {
+		openrouter: included(), vercel: included(), cloudflare: included(), llmgateway: included(),
+	},
+	"Video generation": {
+		openrouter: included("Dedicated asynchronous video API."),
+		vercel: included("Supported through the AI SDK video generation interface."),
+		cloudflare: excluded(),
+		llmgateway: included("Dedicated asynchronous video API."),
+	},
+	"Audio generation": {
+		openrouter: included("Speech generation is publicly documented."),
+		vercel: included("Speech and transcription are publicly documented."),
+		cloudflare: included("TTS and ASR are available through /ai/run."),
+		llmgateway: included("Speech generation is publicly documented."),
+	},
+	"Music generation": {
+		openrouter: excluded(), vercel: excluded(), cloudflare: excluded(), llmgateway: excluded(),
+	},
+	Embeddings: {
+		openrouter: included(), vercel: included(), cloudflare: included(), llmgateway: included(),
+	},
+	"Structured outputs and tool calling": {
+		openrouter: included(), vercel: included(), cloudflare: included(), llmgateway: included(),
+	},
+	"Built-in server tools": {
+		openrouter: included("Includes provider and gateway server tools."),
+		vercel: included("Includes provider tools and AI SDK tooling."),
+		cloudflare: textCell("Provider dependent"),
+		llmgateway: included("Includes web search and provider tools."),
+	},
+	"Request activity logs and export": {
+		openrouter: included(),
+		vercel: included(),
+		cloudflare: included("Persistent logs are included. Logpush requires Workers Paid."),
+		llmgateway: included(),
+	},
+	"Smart auto-routing": {
+		openrouter: included(), vercel: included(), cloudflare: included(), llmgateway: included(),
+	},
+	"Preferred provider selection": {
+		openrouter: included(), vercel: included(), cloudflare: included(), llmgateway: included(),
+	},
+	"Routing presets, fallbacks, and service tiers": {
+		openrouter: included(), vercel: included(), cloudflare: included(), llmgateway: included(),
+	},
+	"Response healing": {
+		openrouter: included("Repairs malformed structured JSON on supported non-streaming requests."),
+		vercel: excluded(), cloudflare: excluded(), llmgateway: excluded(),
+	},
+	Guardrails: {
+		openrouter: included("Public guardrails include budgets, allowlists, ZDR, prompt-injection, and sensitive-data policies."),
+		vercel: excluded(),
+		cloudflare: included("Workers AI usage charges apply."),
+		llmgateway: textCell("Enterprise feature"),
+	},
+	"Asynchronous jobs": {
+		openrouter: textCell("Video jobs"), vercel: textCell("Video generation"), cloudflare: excluded(), llmgateway: textCell("Video jobs"),
+	},
+	"Batch API": {
+		openrouter: excluded(), vercel: excluded(), cloudflare: excluded(), llmgateway: excluded(),
+	},
+	"Files API": {
+		openrouter: included(), vercel: excluded(), cloudflare: excluded(), llmgateway: excluded(),
+	},
+	"Video generation API": {
+		openrouter: included(), vercel: textCell("AI SDK interface"), cloudflare: excluded(), llmgateway: included(),
+	},
+	Webhooks: {
+		openrouter: textCell("Video jobs"), vercel: excluded(), cloudflare: excluded(), llmgateway: textCell("Video jobs"),
+	},
+	"Budgets and spend controls": {
+		openrouter: included(), vercel: included(), cloudflare: included(), llmgateway: included(),
+	},
+	"Prompt caching": {
+		openrouter: included(), vercel: included(), cloudflare: included(), llmgateway: included(),
+	},
+	"Management API": {
+		openrouter: included(), vercel: included(), cloudflare: included(), llmgateway: textCell("Project APIs"),
+	},
+	"Team workspaces": {
+		openrouter: included(), vercel: included(), cloudflare: included(), llmgateway: included(),
+	},
+	"Payment method": {
+		openrouter: textCell("Card, crypto, and more"),
+		vercel: textCell("Card"),
+		cloudflare: textCell("Cloudflare billing account"),
+		llmgateway: textCell("Card; enterprise invoicing"),
+	},
+	"Billing method": {
+		openrouter: textCell("Prepaid credits"),
+		vercel: textCell("Credits or enterprise invoice"),
+		cloudflare: textCell("BYOK or Unified Billing credits"),
+		llmgateway: textCell("Credits, BYOK, or subscription"),
+	},
+	"Bring your own provider keys": {
+		openrouter: included(), vercel: included(), cloudflare: included(), llmgateway: included(),
+	},
+	"BYOK service fee": {
+		openrouter: textCell("1M requests/month free, then 5%"),
+		vercel: textCell("No gateway markup"),
+		cloudflare: textCell("No Unified Billing fee"),
+		llmgateway: textCell("No fee"),
+	},
+	"Usage limits management": {
+		openrouter: included(), vercel: included(), cloudflare: included(), llmgateway: included(),
+	},
+	"Rate limits": {
+		openrouter: textCell("50 free requests/day; high paid limits"),
+		vercel: textCell("Gateway and provider limits"),
+		cloudflare: textCell("200 requests/60 sec with Unified Billing"),
+		llmgateway: textCell("No paid-model rate limit"),
+	},
+	Support: {
+		openrouter: textCell("Community or email"),
+		vercel: textCell("Docs and Vercel support"),
+		cloudflare: textCell("Docs and community"),
+		llmgateway: textCell("Community; SLA on enterprise"),
+	},
+	"Free model chat": {
+		openrouter: included(), vercel: excluded("No hosted chat"), cloudflare: excluded("No hosted chat"), llmgateway: included(),
+	},
+	"Side-by-side model comparison": {
+		openrouter: included(), vercel: excluded(), cloudflare: excluded(), llmgateway: textCell("Chat model selection"),
+	},
+	"Multimodal chat and parameter controls": {
+		openrouter: included(), vercel: excluded("No hosted chat"), cloudflare: excluded("No hosted chat"), llmgateway: included(),
+	},
+	"Image, video, audio, and music studios": {
+		openrouter: textCell("Model dependent"), vercel: excluded("No hosted studio"), cloudflare: excluded("No hosted studio"), llmgateway: included(),
+	},
+	"Realtime voice, speech, and transcription": {
+		openrouter: textCell("Model dependent"), vercel: excluded("No hosted studio"), cloudflare: excluded("No hosted studio"), llmgateway: included(),
+	},
+	"Local chat history": {
+		openrouter: included(), vercel: excluded("No hosted chat"), cloudflare: excluded("No hosted chat"), llmgateway: included(),
+	},
+	"Client SDKs": {
+		openrouter: textCell("TypeScript, Python, Go"),
+		vercel: textCell("TypeScript AI SDK; Python via compatible SDKs"),
+		cloudflare: textCell("TypeScript Workers bindings; REST in any language"),
+		llmgateway: textCell("TypeScript AI SDK provider; OpenAI-compatible SDKs"),
+	},
+	"Agent SDKs": {
+		openrouter: textCell("TypeScript"),
+		vercel: textCell("TypeScript AI SDK agent tooling"),
+		cloudflare: textCell("TypeScript Agents SDK"),
+		llmgateway: excluded(),
+	},
+	"Vercel AI SDK provider": {
+		openrouter: included(), vercel: included(), cloudflare: included(), llmgateway: included(),
+	},
+	"OpenAI and Anthropic SDK compatibility": {
+		openrouter: included(), vercel: included(), cloudflare: included(), llmgateway: included(),
+	},
+	"Framework and coding assistant integrations": {
+		openrouter: included(), vercel: included(), cloudflare: included(), llmgateway: included(),
+	},
+	"Database usage": {
+		openrouter: textCell("Model catalog"), vercel: textCell("Model catalog"), cloudflare: textCell("Model catalog"), llmgateway: textCell("Model catalog"),
+	},
+	"Public model and pricing data": {
+		openrouter: included(), vercel: included(), cloudflare: included(), llmgateway: included(),
+	},
+	"Public provider metadata": {
+		openrouter: included(), vercel: included(), cloudflare: included(), llmgateway: included(),
+	},
+	"Provider data explorer": {
+		openrouter: included(), vercel: included(), cloudflare: included(), llmgateway: included(),
+	},
+	"Token pricing visibility": {
+		openrouter: included(), vercel: included(), cloudflare: included(), llmgateway: included(),
+	},
+	"Multimodal rankings": {
+		openrouter: included("OpenRouter publishes rankings and usage-based model lists across multiple modalities.", "Text, image, audio, video + more"),
+		vercel: included("Vercel AI Gateway leaderboards are filterable by modality.", "Text, image, video"),
+		cloudflare: excluded(), llmgateway: excluded(),
+	},
+	"Benchmarks and performance comparisons": {
+		openrouter: textCell("Provider performance data"), vercel: excluded(), cloudflare: excluded(), llmgateway: excluded(),
+	},
+	"Pricing calculator and request builder": {
+		openrouter: textCell("Pricing data"), vercel: textCell("Model pricing"), cloudflare: textCell("Model pricing"), llmgateway: included(),
+	},
+	"Data API access": {
+		openrouter: included(), vercel: included(), cloudflare: included(), llmgateway: included(),
+	},
+};
+
+function getCompetitorCell(feature: string, competitor: CompetitorKey): Cell {
+	return COMPETITOR_FEATURES[feature]?.[competitor] ?? excluded();
+}
+
+const BEST_BY_FEATURE: Partial<Record<string, ComparisonOption[]>> = {
+	"Credit purchase fee": ["vercel"],
+	"Payment method": ["openrouter"],
+	"Billing method": ["phaseo", "openrouter", "vercel", "cloudflare", "llmgateway"],
+	"BYOK service fee": ["vercel", "cloudflare", "llmgateway"],
+	"Rate limits": ["phaseo", "llmgateway"],
+	"Client SDKs": ["phaseo"],
+	"Agent SDKs": ["phaseo"],
+};
+
+function isBestChoice(feature: string, option: ComparisonOption, cell: Cell): boolean {
+	const explicitLeaders = BEST_BY_FEATURE[feature];
+	if (explicitLeaders) return explicitLeaders.includes(option);
+	return cell.type === "included";
+}
 
 const MATRIX_SECTIONS: MatrixSection[] = [
 	{
 		id: "gateway",
-		title: "Gateway",
+		title: "AI gateway",
 		rows: [
 			{
 				feature: "Gateway usage",
 				free: { type: "included", note: "Limited execution on supported free models" },
 				payg: { type: "included", note: "Production execution traffic" },
-				enterprise: { type: "included", note: "Production + governance workflows" },
 			},
 			{
 				feature: "Credit purchase fee",
-				free: { type: "text", value: "0% (no top-up required)" },
-				payg: { type: "text", value: `${basicTier.feePct.toFixed(1)}% on credit purchases` },
-				enterprise: {
-					type: "text",
-					value: `${enterpriseTier.feePct.toFixed(1)}% on credit purchases`,
-				},
+				free: { type: "not_applicable", inlineText: "No top-up required" },
+				payg: { type: "text", value: `${basicTier.feePct.toFixed(0)}% ($1 minimum) when credits are purchased` },
 			},
 			{
 				feature: "Models",
 				featureHref: "/models",
 				free: { type: "included", note: "Includes free models (count varies)" },
 				payg: { type: "included", note: "Execute across gateway-enabled models" },
-				enterprise: { type: "included", note: "Enterprise governance on model execution" },
 			},
 			{
 				feature: "Providers",
 				featureHref: "/api-providers",
 				free: { type: "included" },
 				payg: { type: "included" },
-				enterprise: { type: "included" },
 			},
 			{
 				feature: "Gateway API access",
 				free: { type: "included" },
 				payg: { type: "included" },
-				enterprise: { type: "included" },
+			},
+			...[
+				"Responses API",
+				"Chat Completions API",
+				"Anthropic Messages API",
+			].map((feature) => ({
+				feature,
+				free: included("Available where a supported free model route exists."),
+				payg: included(),
+			})),
+			...[
+				"Text generation",
+				"Image generation",
+				"Video generation",
+				"Audio generation",
+				"Music generation",
+				"Embeddings",
+			].map((feature) => ({
+				feature,
+				free: included("Available where a supported free model route exists."),
+				payg: included("Support depends on the selected model and provider."),
+			})),
+			{
+				feature: "Structured outputs and tool calling",
+				free: { type: "included", note: "Model support varies." },
+				payg: { type: "included", note: "Model support varies." },
+			},
+			{
+				feature: "Built-in server tools",
+				free: { type: "included", note: "The datetime tool is free. Metered tools require credits." },
+				payg: { type: "included", inlineText: "Tool costs shown separately" },
 			},
 			{
 				feature: "Request activity logs and export",
 				free: { type: "included", note: "View logs only (no export)" },
 				payg: { type: "included", note: "Operational logs with export" },
-				enterprise: { type: "included", note: "Extended audit and retention workflows" },
 			},
 			{
 				feature: "Smart auto-routing",
 				free: { type: "included", note: "Within the supported free model set" },
 				payg: { type: "included" },
-				enterprise: { type: "included" },
 			},
 			{
 				feature: "Preferred provider selection",
 				free: { type: "included", note: "Within the supported free model set" },
 				payg: { type: "included" },
-				enterprise: { type: "included" },
 			},
+			{
+				feature: "Routing presets, fallbacks, and service tiers",
+				free: { type: "included", note: "Routing is limited to supported free model routes." },
+				payg: { type: "included" },
+			},
+			{
+				feature: "Response healing",
+				free: { type: "included", note: "Repairs supported structured responses." },
+				payg: { type: "included", note: "Repairs supported structured responses." },
+			},
+			{
+				feature: "Guardrails",
+				free: { type: "included", note: "Any underlying model usage is billed normally." },
+				payg: { type: "included", note: "Any underlying model usage is billed normally." },
+			},
+			...[
+				"Asynchronous jobs",
+				"Batch API",
+				"Files API",
+				"Video generation API",
+				"Webhooks",
+			].map((feature) => ({
+				feature,
+				free: included("Availability depends on the selected model and provider."),
+				payg: included(),
+			})),
 			{
 				feature: "Budgets and spend controls",
 				free: { type: "not_applicable", note: "Not required for free-model usage" },
 				payg: { type: "included" },
-				enterprise: { type: "included" },
 			},
 			{
 				feature: "Prompt caching",
@@ -228,38 +544,41 @@ const MATRIX_SECTIONS: MatrixSection[] = [
 					note: "Automatic only when a free model supports caching",
 				},
 				payg: { type: "included" },
-				enterprise: { type: "included" },
 			},
 			{
 				feature: "Management API",
 				free: { type: "included" },
 				payg: { type: "included" },
-				enterprise: { type: "included" },
 			},
 			{
 				feature: "Team workspaces",
-				free: { type: "excluded", inlineText: "Single team" },
+				free: { type: "text", value: "Single team" },
 				payg: { type: "included", inlineText: "Multi-team" },
-				enterprise: { type: "included", inlineText: "Org scale" },
-			},
-			...(SHOW_ENTERPRISE_PREVIEW_ROWS ? ENTERPRISE_PREVIEW_ROWS : []),
-			{
-				feature: "Payment options",
-				free: { type: "excluded", inlineText: "No billing" },
-				payg: { type: "included", inlineText: "Card / credits" },
-				enterprise: { type: "included", inlineText: "Card or invoice" },
 			},
 			{
-				feature: "BYOK limits",
-				free: { type: "excluded" },
-				payg: { type: "included" },
-				enterprise: { type: "included" },
+				feature: "Payment method",
+				free: { type: "not_applicable", inlineText: "None required" },
+				payg: { type: "text", value: "Credit or debit card" },
+			},
+			{
+				feature: "Billing method",
+				free: { type: "text", value: "No charge" },
+				payg: { type: "text", value: "Prepaid credits" },
+			},
+			{
+				feature: "Bring your own provider keys",
+				free: { type: "included", note: "Add provider credentials and route through your own provider account." },
+				payg: { type: "included", note: "Priority and fallback BYOK routing are included." },
+			},
+			{
+				feature: "BYOK service fee",
+				free: { type: "text", value: "1M requests/month free, then 2.5%" },
+				payg: { type: "text", value: "1M requests/month free, then 2.5%" },
 			},
 			{
 				feature: "Usage limits management",
 				free: { type: "excluded" },
 				payg: { type: "included" },
-				enterprise: { type: "included" },
 			},
 			{
 				feature: "Rate limits",
@@ -273,61 +592,142 @@ const MATRIX_SECTIONS: MatrixSection[] = [
 					inlineText: "No platform limits",
 					note: "Upstream provider limits may still apply.",
 				},
-				enterprise: {
-					type: "included",
-					inlineText: "No platform limits",
-					note: "Upstream provider limits may still apply.",
-				},
 			},
 			{
-				feature: "Pricing support",
+				feature: "Support",
 				free: { type: "included", inlineText: "Docs" },
-				payg: { type: "included", inlineText: "Standard" },
-				enterprise: { type: "included", inlineText: "Priority" },
+				payg: { type: "included", inlineText: "Included" },
+			},
+		],
+	},
+	{
+		id: "chat",
+		title: "Chat and media studios",
+		rows: [
+			{
+				feature: "Free model chat",
+				featureHref: "/chat",
+				free: { type: "included", note: "Chat with supported free model routes without a credit balance." },
+				payg: { type: "included", note: "Use paid and free models from the same chat." },
+			},
+			{
+				feature: "Side-by-side model comparison",
+				featureHref: "/chat",
+				free: { type: "included" },
+				payg: { type: "included" },
+			},
+			{
+				feature: "Multimodal chat and parameter controls",
+				featureHref: "/chat",
+				free: { type: "included", note: "Model capabilities vary." },
+				payg: { type: "included", note: "Model capabilities vary." },
+			},
+			{
+				feature: "Image, video, audio, and music studios",
+				featureHref: "/chat/image",
+				free: { type: "included", note: "Use a supported free route or BYOK. Your provider charges still apply with BYOK." },
+				payg: { type: "included" },
+			},
+			{
+				feature: "Realtime voice, speech, and transcription",
+				featureHref: "/chat/realtime",
+				free: { type: "included", note: "Use a supported free route or BYOK. Your provider charges still apply with BYOK." },
+				payg: { type: "included" },
+			},
+			{
+				feature: "Local chat history",
+				free: { type: "included" },
+				payg: { type: "included" },
+			},
+		],
+	},
+	{
+		id: "sdks",
+		title: "SDKs and integrations",
+		rows: [
+			{
+				feature: "Client SDKs",
+				featureHref: "/settings/sdk",
+				free: { type: "included", inlineText: "TypeScript, Python, Go, Java, C#, PHP, Ruby, Rust, C++" },
+				payg: { type: "included", inlineText: "TypeScript, Python, Go, Java, C#, PHP, Ruby, Rust, C++" },
+			},
+			{
+				feature: "Agent SDKs",
+				featureHref: "/settings/sdk",
+				free: { type: "included", inlineText: "TypeScript, Python, Go, C#, PHP, Ruby" },
+				payg: { type: "included", inlineText: "TypeScript, Python, Go, C#, PHP, Ruby" },
+			},
+			{
+				feature: "Vercel AI SDK provider",
+				free: { type: "included" },
+				payg: { type: "included" },
+			},
+			{
+				feature: "OpenAI and Anthropic SDK compatibility",
+				free: { type: "included" },
+				payg: { type: "included" },
+			},
+			{
+				feature: "Framework and coding assistant integrations",
+				featureHref: "/works-with",
+				free: { type: "included" },
+				payg: { type: "included" },
 			},
 		],
 	},
 	{
 		id: "database",
-		title: "Database",
+		title: "Model data and discovery",
 		rows: [
 			{
 				feature: "Database usage",
 				free: { type: "included" },
 				payg: { type: "included" },
-				enterprise: { type: "included" },
 			},
 			{
 				feature: "Public model and pricing data",
 				featureHref: "/models",
 				free: { type: "included" },
 				payg: { type: "included" },
-				enterprise: { type: "included" },
 			},
 			{
 				feature: "Public provider metadata",
 				featureHref: "/api-providers",
 				free: { type: "included" },
 				payg: { type: "included" },
-				enterprise: { type: "included" },
 			},
 			{
 				feature: "Provider data explorer",
 				free: { type: "included" },
 				payg: { type: "included" },
-				enterprise: { type: "included" },
 			},
 			{
 				feature: "Token pricing visibility",
 				free: { type: "included" },
 				payg: { type: "included" },
-				enterprise: { type: "included" },
+			},
+			{
+				feature: "Multimodal rankings",
+				featureHref: "/rankings",
+				free: { type: "included", inlineText: "Text, image, embeddings, rerank, audio, video, speech, transcription" },
+				payg: { type: "included", inlineText: "Text, image, embeddings, rerank, audio, video, speech, transcription" },
+			},
+			{
+				feature: "Benchmarks and performance comparisons",
+				featureHref: "/benchmarks",
+				free: { type: "included" },
+				payg: { type: "included" },
+			},
+			{
+				feature: "Pricing calculator and request builder",
+				featureHref: "/tools/pricing-calculator",
+				free: { type: "included" },
+				payg: { type: "included" },
 			},
 			{
 				feature: "Data API access",
-				free: { type: "excluded" },
+				free: { type: "included" },
 				payg: { type: "included" },
-				enterprise: { type: "included" },
 			},
 		],
 	},
@@ -336,151 +736,229 @@ const MATRIX_SECTIONS: MatrixSection[] = [
 const FAQ_SECTIONS: FAQSection[] = [
 	{
 		id: "billing-pricing",
-		title: "Billing and Pricing",
+		title: "Charges and Billing",
 		items: [
 			{
 				id: "how-are-tokens-billed",
-				question: "How are tokens billed?",
+				question: "How is managed model usage billed?",
 				answer:
-					"Input and output usage consumes credits at the model prices shown in the catalog. The only extra platform fee is charged when credits are purchased (top-up fee), not on each token request.",
+					"Input, output, and other billable usage is deducted from your Phaseo credit balance at the model prices shown in the catalog. Phaseo does not add a separate markup to each managed request.",
 			},
 			{
-				id: "do-you-mark-up-provider-pricing",
-				question: "Do you mark up provider pricing?",
+				id: "what-does-phaseo-charge",
+				question: "What does Phaseo charge?",
 				answer:
-					"We do not add an extra per-request markup. Fees are only applied at credit purchase time by plan.",
+					`For managed usage, Phaseo charges a ${basicTier.feePct.toFixed(0)}% fee, with a $1 minimum, when you purchase credits. For BYOK, the first ${BYOK_MONTHLY_FREE_REQUESTS.toLocaleString("en-US")} requests each UTC calendar month have no Phaseo service fee; after that, the fee is ${BYOK_SERVICE_FEE_PERCENT}% of the provider-equivalent cost.`,
+			},
+			{
+				id: "is-top-up-fee-per-request",
+				question: `Is the ${basicTier.feePct.toFixed(0)}% credit fee charged on every request?`,
+				answer:
+					`No. The ${basicTier.feePct.toFixed(0)}% fee, subject to a $1 minimum, is charged once when credits are purchased. Managed model usage then draws down those credits at the catalog price without another Phaseo request markup.`,
 			},
 			{
 				id: "how-is-billing-structured",
-				question: "How is billing structured for Free, Pay As You Go, and Enterprise?",
+				question: "How is billing structured?",
 				answer:
-					"Free includes limited execution on supported free models and public data access. Pay As You Go uses a top-up system where you deposit credits and draw from that balance for usage. Enterprise can use the same credit model or move to invoicing after contacting us.",
+					"Free access includes supported free models in the API and chat, the public model catalog, rankings, benchmarks, calculators, SDKs, and integrations. For paid model usage, purchase credits and draw down that balance as you make requests. There is no subscription tier to select and no recurring commitment.",
+			},
+			{
+				id: "are-sdks-priced-separately",
+				question: "Do SDKs or integrations cost extra?",
+				answer:
+					"No. Phaseo client SDKs, Agent SDKs, compatibility layers, and documented integrations do not require a separate plan or subscription. Requests made through them follow the same managed usage or BYOK pricing shown on this page.",
+			},
+			{
+				id: "enterprise-plan",
+				question: "Do you offer an enterprise plan?",
+				answer:
+					"No. Phaseo does not sell an enterprise plan or require an enterprise contract. Teams of every size use the same pay-as-you-go offering and receive the same core product capabilities.",
+			},
+			{
+				id: "contracts-commitments",
+				question: "Do I need a contract or monthly commitment?",
+				answer:
+					"No. There are no contracts, subscriptions, minimum monthly spends, or annual commitments. Some optional features may have separate transparent pricing in the future, but they will not require an enterprise agreement.",
 			},
 			{
 				id: "are-failed-or-fallback-attempts-billed",
 				question: "Are failed or fallback attempts billed?",
 				answer:
-					"Billing tracks successful model usage. Failed attempts do not add successful usage charges in normal Gateway accounting.",
+					"Phaseo records managed charges for successful model usage. A failed attempt does not add a successful-usage charge. If a fallback provider completes the request, the usage served by that provider is billed normally. BYOK providers may apply their own billing rules to work processed before an error.",
+			},
+			{
+				id: "streaming-pricing",
+				question: "Are streaming responses billed differently?",
+				answer:
+					"No. Streaming changes how the response is delivered, not the Phaseo pricing model. The measured input, output, and other billable usage is charged at the same catalog price as a non-streaming request.",
+			},
+			{
+				id: "data-api-free",
+				question: "Is Data API access free?",
+				answer:
+					"Yes. Data API access is available to everyone. You do not need to purchase gateway credits to query public model, provider, pricing, benchmark, or ranking data.",
 			},
 			{
 				id: "payment-methods",
 				question: "What payment methods do you accept?",
 				answer:
-					"Pay As You Go supports card payments and credit top-ups. Enterprise can be configured for card or invoice-based billing.",
+					"Phaseo currently accepts credit and debit cards for credit top-ups. Cryptocurrency payments are not currently available. Credits are the billing balance used for managed model usage, not a separate payment method.",
+			},
+			{
+				id: "refunds",
+				question: "Can I refund a credit purchase?",
+				answer:
+					"A credit purchase is eligible for a self-serve refund within 24 hours if none of the purchased credits have been used. You can review eligibility and request the refund from Settings → Credits.",
+			},
+			{
+				id: "invoices",
+				question: "Can I download an invoice?",
+				answer:
+					"Yes. PDF invoices are available for completed credit purchases from Settings → Credits. If an invoice is missing for a successful payment, contact support with the payment ID and date.",
 			},
 		],
 	},
 	{
-		id: "usage-rate-limits",
-		title: "Usage and Rate Limits",
+		id: "byok",
+		title: "Bring Your Own Key",
+		items: [
+			{
+				id: "how-does-byok-work",
+				question: "How is BYOK billed?",
+				answer:
+					`Your provider bills model usage directly to your provider account. Phaseo does not charge a service fee for your first ${BYOK_MONTHLY_FREE_REQUESTS.toLocaleString("en-US")} BYOK requests each UTC calendar month. After that allowance, Phaseo charges ${BYOK_SERVICE_FEE_PERCENT}% of the provider-equivalent cost.`,
+			},
+			{
+				id: "what-is-included-with-byok",
+				question: "What is included with BYOK?",
+				answer:
+					"Secure provider-key storage, gateway routing, request logs, provider selection, and priority or fallback key ordering are included. Provider-side quotas, negotiated rates, and billing remain attached to your provider account.",
+			},
+			{
+				id: "provider-equivalent-cost",
+				question: "What does provider-equivalent cost mean?",
+				answer:
+					"It is the catalog cost of the same model, provider route, and measured usage if Phaseo-managed credentials had served the request. After the monthly free allowance, the 2.5% BYOK service fee is calculated from that reference amount, not from the amount you top up or the balance in your provider account.",
+			},
+			{
+				id: "can-i-control-byok-fallback",
+				question: "Can I control when Phaseo uses my provider keys?",
+				answer:
+					"Yes. Priority keys are tried before Phaseo-managed providers. You can also enable fallback BYOK keys that are tried after managed providers.",
+			},
+		],
+	},
+	{
+		id: "usage-controls",
+		title: "Usage and Controls",
 		items: [
 			{
 				id: "do-you-enforce-rate-limits",
 				question: "Do you enforce platform rate limits?",
 				answer:
-					"No. Phaseo does not apply platform-level rate limits across plans. Upstream providers may apply limits, and we actively work with providers to secure the highest practical limits for customers.",
+					"No. Phaseo does not apply platform-level rate limits. Upstream providers may still apply their own limits.",
 			},
 			{
 				id: "can-i-separate-environments",
-				question: "Can I separate environments (dev, staging, production)?",
+				question: "Can I separate development, staging, and production?",
 				answer:
-					"Yes. Create separate API keys and policies per environment so usage, controls, and logs remain isolated.",
+					"Yes. Create separate API keys and policies for each environment so usage, controls, and logs remain isolated.",
 			},
 			{
 				id: "can-i-set-budgets",
 				question: "Can I set budgets and spend controls?",
 				answer:
-					"Yes for paid execution workflows. Free-model usage does not require spend controls, while paid plans can use limits and team-level controls.",
+					"Yes. Pay As You Go includes API-key and team-level limits and spend controls. Free-model usage does not require spend controls.",
 			},
 		],
 	},
 	{
-		id: "routing-latency",
-		title: "Routing and Latency",
+		id: "routing-reliability",
+		title: "Routing and Reliability",
 		items: [
 			{
-				id: "does-routing-affect-latency",
-				question: "Does routing affect latency?",
+				id: "provider-unavailable",
+				question: "What happens if a provider is unavailable?",
 				answer:
-					"We continuously optimize routing to minimize added latency while maintaining secure, reliable request completion, but end-to-end latency can still vary by provider, model, and network conditions.",
+					"Phaseo can retry or route to another provider that supports the selected model when a provider is rate-limited or returns an error. Presets, provider restrictions, and BYOK fallback settings determine which alternatives are available.",
 			},
 			{
-				id: "what-happens-deprecated-model",
-				question: "What happens if a model is deprecated?",
+				id: "routing-mode",
+				question: "Can I optimise routing for price or latency?",
 				answer:
-					"We aim to give as much advance notice as possible for deprecations or retirements, including clear upgrade alternatives, and if a model is no longer routable the API returns a model availability error.",
+					"Yes. Workspace routing modes can rank compatible providers by balanced performance, price, latency, or throughput. You can also use presets to restrict the provider set before routing begins.",
 			},
 			{
-				id: "can-i-pin-model-versions",
-				question: "Can I pin specific model IDs or versions?",
+				id: "region-privacy-routing",
+				question: "Can I restrict regions or require zero data retention?",
 				answer:
-					"Yes. We aim to make model snapshots clear and accessible across the platform, and explicit model IDs let you pin a specific version for as long as that snapshot remains available.",
+					"Yes, when matching provider offers are available. Requests can specify required execution and data regions or require zero-data-retention support. Phaseo returns an error rather than silently using a route that does not meet those requirements.",
+			},
+			{
+				id: "model-pricing-changes",
+				question: "What happens when a model is deprecated or its price changes?",
+				answer:
+					"Phaseo tracks model lifecycle and provider availability in the catalog. Current catalog pricing is applied when a request is served. Use exact model IDs, availability data, and fallback presets when you need controlled migrations between model versions.",
 			},
 		],
 	},
 	{
-		id: "privacy-security",
-		title: "Privacy and Security",
+		id: "apis-features",
+		title: "APIs and Features",
 		items: [
 			{
-				id: "do-you-train-on-data",
-				question: "Do you train on customer data?",
+				id: "openai-anthropic-migration",
+				question: "Can I migrate from OpenAI, Anthropic, or another gateway?",
 				answer:
-					"No. Phaseo does not use customer prompts or outputs to train foundation models.",
+					"Yes. Phaseo provides OpenAI-compatible Chat Completions and Responses APIs, an Anthropic-compatible Messages API, SDK compatibility, and migration guides. Most integrations begin by changing the base URL, API key, and model ID.",
 			},
 			{
-				id: "how-does-byok-work",
-				question: "How does BYOK work?",
+				id: "tools-structured-output",
+				question: "Do you support tools and structured output?",
 				answer:
-					"With BYOK, requests are routed using your provider credentials so usage and provider-side controls remain tied to your provider account.",
+					"Yes. Tool calling, structured-output schemas, server tools, and optional response healing are available where the selected model and endpoint support them. Model capability data is available through the catalog and Data API.",
 			},
 			{
-				id: "do-you-support-sso",
-				question: "Do you support SSO (SAML)?",
+				id: "multimodal-endpoints",
+				question: "Which modalities can I use?",
 				answer:
-					"SAML single sign-on is being rolled out as a self-serve workspace feature and will be included for all customers without an enterprise contract or add-on fee.",
+					"Phaseo supports text, image, video, audio, speech, transcription, music, embeddings, moderation, reranking, OCR, and realtime workflows across supported models and providers. Availability and billing units vary by model.",
 			},
 		],
 	},
 	{
-		id: "models-features",
-		title: "Models and Features",
+		id: "privacy-data",
+		title: "Privacy and Data",
 		items: [
 			{
-				id: "how-to-migrate",
-				question: "How do I migrate from OpenAI or Anthropic?",
+				id: "training-data",
+				question: "Does Phaseo train on my prompts or responses?",
 				answer:
-					"The Gateway is OpenAI-compatible for most integrations. In most cases, you update the base URL, API key, and model IDs.",
+					"No. Phaseo does not use gateway prompts or responses to train its own models. Requests are sent to the provider that serves them, so that provider's data and training policies still apply unless your routing requirements exclude that provider.",
 			},
 			{
-				id: "function-calling-support",
-				question: "Do you support tools and function calling?",
+				id: "request-logging",
+				question: "What request data does Phaseo store?",
 				answer:
-					"Yes, when the selected upstream model supports those capabilities.",
-			},
-			{
-				id: "free-plan-model-access",
-				question: "What model access is included in Free?",
-				answer:
-					"Free includes a limited set of supported free models, while paid plans unlock broader execution and control options.",
+					"Phaseo stores operational and billing metadata such as model, provider, token counts, latency, and errors. Raw prompts and responses are not persistently stored by default. If workspace I/O logging is enabled, payload retention follows the workspace privacy and retention settings.",
 			},
 		],
 	},
 	{
-		id: "reliability-uptime",
-		title: "Reliability and Uptime",
+		id: "support-status",
+		title: "Support and Status",
 		items: [
 			{
-				id: "provider-down",
-				question: "What happens if a provider is down or returns errors?",
+				id: "service-status",
+				question: "Where can I check incidents and uptime?",
 				answer:
-					"Gateway routing and fallback can shift traffic to alternative providers that support your selected model.",
+					"Current service status and incident history are published at status.phaseo.app. Request IDs and activity logs can help support trace a specific failure.",
 			},
 			{
-				id: "where-check-incidents",
-				question: "Where can I check incidents and service health?",
+				id: "contact-support",
+				question: "How do I contact support?",
 				answer:
-					"Operational updates are shared through support and release communications while broader status reporting is expanded.",
+					"Use the contact page or email support@phaseo.ai for account, billing, and technical questions. Bug reports and feature requests can also be filed through the public GitHub repository.",
 			},
 		],
 	},
@@ -490,16 +968,12 @@ export default function PricingPage() {
 	return (
 		<main className="relative min-h-screen overflow-hidden">
 			<div className="container mx-auto max-w-7xl px-4 py-12 sm:py-16">
-				<section className="space-y-6">
-					<div className="inline-flex items-center gap-2 rounded-full border border-zinc-200/70 bg-white/70 px-3 py-1 text-xs text-muted-foreground dark:border-zinc-800/70 dark:bg-zinc-950/60">
-						<BadgeDollarSign className="h-3.5 w-3.5" />
-						Gateway Pricing
-					</div>
+				<section className="space-y-7">
 					<h1 className="max-w-4xl text-4xl font-semibold tracking-tight text-foreground sm:text-5xl">
-						Phaseo Gateway pricing matrix.
+						One pay-as-you-go offering. Every team, every size.
 					</h1>
 					<p className="max-w-3xl text-base leading-7 text-muted-foreground">
-						This page focuses on Gateway plans and capabilities. For model-level token and request cost estimation, use the{" "}
+						Buy credits when you need them and pay for what you use. There is no enterprise plan, no contract, and no monthly or annual commitment. For model-level cost estimates, use the{" "}
 						<Link className="underline underline-offset-4" href="/tools/pricing-calculator">
 							Pricing Calculator
 						</Link>
@@ -514,14 +988,14 @@ export default function PricingPage() {
 					</p>
 					<div className="flex flex-col gap-3 sm:flex-row sm:flex-wrap sm:items-center">
 						<Button asChild className="h-10">
-							<Link href="/settings/tiers">
-								View Your Tier
+							<Link href="/settings/credits">
+								Manage Credits
 								<ArrowRight className="ml-2 h-4 w-4" />
 							</Link>
 						</Button>
 						<Button asChild variant="outline" className="h-10">
-							<Link href="/settings/credits">
-								Manage Credits
+							<Link href="/settings/byok">
+								Manage Provider Keys
 								<ArrowRight className="ml-2 h-4 w-4" />
 							</Link>
 						</Button>
@@ -532,6 +1006,85 @@ export default function PricingPage() {
 							</Link>
 						</Button>
 					</div>
+					<div className="grid border-y border-zinc-200/80 dark:border-zinc-800/80 sm:grid-cols-3 sm:divide-x sm:divide-zinc-200/80 sm:dark:divide-zinc-800/80">
+						{[
+							{
+								icon: WalletCards,
+								title: "Pay as you go",
+								body: "Top up credits only when you need them.",
+							},
+							{
+								icon: FileX2,
+								title: "No enterprise plan",
+								body: "The same core product is available to every team.",
+							},
+							{
+								icon: CalendarOff,
+								title: "No commitments",
+								body: "No contracts, subscriptions, or minimum spend.",
+							},
+						].map((item) => {
+							const Icon = item.icon;
+							return (
+								<div key={item.title} className="flex gap-3 py-5 sm:px-5 sm:first:pl-0 sm:last:pr-0">
+									<Icon className="mt-0.5 h-5 w-5 shrink-0 text-foreground" aria-hidden="true" />
+									<div>
+										<p className="text-sm font-semibold text-foreground">{item.title}</p>
+										<p className="mt-1 text-sm leading-5 text-muted-foreground">{item.body}</p>
+									</div>
+								</div>
+							);
+						})}
+					</div>
+				</section>
+
+				<div className="my-10 sm:my-12">
+					<Separator className="bg-zinc-200/70 dark:bg-zinc-800/70" />
+				</div>
+
+				<section className="space-y-5">
+					<div className="max-w-3xl">
+						<h2 className="text-2xl font-semibold tracking-tight text-foreground sm:text-3xl">
+							What Phaseo charges
+						</h2>
+						<p className="mt-2 text-sm leading-6 text-muted-foreground">
+							Model usage and Phaseo fees are shown separately so you can see what is charged, by whom, and when.
+						</p>
+					</div>
+					<dl className="grid border-y border-zinc-200/80 dark:border-zinc-800/80 lg:grid-cols-3 lg:divide-x lg:divide-zinc-200/80 lg:dark:divide-zinc-800/80">
+						{[
+							{
+								icon: Coins,
+								term: "Managed model usage",
+								value: "Catalog model price",
+								detail: "Deducted from your prepaid credits after successful usage. No additional Phaseo request markup.",
+							},
+							{
+								icon: ReceiptText,
+								term: "Credit purchase",
+								value: `${basicTier.feePct.toFixed(0)}% top-up fee ($1 minimum)`,
+								detail: "Charged when you purchase credits. It is not charged again for each managed request.",
+							},
+							{
+								icon: KeyRound,
+								term: "Bring Your Own Key",
+								value: `${BYOK_MONTHLY_FREE_REQUESTS.toLocaleString("en-US")} requests free, then ${BYOK_SERVICE_FEE_PERCENT}%`,
+								detail: "Your provider bills model usage directly. The allowance resets at the start of each UTC month; the Phaseo fee after that is based on provider-equivalent cost.",
+							},
+						].map((item) => {
+							const Icon = item.icon;
+							return (
+								<div key={item.term} className="flex gap-4 py-5 lg:px-6 lg:first:pl-0 lg:last:pr-0">
+									<Icon className="mt-0.5 h-5 w-5 shrink-0 text-foreground" aria-hidden="true" />
+									<div>
+										<dt className="text-sm font-semibold text-foreground">{item.term}</dt>
+										<dd className="mt-1 text-base font-semibold text-foreground">{item.value}</dd>
+										<p className="mt-2 text-sm leading-5 text-muted-foreground">{item.detail}</p>
+									</div>
+								</div>
+							);
+						})}
+					</dl>
 				</section>
 
 				<div className="my-10 sm:my-12">
@@ -539,22 +1092,37 @@ export default function PricingPage() {
 				</div>
 
 				<section className="space-y-6">
-					<div className="overflow-x-auto rounded-xl border border-zinc-200/70 bg-white/75 dark:border-zinc-800/70 dark:bg-zinc-950/60">
-						<table className={`w-full table-fixed text-left text-sm ${SHOW_ENTERPRISE_PLAN ? "min-w-[1160px]" : "min-w-[920px]"}`}>
+					<PricingComparisonShell>
+						<table className="w-full min-w-[760px] table-fixed text-left text-sm">
 							<colgroup>
-								<col className="w-[40%]" />
-								<col className={SHOW_ENTERPRISE_PLAN ? "w-[20%]" : "w-[30%]"} />
-								<col className={SHOW_ENTERPRISE_PLAN ? "w-[20%]" : "w-[30%]"} />
-								{SHOW_ENTERPRISE_PLAN ? <col className="w-[20%]" /> : null}
+								<col className="feature-column w-[36%]" />
+								<col className="free-column w-[32%]" />
+								<col className="phaseo-column w-[32%]" />
+								{COMPETITORS.map((competitor) => <col key={competitor.key} className="competitor-col hidden w-[16%]" />)}
 							</colgroup>
 							<thead className="border-b border-zinc-200/70 bg-zinc-50/80 dark:border-zinc-800/70 dark:bg-zinc-900/60">
 								<tr>
 									<th className="px-4 py-3 font-medium text-zinc-700 dark:text-zinc-300">Feature</th>
-									<th className="px-4 py-3 text-center font-medium text-zinc-700 dark:text-zinc-300">Free</th>
-									<th className="px-4 py-3 text-center font-bold text-foreground">Pay As You Go</th>
-									{SHOW_ENTERPRISE_PLAN ? (
-										<th className="px-4 py-3 text-center font-medium text-zinc-700 dark:text-zinc-300">Enterprise</th>
-									) : null}
+									<th className="free-column px-4 py-3 text-center font-medium text-zinc-700 dark:text-zinc-300">Free access</th>
+									<th className="px-4 py-3 text-center font-bold text-foreground">
+										<span className="phaseo-default">Pay As You Go</span>
+										<span className="phaseo-compare hidden">
+											<span className="inline-flex items-center justify-center gap-2">
+												<Image src="/logo_light.svg" alt="" width={20} height={20} className="h-5 w-5 dark:hidden" />
+												<Image src="/logo_dark.svg" alt="" width={20} height={20} className="hidden h-5 w-5 dark:block" />
+												Phaseo
+											</span>
+										</span>
+									</th>
+									{COMPETITORS.map((competitor) => (
+										<th key={competitor.key} className="competitor-cell hidden px-4 py-3 text-center font-semibold text-foreground">
+											<a href={competitor.href} target="_blank" rel="noreferrer" className="inline-flex items-center gap-2 underline decoration-transparent underline-offset-4 hover:decoration-current">
+												<ProviderLogo competitor={competitor} />
+												{competitor.name}
+												<ExternalLink className="h-3 w-3" aria-hidden="true" />
+											</a>
+										</th>
+									))}
 								</tr>
 							</thead>
 							<tbody className="divide-y divide-zinc-200/70 dark:divide-zinc-800/70">
@@ -564,14 +1132,14 @@ export default function PricingPage() {
 											className="bg-zinc-50/70 dark:bg-zinc-900/40"
 										>
 											<td
-												colSpan={SHOW_ENTERPRISE_PLAN ? 4 : 3}
-												className="px-4 py-2 text-xs font-semibold uppercase tracking-wide text-zinc-600 dark:text-zinc-300"
+												colSpan={3 + COMPETITORS.length}
+												className="px-4 py-3 text-base font-semibold text-foreground"
 											>
 												{section.title}
 											</td>
 										</tr>
 										{section.rows.map((row) => (
-											<tr key={`${section.id}-${row.feature}`}>
+											<tr key={`${section.id}-${row.feature}`} className="h-[72px]">
 												<td className="px-4 py-3 align-middle text-foreground font-medium">
 													{row.featureHref ? (
 														<Link
@@ -584,18 +1152,22 @@ export default function PricingPage() {
 														row.feature
 													)}
 												</td>
-												<td className="px-4 py-3 align-top text-center"><PlanCell cell={row.free} /></td>
-												<td className="px-4 py-3 align-top text-center"><PlanCell cell={row.payg} /></td>
-												{SHOW_ENTERPRISE_PLAN ? (
-													<td className="px-4 py-3 align-top text-center"><PlanCell cell={row.enterprise} /></td>
-												) : null}
+										<td className="free-column px-4 py-3 align-middle text-center"><PlanCell cell={row.free} label={`${row.feature}, Free access`} /></td>
+										<td className={`${isBestChoice(row.feature, "phaseo", row.payg) ? "best-cell " : ""}px-4 py-3 align-middle text-center`}>
+											<PlanCell cell={row.payg} label={`${row.feature}, Pay As You Go`} />
+										</td>
+										{COMPETITORS.map((competitor) => (
+											<td key={competitor.key} className={`${isBestChoice(row.feature, competitor.key, getCompetitorCell(row.feature, competitor.key)) ? "best-cell " : ""}competitor-cell hidden px-4 py-3 align-middle text-center`}>
+												<PlanCell cell={getCompetitorCell(row.feature, competitor.key)} label={`${row.feature}, ${competitor.name}`} />
+											</td>
+										))}
 											</tr>
 										))}
 									</Fragment>
 								))}
 							</tbody>
 						</table>
-					</div>
+					</PricingComparisonShell>
 				</section>
 
 				<section className="space-y-6 py-10 sm:py-12">
@@ -605,18 +1177,13 @@ export default function PricingPage() {
 						</h2>
 					</div>
 					<div className="space-y-8">
-						{FAQ_SECTIONS.map((section) => {
-							const visibleItems = SHOW_ENTERPRISE_PLAN
-								? section.items
-								: section.items.filter((item) => !/enterprise/i.test(`${item.question} ${item.answer}`));
-							if (visibleItems.length === 0) return null;
-							return (
+						{FAQ_SECTIONS.map((section) => (
 							<div key={section.id} className="space-y-2">
 								<h3 className="text-base font-semibold text-zinc-700 dark:text-zinc-200">
 									{section.title}
 								</h3>
 								<Accordion type="single" collapsible>
-									{visibleItems.map((item) => (
+									{section.items.map((item) => (
 										<AccordionItem key={item.id} value={`${section.id}-${item.id}`}>
 											<AccordionTrigger>{item.question}</AccordionTrigger>
 											<AccordionContent className="text-muted-foreground leading-6">
@@ -626,8 +1193,7 @@ export default function PricingPage() {
 									))}
 								</Accordion>
 							</div>
-							);
-						})}
+						))}
 					</div>
 				</section>
 
@@ -636,19 +1202,19 @@ export default function PricingPage() {
 						<CardHeader className="space-y-2">
 							<CardTitle className="text-2xl tracking-tight">Ready to get started?</CardTitle>
 							<p className="text-sm leading-6 text-muted-foreground">
-								Start with Pay As You Go and upgrade automatically as your usage grows.
+								Start free, add credits when you need them, and keep the same pay-as-you-go terms as you grow.
 							</p>
 						</CardHeader>
 						<CardContent className="flex flex-col gap-3 sm:flex-row sm:flex-wrap sm:items-center">
-							<Button asChild className="h-10">
+							<Button asChild className="h-10 rounded-xl">
 								<Link href="/">
 									Open Platform
 									<ArrowRight className="ml-2 h-4 w-4" />
 								</Link>
 							</Button>
-							<Button asChild variant="outline" className="h-10">
-								<Link href="/contact">
-									Talk to sales
+							<Button asChild variant="outline" className="h-10 rounded-xl">
+								<Link href="mailto:support@phaseo.ai">
+									Ask a pricing question
 									<ArrowRight className="ml-2 h-4 w-4" />
 								</Link>
 							</Button>

--- a/apps/web/src/app/(dashboard)/settings/byok/page.tsx
+++ b/apps/web/src/app/(dashboard)/settings/byok/page.tsx
@@ -10,8 +10,8 @@ import ByokFallbackToggle from "@/components/(gateway)/settings/byok/ByokFallbac
 
 export const metadata = { title: "BYOK - Settings" };
 
-const BYOK_MONTHLY_FREE_REQUESTS = 100_000;
-const BYOK_FEE_PERCENT = 3.5;
+const BYOK_MONTHLY_FREE_REQUESTS = 1_000_000;
+const BYOK_FEE_PERCENT = 2.5;
 
 type KeyEntry = {
 	id: string;

--- a/apps/web/src/app/(dashboard)/tools/pricing-calculator/actions.ts
+++ b/apps/web/src/app/(dashboard)/tools/pricing-calculator/actions.ts
@@ -1,0 +1,11 @@
+"use server";
+
+import { fetchFrontendPricingModels } from "@/lib/fetchers/frontend/fetchFrontendPricingModels";
+
+export async function loadPricingCalculatorModels(modelIds: string[]) {
+	const ids = [...new Set(
+		modelIds.map((value) => value.trim()).filter(Boolean),
+	)].slice(0, 100);
+	if (ids.length === 0) return [];
+	return fetchFrontendPricingModels(ids);
+}

--- a/apps/web/src/app/(dashboard)/tools/pricing-calculator/page.tsx
+++ b/apps/web/src/app/(dashboard)/tools/pricing-calculator/page.tsx
@@ -2,9 +2,12 @@ import { Metadata } from "next";
 import { Suspense } from "react";
 import { buildMetadata } from "@/lib/seo";
 import PricingCalculator from "@/components/(tools)/PricingCalculator";
-import { fetchFrontendPricingModels } from "@/lib/fetchers/frontend/fetchPublicCatalog";
+import { fetchFrontendModels } from "@/lib/fetchers/frontend/fetchPublicCatalog";
+import { fetchFrontendPricingModels } from "@/lib/fetchers/frontend/fetchFrontendPricingModels";
+import { fetchFrontendGatewayModels } from "@/lib/fetchers/frontend/fetchFrontendGatewayModels";
 import type { PricingModel } from "@/lib/fetchers/pricing/getPricingModels";
 import { loadPricingCalculatorSearchParams } from "./search-params";
+import { sanitizeModelSelections } from "@/components/(tools)/pricing-calculator/calculatorState";
 
 export const metadata: Metadata = buildMetadata({
 	title: "AI Pricing Calculator: Compare LLM API Costs",
@@ -39,33 +42,53 @@ async function PricingCalculatorPageContent({
 }: {
 	searchParams: Promise<Record<string, string | string[] | undefined>>;
 }) {
-	let models: PricingModel[] = [];
-	try {
-		models = await fetchFrontendPricingModels();
-	} catch (error) {
-		console.error("[pricing-calculator] failed to load pricing models", error);
-	}
-	const resolvedSearchParams = await searchParams;
+	const [catalogueResult, cachedModelsResult, resolvedSearchParams] = await Promise.all([
+		fetchFrontendModels().catch(() => []),
+		fetchFrontendGatewayModels().catch(() => []),
+		searchParams,
+	]);
 	const parsedParams =
 		loadPricingCalculatorSearchParams(resolvedSearchParams);
+	const selectedModelIds = sanitizeModelSelections(parsedParams.selections).map(
+		(selection) => selection.modelId,
+	);
+	if (selectedModelIds.length === 0) {
+		selectedModelIds.push(...parsedParams.models);
+	}
+	if (selectedModelIds.length === 0 && parsedParams.model) {
+		selectedModelIds.push(parsedParams.model);
+	}
+	const pricingModels: PricingModel[] = selectedModelIds.length > 0
+		? await fetchFrontendPricingModels(selectedModelIds).catch(() => [])
+		: [];
+	const catalogModels = catalogueResult.map((model) => ({
+		modelId: model.model_id,
+		displayName: model.name || model.model_id,
+		organisationId: model.organisation_id || model.model_id.split("/")[0] || "unknown",
+		organisationName: model.organisation_name || model.organisation_id || "Unknown",
+		releaseDate: model.release_date,
+		announcementDate: model.announcement_date,
+	}));
+	const cachedModels = cachedModelsResult;
 
-	// Extract model names for structured data
-	const modelNames = Array.from(
-		new Set(models.map((m) => m.display_name || m.model))
-	)
-		.sort()
-		.slice(0, 100); // Top 100 for structured data
-
-	const providers = Array.from(new Set(models.map((m) => m.provider))).sort();
+	const providers = Array.from(new Set(cachedModels.map((model) => model.providerId))).sort();
 
 	return (
 		<PricingCalculator
-			initialModels={models}
+			initialModels={pricingModels}
+			catalogModels={catalogModels}
+			cachedModels={cachedModels}
 			initialModel={parsedParams.model || undefined}
 			initialEndpoint={parsedParams.endpoint || undefined}
 			initialProvider={parsedParams.provider || undefined}
 			initialPlan={parsedParams.plan || undefined}
-			totalModelsCount={modelNames.length}
+			initialSelectedModels={parsedParams.models}
+			initialSelections={parsedParams.selections}
+			initialModelConfigs={parsedParams.configs}
+			initialMeterInputs={parsedParams.usage}
+			initialRequestMultiplier={parsedParams.requests}
+			initialPricingTimeUtc={parsedParams.time || undefined}
+			totalModelsCount={catalogModels.length}
 			providersCount={providers.length}
 		/>
 	);

--- a/apps/web/src/app/(dashboard)/tools/pricing-calculator/search-params.ts
+++ b/apps/web/src/app/(dashboard)/tools/pricing-calculator/search-params.ts
@@ -1,4 +1,21 @@
-import { createLoader, parseAsString } from "nuqs/server";
+import {
+	createLoader,
+	parseAsArrayOf,
+	parseAsInteger,
+	parseAsJson,
+	parseAsString,
+} from "nuqs/server";
+
+type CalculatorModelConfig = {
+	endpoint: string;
+	provider: string;
+	pricingPlan: string;
+};
+
+type CalculatorModelSelection = {
+	id: string;
+	modelId: string;
+};
 
 export const pricingCalculatorSearchParams = {
 	model: parseAsString.withDefault("").withOptions({
@@ -14,6 +31,40 @@ export const pricingCalculatorSearchParams = {
 		clearOnDefault: true,
 	}),
 	plan: parseAsString.withDefault("").withOptions({
+		shallow: true,
+		clearOnDefault: true,
+	}),
+	models: parseAsArrayOf(parseAsString).withDefault([]).withOptions({
+		shallow: true,
+		clearOnDefault: true,
+	}),
+	selections: parseAsJson<CalculatorModelSelection[]>((value) =>
+		Array.isArray(value) ? value as CalculatorModelSelection[] : null
+	).withDefault([]).withOptions({
+		shallow: true,
+		clearOnDefault: true,
+	}),
+	configs: parseAsJson<Record<string, CalculatorModelConfig>>((value) =>
+		value && typeof value === "object" && !Array.isArray(value)
+			? value as Record<string, CalculatorModelConfig>
+			: null
+	).withDefault({}).withOptions({
+		shallow: true,
+		clearOnDefault: true,
+	}),
+	usage: parseAsJson<Record<string, string>>((value) =>
+		value && typeof value === "object" && !Array.isArray(value)
+			? value as Record<string, string>
+			: null
+	).withDefault({}).withOptions({
+		shallow: true,
+		clearOnDefault: true,
+	}),
+	requests: parseAsInteger.withDefault(1).withOptions({
+		shallow: true,
+		clearOnDefault: true,
+	}),
+	time: parseAsString.withDefault("").withOptions({
 		shallow: true,
 		clearOnDefault: true,
 	}),

--- a/apps/web/src/components/(chat)/VirtualizedModelCatalog.tsx
+++ b/apps/web/src/components/(chat)/VirtualizedModelCatalog.tsx
@@ -55,6 +55,8 @@ type VirtualizedModelCatalogProps<T> = {
 	onActiveItemChange: (itemKey: string) => void;
 	onSelectItem: (item: T) => void;
 	renderItem: (item: T) => ReactNode;
+	estimateItemSize?: number;
+	emptyContent?: ReactNode;
 };
 
 export function VirtualizedModelCatalog<T>({
@@ -65,6 +67,8 @@ export function VirtualizedModelCatalog<T>({
 	onActiveItemChange,
 	onSelectItem,
 	renderItem,
+	estimateItemSize = 36,
+	emptyContent = "No models found.",
 }: VirtualizedModelCatalogProps<T>) {
 	const [scrollViewport, setScrollViewport] =
 		useState<HTMLDivElement | null>(null);
@@ -87,7 +91,7 @@ export function VirtualizedModelCatalog<T>({
 			const row = rows[index];
 			if (row?.type === "heading") return 32;
 			if (row?.type === "separator") return 9;
-			return 36;
+			return estimateItemSize;
 		},
 		overscan: 10,
 	});
@@ -98,7 +102,7 @@ export function VirtualizedModelCatalog<T>({
 	}, [activeRowIndex, virtualizer]);
 
 	if (rows.length === 0) {
-		return <div className="py-6 text-center text-sm">No models found.</div>;
+		return <div className="py-6 text-center text-sm">{emptyContent}</div>;
 	}
 
 	return (

--- a/apps/web/src/components/(data)/model/pricing/pricingHelpers.ts
+++ b/apps/web/src/components/(data)/model/pricing/pricingHelpers.ts
@@ -1544,7 +1544,7 @@ export function calculateUnits(
 ): number {
     const { pricePerUnit } = resolvePricingMeterPrice(meter, pricingTimeUtc);
     const unitSize = meter.unit_size || 1;
-    if (pricePerUnit === 0) return 0;
+	if (pricePerUnit === 0) return Number.POSITIVE_INFINITY;
     return (budget / pricePerUnit) * unitSize;
 }
 
@@ -1552,6 +1552,7 @@ export function calculateUnits(
  * Format numbers with K/M/B/T/Q suffixes
  */
 export function formatQuantity(n: number): string {
+	if (n === Number.POSITIVE_INFINITY) return "Unlimited";
     if (n >= 1_000_000_000_000_000) return `${(n / 1_000_000_000_000_000).toFixed(1)}Q`;
     if (n >= 1_000_000_000_000) return `${(n / 1_000_000_000_000).toFixed(1)}T`;
     if (n >= 1_000_000_000) return `${(n / 1_000_000_000).toFixed(1)}B`;

--- a/apps/web/src/components/(tools)/PricingCalculator.tsx
+++ b/apps/web/src/components/(tools)/PricingCalculator.tsx
@@ -1,7 +1,13 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
-import { useQueryState } from "nuqs";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import {
+	parseAsArrayOf,
+	parseAsInteger,
+	parseAsJson,
+	parseAsString,
+	useQueryStates,
+} from "nuqs";
 import { Card, CardContent } from "@/components/ui/card";
 import { CheckCircle2 } from "lucide-react";
 import {
@@ -11,20 +17,27 @@ import {
 	PricingReference,
 } from "@/components/(tools)/pricing-calculator";
 import type { SelectedPricingModelConfig } from "@/components/(tools)/pricing-calculator/ModelSelector";
+import type { GatewaySupportedModel } from "@/lib/fetchers/gateway/getGatewaySupportedModelIds";
+import {
+	comparePricingEndpoints,
+	createModelSelectionId,
+	sameStringArray,
+	sanitizeMeterInputs,
+	sanitizeModelConfigs,
+	sanitizeModelSelections,
+	sanitizePricingTime,
+	sanitizeRequestMultiplier,
+} from "@/components/(tools)/pricing-calculator/calculatorState";
+import type { CalculatorModelSelection } from "@/components/(tools)/pricing-calculator/calculatorState";
+import type { CalculatorCatalogModel } from "@/components/(tools)/pricing-calculator/calculatorState";
+import { loadPricingCalculatorModels } from "@/app/(dashboard)/tools/pricing-calculator/actions";
 import {
 	type PricingMeter,
 } from "@/components/(data)/model/pricing/pricingHelpers";
+import { selectPricingMetersForUsage } from "@/components/(tools)/pricing-calculator/pricingMeterConditions";
 
 function getCurrentUtcTime() {
 	return new Date().toISOString().slice(11, 16);
-}
-
-function releaseTimestamp(
-	releaseDate?: string | null,
-	announcementDate?: string | null
-): number {
-	const parsed = Date.parse(releaseDate || announcementDate || "");
-	return Number.isFinite(parsed) ? parsed : Number.NEGATIVE_INFINITY;
 }
 
 type PricingModel = {
@@ -40,10 +53,18 @@ type PricingModel = {
 
 type PricingCalculatorProps = {
 	initialModels?: PricingModel[];
+	catalogModels?: CalculatorCatalogModel[];
+	cachedModels?: GatewaySupportedModel[];
 	initialModel?: string;
 	initialEndpoint?: string;
 	initialProvider?: string;
 	initialPlan?: string;
+	initialSelectedModels?: string[];
+	initialSelections?: CalculatorModelSelection[];
+	initialModelConfigs?: Record<string, SelectedPricingModelConfig>;
+	initialMeterInputs?: Record<string, string>;
+	initialRequestMultiplier?: number;
+	initialPricingTimeUtc?: string;
 	totalModelsCount?: number;
 	providersCount?: number;
 };
@@ -52,221 +73,237 @@ type SelectedPricingModel = PricingModel & {
 	key: string;
 	label: string;
 	pricingPlan: string;
+	allMeters: PricingMeter[];
 };
+
+function mergePricingModels(current: PricingModel[], incoming: PricingModel[]): PricingModel[] {
+	const rows = new Map(current.map((row) => [
+		`${row.provider}:${row.model}:${row.endpoint}:${row.pricing_plan || "standard"}`,
+		row,
+	]));
+	for (const row of incoming) {
+		rows.set(
+			`${row.provider}:${row.model}:${row.endpoint}:${row.pricing_plan || "standard"}`,
+			row,
+		);
+	}
+	return [...rows.values()];
+}
+
+function resolveDefaultPricingConfig(
+	models: PricingModel[],
+	modelId: string,
+	preferred?: Partial<SelectedPricingModelConfig>,
+): SelectedPricingModelConfig | null {
+	const rows = models.filter((row) => row.model === modelId);
+	if (rows.length === 0) return null;
+	const endpoints = [...new Set(rows.map((row) => row.endpoint))].sort(comparePricingEndpoints);
+	const endpoint = preferred?.endpoint && endpoints.includes(preferred.endpoint)
+		? preferred.endpoint
+		: endpoints[0] || "";
+	const providerRows = rows.filter((row) => row.endpoint === endpoint);
+	const providers = [...new Set(providerRows.map((row) => row.provider))].sort();
+	const provider = preferred?.provider && providers.includes(preferred.provider)
+		? preferred.provider
+		: providers[0] || "";
+	const plans = [...new Set(providerRows
+		.filter((row) => row.provider === provider)
+		.map((row) => row.pricing_plan || "standard"))]
+		.sort((left, right) => {
+			if (left === "standard") return -1;
+			if (right === "standard") return 1;
+			return left.localeCompare(right);
+		});
+	const pricingPlan = preferred?.pricingPlan && plans.includes(preferred.pricingPlan)
+		? preferred.pricingPlan
+		: plans[0] || "";
+	return endpoint && provider && pricingPlan ? { endpoint, provider, pricingPlan } : null;
+}
 
 export default function PricingCalculator({
 	initialModels,
+	catalogModels = [],
+	cachedModels = [],
 	initialModel,
 	initialEndpoint,
 	initialProvider,
 	initialPlan,
+	initialSelectedModels = [],
+	initialSelections = [],
+	initialModelConfigs = {},
+	initialMeterInputs = {},
+	initialRequestMultiplier = 1,
+	initialPricingTimeUtc,
 	totalModelsCount = 500,
 	providersCount = 10,
 }: PricingCalculatorProps) {
-	const models = useMemo(() => initialModels || [], [initialModels]);
+	const [models, setModels] = useState<PricingModel[]>(() => initialModels || []);
+	const [loadingModelIds, setLoadingModelIds] = useState<string[]>([]);
+	const [pricingNotice, setPricingNotice] = useState<string | null>(null);
 
-	const roundedTotalModelsCount = useMemo(
-		() => Math.ceil(totalModelsCount / 50) * 50,
-		[totalModelsCount]
-	);
-
-	const [selectedModelId, setSelectedModelId] = useQueryState("model", {
-		defaultValue: initialModel || "",
+	const [queryState, setQueryState] = useQueryStates({
+		model: parseAsString.withDefault(initialModel || "").withOptions({ clearOnDefault: false }),
+		endpoint: parseAsString.withDefault(initialEndpoint || "").withOptions({ clearOnDefault: false }),
+		provider: parseAsString.withDefault(initialProvider || "").withOptions({ clearOnDefault: false }),
+		plan: parseAsString.withDefault(initialPlan || "").withOptions({ clearOnDefault: false }),
+		models: parseAsArrayOf(parseAsString).withDefault(
+			initialSelectedModels.length > 0
+				? initialSelectedModels
+				: initialModel
+					? [initialModel]
+					: []
+		).withOptions({ clearOnDefault: false }),
+		selections: parseAsJson<CalculatorModelSelection[]>((value) =>
+			Array.isArray(value) ? sanitizeModelSelections(value) : null
+		).withDefault(initialSelections).withOptions({ clearOnDefault: false }),
+		configs: parseAsJson<Record<string, SelectedPricingModelConfig>>((value) =>
+			value && typeof value === "object" && !Array.isArray(value)
+				? value as Record<string, SelectedPricingModelConfig>
+				: null
+		).withDefault(
+			initialModelConfigs
+		).withOptions({ clearOnDefault: false }),
+		usage: parseAsJson<Record<string, string>>((value) =>
+			value && typeof value === "object" && !Array.isArray(value)
+				? value as Record<string, string>
+				: null
+		).withDefault(initialMeterInputs).withOptions({ clearOnDefault: false }),
+		requests: parseAsInteger.withDefault(
+			sanitizeRequestMultiplier(initialRequestMultiplier)
+		).withOptions({ clearOnDefault: false }),
+		time: parseAsString.withDefault(initialPricingTimeUtc || "").withOptions({ clearOnDefault: false }),
 	});
-	const [, setSelectedEndpoint] = useQueryState("endpoint", {
-		defaultValue: initialEndpoint || "",
-	});
-	const [, setSelectedProvider] = useQueryState("provider", {
-		defaultValue: initialProvider || "",
-	});
-	const [, setSelectedPricingPlan] = useQueryState("plan", {
-		defaultValue: initialPlan || "",
-	});
 
-	const [selectedModelIds, setSelectedModelIds] = useState<string[]>(
-		initialModel ? [initialModel] : []
-	);
-	const [modelConfigs, setModelConfigs] = useState<
-		Record<string, SelectedPricingModelConfig>
-	>({});
-	const [meterInputs, setMeterInputs] = useState<Record<string, string>>({});
-	const [requestMultiplier, setRequestMultiplier] = useState<number>(1);
-	const [pricingTimeUtc, setPricingTimeUtc] = useState<string>("00:00");
-
-	useEffect(() => {
-		setPricingTimeUtc(getCurrentUtcTime());
-	}, []);
-
-	const modelsByReleaseDate = useMemo(() => {
-		const unique = new Map<
-			string,
-			{
-				modelId: string;
-				displayName: string;
-				releaseDate?: string | null;
-				announcementDate?: string | null;
-			}
-		>();
-		for (const row of models) {
-			if (!unique.has(row.model)) {
-				unique.set(row.model, {
-					modelId: row.model,
-					displayName: row.display_name || row.model,
-					releaseDate: row.release_date,
-					announcementDate: row.announcement_date,
-				});
-			}
-		}
-		return Array.from(unique.values()).sort((a, b) => {
-			const dateDiff =
-				releaseTimestamp(b.releaseDate, b.announcementDate) -
-				releaseTimestamp(a.releaseDate, a.announcementDate);
-			if (dateDiff !== 0) return dateDiff;
-			return a.displayName.localeCompare(b.displayName);
-		});
-	}, [models]);
-
-	const selectionOptions = useMemo(() => {
-		const map = new Map<
-			string,
-			Map<string, Map<string, Set<string>>>
-		>();
-
-		for (const row of models) {
-			if (!map.has(row.model)) {
-				map.set(row.model, new Map());
-			}
-			const endpointMap = map.get(row.model)!;
-			if (!endpointMap.has(row.endpoint)) {
-				endpointMap.set(row.endpoint, new Map());
-			}
-			const providerMap = endpointMap.get(row.endpoint)!;
-			if (!providerMap.has(row.provider)) {
-				providerMap.set(row.provider, new Set());
-			}
-			providerMap.get(row.provider)!.add(row.pricing_plan || "standard");
-		}
-
-		return map;
-	}, [models]);
-
-	const getDefaultConfig = (
+	const getDefaultConfig = useCallback((
 		modelId: string,
 		preferred?: Partial<SelectedPricingModelConfig>
-	): SelectedPricingModelConfig | null => {
-		const endpointMap = selectionOptions.get(modelId);
-		if (!endpointMap) return null;
+	): SelectedPricingModelConfig | null =>
+		resolveDefaultPricingConfig(models, modelId, preferred), [models]);
+	const catalogModelIds = useMemo(
+		() => new Set(catalogModels.map((model) => model.modelId)),
+		[catalogModels],
+	);
 
-		const endpoints = Array.from(endpointMap.keys()).sort();
-		const endpoint =
-			preferred?.endpoint && endpointMap.has(preferred.endpoint)
-				? preferred.endpoint
-				: endpoints[0] || "";
-		const providerMap = endpointMap.get(endpoint);
-		if (!providerMap) return null;
-
-		const providers = Array.from(providerMap.keys()).sort();
-		const provider =
-			preferred?.provider && providerMap.has(preferred.provider)
-				? preferred.provider
-				: providers[0] || "";
-		const plans = Array.from(providerMap.get(provider) ?? []).sort((a, b) => {
-			if (a === "standard") return -1;
-			if (b === "standard") return 1;
-			return a.localeCompare(b);
-		});
-		const pricingPlan =
-			preferred?.pricingPlan && plans.includes(preferred.pricingPlan)
-				? preferred.pricingPlan
-				: plans.includes("standard")
-					? "standard"
-					: plans[0] || "";
-
-		return { endpoint, provider, pricingPlan };
-	};
-
-	useEffect(() => {
-		if (modelsByReleaseDate.length === 0) return;
-		if (selectedModelIds.length > 0) return;
-		const initialSelection =
-			selectedModelId && selectionOptions.has(selectedModelId)
-				? selectedModelId
-				: modelsByReleaseDate[0]?.modelId;
-		if (!initialSelection) return;
-		setSelectedModelIds([initialSelection]);
-	}, [
-		modelsByReleaseDate,
-		selectedModelId,
-		selectedModelIds.length,
-		selectionOptions,
-	]);
-
-	useEffect(() => {
-		if (!selectedModelId) return;
-		setSelectedModelIds((current) =>
-			current.includes(selectedModelId) ? current : [selectedModelId, ...current]
+	const selectedModels = useMemo<CalculatorModelSelection[]>(() => {
+		const explicitSelections = sanitizeModelSelections(queryState.selections).filter(
+			(selection) => catalogModelIds.has(selection.modelId)
 		);
-	}, [selectedModelId]);
+		if (explicitSelections.length > 0) return explicitSelections;
+		const legacyModelIds = queryState.models.length > 0
+			? queryState.models
+			: queryState.model
+				? [queryState.model]
+				: [];
+		const legacySelections = legacyModelIds
+			.filter((modelId) => catalogModelIds.has(modelId))
+			.reduce<CalculatorModelSelection[]>((selections, modelId) => [
+				...selections,
+				{ id: createModelSelectionId(modelId, selections), modelId },
+			], []);
+		if (legacySelections.length > 0) return legacySelections;
+		return [];
+	}, [catalogModelIds, queryState.model, queryState.models, queryState.selections]);
+	const selectedModelIds = useMemo(
+		() => selectedModels.map((selection) => selection.modelId),
+		[selectedModels]
+	);
+
+	const requestedConfigs = useMemo(
+		() => sanitizeModelConfigs(queryState.configs),
+		[queryState.configs]
+	);
+	const modelConfigs = useMemo(() => {
+		const next: Record<string, SelectedPricingModelConfig> = {};
+		for (const [index, selection] of selectedModels.entries()) {
+			const preferred = requestedConfigs[selection.id] ??
+				(index === 0 ? requestedConfigs[selection.modelId] : undefined) ?? (index === 0
+				? {
+					endpoint: queryState.endpoint,
+					provider: queryState.provider,
+					pricingPlan: queryState.plan,
+				}
+				: undefined);
+			const config = getDefaultConfig(selection.modelId, preferred);
+			if (config) next[selection.id] = config;
+		}
+		return next;
+	}, [
+		getDefaultConfig,
+		queryState.endpoint,
+		queryState.plan,
+		queryState.provider,
+		requestedConfigs,
+		selectedModels,
+	]);
+	const meterInputs = useMemo(
+		() => sanitizeMeterInputs(queryState.usage),
+		[queryState.usage]
+	);
+	const requestMultiplier = sanitizeRequestMultiplier(queryState.requests);
+	const pricingTimeUtc = sanitizePricingTime(queryState.time) || "00:00";
 
 	useEffect(() => {
-		if (selectedModelIds.length === 0) return;
-		setModelConfigs((current) => {
-			let changed = false;
-			const next: Record<string, SelectedPricingModelConfig> = {};
-			for (const modelId of selectedModelIds) {
-				const defaultConfig = getDefaultConfig(modelId, {
-					endpoint: current[modelId]?.endpoint || initialEndpoint,
-					provider: current[modelId]?.provider || initialProvider,
-					pricingPlan: current[modelId]?.pricingPlan || initialPlan,
-				});
-				if (!defaultConfig) continue;
-				next[modelId] = defaultConfig;
-				if (
-					current[modelId]?.endpoint !== defaultConfig.endpoint ||
-					current[modelId]?.provider !== defaultConfig.provider ||
-					current[modelId]?.pricingPlan !== defaultConfig.pricingPlan
-				) {
-					changed = true;
-				}
-			}
-			if (Object.keys(current).length !== Object.keys(next).length) {
-				changed = true;
-			}
-			return changed ? next : current;
+		if (sanitizePricingTime(queryState.time)) return;
+		setQueryState({ time: getCurrentUtcTime() });
+	}, [queryState.time, setQueryState]);
+
+	useEffect(() => {
+		const primarySelection = selectedModels[0];
+		const primaryModelId = primarySelection?.modelId || "";
+		const primaryConfig = primarySelection ? modelConfigs[primarySelection.id] : null;
+		const configsMatch = JSON.stringify(queryState.configs) === JSON.stringify(modelConfigs);
+		const usageMatches = JSON.stringify(queryState.usage) === JSON.stringify(meterInputs);
+		const selectionsMatch = JSON.stringify(queryState.selections) === JSON.stringify(selectedModels);
+		if (
+			sameStringArray(queryState.models, selectedModelIds) &&
+			selectionsMatch &&
+			configsMatch &&
+			usageMatches &&
+			queryState.requests === requestMultiplier &&
+			queryState.model === primaryModelId &&
+			queryState.endpoint === (primaryConfig?.endpoint || "") &&
+			queryState.provider === (primaryConfig?.provider || "") &&
+			queryState.plan === (primaryConfig?.pricingPlan || "")
+		) {
+			return;
+		}
+		setQueryState({
+			models: selectedModelIds,
+			selections: selectedModels,
+			configs: modelConfigs,
+			usage: meterInputs,
+			requests: requestMultiplier,
+			model: primaryModelId,
+			endpoint: primaryConfig?.endpoint || "",
+			provider: primaryConfig?.provider || "",
+			plan: primaryConfig?.pricingPlan || "",
 		});
 	}, [
-		initialEndpoint,
-		initialPlan,
-		initialProvider,
-		selectedModelIds,
-		selectionOptions,
-	]);
-
-	useEffect(() => {
-		const primaryModelId = selectedModelIds[0] || "";
-		const primaryConfig = primaryModelId ? modelConfigs[primaryModelId] : null;
-
-		setSelectedModelId(primaryModelId);
-		setSelectedEndpoint(primaryConfig?.endpoint || "");
-		setSelectedProvider(primaryConfig?.provider || "");
-		setSelectedPricingPlan(primaryConfig?.pricingPlan || "");
-	}, [
+		meterInputs,
 		modelConfigs,
+		queryState.configs,
+		queryState.endpoint,
+		queryState.model,
+		queryState.models,
+		queryState.plan,
+		queryState.provider,
+		queryState.requests,
+		queryState.selections,
+		queryState.usage,
+		requestMultiplier,
 		selectedModelIds,
-		setSelectedEndpoint,
-		setSelectedModelId,
-		setSelectedPricingPlan,
-		setSelectedProvider,
+		selectedModels,
+		setQueryState,
 	]);
 
 	const selectedModelData = useMemo<SelectedPricingModel[]>(() => {
-		return selectedModelIds
-			.map((modelId) => {
-				const config = modelConfigs[modelId] ?? getDefaultConfig(modelId);
+		return selectedModels
+			.map((selection) => {
+				const config = modelConfigs[selection.id] ?? getDefaultConfig(selection.modelId);
 				if (!config) return null;
 				const row = models.find(
 					(item) =>
-						item.model === modelId &&
+						item.model === selection.modelId &&
 						item.endpoint === config.endpoint &&
 						item.provider === config.provider &&
 						(item.pricing_plan || "standard") === config.pricingPlan
@@ -274,13 +311,15 @@ export default function PricingCalculator({
 				if (!row) return null;
 				return {
 					...row,
-					key: modelId,
+					allMeters: row.meters,
+					meters: selectPricingMetersForUsage(row.meters, meterInputs),
+					key: selection.id,
 					label: row.display_name || row.model,
 					pricingPlan: config.pricingPlan,
 				};
 			})
 			.filter((row): row is SelectedPricingModel => Boolean(row));
-	}, [modelConfigs, models, selectedModelIds, selectionOptions]);
+	}, [getDefaultConfig, meterInputs, modelConfigs, models, selectedModels]);
 
 	const allSelectedMeters = useMemo(() => {
 		const map = new Map<string, PricingMeter>();
@@ -297,55 +336,83 @@ export default function PricingCalculator({
 	const comparisonModels = useMemo(
 		() =>
 			selectedModelData.map((model) => ({
-				key: `${model.model}:${model.provider}:${model.endpoint}:${model.pricingPlan}`,
+				key: model.key,
 				label: model.label,
 				modelId: model.model,
 				provider: model.provider,
 				pricingPlan: model.pricingPlan,
 				meters: model.meters,
+				allMeters: model.allMeters,
 			})),
 		[selectedModelData]
 	);
 
-	const handleToggleModel = (modelId: string) => {
-		setSelectedModelIds((current) => {
-			if (current.includes(modelId)) {
-				setMeterInputs({});
-				return current.filter((id) => id !== modelId);
+	const handleAddModel = async (modelId: string) => {
+		if (loadingModelIds.length > 0) return;
+		setPricingNotice(null);
+		let pricingRows = models.filter((row) => row.model === modelId);
+		if (pricingRows.length === 0) {
+			setLoadingModelIds([modelId]);
+			try {
+				pricingRows = await loadPricingCalculatorModels([modelId]);
+				if (pricingRows.length > 0) {
+					setModels((current) => mergePricingModels(current, pricingRows));
+				}
+			} catch {
+				setPricingNotice("Pricing could not be loaded for this model. Please try again.");
+				return;
+			} finally {
+				setLoadingModelIds([]);
 			}
-			const defaultConfig = getDefaultConfig(modelId);
-			if (defaultConfig) {
-				setModelConfigs((configs) => ({
-					...configs,
-					[modelId]: defaultConfig,
-				}));
-			}
-			setMeterInputs({});
-			return [...current, modelId];
+		}
+		const defaultConfig = resolveDefaultPricingConfig(pricingRows, modelId);
+		if (!defaultConfig) {
+			const modelName = catalogModels.find((model) => model.modelId === modelId)?.displayName || modelId;
+			setPricingNotice(`No pricing meters are currently published for ${modelName}.`);
+			return;
+		}
+		const selection = {
+			id: createModelSelectionId(modelId, selectedModels),
+			modelId,
+		};
+		const nextSelections = [...selectedModels, selection];
+		setQueryState({
+			selections: nextSelections,
+			models: nextSelections.map((item) => item.modelId),
+			configs: { ...modelConfigs, [selection.id]: defaultConfig },
+			usage: {},
+		});
+	};
+
+	const handleRemoveModel = (selectionId: string) => {
+		const nextSelections = selectedModels.filter((selection) => selection.id !== selectionId);
+		const nextConfigs = { ...modelConfigs };
+		delete nextConfigs[selectionId];
+		setQueryState({
+			selections: nextSelections,
+			models: nextSelections.map((item) => item.modelId),
+			configs: nextConfigs,
+			usage: {},
 		});
 	};
 
 	const handleUpdateModelConfig = (
-		modelId: string,
+		selectionId: string,
 		patch: Partial<SelectedPricingModelConfig>
 	) => {
-		setModelConfigs((current) => {
-			const existing = current[modelId] ?? getDefaultConfig(modelId);
-			const next = getDefaultConfig(modelId, { ...existing, ...patch });
-			if (!next) return current;
-			return {
-				...current,
-				[modelId]: next,
-			};
+		const selection = selectedModels.find((item) => item.id === selectionId);
+		if (!selection) return;
+		const existing = modelConfigs[selectionId] ?? getDefaultConfig(selection.modelId);
+		const next = getDefaultConfig(selection.modelId, { ...existing, ...patch });
+		if (!next) return;
+		setQueryState({
+			configs: { ...modelConfigs, [selectionId]: next },
+			usage: {},
 		});
-		setMeterInputs({});
 	};
 
 	const handleMeterInputChange = (meter: string, value: string) => {
-		setMeterInputs((prev: Record<string, string>) => ({
-			...prev,
-			[meter]: value,
-		}));
+		setQueryState({ usage: { ...meterInputs, [meter]: value } });
 	};
 
 	return (
@@ -363,11 +430,11 @@ export default function PricingCalculator({
 					<div className="flex flex-wrap gap-2 text-xs text-muted-foreground">
 						<span className="inline-flex items-center gap-1 rounded-full border bg-background/70 px-2.5 py-1">
 							<CheckCircle2 className="h-3.5 w-3.5 text-green-600" />
-							{roundedTotalModelsCount}+ models
+							{totalModelsCount.toLocaleString()} models
 						</span>
 						<span className="inline-flex items-center gap-1 rounded-full border bg-background/70 px-2.5 py-1">
 							<CheckCircle2 className="h-3.5 w-3.5 text-green-600" />
-							{providersCount}+ providers
+							{providersCount.toLocaleString()} providers
 						</span>
 						<span className="inline-flex items-center gap-1 rounded-full border bg-background/70 px-2.5 py-1">
 							<CheckCircle2 className="h-3.5 w-3.5 text-green-600" />
@@ -378,17 +445,19 @@ export default function PricingCalculator({
 			</header>
 
 			<div className="space-y-5">
-				<div className="grid grid-cols-1 2xl:grid-cols-12 gap-6 items-start">
-					<div className="2xl:col-span-8">
-						<ModelSelector
-							models={models}
-							selectedModelIds={selectedModelIds}
-							modelConfigs={modelConfigs}
-							onToggleModel={handleToggleModel}
-							onUpdateModelConfig={handleUpdateModelConfig}
-						/>
-					</div>
-					<div className="2xl:col-span-4">
+				<ModelSelector
+					models={models}
+					catalogModels={catalogModels}
+					cachedModels={cachedModels}
+					selectedModels={selectedModels}
+					modelConfigs={modelConfigs}
+					loadingModelIds={loadingModelIds}
+					pricingNotice={pricingNotice}
+					onAddModel={handleAddModel}
+					onRemoveModel={handleRemoveModel}
+					onUpdateModelConfig={handleUpdateModelConfig}
+				/>
+
 						{allSelectedMeters.length > 0 ? (
 							<UsageInputs
 								meters={allSelectedMeters}
@@ -396,8 +465,12 @@ export default function PricingCalculator({
 								requestMultiplier={requestMultiplier}
 								pricingTimeUtc={pricingTimeUtc}
 								onMeterInputChange={handleMeterInputChange}
-								onRequestMultiplierChange={setRequestMultiplier}
-								onPricingTimeUtcChange={setPricingTimeUtc}
+								onRequestMultiplierChange={(value) =>
+									setQueryState({ requests: sanitizeRequestMultiplier(value) })
+								}
+								onPricingTimeUtcChange={(value) =>
+									setQueryState({ time: sanitizePricingTime(value) })
+								}
 							/>
 						) : (
 							<Card>
@@ -408,8 +481,6 @@ export default function PricingCalculator({
 								</CardContent>
 							</Card>
 						)}
-					</div>
-				</div>
 
 				{selectedModelData.length > 0 ? (
 					<>

--- a/apps/web/src/components/(tools)/pricing-calculator/CostBreakdown.tsx
+++ b/apps/web/src/components/(tools)/pricing-calculator/CostBreakdown.tsx
@@ -2,6 +2,7 @@
 
 import { useMemo } from "react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { ScrollArea } from "@/components/ui/scroll-area";
 import {
 	Table,
 	TableBody,
@@ -12,21 +13,19 @@ import {
 } from "@/components/ui/table";
 import {
 	fmtUSD,
-	formatQuantity,
 	formatMeterName,
 	formatPricingTimeWindow,
+	formatQuantity,
 	resolvePricingMeterPrice,
 	type PricingMeter,
 } from "@/components/(data)/model/pricing/pricingHelpers";
-
-type ComparisonPricingModel = {
-	key: string;
-	label: string;
-	modelId?: string;
-	provider: string;
-	pricingPlan: string;
-	meters: PricingMeter[];
-};
+import { sanitizeRequestMultiplier } from "./calculatorState";
+import {
+	MeterLabel,
+	PricingModelHeader,
+	formatSentenceLabel,
+	type ComparisonPricingModel,
+} from "./PricingTableVisuals";
 
 interface CostBreakdownProps {
 	meters: PricingMeter[];
@@ -44,34 +43,10 @@ function calculateLineCost(
 ): number {
 	const inputValue = parseFloat(meterInputs[meter.meter] || "0");
 	if (!Number.isFinite(inputValue) || inputValue <= 0) return 0;
-
-	const multipliedValue = inputValue * requestMultiplier;
+	const multipliedValue = inputValue * sanitizeRequestMultiplier(requestMultiplier);
 	const unitSize = Number(meter.unit_size) > 0 ? Number(meter.unit_size) : 1;
-	const billedUnits = multipliedValue / unitSize;
 	const { pricePerUnit } = resolvePricingMeterPrice(meter, pricingTimeUtc);
-
-	return billedUnits * pricePerUnit;
-}
-
-function formatProviderLabel(providerId: string): string {
-	const known: Record<string, string> = {
-		openai: "OpenAI",
-		anthropic: "Anthropic",
-		google: "Google",
-		"google-ai-studio": "Google AI Studio",
-		"google-vertex": "Google Vertex",
-		"x-ai": "xAI",
-		aws: "AWS",
-		azure: "Azure",
-	};
-
-	if (known[providerId]) {
-		return known[providerId];
-	}
-
-	return providerId
-		.replace(/[-_]+/g, " ")
-		.replace(/\b\w/g, (char) => char.toUpperCase());
+	return (multipliedValue / unitSize) * pricePerUnit;
 }
 
 export function CostBreakdown({
@@ -81,153 +56,94 @@ export function CostBreakdown({
 	pricingTimeUtc,
 	comparisonModels,
 }: CostBreakdownProps) {
-	const activeModels = useMemo(
+	const safeRequestMultiplier = sanitizeRequestMultiplier(requestMultiplier);
+	const activeModels = useMemo<ComparisonPricingModel[]>(
 		() =>
 			comparisonModels && comparisonModels.length > 0
 				? comparisonModels
-				: [
-						{
-							key: "primary",
-							label: "Selected Model",
-							provider: "selected",
-							pricingPlan: "standard",
-							meters,
-						},
-				  ],
+				: [{ key: "primary", label: "Selected Model", provider: "selected", pricingPlan: "standard", meters }],
 		[comparisonModels, meters]
 	);
-
 	const activeMeterNames = useMemo(() => {
 		const names = new Set<string>();
 		for (const meter of meters) {
-			if (parseFloat(meterInputs[meter.meter] || "0") > 0) {
-				names.add(meter.meter);
-			}
+			if (parseFloat(meterInputs[meter.meter] || "0") > 0) names.add(meter.meter);
 		}
-		return Array.from(names).sort((a, b) =>
-			formatMeterName(a).localeCompare(formatMeterName(b))
+		return Array.from(names).sort((left, right) =>
+			formatMeterName(left).localeCompare(formatMeterName(right))
 		);
 	}, [meterInputs, meters]);
+	const totalsByModel = useMemo(
+		() => new Map(activeModels.map((model) => [
+			model.key,
+			model.meters.reduce(
+				(total, meter) => total + calculateLineCost(meter, meterInputs, safeRequestMultiplier, pricingTimeUtc),
+				0
+			),
+		])),
+		[activeModels, meterInputs, pricingTimeUtc, safeRequestMultiplier]
+	);
 
-	const totalsByModel = useMemo(() => {
-		return new Map(
-			activeModels.map((model) => {
-				const total = model.meters.reduce(
-					(sum, meter) =>
-						sum +
-						calculateLineCost(
-							meter,
-							meterInputs,
-							requestMultiplier,
-							pricingTimeUtc
-						),
-					0
-				);
-				return [model.key, total];
-			})
-		);
-	}, [activeModels, meterInputs, pricingTimeUtc, requestMultiplier]);
-
-	if (activeMeterNames.length === 0) {
-		return null;
-	}
+	if (activeMeterNames.length === 0) return null;
 
 	return (
 		<Card>
-			<CardHeader>
-				<CardTitle>Cost Estimate</CardTitle>
+			<CardHeader className="border-b bg-muted/10">
+				<CardTitle className="flex items-center justify-between gap-3">
+					<span>Cost estimate</span>
+					<span className="text-xs font-normal text-muted-foreground">
+						{activeModels.length} model{activeModels.length === 1 ? "" : "s"}
+					</span>
+				</CardTitle>
 			</CardHeader>
-			<CardContent className="space-y-4">
-				<div className="overflow-x-auto rounded-lg border">
+			<CardContent className="space-y-4 pt-5">
+				<ScrollArea scrollBarOrientation="horizontal" className="w-full rounded-xl border" viewportClassName="rounded-xl">
 					<Table>
 						<TableHeader>
-							<TableRow>
-								<TableHead className="sticky left-0 z-10 min-w-[220px] bg-background">
-									Meter
-								</TableHead>
+							<TableRow className="bg-muted/20 hover:bg-muted/20">
+								<TableHead className="sticky left-0 z-10 min-w-[250px] bg-muted/20">Usage</TableHead>
 								{activeModels.map((model) => (
-									<TableHead
-										key={`estimate-head-${model.key}`}
-										className="min-w-[190px]"
-									>
-										<div className="space-y-1">
-											<p className="truncate font-medium">{model.label}</p>
-											<p className="truncate text-xs font-normal text-muted-foreground">
-												{formatProviderLabel(model.provider)} · {model.pricingPlan}
-											</p>
-										</div>
+									<TableHead key={`estimate-head-${model.key}`} className="min-w-[240px]">
+										<PricingModelHeader model={model} />
 									</TableHead>
 								))}
 							</TableRow>
 						</TableHeader>
 						<TableBody>
-							<TableRow className="bg-primary/5">
-								<TableCell className="sticky left-0 z-10 bg-primary/5 font-semibold">
-									Estimated total
+							<TableRow className="bg-primary/5 hover:bg-primary/5">
+								<TableCell className="sticky left-0 z-10 bg-primary/5">
+									<MeterLabel meterName="total_cost" label="Estimated total" description="Across entered usage" />
 								</TableCell>
 								{activeModels.map((model) => (
-									<TableCell
-										key={`estimate-total-${model.key}`}
-										className="font-semibold"
-									>
-										{fmtUSD(totalsByModel.get(model.key) ?? 0)}
+									<TableCell key={`estimate-total-${model.key}`}>
+										<span className="text-base font-semibold tabular-nums">{fmtUSD(totalsByModel.get(model.key) ?? 0)}</span>
 									</TableCell>
 								))}
 							</TableRow>
 							{activeMeterNames.map((meterName) => {
 								const inputValue = parseFloat(meterInputs[meterName] || "0");
-								const multipliedValue = inputValue * requestMultiplier;
-
+								const multipliedValue = inputValue * safeRequestMultiplier;
 								return (
 									<TableRow key={`estimate-row-${meterName}`}>
 										<TableCell className="sticky left-0 z-10 bg-background">
-											<div className="space-y-1">
-												<p className="font-medium">
-													{formatMeterName(meterName)}
-												</p>
-												<p className="text-xs text-muted-foreground">
-													{formatQuantity(multipliedValue)} total usage
-												</p>
-											</div>
+											<MeterLabel
+												meterName={meterName}
+												label={formatSentenceLabel(formatMeterName(meterName))}
+												description={`${formatQuantity(multipliedValue)} total usage`}
+											/>
 										</TableCell>
 										{activeModels.map((model) => {
-											const meter =
-												model.meters.find((item) => item.meter === meterName) ??
-												null;
-											if (!meter) {
-												return (
-													<TableCell key={`estimate-${model.key}-${meterName}`}>
-														-
-													</TableCell>
-												);
-											}
-											const resolvedPrice = resolvePricingMeterPrice(
-												meter,
-												pricingTimeUtc
-											);
-											const lineCost = calculateLineCost(
-												meter,
-												meterInputs,
-												requestMultiplier,
-												pricingTimeUtc
-											);
-
+											const meter = model.meters.find((item) => item.meter === meterName);
+											if (!meter) return <TableCell key={`estimate-${model.key}-${meterName}`} className="text-muted-foreground">Not priced</TableCell>;
+											const resolvedPrice = resolvePricingMeterPrice(meter, pricingTimeUtc);
+											const lineCost = calculateLineCost(meter, meterInputs, safeRequestMultiplier, pricingTimeUtc);
 											return (
 												<TableCell key={`estimate-${model.key}-${meterName}`}>
-													<div className="space-y-1">
-														<p className="font-medium">{fmtUSD(lineCost)}</p>
-														<p className="text-xs text-muted-foreground">
-															{fmtUSD(resolvedPrice.pricePerUnit)} /{" "}
-															{meter.unit_size.toLocaleString()} {meter.unit}
-														</p>
-														{resolvedPrice.timeWindow ? (
-															<p className="text-xs text-muted-foreground">
-																{formatPricingTimeWindow(
-																	resolvedPrice.timeWindow
-																)}
-															</p>
-														) : null}
-													</div>
+													<p className="font-semibold tabular-nums">{fmtUSD(lineCost)}</p>
+													<p className="mt-1 text-xs text-muted-foreground">
+														{fmtUSD(resolvedPrice.pricePerUnit)} per {meter.unit_size.toLocaleString()} {meter.unit}
+													</p>
+													{resolvedPrice.timeWindow ? <p className="mt-1 text-xs text-muted-foreground">{formatPricingTimeWindow(resolvedPrice.timeWindow)}</p> : null}
 												</TableCell>
 											);
 										})}
@@ -236,10 +152,9 @@ export function CostBreakdown({
 							})}
 						</TableBody>
 					</Table>
-				</div>
+				</ScrollArea>
 				<p className="text-xs text-muted-foreground">
-					Inputs are multiplied by {requestMultiplier.toLocaleString()} request
-					{requestMultiplier === 1 ? "" : "s"} before costs are calculated.
+					Inputs are multiplied by {safeRequestMultiplier.toLocaleString()} request{safeRequestMultiplier === 1 ? "" : "s"} before costs are calculated.
 				</p>
 			</CardContent>
 		</Card>

--- a/apps/web/src/components/(tools)/pricing-calculator/ModelSelector.tsx
+++ b/apps/web/src/components/(tools)/pricing-calculator/ModelSelector.tsx
@@ -1,29 +1,39 @@
 "use client";
 
 import { useMemo, useState } from "react";
+import {
+	ModelSelector as ModelPicker,
+	ModelSelectorContent,
+	ModelSelectorInput,
+	ModelSelectorTrigger,
+} from "@/components/ai-elements/model-selector";
+import { VirtualizedModelCatalog } from "@/components/(chat)/VirtualizedModelCatalog";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { Checkbox } from "@/components/ui/checkbox";
-import { Input } from "@/components/ui/input";
-import { Label } from "@/components/ui/label";
 import {
 	Select,
 	SelectContent,
 	SelectItem,
 	SelectTrigger,
-	SelectValue,
 } from "@/components/ui/select";
-import {
-	Table,
-	TableBody,
-	TableCell,
-	TableHead,
-	TableHeader,
-	TableRow,
-} from "@/components/ui/table";
 import { Logo } from "@/components/Logo";
-import { X } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { getTierFilterMeta } from "@/lib/models/tierFilterStyles";
+import { comparePricingEndpoints } from "./calculatorState";
+import type { CalculatorCatalogModel, CalculatorModelSelection } from "./calculatorState";
+import type { GatewaySupportedModel } from "@/lib/fetchers/gateway/getGatewaySupportedModelIds";
+import {
+	Braces,
+	CalendarDays,
+	ChevronsUpDown,
+	DatabaseZap,
+	Plus,
+	Search,
+	Server,
+	LoaderCircle,
+	X,
+} from "lucide-react";
 
 function formatProviderLabel(providerId: string): string {
 	const known: Record<string, string> = {
@@ -33,23 +43,29 @@ function formatProviderLabel(providerId: string): string {
 		"google-ai-studio": "Google AI Studio",
 		"google-vertex": "Google Vertex",
 		"spacex-ai": "SpaceXAI",
+		"x-ai": "xAI",
 		aws: "AWS",
 		azure: "Azure",
 	};
-
-	if (known[providerId]) {
-		return known[providerId];
-	}
-
-	return providerId
+	return known[providerId] ?? providerId
 		.replace(/[-_]+/g, " ")
 		.replace(/\b\w/g, (char) => char.toUpperCase());
 }
 
 function formatPlanLabel(plan: string): string {
-	return plan
-		.replace(/[-_]+/g, " ")
-		.replace(/\b\w/g, (char) => char.toUpperCase());
+	const value = plan.replace(/[-_]+/g, " ").trim().toLowerCase();
+	return value ? value[0].toUpperCase() + value.slice(1) : "";
+}
+
+function formatEndpointLabel(endpoint: string): string {
+	const value = endpoint.replace(/[._-]+/g, " ").trim().toLowerCase();
+	return value ? value[0].toUpperCase() + value.slice(1) : "";
+}
+
+function PricingPlanIcon({ plan, className }: { plan: string; className?: string }) {
+	const tier = getTierFilterMeta(plan);
+	const Icon = tier.icon;
+	return <Icon className={cn("size-4", className, tier.iconClassName)} />;
 }
 
 function releaseTimestamp(
@@ -64,11 +80,15 @@ function formatReleaseDate(
 	releaseDate?: string | null,
 	announcementDate?: string | null
 ): string {
-	const date = releaseDate || announcementDate;
-	if (!date) return "Unknown";
-	const parsed = new Date(date);
-	if (Number.isNaN(parsed.getTime())) return "Unknown";
-	return parsed.toISOString().slice(0, 10);
+	const value = releaseDate || announcementDate;
+	if (!value) return "Release unknown";
+	const parsed = new Date(value);
+	if (Number.isNaN(parsed.getTime())) return "Release unknown";
+	return new Intl.DateTimeFormat("en", {
+		day: "numeric",
+		month: "short",
+		year: "numeric",
+	}).format(parsed);
 }
 
 type PricingModel = {
@@ -96,23 +116,48 @@ export type SelectedPricingModelConfig = {
 
 interface ModelSelectorProps {
 	models: PricingModel[];
-	selectedModelIds: string[];
+	catalogModels: CalculatorCatalogModel[];
+	cachedModels?: GatewaySupportedModel[];
+	selectedModels: CalculatorModelSelection[];
 	modelConfigs: Record<string, SelectedPricingModelConfig>;
-	onToggleModel: (modelId: string) => void;
+	loadingModelIds?: string[];
+	pricingNotice?: string | null;
+	onAddModel: (modelId: string) => void | Promise<void>;
+	onRemoveModel: (selectionId: string) => void;
 	onUpdateModelConfig: (
-		modelId: string,
+		selectionId: string,
 		patch: Partial<SelectedPricingModelConfig>
 	) => void;
 }
 
 export function ModelSelector({
 	models,
-	selectedModelIds,
+	catalogModels,
+	cachedModels = [],
+	selectedModels,
 	modelConfigs,
-	onToggleModel,
+	loadingModelIds = [],
+	pricingNotice,
+	onAddModel,
+	onRemoveModel,
 	onUpdateModelConfig,
 }: ModelSelectorProps) {
+	const [open, setOpen] = useState(false);
 	const [query, setQuery] = useState("");
+	const [activeModelId, setActiveModelId] = useState<string | null>(null);
+
+	const cachedByModelId = useMemo(() => {
+		const map = new Map<string, GatewaySupportedModel[]>();
+		for (const model of cachedModels) {
+			for (const id of [model.selectorModelId, model.modelId, model.internalModelId]) {
+				if (!id) continue;
+				const rows = map.get(id) ?? [];
+				if (!rows.includes(model)) rows.push(model);
+				map.set(id, rows);
+			}
+		}
+		return map;
+	}, [cachedModels]);
 
 	const modelOptions = useMemo(() => {
 		const modelMap = new Map<
@@ -120,38 +165,52 @@ export function ModelSelector({
 			{
 				modelId: string;
 				displayName: string;
+				organisationId: string;
+				organisationName: string;
 				releaseDate?: string | null;
 				announcementDate?: string | null;
 				providers: Set<string>;
 				endpoints: Set<string>;
-				meterCount: Set<string>;
+				meters: Set<string>;
 			}
 		>();
+		for (const model of catalogModels) {
+			const cachedRows = cachedByModelId.get(model.modelId) ?? [];
+			modelMap.set(model.modelId, {
+				modelId: model.modelId,
+				displayName: model.displayName,
+				organisationId: model.organisationId,
+				organisationName: model.organisationName,
+				releaseDate: model.releaseDate,
+				announcementDate: model.announcementDate,
+				providers: new Set(cachedRows.map((row) => row.providerId)),
+				endpoints: new Set(cachedRows.flatMap((row) => row.capabilities)),
+				meters: new Set<string>(),
+			});
+		}
 
 		for (const row of models) {
-			if (!modelMap.has(row.model)) {
-				modelMap.set(row.model, {
-					modelId: row.model,
-					displayName: row.display_name || row.model,
-					releaseDate: row.release_date,
-					announcementDate: row.announcement_date,
-					providers: new Set(),
-					endpoints: new Set(),
-					meterCount: new Set(),
-				});
-			}
-			const entry = modelMap.get(row.model)!;
+			const cachedRows = cachedByModelId.get(row.model) ?? [];
+			const cached = cachedRows[0];
+			const organisationId =
+				cached?.organisationId?.trim() || row.model.split("/")[0] || row.provider;
+			const entry = modelMap.get(row.model) ?? {
+				modelId: row.model,
+				displayName: row.display_name || cached?.modelName || row.model,
+				organisationId,
+				organisationName:
+					cached?.organisationName || formatProviderLabel(organisationId),
+				releaseDate: row.release_date || cached?.releaseDate,
+				announcementDate: row.announcement_date || cached?.announcementDate,
+				providers: new Set<string>(),
+				endpoints: new Set<string>(),
+				meters: new Set<string>(),
+			};
 			entry.providers.add(row.provider);
 			entry.endpoints.add(row.endpoint);
-			for (const meter of row.meters) {
-				entry.meterCount.add(meter.meter);
-			}
-			if (!entry.releaseDate && row.release_date) {
-				entry.releaseDate = row.release_date;
-			}
-			if (!entry.announcementDate && row.announcement_date) {
-				entry.announcementDate = row.announcement_date;
-			}
+			for (const meter of row.meters) entry.meters.add(meter.meter);
+			for (const cachedRow of cachedRows) entry.providers.add(cachedRow.providerId);
+			modelMap.set(row.model, entry);
 		}
 
 		return Array.from(modelMap.values())
@@ -159,14 +218,14 @@ export function ModelSelector({
 				...model,
 				providers: Array.from(model.providers).sort(),
 				endpoints: Array.from(model.endpoints).sort(),
-				meterCount: model.meterCount.size,
-				sortTs: releaseTimestamp(model.releaseDate, model.announcementDate),
+				meterCount: model.meters.size,
+				sortTimestamp: releaseTimestamp(model.releaseDate, model.announcementDate),
 			}))
-			.sort((a, b) => {
-				if (a.sortTs !== b.sortTs) return b.sortTs - a.sortTs;
-				return a.displayName.localeCompare(b.displayName);
-			});
-	}, [models]);
+			.sort((left, right) =>
+				right.sortTimestamp - left.sortTimestamp ||
+				left.displayName.localeCompare(right.displayName)
+			);
+	}, [cachedByModelId, catalogModels, models]);
 
 	const optionByModelId = useMemo(
 		() => new Map(modelOptions.map((model) => [model.modelId, model])),
@@ -174,322 +233,301 @@ export function ModelSelector({
 	);
 
 	const selectionOptions = useMemo(() => {
-		const map = new Map<
-			string,
-			Map<string, Map<string, Set<string>>>
-		>();
-
+		const map = new Map<string, Map<string, Map<string, Set<string>>>>();
 		for (const row of models) {
-			if (!map.has(row.model)) {
-				map.set(row.model, new Map());
-			}
-			const endpointMap = map.get(row.model)!;
-			if (!endpointMap.has(row.endpoint)) {
-				endpointMap.set(row.endpoint, new Map());
-			}
-			const providerMap = endpointMap.get(row.endpoint)!;
-			if (!providerMap.has(row.provider)) {
-				providerMap.set(row.provider, new Set());
-			}
-			providerMap.get(row.provider)!.add(row.pricing_plan || "standard");
+			const endpointMap = map.get(row.model) ?? new Map();
+			const providerMap = endpointMap.get(row.endpoint) ?? new Map();
+			const plans = providerMap.get(row.provider) ?? new Set<string>();
+			plans.add(row.pricing_plan || "standard");
+			providerMap.set(row.provider, plans);
+			endpointMap.set(row.endpoint, providerMap);
+			map.set(row.model, endpointMap);
 		}
-
 		return map;
 	}, [models]);
 
-	const selectedModelSet = useMemo(
-		() => new Set(selectedModelIds),
-		[selectedModelIds]
-	);
-
+	const selectionCountByModelId = useMemo(() => {
+		const counts = new Map<string, number>();
+		for (const selection of selectedModels) {
+			counts.set(selection.modelId, (counts.get(selection.modelId) ?? 0) + 1);
+		}
+		return counts;
+	}, [selectedModels]);
+	const loadingModelSet = useMemo(() => new Set(loadingModelIds), [loadingModelIds]);
 	const normalizedQuery = query.trim().toLowerCase();
 	const filteredModels = useMemo(() => {
 		if (!normalizedQuery) return modelOptions;
-		return modelOptions.filter((model) => {
-			const haystack = [
+		return modelOptions.filter((model) =>
+			[
 				model.displayName,
 				model.modelId,
-				formatReleaseDate(model.releaseDate, model.announcementDate),
+				model.organisationName,
+				model.organisationId,
 				model.providers.join(" "),
 				model.endpoints.join(" "),
 			]
 				.join(" ")
-				.toLowerCase();
-			return haystack.includes(normalizedQuery);
-		});
+				.toLowerCase()
+				.includes(normalizedQuery)
+		);
 	}, [modelOptions, normalizedQuery]);
 
-	const visibleModels = filteredModels.slice(0, 160);
+	const visibleActiveModelId = filteredModels.some(
+		(model) => model.modelId === activeModelId
+	)
+		? activeModelId
+		: filteredModels[0]?.modelId ?? null;
 
 	const getEndpointOptions = (modelId: string) =>
-		Array.from(selectionOptions.get(modelId)?.keys() ?? []).sort();
-
+		Array.from(selectionOptions.get(modelId)?.keys() ?? []).sort(comparePricingEndpoints);
 	const getProviderOptions = (modelId: string, endpoint: string) =>
 		Array.from(selectionOptions.get(modelId)?.get(endpoint)?.keys() ?? []).sort();
-
-	const getPlanOptions = (
-		modelId: string,
-		endpoint: string,
-		provider: string
-	) =>
+	const getPlanOptions = (modelId: string, endpoint: string, provider: string) =>
 		Array.from(
 			selectionOptions.get(modelId)?.get(endpoint)?.get(provider) ?? []
-		).sort((a, b) => {
-			if (a === "standard") return -1;
-			if (b === "standard") return 1;
-			return a.localeCompare(b);
+		).sort((left, right) => {
+			if (left === "standard") return -1;
+			if (right === "standard") return 1;
+			return left.localeCompare(right);
 		});
 
 	return (
-		<Card>
-			<CardHeader className="pb-4">
-				<CardTitle className="flex flex-wrap items-center justify-between gap-3">
-					<span>Models</span>
-					<div className="flex flex-wrap items-center gap-2">
-						<Badge variant="outline" className="text-[11px]">
-							Sorted by release date
-						</Badge>
-						<Badge variant="outline" className="text-[11px]">
-							{selectedModelIds.length} selected
-						</Badge>
+		<Card className="gap-0 overflow-hidden py-0">
+			<CardHeader className="rounded-none border-b bg-muted/15 p-5">
+				<CardTitle className="flex flex-wrap items-start justify-between gap-3">
+					<div className="space-y-1">
+						<span className="text-base">Choose models</span>
+						<p className="text-xs font-normal text-muted-foreground">
+							Search the full model catalogue and add as many comparisons as you need.
+						</p>
 					</div>
+					<Badge variant="outline" className="rounded-lg bg-background text-xs">
+						{selectedModels.length} selected
+					</Badge>
 				</CardTitle>
 			</CardHeader>
-			<CardContent className="space-y-5">
-				<div className="space-y-2">
-					<Label htmlFor="pricing-model-search">Search models</Label>
-					<Input
-						id="pricing-model-search"
-						value={query}
-						onChange={(event) => setQuery(event.target.value)}
-						placeholder="Search by model, provider, endpoint, or release date"
-					/>
-				</div>
-
-				<div className="overflow-hidden rounded-lg border">
-					<div className="max-h-[440px] overflow-auto">
-						<Table>
-							<TableHeader className="sticky top-0 z-10 bg-background">
-								<TableRow>
-									<TableHead className="w-[52px]">Use</TableHead>
-									<TableHead className="min-w-[280px]">Model</TableHead>
-									<TableHead className="min-w-[110px]">Released</TableHead>
-									<TableHead className="min-w-[160px]">Providers</TableHead>
-									<TableHead className="min-w-[120px] text-right">Meters</TableHead>
-								</TableRow>
-							</TableHeader>
-							<TableBody>
-								{visibleModels.map((model) => {
-									const isSelected = selectedModelSet.has(model.modelId);
+			<CardContent className="space-y-4 p-5">
+				<ModelPicker
+					open={open}
+					onOpenChange={(nextOpen) => {
+						setOpen(nextOpen);
+						if (!nextOpen) setQuery("");
+					}}
+				>
+					<ModelSelectorTrigger asChild>
+						<Button
+							type="button"
+							variant="outline"
+							className="h-13 w-full justify-between rounded-lg border-dashed bg-background px-4 text-left shadow-none hover:border-foreground/25 hover:bg-muted/30"
+						>
+							<span className="flex min-w-0 items-center gap-3">
+								<span className="flex size-8 shrink-0 items-center justify-center rounded-lg bg-primary/10 text-primary">
+									<Search className="size-4" />
+								</span>
+								<span className="min-w-0">
+									<span className="block truncate text-sm font-medium">Search models</span>
+									<span className="block truncate text-xs text-muted-foreground">
+										{modelOptions.length.toLocaleString()} models in the catalogue
+									</span>
+								</span>
+							</span>
+							<ChevronsUpDown className="size-4 text-muted-foreground" />
+						</Button>
+					</ModelSelectorTrigger>
+					<ModelSelectorContent
+						title="Select models for pricing comparison"
+						className="w-[min(94vw,920px)] max-w-3xl"
+						commandProps={{ shouldFilter: false }}
+					>
+						<ModelSelectorInput
+							placeholder="Search models, organisations, providers, or endpoints..."
+							value={query}
+							onValueChange={(value) => {
+								setQuery(value);
+								setActiveModelId(null);
+							}}
+							onKeyDown={(event) => {
+								if (filteredModels.length === 0) return;
+								const currentIndex = filteredModels.findIndex(
+									(model) => model.modelId === visibleActiveModelId
+								);
+								if (event.key === "ArrowDown" || event.key === "ArrowUp") {
+									event.preventDefault();
+									const direction = event.key === "ArrowDown" ? 1 : -1;
+									const nextIndex = currentIndex < 0
+										? 0
+										: (currentIndex + direction + filteredModels.length) % filteredModels.length;
+									setActiveModelId(filteredModels[nextIndex]?.modelId ?? null);
+								}
+								if (event.key === "Enter" && visibleActiveModelId) {
+									event.preventDefault();
+									onAddModel(visibleActiveModelId);
+								}
+							}}
+						/>
+						<div className="flex items-center justify-between border-b px-4 py-2 text-xs text-muted-foreground">
+							<span>{filteredModels.length.toLocaleString()} models</span>
+							<span>Models can be added more than once</span>
+						</div>
+						<VirtualizedModelCatalog
+							sections={[{
+								key: "priced-models",
+								heading: normalizedQuery ? "Search results" : "Recently released",
+								items: filteredModels,
+							}]}
+							getItemKey={(model) => model.modelId}
+							activeItemKey={visibleActiveModelId}
+							isItemDisabled={(model) => loadingModelSet.has(model.modelId)}
+							onActiveItemChange={setActiveModelId}
+							onSelectItem={(model) => onAddModel(model.modelId)}
+							estimateItemSize={56}
+							emptyContent="No models found."
+							renderItem={(model) => {
+									const selectedCount = selectionCountByModelId.get(model.modelId) ?? 0;
 									return (
-										<TableRow
-											key={model.modelId}
-											className={isSelected ? "bg-primary/5" : undefined}
+										<div
+											data-checked={selectedCount > 0}
+											className={cn("flex h-14 w-full items-center gap-3 rounded-lg px-2", selectedCount > 0 && "bg-primary/5")}
 										>
-											<TableCell>
-												<Checkbox
-													checked={isSelected}
-													onCheckedChange={() => onToggleModel(model.modelId)}
-													aria-label={`Select ${model.displayName}`}
-												/>
-											</TableCell>
-											<TableCell>
-												<button
-													type="button"
-													onClick={() => onToggleModel(model.modelId)}
-													className="block max-w-[360px] text-left"
-												>
-													<span className="block truncate text-sm font-medium">
-														{model.displayName}
-													</span>
-													<span className="block truncate text-xs text-muted-foreground">
-														{model.modelId}
-													</span>
-												</button>
-											</TableCell>
-											<TableCell className="text-sm">
-												{formatReleaseDate(
-													model.releaseDate,
-													model.announcementDate
-												)}
-											</TableCell>
-											<TableCell>
-												<div className="flex items-center gap-1.5">
-													{model.providers.slice(0, 5).map((providerId) => (
-														<Logo
-															key={providerId}
-															id={providerId}
-															width={16}
-															height={16}
-															className="h-4 w-4 shrink-0"
-															fallback={
-																<div className="h-4 w-4 rounded bg-muted" />
-															}
-														/>
-													))}
-													<span className="text-xs text-muted-foreground">
-														{model.providers.length}
-													</span>
-												</div>
-											</TableCell>
-											<TableCell className="text-right text-sm">
-												{model.meterCount}
-											</TableCell>
-										</TableRow>
+											<Logo
+												id={model.organisationId}
+												alt={model.organisationName}
+												width={28}
+												height={28}
+												className="size-7 shrink-0 rounded-md"
+												fallback={<div className="size-7 rounded-md bg-muted" />}
+											/>
+											<span className="min-w-0 flex-1">
+												<span className="block truncate text-sm font-medium">{model.displayName}</span>
+												<span className="block truncate text-xs text-muted-foreground">
+													{model.organisationName} • {model.modelId}
+												</span>
+											</span>
+											<span className="hidden shrink-0 items-center gap-1.5 sm:flex">
+												<Badge variant="secondary" className="rounded-md text-[10px]">
+													{model.providers.length} provider{model.providers.length === 1 ? "" : "s"}
+												</Badge>
+												<Badge variant="outline" className="rounded-md text-[10px]">
+													{model.meterCount > 0 ? `${model.meterCount} meters` : "Pricing on add"}
+												</Badge>
+											</span>
+											{selectedCount > 0 ? (
+												<Badge variant="outline" className="shrink-0 rounded-md text-[10px]">
+													{selectedCount} added
+												</Badge>
+											) : null}
+											{loadingModelSet.has(model.modelId) ? (
+												<LoaderCircle className="size-4 shrink-0 animate-spin text-muted-foreground" />
+											) : (
+												<Plus className="size-4 shrink-0 text-muted-foreground" />
+											)}
+										</div>
 									);
-								})}
-							</TableBody>
-						</Table>
-					</div>
-					{filteredModels.length > visibleModels.length ? (
-						<div className="border-t bg-muted/30 px-3 py-2 text-xs text-muted-foreground">
-							Showing {visibleModels.length.toLocaleString()} of{" "}
-							{filteredModels.length.toLocaleString()} matching models. Refine
-							the search to narrow the list.
-						</div>
-					) : null}
+							}}
+						/>
+						{pricingNotice ? (
+							<p className="px-1 text-xs text-amber-700 dark:text-amber-300">{pricingNotice}</p>
+						) : null}
+					</ModelSelectorContent>
+				</ModelPicker>
+
+				<div className="grid gap-3 xl:grid-cols-2">
+					{selectedModels.map((selection, index) => {
+						const modelId = selection.modelId;
+						const option = optionByModelId.get(modelId);
+						const config = modelConfigs[selection.id];
+						const endpointOptions = getEndpointOptions(modelId);
+						const endpoint = config?.endpoint || endpointOptions[0] || "";
+						const providerOptions = getProviderOptions(modelId, endpoint);
+						const provider = config?.provider || providerOptions[0] || "";
+						const planOptions = getPlanOptions(modelId, endpoint, provider);
+						return (
+							<div key={selection.id} className="rounded-xl border bg-muted/10 p-4 shadow-xs">
+								<div className="flex items-start gap-3">
+									<Logo
+										id={option?.organisationId || modelId.split("/")[0]}
+										width={36}
+										height={36}
+										className="size-9 shrink-0 rounded-lg"
+										fallback={<div className="size-9 rounded-lg bg-muted" />}
+									/>
+									<div className="min-w-0 flex-1">
+										<div className="flex items-center gap-2">
+											<span className="truncate text-sm font-semibold">{option?.displayName || modelId}</span>
+											<Badge variant="outline" className="rounded-md px-1.5 text-[10px]">#{index + 1}</Badge>
+										</div>
+										<p className="truncate text-xs text-muted-foreground">{modelId}</p>
+									</div>
+									<Button
+										type="button"
+										variant="ghost"
+										size="icon-sm"
+										className="rounded-lg text-muted-foreground hover:text-destructive"
+										onClick={() => onRemoveModel(selection.id)}
+										aria-label={`Remove ${option?.displayName || modelId}`}
+									>
+										<X className="size-4" />
+									</Button>
+								</div>
+
+								<div className="mt-4 grid gap-2 sm:grid-cols-3">
+									<div className="space-y-1.5">
+										<span className="text-xs font-medium text-muted-foreground">Endpoint</span>
+										<Select
+										value={endpoint}
+										onValueChange={(nextEndpoint) => onUpdateModelConfig(selection.id, { endpoint: nextEndpoint, provider: "", pricingPlan: "" })}
+									>
+										<SelectTrigger className="h-11 w-full rounded-xl border bg-background px-3">
+											<Braces className="size-4 text-muted-foreground" />
+											<span className="min-w-0 flex-1 truncate text-left">{formatEndpointLabel(endpoint)}</span>
+										</SelectTrigger>
+										<SelectContent align="start">
+											{endpointOptions.map((value) => <SelectItem key={value} value={value}><Braces className="size-4 text-muted-foreground" />{formatEndpointLabel(value)}</SelectItem>)}
+										</SelectContent>
+										</Select>
+									</div>
+
+									<div className="space-y-1.5">
+										<span className="text-xs font-medium text-muted-foreground">Provider</span>
+										<Select
+										value={provider}
+										onValueChange={(nextProvider) => onUpdateModelConfig(selection.id, { provider: nextProvider, pricingPlan: "" })}
+									>
+										<SelectTrigger className="h-11 w-full rounded-xl border bg-background px-3">
+											<Logo id={provider} width={16} height={16} className="size-4" fallback={<Server className="size-4 text-muted-foreground" />} />
+											<span className="min-w-0 flex-1 truncate text-left">{formatProviderLabel(provider)}</span>
+										</SelectTrigger>
+										<SelectContent align="start">
+											{providerOptions.map((value) => <SelectItem key={value} value={value}><Logo id={value} width={16} height={16} className="size-4" fallback={<div className="size-4 rounded bg-muted" />} />{formatProviderLabel(value)}</SelectItem>)}
+										</SelectContent>
+										</Select>
+									</div>
+
+									<div className="space-y-1.5">
+										<span className="text-xs font-medium text-muted-foreground">Pricing plan</span>
+										<Select
+										value={config?.pricingPlan || planOptions[0] || ""}
+										onValueChange={(pricingPlan) => onUpdateModelConfig(selection.id, { pricingPlan })}
+									>
+										<SelectTrigger className="h-11 w-full rounded-xl border bg-background px-3">
+											<PricingPlanIcon plan={config?.pricingPlan || planOptions[0] || ""} />
+											<span className="min-w-0 flex-1 truncate text-left">{formatPlanLabel(config?.pricingPlan || planOptions[0] || "")}</span>
+										</SelectTrigger>
+										<SelectContent align="start">
+											{planOptions.map((value) => <SelectItem key={value} value={value}><PricingPlanIcon plan={value} />{formatPlanLabel(value)}</SelectItem>)}
+										</SelectContent>
+										</Select>
+									</div>
+								</div>
+
+								<div className="mt-3 flex flex-wrap gap-1.5 text-[11px] text-muted-foreground">
+									<span className="inline-flex items-center gap-1 rounded-md bg-muted px-2 py-1"><CalendarDays className="size-3" />{formatReleaseDate(option?.releaseDate, option?.announcementDate)}</span>
+									<span className="inline-flex items-center gap-1 rounded-md bg-muted px-2 py-1"><DatabaseZap className="size-3" />{option?.meterCount ?? 0} priced meters</span>
+								</div>
+							</div>
+						);
+					})}
 				</div>
-
-				{selectedModelIds.length > 0 ? (
-					<div className="space-y-3">
-						<div className="flex items-center justify-between gap-3">
-							<h3 className="text-sm font-semibold">Selected Model Pricing</h3>
-							<p className="text-xs text-muted-foreground">
-								Configure endpoint, provider, and plan per selected model.
-							</p>
-						</div>
-						<div className="overflow-x-auto rounded-lg border">
-							<Table>
-								<TableHeader>
-									<TableRow>
-										<TableHead className="min-w-[260px]">Model</TableHead>
-										<TableHead className="min-w-[190px]">Endpoint</TableHead>
-										<TableHead className="min-w-[190px]">Provider</TableHead>
-										<TableHead className="min-w-[160px]">Plan</TableHead>
-										<TableHead className="w-[56px]" />
-									</TableRow>
-								</TableHeader>
-								<TableBody>
-									{selectedModelIds.map((modelId) => {
-										const option = optionByModelId.get(modelId);
-										const config = modelConfigs[modelId];
-										const endpointOptions = getEndpointOptions(modelId);
-										const providerOptions = getProviderOptions(
-											modelId,
-											config?.endpoint || endpointOptions[0] || ""
-										);
-										const planOptions = getPlanOptions(
-											modelId,
-											config?.endpoint || endpointOptions[0] || "",
-											config?.provider || providerOptions[0] || ""
-										);
-
-										return (
-											<TableRow key={`selected-${modelId}`}>
-												<TableCell>
-													<div className="max-w-[320px]">
-														<p className="truncate text-sm font-medium">
-															{option?.displayName || modelId}
-														</p>
-														<p className="truncate text-xs text-muted-foreground">
-															{modelId}
-														</p>
-													</div>
-												</TableCell>
-												<TableCell>
-													<Select
-														value={config?.endpoint || endpointOptions[0] || ""}
-														onValueChange={(endpoint) =>
-															onUpdateModelConfig(modelId, {
-																endpoint,
-																provider: "",
-																pricingPlan: "",
-															})
-														}
-													>
-														<SelectTrigger className="h-9">
-															<SelectValue placeholder="Endpoint" />
-														</SelectTrigger>
-														<SelectContent>
-															{endpointOptions.map((endpoint) => (
-																<SelectItem key={endpoint} value={endpoint}>
-																	{endpoint}
-																</SelectItem>
-															))}
-														</SelectContent>
-													</Select>
-												</TableCell>
-												<TableCell>
-													<Select
-														value={config?.provider || providerOptions[0] || ""}
-														onValueChange={(provider) =>
-															onUpdateModelConfig(modelId, {
-																provider,
-																pricingPlan: "",
-															})
-														}
-													>
-														<SelectTrigger className="h-9">
-															<SelectValue placeholder="Provider" />
-														</SelectTrigger>
-														<SelectContent>
-															{providerOptions.map((provider) => (
-																<SelectItem key={provider} value={provider}>
-																	<div className="flex items-center gap-2">
-																		<Logo
-																			id={provider}
-																			width={14}
-																			height={14}
-																			className="h-3.5 w-3.5"
-																			fallback={
-																				<div className="h-3.5 w-3.5 rounded bg-muted" />
-																			}
-																		/>
-																		{formatProviderLabel(provider)}
-																	</div>
-																</SelectItem>
-															))}
-														</SelectContent>
-													</Select>
-												</TableCell>
-												<TableCell>
-													<Select
-														value={config?.pricingPlan || planOptions[0] || ""}
-														onValueChange={(pricingPlan) =>
-															onUpdateModelConfig(modelId, { pricingPlan })
-														}
-													>
-														<SelectTrigger className="h-9">
-															<SelectValue placeholder="Plan" />
-														</SelectTrigger>
-														<SelectContent>
-															{planOptions.map((plan) => (
-																<SelectItem key={plan} value={plan}>
-																	{formatPlanLabel(plan)}
-																</SelectItem>
-															))}
-														</SelectContent>
-													</Select>
-												</TableCell>
-												<TableCell>
-													<Button
-														type="button"
-														variant="ghost"
-														size="icon"
-														onClick={() => onToggleModel(modelId)}
-														aria-label={`Remove ${option?.displayName || modelId}`}
-													>
-														<X className="h-4 w-4" />
-													</Button>
-												</TableCell>
-											</TableRow>
-										);
-									})}
-								</TableBody>
-							</Table>
-						</div>
-					</div>
-				) : null}
 			</CardContent>
 		</Card>
 	);

--- a/apps/web/src/components/(tools)/pricing-calculator/ModelSelector.tsx
+++ b/apps/web/src/components/(tools)/pricing-calculator/ModelSelector.tsx
@@ -380,7 +380,7 @@ export function ModelSelector({
 							isItemDisabled={(model) => loadingModelSet.has(model.modelId)}
 							onActiveItemChange={setActiveModelId}
 							onSelectItem={(model) => onAddModel(model.modelId)}
-							estimateItemSize={56}
+							estimateItemSize={64}
 							emptyContent="No models found."
 							renderItem={(model) => {
 									const selectedCount = selectionCountByModelId.get(model.modelId) ?? 0;

--- a/apps/web/src/components/(tools)/pricing-calculator/PricingReference.tsx
+++ b/apps/web/src/components/(tools)/pricing-calculator/PricingReference.tsx
@@ -1,8 +1,8 @@
 "use client";
 
-import Link from "next/link";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { ScrollArea } from "@/components/ui/scroll-area";
 import {
 	Table,
 	TableBody,
@@ -14,35 +14,29 @@ import {
 import {
 	calculateCost,
 	calculateUnits,
-	formatQuantity,
+	fmtUSD,
 	formatMeterName,
+	formatPricingTimeWindow,
+	formatQuantity,
 	getExamplesForMeter,
 	parseMeter,
-	fmtUSD,
-	formatPricingTimeWindow,
 	resolvePricingMeterPrice,
 	type PricingMeter,
 } from "@/components/(data)/model/pricing/pricingHelpers";
-import { getModelDetailsHref } from "@/lib/models/modelHref";
-
-const BLENDED_USAGE_EXAMPLES = [100_000, 1_000_000, 100_000_000];
-const BLENDED_BUDGET_EXAMPLES = [1, 10, 100];
-
-type ComparisonPricingModel = {
-	key: string;
-	label: string;
-	modelId?: string;
-	provider: string;
-	pricingPlan: string;
-	meters: PricingMeter[];
-};
-
-type BlendedRate = {
-	blendedPricePerToken: number;
-	blendedPer1M: number;
-	inputPer1M: number;
-	outputPer1M: number;
-};
+import {
+	calculateArtificialAnalysisBlendedRate,
+	type BlendedRate,
+} from "./blendedRate";
+import {
+	MeterLabel,
+	PricingModelHeader,
+	formatSentenceLabel,
+	type ComparisonPricingModel,
+} from "./PricingTableVisuals";
+import {
+	getPricingContextTiers,
+	type PricingContextTier,
+} from "./pricingMeterConditions";
 
 interface PricingReferenceProps {
 	meters: PricingMeter[];
@@ -54,143 +48,57 @@ interface PricingReferenceProps {
 	comparisonModels?: ComparisonPricingModel[];
 }
 
-function calculateBlendedRate(
-	meters: PricingMeter[],
-	pricingTimeUtc: string
-): BlendedRate | null {
-	const inputMeter = meters.find(
-		(m) =>
-			m.meter.toLowerCase().includes("input") &&
-			m.meter.toLowerCase().includes("token") &&
-			!m.meter.toLowerCase().includes("cached")
-	);
-	const outputMeter = meters.find(
-		(m) =>
-			m.meter.toLowerCase().includes("output") &&
-			m.meter.toLowerCase().includes("token")
-	);
+const TOKEN_VOLUME_PRESETS = [1_000_000, 10_000_000, 100_000_000, 1_000_000_000];
+const BUDGET_PRESETS = [1, 10, 100, 1_000];
 
-	if (!inputMeter || !outputMeter) return null;
-
-	const inputPricePerToken =
-		resolvePricingMeterPrice(inputMeter, pricingTimeUtc).pricePerUnit /
-		(inputMeter.unit_size || 1);
-	const outputPricePerToken =
-		resolvePricingMeterPrice(outputMeter, pricingTimeUtc).pricePerUnit /
-		(outputMeter.unit_size || 1);
-	const blendedPricePerToken =
-		inputPricePerToken * 0.9 + outputPricePerToken * 0.1;
-
-	return {
-		blendedPricePerToken,
-		blendedPer1M: blendedPricePerToken * 1_000_000,
-		inputPer1M: inputPricePerToken * 1_000_000,
-		outputPer1M: outputPricePerToken * 1_000_000,
-	};
+function isTokenMeter(meter: PricingMeter): boolean {
+	return parseMeter(meter.meter).unit === "token" || meter.unit.toLowerCase().includes("token");
 }
 
-function formatUnitPrice(
-	meter: PricingMeter,
-	unitLabel: string,
-	pricingTimeUtc: string
-) {
-	const normalizedUnit = unitLabel.toLowerCase();
-	const isTokenUnit = normalizedUnit.includes("token");
-	const unitSize = meter.unit_size || 1;
-	const { pricePerUnit, pricePerUnitRaw } = resolvePricingMeterPrice(
-		meter,
-		pricingTimeUtc
-	);
-
-	if (isTokenUnit && Number.isFinite(pricePerUnit)) {
-		const perTokenPrice = pricePerUnit / unitSize;
-		const perMillionTokens = perTokenPrice * 1_000_000;
-		return `${fmtUSD(perMillionTokens)} / 1M tokens`;
+function formatUnitPrice(meter: PricingMeter, pricingTimeUtc: string) {
+	const derivedUnit = parseMeter(meter.meter).unit;
+	const unitLabel = derivedUnit !== "unknown" ? derivedUnit : meter.unit;
+	const { pricePerUnit, pricePerUnitRaw } = resolvePricingMeterPrice(meter, pricingTimeUtc);
+	if (unitLabel.toLowerCase().includes("token")) {
+		return `${fmtUSD((pricePerUnit / (meter.unit_size || 1)) * 1_000_000)} per 1M tokens`;
 	}
-
-	return `${pricePerUnitRaw} ${meter.currency} / ${meter.unit_size} ${unitLabel}`;
+	return `${pricePerUnitRaw} ${meter.currency} per ${meter.unit_size.toLocaleString()} ${unitLabel}`;
 }
 
-function getMeterSortPriority(meterName: string): number {
-	const normalized = meterName.toLowerCase();
-	const isInputTextTokens =
-		normalized.includes("input") &&
-		normalized.includes("text") &&
-		normalized.includes("token") &&
-		!normalized.includes("cached");
-	const isOutputTextTokens =
-		normalized.includes("output") &&
-		normalized.includes("text") &&
-		normalized.includes("token");
-
-	if (isInputTextTokens) return 0;
-	if (isOutputTextTokens) return 1;
-	return 2;
+function meterSortPriority(meterName: string) {
+	const name = meterName.toLowerCase();
+	if (name.includes("input") && name.includes("text") && !name.includes("cached")) return 0;
+	if (name.includes("output") && name.includes("text")) return 1;
+	if (name.includes("cached")) return 2;
+	return 3;
 }
 
-function formatProviderLabel(providerId: string): string {
-	const known: Record<string, string> = {
-		openai: "OpenAI",
-		anthropic: "Anthropic",
-		google: "Google",
-		"google-ai-studio": "Google AI Studio",
-		"google-vertex": "Google Vertex",
-		"spacex-ai": "SpaceXAI",
-		aws: "AWS",
-		azure: "Azure",
-	};
-
-	if (known[providerId]) {
-		return known[providerId];
-	}
-
-	return providerId
-		.replace(/[-_]+/g, " ")
-		.replace(/\b\w/g, (char) => char.toUpperCase());
+function contextMeter(tier: PricingContextTier, meterName: string) {
+	return tier.meters.find((meter) => meter.meter === meterName);
 }
 
-function formatUsageUnit(quantity: number, unitLabel: string) {
-	const normalized = unitLabel.trim().toLowerCase();
-	if (normalized === "token" || normalized === "tokens") {
-		return quantity === 1 ? "token" : "tokens";
-	}
-	return unitLabel;
-}
-
-function getPricingModelHref(model: ComparisonPricingModel) {
-	if (!model.modelId) return null;
-	const [orgFromModelId] = model.modelId.split("/");
-	const organisationId = model.modelId.includes("/")
-		? orgFromModelId
-		: model.provider;
-	return getModelDetailsHref(organisationId, model.modelId);
-}
-
-function ModelColumnHeader({ model }: { model: ComparisonPricingModel }) {
-	const modelHref = getPricingModelHref(model);
-	const providerHref = `/api-providers/${encodeURIComponent(model.provider)}`;
-	const modelLabel = (
-		<p className="truncate text-sm font-medium">{model.label}</p>
-	);
-
+function ContextRateStack({
+	tiers,
+	meterName,
+	pricingTimeUtc,
+}: {
+	tiers: PricingContextTier[];
+	meterName: string;
+	pricingTimeUtc: string;
+}) {
 	return (
-		<div className="max-w-[220px] space-y-1">
-			{modelHref ? (
-				<Link
-					href={modelHref}
-					className="block underline decoration-transparent transition-colors duration-200 hover:decoration-current"
-				>
-					{modelLabel}
-				</Link>
-			) : (
-				modelLabel
-			)}
-			<Link
-				href={providerHref}
-				className="block truncate text-xs font-normal text-muted-foreground underline decoration-transparent transition-colors duration-200 hover:decoration-current"
-			>
-				{formatProviderLabel(model.provider)} · {model.pricingPlan}
-			</Link>
+		<div className={tiers.length > 1 ? "grid gap-2 sm:grid-cols-2" : "grid gap-2"}>
+			{tiers.map((tier) => {
+				const meter = contextMeter(tier, meterName);
+				if (!meter) return null;
+				return (
+					<div key={tier.key} className="min-h-[74px] rounded-lg border bg-muted/20 px-3 py-2.5">
+						<p className="text-[10px] font-medium text-muted-foreground">{tier.label}</p>
+						<p className="mt-0.5 text-sm font-semibold tabular-nums">{formatUnitPrice(meter, pricingTimeUtc)}</p>
+						<p className="mt-0.5 text-[10px] text-muted-foreground">{tier.detail}</p>
+					</div>
+				);
+			})}
 		</div>
 	);
 }
@@ -204,252 +112,188 @@ export function PricingReference({
 	pricingTimeUtc,
 	comparisonModels,
 }: PricingReferenceProps) {
-	if (meters.length === 0) {
-		return null;
-	}
-
-	const displayPlan = pricingPlan || "standard";
-	const activeModels =
+	if (meters.length === 0) return null;
+	const activeModels: ComparisonPricingModel[] =
 		comparisonModels && comparisonModels.length > 0
 			? comparisonModels
-			: [
-					{
-						key: "primary",
-						label: selectedModelLabel || selectedModelId || "Selected Model",
-						modelId: selectedModelId,
-						provider:
-							selectedProvider ||
-							(selectedModelId?.includes("/") ? selectedModelId.split("/")[0] : "selected"),
-						pricingPlan: displayPlan,
-						meters,
-					},
-			  ];
-
-	const blendedByModel = activeModels.map((model) => ({
-		key: model.key,
-		blended: calculateBlendedRate(model.meters, pricingTimeUtc),
-	}));
-
-	const hasBlendedComparison = blendedByModel.some((model) => Boolean(model.blended));
-	const allMeterNames = Array.from(
+			: [{
+				key: "primary",
+				label: selectedModelLabel || selectedModelId || "Selected Model",
+				modelId: selectedModelId,
+				provider: selectedProvider || selectedModelId?.split("/")[0] || "selected",
+				pricingPlan: pricingPlan || "standard",
+				meters,
+			}];
+	const contextTiersByModel = new Map(
+		activeModels.map((model) => [model.key, getPricingContextTiers(model.allMeters ?? model.meters)])
+	);
+	const hasContextTiers = [...contextTiersByModel.values()].some((tiers) => tiers.length > 1);
+	const blendedTiersByModel = new Map(
+		activeModels.map((model) => [
+			model.key,
+			(contextTiersByModel.get(model.key) ?? []).map((tier) => ({
+				tier,
+				rate: calculateArtificialAnalysisBlendedRate(tier.meters, pricingTimeUtc),
+			})).filter((entry): entry is { tier: PricingContextTier; rate: BlendedRate } => Boolean(entry.rate)),
+		])
+	);
+	const hasBlendedRates = [...blendedTiersByModel.values()].some((tiers) => tiers.length > 0);
+	const meterNames = Array.from(
 		new Set(activeModels.flatMap((model) => model.meters.map((meter) => meter.meter)))
-	).sort((a, b) => {
-		const priorityDiff = getMeterSortPriority(a) - getMeterSortPriority(b);
-		if (priorityDiff !== 0) return priorityDiff;
-		return formatMeterName(a).localeCompare(formatMeterName(b));
-	});
+	).sort((left, right) =>
+		meterSortPriority(left) - meterSortPriority(right) ||
+		formatMeterName(left).localeCompare(formatMeterName(right))
+	);
 
 	return (
 		<Card>
-			<CardHeader>
+			<CardHeader className="border-b bg-muted/10">
 				<CardTitle className="flex flex-wrap items-center justify-between gap-2">
-					<div className="flex items-center gap-2">
-						<span>Pricing Reference</span>
-						<Badge variant="outline" className="text-[11px]">
-							{activeModels.length} model{activeModels.length === 1 ? "" : "s"}
-						</Badge>
-					</div>
+					<span>Pricing reference</span>
+					<Badge variant="outline" className="rounded-lg bg-background text-[11px]">
+						Rates at {pricingTimeUtc} UTC
+					</Badge>
 				</CardTitle>
+				{hasContextTiers ? (
+					<p className="text-xs text-muted-foreground">
+						Standard and long-context rates are shown together. Cost totals continue to follow the input tokens entered above.
+					</p>
+				) : null}
 			</CardHeader>
-			<CardContent className="space-y-6">
-				{hasBlendedComparison ? (
-					<div className="space-y-3 rounded-lg border bg-primary/5 p-4">
+			<CardContent className="space-y-6 pt-5">
+				{hasBlendedRates ? (
+					<section className="space-y-3">
 						<div>
-							<h4 className="text-sm font-semibold">Blended Rate</h4>
+							<h3 className="text-sm font-semibold">Text token snapshot</h3>
 							<p className="text-xs text-muted-foreground">
-								90% input and 10% output token ratio
+								Artificial Analysis-style 7:2:1 mix of cache-hit input, regular input, and output. Cache writes and storage are excluded.
 							</p>
 						</div>
-						<div className="overflow-x-auto rounded-lg border bg-background">
+						<ScrollArea scrollBarOrientation="horizontal" className="w-full rounded-xl border" viewportClassName="rounded-xl">
 							<Table>
 								<TableHeader>
-									<TableRow>
-										<TableHead className="sticky left-0 z-10 min-w-[190px] bg-background">
-											Metric
-										</TableHead>
-										{activeModels.map((model) => (
-											<TableHead key={`blend-head-${model.key}`} className="min-w-[220px]">
-												<ModelColumnHeader model={model} />
-											</TableHead>
-										))}
+									<TableRow className="bg-muted/20 hover:bg-muted/20">
+										<TableHead className="sticky left-0 z-10 min-w-[250px] bg-muted/20">Rate</TableHead>
+										{activeModels.map((model) => <TableHead key={`blend-head-${model.key}`} className="min-w-[240px]"><PricingModelHeader model={model} /></TableHead>)}
 									</TableRow>
 								</TableHeader>
 								<TableBody>
 									{[
-										{
-											key: "blended",
-											label: "Blended / 1M",
-											value: (rate: BlendedRate) => fmtUSD(rate.blendedPer1M),
-										},
-										{
-											key: "input",
-											label: "Input / 1M",
-											value: (rate: BlendedRate) => fmtUSD(rate.inputPer1M),
-										},
-										{
-											key: "output",
-											label: "Output / 1M",
-											value: (rate: BlendedRate) => fmtUSD(rate.outputPer1M),
-										},
-										...BLENDED_USAGE_EXAMPLES.map((tokens) => ({
-											key: `usage-${tokens}`,
-											label: `${formatQuantity(tokens)} tokens`,
-											value: (rate: BlendedRate) =>
-												fmtUSD(
-													calculateCost(
-														tokens,
-														{
-															unit_size: 1,
-															price_per_unit: String(rate.blendedPricePerToken),
-														},
-														pricingTimeUtc
-													)
-												),
-										})),
-										...BLENDED_BUDGET_EXAMPLES.map((budget) => ({
-											key: `budget-${budget}`,
-											label: `Usage for ${fmtUSD(budget)}`,
-											value: (rate: BlendedRate) => {
-												const units = calculateUnits(
-													budget,
-													{
-														unit_size: 1,
-														price_per_unit: String(rate.blendedPricePerToken),
-													},
-													pricingTimeUtc
-												);
-												return `${formatQuantity(units)} ${formatUsageUnit(
-													units,
-													"tokens"
-												)}`;
-											},
-										})),
+										{ key: "blended", label: "Blended rate", description: "7:2:1 per 1M tokens", value: (rate: BlendedRate) => rate.blendedPer1M },
+										{ key: "cache", label: "Cache-hit input", description: "70% of the blend", value: (rate: BlendedRate) => rate.cacheHitPer1M },
+										{ key: "input", label: "Regular input", description: "20% of the blend", value: (rate: BlendedRate) => rate.inputPer1M },
+										{ key: "output", label: "Output", description: "10% of the blend", value: (rate: BlendedRate) => rate.outputPer1M },
 									].map((row) => (
-										<TableRow key={`blend-row-${row.key}`}>
-											<TableCell className="sticky left-0 z-10 bg-background font-medium">
-												{row.label}
+										<TableRow key={row.key}>
+											<TableCell className="sticky left-0 z-10 bg-background">
+												<div className="min-w-[190px]">
+													<p className="text-sm font-medium">{row.label}</p>
+													<p className="text-xs text-muted-foreground">{row.description}</p>
+												</div>
 											</TableCell>
-											{activeModels.map((model) => {
-												const blendedModel = blendedByModel.find(
-													(entry) => entry.key === model.key
-												);
-												return (
-													<TableCell key={`blend-${row.key}-${model.key}`}>
-														{blendedModel?.blended
-															? row.value(blendedModel.blended)
-															: "-"}
-													</TableCell>
-												);
-											})}
+										{activeModels.map((model) => {
+											const tierRates = blendedTiersByModel.get(model.key) ?? [];
+											if (tierRates.length === 0) return <TableCell key={`${row.key}-${model.key}`} className="text-sm text-muted-foreground">Not available</TableCell>;
+											return (
+												<TableCell key={`${row.key}-${model.key}`}>
+													<div className={tierRates.length > 1 ? "grid gap-2 sm:grid-cols-2" : "grid gap-2"}>
+														{tierRates.map(({ tier, rate }) => (
+															<div key={tier.key} className="flex min-h-[62px] items-center justify-between gap-3 rounded-lg border bg-muted/20 px-3 py-2">
+																<span>
+																	<span className="block text-[10px] font-medium text-muted-foreground">{tier.label}</span>
+																	<span className="block text-[10px] text-muted-foreground">{tier.detail}</span>
+																</span>
+																<span className="font-semibold tabular-nums">{fmtUSD(row.value(rate))}</span>
+															</div>
+														))}
+													</div>
+												</TableCell>
+											);
+										})}
 										</TableRow>
 									))}
 								</TableBody>
 							</Table>
-						</div>
-					</div>
+							</ScrollArea>
+							{[...blendedTiersByModel.values()].flat().some(({ rate }) => rate.usesInputForCache) ? (
+								<p className="text-[11px] text-muted-foreground">
+									Where no cache-hit price is published, the regular input price is used for that part of the blend.
+								</p>
+							) : null}
+						</section>
 				) : null}
 
-				{allMeterNames.map((meterName) => {
-					const meterByModel = activeModels.map((model) => ({
-						key: model.key,
-						meter: model.meters.find((item) => item.meter === meterName) || null,
-					}));
-					const baseMeter = meterByModel.find((entry) => entry.meter)?.meter;
-					if (!baseMeter) {
-						return null;
-					}
-
-					const examples = getExamplesForMeter(baseMeter);
-					const budgets = [1, 10, 100];
-					const derivedUnit = parseMeter(baseMeter.meter).unit;
-					const unitLabel =
-						derivedUnit !== "unknown" ? derivedUnit : baseMeter.unit;
-
-					const rows = [
-						{
-							key: "rate",
-							label: "Unit price",
-							value: (meter: PricingMeter) =>
-								formatUnitPrice(meter, unitLabel, pricingTimeUtc),
-						},
-						{
-							key: "window",
-							label: "Active time window",
-							value: (meter: PricingMeter) => {
-								const activeWindow = resolvePricingMeterPrice(
-									meter,
-									pricingTimeUtc
-								).timeWindow;
-								return activeWindow
-									? formatPricingTimeWindow(activeWindow)
-									: "Base rate";
-							},
-						},
-						...examples.map((quantity) => ({
-							key: `usage-${quantity}`,
-							label: `Cost for ${formatQuantity(quantity)} ${unitLabel}`,
-							value: (meter: PricingMeter) =>
-								fmtUSD(calculateCost(quantity, meter, pricingTimeUtc)),
-						})),
-						...budgets.map((budget) => ({
-							key: `budget-${budget}`,
-							label: `Usage for ${fmtUSD(budget)}`,
-							value: (meter: PricingMeter) => {
-								const units = calculateUnits(budget, meter, pricingTimeUtc);
-								return `${formatQuantity(units)} ${formatUsageUnit(
-									units,
-									unitLabel
-								)}`;
-							},
-						})),
-					];
-
-					return (
-						<div key={meterName} className="space-y-3 rounded-lg border p-4">
-							<h4 className="text-sm font-semibold">
-								{formatMeterName(meterName)}
-							</h4>
-							<div className="overflow-x-auto rounded-lg border">
-								<Table>
-									<TableHeader>
-										<TableRow>
-											<TableHead className="sticky left-0 z-10 min-w-[220px] bg-background">
-												Metric
-											</TableHead>
-											{activeModels.map((model) => (
-												<TableHead
-													key={`${meterName}-head-${model.key}`}
-													className="min-w-[220px]"
-												>
-													<ModelColumnHeader model={model} />
-												</TableHead>
-											))}
+				<section className="space-y-3">
+					<div>
+						<h3 className="text-sm font-semibold">All priced meters</h3>
+						<p className="text-xs text-muted-foreground">Unit rates with fixed token-volume and budget comparisons where applicable.</p>
+					</div>
+					<ScrollArea scrollBarOrientation="horizontal" className="w-full rounded-xl border" viewportClassName="rounded-xl">
+						<Table>
+							<TableHeader>
+								<TableRow className="bg-muted/20 hover:bg-muted/20">
+									<TableHead className="sticky left-0 z-10 min-w-[250px] bg-muted/20">Meter</TableHead>
+								{activeModels.map((model) => <TableHead key={`meter-head-${model.key}`} className="min-w-[360px]"><PricingModelHeader model={model} /></TableHead>)}
+								</TableRow>
+							</TableHeader>
+							<TableBody>
+								{meterNames.map((meterName) => {
+									const representative = activeModels.flatMap((model) => model.meters).find((meter) => meter.meter === meterName);
+									const example = representative ? getExamplesForMeter(representative)[1] ?? getExamplesForMeter(representative)[0] ?? 1 : 1;
+									return (
+										<TableRow key={meterName}>
+											<TableCell className="sticky left-0 z-10 bg-background"><MeterLabel meterName={meterName} label={formatSentenceLabel(formatMeterName(meterName))} description={representative?.unit || "Usage"} /></TableCell>
+											{activeModels.map((model) => {
+												const meter = model.meters.find((item) => item.meter === meterName);
+												if (!meter) return <TableCell key={`${meterName}-${model.key}`} className="text-sm text-muted-foreground">Not priced</TableCell>;
+												const timeWindow = resolvePricingMeterPrice(meter, pricingTimeUtc).timeWindow;
+												const contextTiers = contextTiersByModel.get(model.key) ?? [];
+												return (
+													<TableCell key={`${meterName}-${model.key}`}>
+										<ContextRateStack tiers={contextTiers} meterName={meterName} pricingTimeUtc={pricingTimeUtc} />
+										{isTokenMeter(meter) ? (
+											<div className="mt-3 space-y-3 border-t pt-3">
+												<p className="text-[10px] font-medium text-muted-foreground">Current rate calculations</p>
+														<div>
+															<p className="mb-1.5 text-[10px] font-medium text-muted-foreground">Token volume</p>
+															<div className="grid grid-cols-4 gap-2">
+																{TOKEN_VOLUME_PRESETS.map((quantity) => (
+																	<div key={quantity} className="min-w-0">
+																		<p className="text-[10px] text-muted-foreground">{formatQuantity(quantity)}</p>
+																		<p className="truncate text-xs font-semibold tabular-nums">{fmtUSD(calculateCost(quantity, meter, pricingTimeUtc))}</p>
+																	</div>
+																))}
+															</div>
+														</div>
+														<div>
+															<p className="mb-1.5 text-[10px] font-medium text-muted-foreground">Budget buys</p>
+															<div className="grid grid-cols-4 gap-2">
+																{BUDGET_PRESETS.map((budget) => (
+																	<div key={budget} className="min-w-0">
+																		<p className="text-[10px] text-muted-foreground">${budget.toLocaleString()}</p>
+																		<p className="truncate text-xs font-semibold tabular-nums">{formatQuantity(calculateUnits(budget, meter, pricingTimeUtc))}</p>
+																	</div>
+																))}
+															</div>
+														</div>
+													</div>
+												) : (
+													<>
+														<p className="mt-1 text-xs text-muted-foreground">{formatQuantity(example)} costs {fmtUSD(calculateCost(example, meter, pricingTimeUtc))}</p>
+														<p className="mt-1 text-xs text-muted-foreground">$10 buys {formatQuantity(calculateUnits(10, meter, pricingTimeUtc))}</p>
+													</>
+												)}
+														{timeWindow ? <p className="mt-1 text-[11px] text-muted-foreground">{formatPricingTimeWindow(timeWindow)}</p> : null}
+													</TableCell>
+												);
+											})}
 										</TableRow>
-									</TableHeader>
-									<TableBody>
-										{rows.map((row) => (
-											<TableRow key={`${meterName}-row-${row.key}`}>
-												<TableCell className="sticky left-0 z-10 bg-background font-medium">
-													{row.label}
-												</TableCell>
-												{activeModels.map((model) => {
-													const entry = meterByModel.find(
-														(item) => item.key === model.key
-													);
-													return (
-														<TableCell key={`${meterName}-${row.key}-${model.key}`}>
-															{entry?.meter ? row.value(entry.meter) : "-"}
-														</TableCell>
-													);
-												})}
-											</TableRow>
-										))}
-									</TableBody>
-								</Table>
-							</div>
-						</div>
-					);
-				})}
+									);
+								})}
+							</TableBody>
+						</Table>
+					</ScrollArea>
+				</section>
 			</CardContent>
 		</Card>
 	);

--- a/apps/web/src/components/(tools)/pricing-calculator/PricingTableVisuals.tsx
+++ b/apps/web/src/components/(tools)/pricing-calculator/PricingTableVisuals.tsx
@@ -1,0 +1,137 @@
+import Link from "next/link";
+import { Badge } from "@/components/ui/badge";
+import { Logo } from "@/components/Logo";
+import { getModelDetailsHref } from "@/lib/models/modelHref";
+import { getTierFilterMeta } from "@/lib/models/tierFilterStyles";
+import type { PricingMeter } from "@/components/(data)/model/pricing/pricingHelpers";
+import {
+	Activity,
+	AudioLines,
+	CircleDollarSign,
+	DatabaseZap,
+	Gauge,
+	Hash,
+	Image as ImageIcon,
+	MessageSquareText,
+	MousePointerClick,
+	Video,
+} from "lucide-react";
+
+export type ComparisonPricingModel = {
+	key: string;
+	label: string;
+	modelId?: string;
+	provider: string;
+	pricingPlan: string;
+	meters: PricingMeter[];
+	allMeters?: PricingMeter[];
+};
+
+export function formatSentenceLabel(value: string): string {
+	const normalized = value.trim();
+	return normalized
+		? normalized[0].toUpperCase() + normalized.slice(1).toLowerCase()
+		: "";
+}
+
+export function formatProviderLabel(providerId: string): string {
+	const known: Record<string, string> = {
+		openai: "OpenAI",
+		anthropic: "Anthropic",
+		google: "Google",
+		"google-ai-studio": "Google AI Studio",
+		"google-vertex": "Google Vertex",
+		"x-ai": "xAI",
+		aws: "AWS",
+		azure: "Azure",
+	};
+	return known[providerId] ?? providerId
+		.replace(/[-_]+/g, " ")
+		.replace(/\b\w/g, (char) => char.toUpperCase());
+}
+
+function modelOrganisationId(model: ComparisonPricingModel) {
+	return model.modelId?.split("/")[0] || model.provider;
+}
+
+function modelHref(model: ComparisonPricingModel) {
+	if (!model.modelId) return null;
+	return getModelDetailsHref(modelOrganisationId(model), model.modelId);
+}
+
+export function PricingModelHeader({ model }: { model: ComparisonPricingModel }) {
+	const href = modelHref(model);
+	const tier = getTierFilterMeta(model.pricingPlan);
+	const TierIcon = tier.icon;
+	const normalizedPlan = model.pricingPlan.replace(/[-_]+/g, " ").trim().toLowerCase();
+	const planLabel = normalizedPlan
+		? normalizedPlan[0].toUpperCase() + normalizedPlan.slice(1)
+		: "Standard";
+	const label = <span className="truncate text-sm font-semibold">{model.label}</span>;
+	return (
+		<div className="min-w-[210px] py-1">
+			<div className="flex min-w-0 items-center gap-2">
+				<Logo
+					id={modelOrganisationId(model)}
+					width={16}
+					height={16}
+					className="size-4 shrink-0 rounded-sm"
+					fallback={<div className="size-4 rounded-sm bg-muted" />}
+				/>
+				{href ? <Link href={href} className="min-w-0 hover:underline">{label}</Link> : label}
+			</div>
+			<div className="mt-1.5 flex min-w-0 items-center gap-2">
+					<Logo
+						id={model.provider}
+						width={16}
+						height={16}
+						className="size-4 shrink-0 rounded-sm"
+						fallback={<div className="size-4 rounded-sm bg-muted" />}
+					/>
+					<span className="truncate text-xs font-normal text-muted-foreground">
+						{formatProviderLabel(model.provider)}
+					</span>
+					<Badge variant="outline" className="h-5 shrink-0 gap-1 rounded-md px-1.5 text-[9px] font-medium">
+						<TierIcon className={`size-3 ${tier.iconClassName}`} />
+						{planLabel}
+					</Badge>
+			</div>
+		</div>
+	);
+}
+
+function MeterGlyph({ meterName, className = "size-4" }: { meterName: string; className?: string }) {
+	const normalized = meterName.toLowerCase();
+	if (normalized.includes("cache")) return <DatabaseZap className={className} />;
+	if (normalized.includes("image")) return <ImageIcon className={className} />;
+	if (normalized.includes("audio") || normalized.includes("speech")) return <AudioLines className={className} />;
+	if (normalized.includes("video")) return <Video className={className} />;
+	if (normalized.includes("request")) return <MousePointerClick className={className} />;
+	if (normalized.includes("message") || normalized.includes("text")) return <MessageSquareText className={className} />;
+	if (normalized.includes("token")) return <Hash className={className} />;
+	if (normalized.includes("cost") || normalized.includes("price")) return <CircleDollarSign className={className} />;
+	if (normalized.includes("total")) return <Activity className={className} />;
+	return <Gauge className={className} />;
+}
+
+export function MeterLabel({
+	meterName,
+	label,
+	description,
+}: {
+	meterName: string;
+	label: string;
+	description?: string;
+}) {
+	return (
+		<div className="flex min-w-[190px] items-center gap-2.5">
+			<span className="flex size-8 shrink-0 items-center justify-center rounded-lg bg-muted text-muted-foreground">
+				<MeterGlyph meterName={meterName} />
+			</span>
+			<span className="min-w-0">
+				<span className="block text-sm font-medium">{label}</span>
+				{description ? <span className="block text-xs font-normal text-muted-foreground">{description}</span> : null}
+			</span>
+		</div>
+	);
+}

--- a/apps/web/src/components/(tools)/pricing-calculator/UsageInputs.tsx
+++ b/apps/web/src/components/(tools)/pricing-calculator/UsageInputs.tsx
@@ -5,13 +5,25 @@ import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import { Clock3 } from "lucide-react";
 import {
-	getMeterInputConfig,
+	Clock3,
+	DatabaseZap,
+	Hash,
+	Image as ImageIcon,
+	Layers3,
+	MessageSquareText,
+	MousePointerClick,
+	Music2,
+	Video,
+} from "lucide-react";
+import {
 	formatMeterName,
+	getMeterInputConfig,
 	parseMeter,
 	type PricingMeter,
 } from "@/components/(data)/model/pricing/pricingHelpers";
+import { sanitizeRequestMultiplier } from "./calculatorState";
+import { formatSentenceLabel } from "./PricingTableVisuals";
 
 interface UsageInputsProps {
 	meters: PricingMeter[];
@@ -21,6 +33,18 @@ interface UsageInputsProps {
 	onMeterInputChange: (meter: string, value: string) => void;
 	onRequestMultiplierChange: (value: number) => void;
 	onPricingTimeUtcChange: (value: string) => void;
+}
+
+function MeterInputIcon({ meterName }: { meterName: string }) {
+	const name = meterName.toLowerCase();
+	if (name.includes("cached")) return <DatabaseZap className="size-4" />;
+	if (name.includes("image")) return <ImageIcon className="size-4" />;
+	if (name.includes("video")) return <Video className="size-4" />;
+	if (name.includes("music") || name.includes("audio")) return <Music2 className="size-4" />;
+	if (name.includes("request")) return <MousePointerClick className="size-4" />;
+	if (name.includes("text")) return <MessageSquareText className="size-4" />;
+	if (name.includes("token")) return <Hash className="size-4" />;
+	return <Layers3 className="size-4" />;
 }
 
 export function UsageInputs({
@@ -35,99 +59,97 @@ export function UsageInputs({
 	const uniqueMeters = useMemo(() => {
 		const map = new Map<string, PricingMeter>();
 		for (const meter of meters) {
-			if (!map.has(meter.meter)) {
-				map.set(meter.meter, meter);
-			}
+			if (!map.has(meter.meter)) map.set(meter.meter, meter);
 		}
 		return Array.from(map.values());
 	}, [meters]);
 
-	const setCurrentUtcTime = () => {
-		onPricingTimeUtcChange(new Date().toISOString().slice(11, 16));
-	};
-
 	return (
 		<Card>
-			<CardHeader>
-				<CardTitle>Usage Inputs</CardTitle>
-			</CardHeader>
-			<CardContent className="space-y-4">
-				{uniqueMeters.map((meter) => {
-					const inputConfig = getMeterInputConfig(meter.unit, meter.meter);
-					const derivedUnit = parseMeter(meter.meter).unit;
-					const unitLabel =
-						derivedUnit !== "unknown" ? derivedUnit : meter.unit;
-					return (
-						<div key={meter.meter} className="space-y-2">
-							<Label htmlFor={meter.meter}>
-								{formatMeterName(meter.meter)}
-								<span className="text-xs text-muted-foreground ml-2">
-									({unitLabel})
-								</span>
-							</Label>
-							<Input
-								id={meter.meter}
-								type={inputConfig.type}
-								min="0"
-								step={inputConfig.step}
-								value={meterInputs[meter.meter] || ""}
-								onChange={(e) =>
-									onMeterInputChange(meter.meter, e.target.value)
-								}
-								placeholder={inputConfig.placeholder}
-							/>
-						</div>
-					);
-				})}
-
-				<div className="space-y-2 border-t pt-4">
-					<Label htmlFor="request-multiplier">
-						Number of Requests
-						<span className="text-xs text-muted-foreground block mt-1">
-							Multiply all meter values by this number
-						</span>
-					</Label>
-					<Input
-						id="request-multiplier"
-						type="number"
-						min="1"
-						step="1"
-						value={requestMultiplier}
-						onChange={(e) =>
-							onRequestMultiplierChange(parseInt(e.target.value, 10) || 1)
-						}
-						placeholder="1"
-					/>
-					<p className="text-xs text-muted-foreground">
-						Example: 100 input tokens x 1000 requests = 100,000 total tokens
+			<CardHeader className="border-b bg-muted/10">
+				<CardTitle className="space-y-1">
+					<span>Usage inputs</span>
+					<p className="text-xs font-normal text-muted-foreground">
+						Enter the usage for one request, then scale it across your expected request volume.
 					</p>
+				</CardTitle>
+			</CardHeader>
+			<CardContent className="space-y-4 pt-5">
+				<div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-3">
+					{uniqueMeters.map((meter) => {
+						const inputConfig = getMeterInputConfig(meter.unit, meter.meter);
+						const derivedUnit = parseMeter(meter.meter).unit;
+						const unitLabel = derivedUnit !== "unknown" ? derivedUnit : meter.unit;
+						return (
+							<div key={meter.meter} className="rounded-xl border bg-muted/10 p-3">
+								<Label htmlFor={meter.meter} className="mb-2 flex items-center gap-2">
+									<span className="flex size-7 items-center justify-center rounded-lg bg-background text-muted-foreground shadow-xs">
+										<MeterInputIcon meterName={meter.meter} />
+									</span>
+									<span className="min-w-0">
+										<span className="block truncate text-xs font-medium">{formatSentenceLabel(formatMeterName(meter.meter))}</span>
+										<span className="block text-[10px] font-normal text-muted-foreground">Per request • {unitLabel}</span>
+									</span>
+								</Label>
+								<Input
+									id={meter.meter}
+									type={inputConfig.type}
+									min="0"
+									step={inputConfig.step}
+									value={meterInputs[meter.meter] || ""}
+									onChange={(event) => onMeterInputChange(meter.meter, event.target.value)}
+									placeholder={inputConfig.placeholder}
+									className="h-10 rounded-lg bg-background"
+								/>
+							</div>
+						);
+					})}
 				</div>
 
-				<div className="space-y-2 border-t pt-4">
-					<Label htmlFor="pricing-time-utc">
-						Pricing Time
-						<span className="text-xs text-muted-foreground block mt-1">
-							UTC time used for provider time-window prices
-						</span>
-					</Label>
-					<div className="flex gap-2">
+				<div className="grid gap-3 border-t pt-4 md:grid-cols-2">
+					<div className="rounded-xl border bg-muted/10 p-3">
+						<Label htmlFor="request-multiplier" className="mb-2 flex items-center gap-2 text-xs">
+							<MousePointerClick className="size-4 text-muted-foreground" />
+							Number of requests
+						</Label>
 						<Input
-							id="pricing-time-utc"
-							type="time"
-							step="60"
-							value={pricingTimeUtc}
-							onChange={(e) => onPricingTimeUtcChange(e.target.value)}
+							id="request-multiplier"
+							type="number"
+							min="1"
+							step="1"
+							value={requestMultiplier}
+							onChange={(event) => onRequestMultiplierChange(sanitizeRequestMultiplier(Number(event.target.value)))}
+							className="h-10 rounded-lg bg-background"
 						/>
-						<Button
-							type="button"
-							variant="outline"
-							size="icon"
-							onClick={setCurrentUtcTime}
-							aria-label="Use current UTC time"
-							title="Use current UTC time"
-						>
-							<Clock3 className="h-4 w-4" />
-						</Button>
+						<p className="mt-2 text-[11px] text-muted-foreground">Every meter value is multiplied by this request count.</p>
+					</div>
+
+					<div className="rounded-xl border bg-muted/10 p-3">
+						<Label htmlFor="pricing-time-utc" className="mb-2 flex items-center gap-2 text-xs">
+							<Clock3 className="size-4 text-muted-foreground" />
+							Pricing time in UTC
+						</Label>
+						<div className="flex gap-2">
+							<Input
+								id="pricing-time-utc"
+								type="time"
+								step="60"
+								value={pricingTimeUtc}
+								onChange={(event) => onPricingTimeUtcChange(event.target.value)}
+								className="h-10 rounded-lg bg-background"
+							/>
+							<Button
+								type="button"
+								variant="outline"
+								size="icon"
+								className="size-10 rounded-lg bg-background"
+								onClick={() => onPricingTimeUtcChange(new Date().toISOString().slice(11, 16))}
+								aria-label="Use current UTC time"
+							>
+								<Clock3 className="size-4" />
+							</Button>
+						</div>
+						<p className="mt-2 text-[11px] text-muted-foreground">Used when a provider has time-window pricing.</p>
 					</div>
 				</div>
 			</CardContent>

--- a/apps/web/src/components/(tools)/pricing-calculator/blendedRate.ts
+++ b/apps/web/src/components/(tools)/pricing-calculator/blendedRate.ts
@@ -1,0 +1,55 @@
+import {
+	resolvePricingMeterPrice,
+	type PricingMeter,
+} from "@/components/(data)/model/pricing/pricingHelpers";
+
+export type BlendedRate = {
+	blendedPer1M: number;
+	cacheHitPer1M: number;
+	inputPer1M: number;
+	outputPer1M: number;
+	usesInputForCache: boolean;
+};
+
+function pricePerMillion(meter: PricingMeter, pricingTimeUtc: string): number {
+	return (
+		(resolvePricingMeterPrice(meter, pricingTimeUtc).pricePerUnit /
+			(meter.unit_size || 1)) * 1_000_000
+	);
+}
+
+export function calculateArtificialAnalysisBlendedRate(
+	meters: PricingMeter[],
+	pricingTimeUtc: string
+): BlendedRate | null {
+	const inputMeter = meters.find((meter) => {
+		const name = meter.meter.toLowerCase();
+		return name.includes("input") && name.includes("token") && !name.includes("cache");
+	});
+	const outputMeter = meters.find((meter) => {
+		const name = meter.meter.toLowerCase();
+		return name.includes("output") && name.includes("token");
+	});
+	if (!inputMeter || !outputMeter) return null;
+
+	const cacheHitMeter = meters.find((meter) => {
+		const name = meter.meter.toLowerCase();
+		const isCacheRead =
+			(name.includes("cache") && (name.includes("read") || name.includes("hit"))) ||
+			name.includes("cached_input");
+		return isCacheRead && name.includes("token") && !name.includes("write");
+	});
+	const inputPer1M = pricePerMillion(inputMeter, pricingTimeUtc);
+	const outputPer1M = pricePerMillion(outputMeter, pricingTimeUtc);
+	const cacheHitPer1M = cacheHitMeter
+		? pricePerMillion(cacheHitMeter, pricingTimeUtc)
+		: inputPer1M;
+
+	return {
+		inputPer1M,
+		outputPer1M,
+		cacheHitPer1M,
+		usesInputForCache: !cacheHitMeter,
+		blendedPer1M: cacheHitPer1M * 0.7 + inputPer1M * 0.2 + outputPer1M * 0.1,
+	};
+}

--- a/apps/web/src/components/(tools)/pricing-calculator/calculatorState.test.ts
+++ b/apps/web/src/components/(tools)/pricing-calculator/calculatorState.test.ts
@@ -1,0 +1,80 @@
+import {
+	comparePricingEndpoints,
+	createModelSelectionId,
+	sameStringArray,
+	sanitizeMeterInputs,
+	sanitizeModelConfigs,
+	sanitizeModelSelections,
+	sanitizePricingTime,
+	sanitizeRequestMultiplier,
+} from "./calculatorState";
+
+describe("pricing calculator URL state", () => {
+	test.each([
+		[Number.NaN, 1],
+		[Number.POSITIVE_INFINITY, 1],
+		[-5, 1],
+		[0, 1],
+		[1.9, 1],
+		[25, 25],
+	])("sanitizes request multiplier %p to %p", (value, expected) => {
+		expect(sanitizeRequestMultiplier(value)).toBe(expected);
+	});
+
+	test("accepts only valid UTC times", () => {
+		expect(sanitizePricingTime("09:45")).toBe("09:45");
+		expect(sanitizePricingTime("24:00")).toBe("");
+		expect(sanitizePricingTime("not-a-time")).toBe("");
+	});
+
+	test("drops malformed and negative meter inputs", () => {
+		expect(
+			sanitizeMeterInputs({ input_tokens: "1000", output_tokens: "-2", invalid: {} })
+		).toEqual({ input_tokens: "1000" });
+	});
+
+	test("keeps only complete model configurations", () => {
+		expect(
+			sanitizeModelConfigs({
+				"openai/gpt": {
+					endpoint: "responses",
+					provider: "openai",
+					pricingPlan: "standard",
+				},
+				broken: { endpoint: "responses" },
+			})
+		).toEqual({
+			"openai/gpt": {
+				endpoint: "responses",
+				provider: "openai",
+				pricingPlan: "standard",
+			},
+		});
+	});
+
+	test("compares model selections in order", () => {
+		expect(sameStringArray(["a", "b"], ["a", "b"])).toBe(true);
+		expect(sameStringArray(["a", "b"], ["b", "a"])).toBe(false);
+	});
+
+	test("keeps duplicate models as independently addressable selections", () => {
+		const selections = [{ id: "openai/gpt", modelId: "openai/gpt" }];
+		expect(createModelSelectionId("openai/gpt", selections)).toBe("openai/gpt::2");
+		expect(sanitizeModelSelections([
+			...selections,
+			{ id: "openai/gpt::2", modelId: "openai/gpt" },
+			{ id: "openai/gpt::2", modelId: "duplicate-is-dropped" },
+		])).toEqual([
+			{ id: "openai/gpt", modelId: "openai/gpt" },
+			{ id: "openai/gpt::2", modelId: "openai/gpt" },
+		]);
+	});
+
+	test("prefers synchronous generation endpoints over batch endpoints", () => {
+		expect(["batch", "text.generate", "responses"].sort(comparePricingEndpoints)).toEqual([
+			"responses",
+			"text.generate",
+			"batch",
+		]);
+	});
+});

--- a/apps/web/src/components/(tools)/pricing-calculator/calculatorState.ts
+++ b/apps/web/src/components/(tools)/pricing-calculator/calculatorState.ts
@@ -1,0 +1,129 @@
+export type CalculatorModelConfig = {
+	endpoint: string;
+	provider: string;
+	pricingPlan: string;
+};
+
+export type CalculatorModelSelection = {
+	id: string;
+	modelId: string;
+};
+
+export type CalculatorCatalogModel = {
+	modelId: string;
+	displayName: string;
+	organisationId: string;
+	organisationName: string;
+	releaseDate?: string | null;
+	announcementDate?: string | null;
+};
+
+const UTC_TIME_PATTERN = /^(?:[01]\d|2[0-3]):[0-5]\d$/;
+
+const ENDPOINT_PREFERENCE = [
+	"responses",
+	"text.generate",
+	"chat.completions",
+	"messages",
+	"text.embed",
+	"image.generate",
+	"audio.speech",
+	"video.generate",
+];
+
+export function comparePricingEndpoints(left: string, right: string): number {
+	const leftIndex = ENDPOINT_PREFERENCE.indexOf(left);
+	const rightIndex = ENDPOINT_PREFERENCE.indexOf(right);
+	if (leftIndex !== -1 || rightIndex !== -1) {
+		if (leftIndex === -1) return 1;
+		if (rightIndex === -1) return -1;
+		return leftIndex - rightIndex;
+	}
+	const leftIsAsync = /batch|async|file/i.test(left);
+	const rightIsAsync = /batch|async|file/i.test(right);
+	if (leftIsAsync !== rightIsAsync) return leftIsAsync ? 1 : -1;
+	return left.localeCompare(right);
+}
+
+export function sanitizeRequestMultiplier(value: number): number {
+	if (!Number.isFinite(value)) return 1;
+	return Math.max(1, Math.trunc(value));
+}
+
+export function sanitizePricingTime(value?: string | null): string {
+	return value && UTC_TIME_PATTERN.test(value) ? value : "";
+}
+
+export function sanitizeMeterInputs(
+	value: Record<string, unknown> | null | undefined
+): Record<string, string> {
+	if (!value || typeof value !== "object" || Array.isArray(value)) return {};
+
+	const sanitized: Record<string, string> = {};
+	for (const [meter, rawValue] of Object.entries(value)) {
+		if (typeof rawValue !== "string") continue;
+		const parsed = Number(rawValue);
+		if (rawValue === "" || (Number.isFinite(parsed) && parsed >= 0)) {
+			sanitized[meter] = rawValue;
+		}
+	}
+	return sanitized;
+}
+
+export function sanitizeModelConfigs(
+	value: Record<string, unknown> | null | undefined
+): Record<string, CalculatorModelConfig> {
+	if (!value || typeof value !== "object" || Array.isArray(value)) return {};
+
+	const sanitized: Record<string, CalculatorModelConfig> = {};
+	for (const [modelId, rawConfig] of Object.entries(value)) {
+		if (!rawConfig || typeof rawConfig !== "object" || Array.isArray(rawConfig)) {
+			continue;
+		}
+		const config = rawConfig as Record<string, unknown>;
+		if (
+			typeof config.endpoint !== "string" ||
+			typeof config.provider !== "string" ||
+			typeof config.pricingPlan !== "string"
+		) {
+			continue;
+		}
+		sanitized[modelId] = {
+			endpoint: config.endpoint,
+			provider: config.provider,
+			pricingPlan: config.pricingPlan,
+		};
+	}
+	return sanitized;
+}
+
+export function sanitizeModelSelections(value: unknown): CalculatorModelSelection[] {
+	if (!Array.isArray(value)) return [];
+	const seen = new Set<string>();
+	const selections: CalculatorModelSelection[] = [];
+	for (const rawSelection of value) {
+		if (!rawSelection || typeof rawSelection !== "object" || Array.isArray(rawSelection)) continue;
+		const selection = rawSelection as Record<string, unknown>;
+		if (typeof selection.id !== "string" || typeof selection.modelId !== "string") continue;
+		if (!selection.id || !selection.modelId || seen.has(selection.id)) continue;
+		seen.add(selection.id);
+		selections.push({ id: selection.id, modelId: selection.modelId });
+	}
+	return selections;
+}
+
+export function createModelSelectionId(
+	modelId: string,
+	selections: CalculatorModelSelection[]
+): string {
+	if (!selections.some((selection) => selection.id === modelId)) return modelId;
+	let suffix = 2;
+	while (selections.some((selection) => selection.id === `${modelId}::${suffix}`)) {
+		suffix += 1;
+	}
+	return `${modelId}::${suffix}`;
+}
+
+export function sameStringArray(left: string[], right: string[]): boolean {
+	return left.length === right.length && left.every((value, index) => value === right[index]);
+}

--- a/apps/web/src/components/(tools)/pricing-calculator/pricingCalculatorMath.test.ts
+++ b/apps/web/src/components/(tools)/pricing-calculator/pricingCalculatorMath.test.ts
@@ -46,6 +46,30 @@ describe("pricing calculator arithmetic", () => {
 		expect(tiers.map((tier) => tier.meters.at(0)?.price_per_unit)).toEqual(["30", "45"]);
 	});
 
+	test("does not guess a conditional rate when a required parameter is unavailable", () => {
+		const meters = [
+			{
+				meter: "output_image",
+				unit: "image",
+				unit_size: 1,
+				price_per_unit: "0.011",
+				currency: "USD",
+				conditions: [{ path: "image_params.quality", op: "eq", value: "low" }],
+			},
+			{
+				meter: "output_image",
+				unit: "image",
+				unit_size: 1,
+				price_per_unit: "0.25",
+				currency: "USD",
+				conditions: [{ path: "image_params.quality", op: "eq", value: "high" }],
+			},
+		];
+
+		expect(selectPricingMetersForUsage(meters, {})).toEqual([]);
+		expect(selectPricingMetersForUsage(meters, { "image_params.quality": "high" }).at(0)?.price_per_unit).toBe("0.25");
+	});
+
 	test("calculates usage cost from the meter unit size", () => {
 		expect(calculateCost(2_000_000, inputTokenMeter)).toBe(10);
 	});

--- a/apps/web/src/components/(tools)/pricing-calculator/pricingCalculatorMath.test.ts
+++ b/apps/web/src/components/(tools)/pricing-calculator/pricingCalculatorMath.test.ts
@@ -1,0 +1,86 @@
+import {
+	calculateCost,
+	calculateUnits,
+	formatQuantity,
+} from "@/components/(data)/model/pricing/pricingHelpers";
+import { calculateArtificialAnalysisBlendedRate } from "./blendedRate";
+import {
+	getPricingContextTiers,
+	selectPricingMetersForUsage,
+} from "./pricingMeterConditions";
+
+const inputTokenMeter = {
+	unit_size: 1_000_000,
+	price_per_unit: "5",
+};
+
+describe("pricing calculator arithmetic", () => {
+	test("uses standard pricing until a long-context condition matches", () => {
+		const meters = [
+			{
+				meter: "output_text_tokens",
+				unit: "token",
+				unit_size: 1_000_000,
+				price_per_unit: "45",
+				currency: "USD",
+				conditions: [{ path: "input_tokens", op: "gt", value: 272_000 }],
+			},
+			{
+				meter: "output_text_tokens",
+				unit: "token",
+				unit_size: 1_000_000,
+				price_per_unit: "30",
+				currency: "USD",
+				conditions: [],
+			},
+		];
+
+		expect(selectPricingMetersForUsage(meters, {}).at(0)?.price_per_unit).toBe("30");
+		expect(selectPricingMetersForUsage(meters, { input_text_tokens: 272_001 }).at(0)?.price_per_unit).toBe("45");
+
+		const tiers = getPricingContextTiers(meters);
+		expect(tiers.map((tier) => ({ label: tier.label, detail: tier.detail }))).toEqual([
+			{ label: "Standard context", detail: "Up to 272K input tokens" },
+			{ label: "Long context", detail: "Over 272K input tokens" },
+		]);
+		expect(tiers.map((tier) => tier.meters.at(0)?.price_per_unit)).toEqual(["30", "45"]);
+	});
+
+	test("calculates usage cost from the meter unit size", () => {
+		expect(calculateCost(2_000_000, inputTokenMeter)).toBe(10);
+	});
+
+	test("never returns a negative cost", () => {
+		expect(calculateCost(-2_000_000, inputTokenMeter)).toBe(0);
+	});
+
+	test("represents free usage as unlimited", () => {
+		const units = calculateUnits(10, {
+			unit_size: 1_000_000,
+			price_per_unit: "0",
+		});
+		expect(units).toBe(Number.POSITIVE_INFINITY);
+		expect(formatQuantity(units)).toBe("Unlimited");
+	});
+
+	test("uses the Artificial Analysis 7:2:1 cache-input-output blend", () => {
+		const rate = calculateArtificialAnalysisBlendedRate([
+			{ meter: "cached_read_text_tokens", unit: "token", unit_size: 1_000_000, price_per_unit: "1", currency: "USD" },
+			{ meter: "input_text_tokens", unit: "token", unit_size: 1_000_000, price_per_unit: "5", currency: "USD" },
+			{ meter: "output_text_tokens", unit: "token", unit_size: 1_000_000, price_per_unit: "10", currency: "USD" },
+		], "12:00");
+
+		expect(rate?.blendedPer1M).toBe(2.7);
+		expect(rate?.usesInputForCache).toBe(false);
+	});
+
+	test("uses the input rate for the cache share when no cache-hit rate exists", () => {
+		const rate = calculateArtificialAnalysisBlendedRate([
+			{ meter: "input_text_tokens", unit: "token", unit_size: 1_000_000, price_per_unit: "5", currency: "USD" },
+			{ meter: "output_text_tokens", unit: "token", unit_size: 1_000_000, price_per_unit: "10", currency: "USD" },
+		], "12:00");
+
+		expect(rate?.blendedPer1M).toBe(5.5);
+		expect(rate?.usesInputForCache).toBe(true);
+	});
+});

--- a/apps/web/src/components/(tools)/pricing-calculator/pricingMeterConditions.ts
+++ b/apps/web/src/components/(tools)/pricing-calculator/pricingMeterConditions.ts
@@ -68,16 +68,21 @@ function conditionMatches(
 	usage: Record<string, string | number | undefined>,
 ): boolean {
 	const path = typeof condition.path === "string" ? condition.path : "";
+	if (!path) return false;
+	if (condition.op === "eq" || condition.op === "neq") {
+		const actual = usage[path];
+		if (actual === undefined) return false;
+		const matches = String(actual) === String(condition.value);
+		return condition.op === "eq" ? matches : !matches;
+	}
 	const expected = Number(condition.value);
-	if (!path || !Number.isFinite(expected)) return false;
+	if (!Number.isFinite(expected)) return false;
 	const actual = numericUsageValue(usage, path);
 	switch (condition.op) {
 		case "gt": return actual > expected;
 		case "gte": return actual >= expected;
 		case "lt": return actual < expected;
 		case "lte": return actual <= expected;
-		case "eq": return actual === expected;
-		case "neq": return actual !== expected;
 		default: return false;
 	}
 }
@@ -116,8 +121,7 @@ export function selectPricingMetersForUsage(
 
 	return [...grouped.values()].map((candidates) => {
 		const matching = candidates.filter((meter) => meterConditionsMatch(meter, usage));
-		const pool = matching.length > 0 ? matching : candidates;
-		return pool.toSorted((a, b) => {
+		return matching.toSorted((a, b) => {
 			const conditionDifference = (b.conditions?.length ?? 0) - (a.conditions?.length ?? 0);
 			if (conditionDifference !== 0) return conditionDifference;
 			const aRate = Number(a.price_per_unit) / (Number(a.unit_size) || 1);

--- a/apps/web/src/components/(tools)/pricing-calculator/pricingMeterConditions.ts
+++ b/apps/web/src/components/(tools)/pricing-calculator/pricingMeterConditions.ts
@@ -1,0 +1,164 @@
+import type { PricingMeter } from "@/components/(data)/model/pricing/pricingHelpers";
+
+type PricingMeterCondition = {
+	path?: unknown;
+	op?: unknown;
+	value?: unknown;
+	or_group?: unknown;
+};
+
+export type PricingContextTier = {
+	key: string;
+	label: string;
+	detail: string;
+	inputTokens: number;
+	meters: PricingMeter[];
+};
+
+function compactTokenCount(value: number): string {
+	if (value >= 1_000_000) return `${Number((value / 1_000_000).toFixed(2))}M`;
+	if (value >= 1_000) return `${Number((value / 1_000).toFixed(1))}K`;
+	return value.toLocaleString();
+}
+
+function inputTokenThresholds(meters: PricingMeter[]): number[] {
+	const thresholds = new Set<number>();
+	for (const meter of meters) {
+		for (const condition of Array.isArray(meter.conditions) ? meter.conditions : []) {
+			const candidate = condition as PricingMeterCondition;
+			if (candidate.path !== "input_tokens") continue;
+			if (!["gt", "gte", "lt", "lte"].includes(String(candidate.op))) continue;
+			const value = Number(candidate.value);
+			if (Number.isFinite(value) && value > 0) thresholds.add(value);
+		}
+	}
+	return [...thresholds].toSorted((a, b) => a - b);
+}
+
+function meterRateSignature(meters: PricingMeter[]): string {
+	return meters
+		.map((meter) => `${meter.meter}:${meter.unit}:${meter.currency}:${meter.unit_size}:${meter.price_per_unit}`)
+		.toSorted()
+		.join("|");
+}
+
+function numericUsageValue(
+	usage: Record<string, string | number | undefined>,
+	path: string,
+): number {
+	const direct = Number(usage[path] ?? 0);
+	if (path !== "input_tokens" && path !== "output_tokens") {
+		return Number.isFinite(direct) ? direct : 0;
+	}
+	if (usage[path] !== undefined && Number.isFinite(direct)) return direct;
+
+	const tokenDirection = path === "input_tokens" ? "input" : "output";
+	return Object.entries(usage).reduce((total, [meter, rawValue]) => {
+		const isDirectionalMeter = meter.includes(`${tokenDirection}_`) && meter.endsWith("_tokens");
+		const isInputCacheMeter = tokenDirection === "input" &&
+			meter.startsWith("cached_") && meter.endsWith("_tokens");
+		if (!isDirectionalMeter && !isInputCacheMeter) return total;
+		const value = Number(rawValue ?? 0);
+		return total + (Number.isFinite(value) ? Math.max(0, value) : 0);
+	}, 0);
+}
+
+function conditionMatches(
+	condition: PricingMeterCondition,
+	usage: Record<string, string | number | undefined>,
+): boolean {
+	const path = typeof condition.path === "string" ? condition.path : "";
+	const expected = Number(condition.value);
+	if (!path || !Number.isFinite(expected)) return false;
+	const actual = numericUsageValue(usage, path);
+	switch (condition.op) {
+		case "gt": return actual > expected;
+		case "gte": return actual >= expected;
+		case "lt": return actual < expected;
+		case "lte": return actual <= expected;
+		case "eq": return actual === expected;
+		case "neq": return actual !== expected;
+		default: return false;
+	}
+}
+
+function meterConditionsMatch(
+	meter: PricingMeter,
+	usage: Record<string, string | number | undefined>,
+): boolean {
+	const conditions = Array.isArray(meter.conditions)
+		? meter.conditions as PricingMeterCondition[]
+		: [];
+	if (conditions.length === 0) return true;
+	const groups = new Map<string, PricingMeterCondition[]>();
+	for (const condition of conditions) {
+		const key = String(condition.or_group ?? "default");
+		const group = groups.get(key) ?? [];
+		group.push(condition);
+		groups.set(key, group);
+	}
+	return [...groups.values()].some((group) =>
+		group.every((condition) => conditionMatches(condition, usage))
+	);
+}
+
+export function selectPricingMetersForUsage(
+	meters: PricingMeter[],
+	usage: Record<string, string | number | undefined>,
+): PricingMeter[] {
+	const grouped = new Map<string, PricingMeter[]>();
+	for (const meter of meters) {
+		const key = `${meter.meter}:${meter.unit}:${meter.currency}`;
+		const group = grouped.get(key) ?? [];
+		group.push(meter);
+		grouped.set(key, group);
+	}
+
+	return [...grouped.values()].map((candidates) => {
+		const matching = candidates.filter((meter) => meterConditionsMatch(meter, usage));
+		const pool = matching.length > 0 ? matching : candidates;
+		return pool.toSorted((a, b) => {
+			const conditionDifference = (b.conditions?.length ?? 0) - (a.conditions?.length ?? 0);
+			if (conditionDifference !== 0) return conditionDifference;
+			const aRate = Number(a.price_per_unit) / (Number(a.unit_size) || 1);
+			const bRate = Number(b.price_per_unit) / (Number(b.unit_size) || 1);
+			return aRate - bRate;
+		})[0];
+	}).filter((meter): meter is PricingMeter => Boolean(meter));
+}
+
+export function getPricingContextTiers(meters: PricingMeter[]): PricingContextTier[] {
+	const thresholds = inputTokenThresholds(meters);
+	const standardMeters = selectPricingMetersForUsage(meters, { input_tokens: 0 });
+	if (thresholds.length === 0) {
+		return [{
+			key: "current",
+			label: "Published rate",
+			detail: "No context-based price change",
+			inputTokens: 0,
+			meters: standardMeters,
+		}];
+	}
+
+	const samples = [0, ...thresholds.map((threshold) => threshold + 1)];
+	const tiers = samples.map((inputTokens, index): PricingContextTier => {
+		const lowerThreshold = index > 0 ? thresholds[index - 1] : null;
+		const upperThreshold = thresholds[index] ?? null;
+		const detail = lowerThreshold === null
+			? `Up to ${compactTokenCount(upperThreshold ?? 0)} input tokens`
+			: upperThreshold === null
+				? `Over ${compactTokenCount(lowerThreshold)} input tokens`
+				: `${compactTokenCount(lowerThreshold)} to ${compactTokenCount(upperThreshold)} input tokens`;
+		return {
+			key: index === 0 ? "standard-context" : `context-${inputTokens}`,
+			label: index === 0 ? "Standard context" : index === samples.length - 1 ? "Long context" : `Context tier ${index + 1}`,
+			detail,
+			inputTokens,
+			meters: selectPricingMetersForUsage(meters, { input_tokens: inputTokens }),
+		};
+	});
+
+	return tiers.filter((tier, index) =>
+		index === 0 || meterRateSignature(tier.meters) !== meterRateSignature(tiers[index - 1].meters)
+	);
+}

--- a/apps/web/src/lib/auth/authOrigin.test.ts
+++ b/apps/web/src/lib/auth/authOrigin.test.ts
@@ -46,6 +46,7 @@ describe("auth origin helpers", () => {
 	it("never uses an arbitrary URL for preview auth callbacks", () => {
 		expect(
 			resolveVercelPreviewAuthOrigin({
+				NODE_ENV: "production",
 				VERCEL_ENV: "preview",
 				VERCEL_URL: "https://example.com",
 			} as NodeJS.ProcessEnv),

--- a/apps/web/src/lib/fetchers/frontend/fetchFrontendPricingModels.ts
+++ b/apps/web/src/lib/fetchers/frontend/fetchFrontendPricingModels.ts
@@ -1,0 +1,17 @@
+import type { PricingModel } from "@/lib/fetchers/pricing/getPricingModels";
+import { fetchPublicWebApi } from "@/lib/web-api/client";
+
+export async function fetchFrontendPricingModels(
+	modelIds: string[] = [],
+): Promise<PricingModel[]> {
+	const ids = [...new Set(modelIds.map((value) => value.trim()).filter(Boolean))];
+	const query = ids.length > 0
+		? `?model_ids=${encodeURIComponent(ids.join(","))}`
+		: "";
+	const models = (await fetchPublicWebApi<{ models: PricingModel[] }>(
+		`/api/_web/pricing/models${query}`,
+	)).models;
+	if (ids.length === 0) return models;
+	const requested = new Set(ids);
+	return models.filter((model) => requested.has(model.model));
+}

--- a/apps/web/src/lib/fetchers/frontend/fetchPublicCatalog.ts
+++ b/apps/web/src/lib/fetchers/frontend/fetchPublicCatalog.ts
@@ -100,7 +100,6 @@ import {
 	fetchOptionalPublicWebApi,
 	fetchPublicWebApi,
 } from "@/lib/web-api/client";
-import type { PricingModel } from "@/lib/fetchers/pricing/getPricingModels";
 import type {
 	AppsIndexabilitySnapshot,
 	MarketShareData,
@@ -703,10 +702,6 @@ export async function fetchFrontendCountry(
 		`/api/_web/countries/${encodeURIComponent(iso.toUpperCase())}`,
 	);
 	return payload?.country ?? null;
-}
-
-export async function fetchFrontendPricingModels(): Promise<PricingModel[]> {
-	return (await fetchPublicWebApi<{ models: PricingModel[] }>("/api/_web/pricing/models")).models;
 }
 
 export async function fetchFrontendMarketplacePresets(): Promise<


### PR DESCRIPTION
## Summary

- clarify that Phaseo is entirely pay as you go, with no enterprise plan, contracts, or monthly and yearly commitments
- present BYOK pricing as 1 million requests free each month, then a 2.5% service fee, and align gateway billing logic and tests
- rebuild the pricing comparison with clearer feature rows, competitor columns, restrained highlights, provider logos, and expanded FAQs
- rebuild the pricing calculator around the cached model catalogue, virtualized multi-model selection, duplicate model comparisons, URL-persisted state, and richer provider and plan controls
- support context-dependent pricing meters, including aligned standard and long-context comparisons across models
- keep catalogue discovery on `/models` and load selected pricing through the Cloudflare pricing endpoint backed by the V2 normalized data tables
- paginate and filter V2 provider routes so the calculator can find models beyond the first PostgREST page without downloading unrelated pricing meters

## Data path

The calculator uses the main cached `/models` catalogue for model discovery. Once models are selected, it requests pricing meters from the Cloudflare web API route, which reads `v2_model_provider_routes`, `v2_models`, `v2_pricing_skus`, and `v2_pricing_sku_meters`.

## Validation

- `pnpm --filter @phaseo/web typecheck`
- `pnpm --filter @phaseo/web-api typecheck`
- `pnpm --filter @phaseo/gateway-api typecheck`
- calculator Jest suites: 18 tests passed
- V2 pricing endpoint Vitest suite: 3 tests passed
- BYOK fee Vitest suite: 5 tests passed
- scoped ESLint across changed web, web API, and gateway files: 0 errors
- `git diff --check`

The full web lint still reports existing repository-wide baseline findings in unrelated files; the files changed here pass the scoped lint with two warnings and no errors.

Created with Codex
