### PR TITLE
Fix gateway context capability params and timing capture

### DIFF
--- a/apps/api/src/core/types.ts
+++ b/apps/api/src/core/types.ts
@@ -96,9 +96,10 @@ export type RequestMeta = {
     streamDisconnectAction?: "cancel_upstream" | "drain_upstream";
     before_ms?: number;           // Gateway preflight ("before" stage) latency
     beforeContextMs?: number;     // Context fetch + enrichment latency inside before
-    beforeContextCacheStatus?: "hit" | "miss" | "bypass";
+    beforeContextCacheStatus?: "hit" | "miss" | "bypass" | "credit_refresh";
     beforeContextKeyVersionMs?: number;
     beforeContextCacheReadMs?: number;
+    beforeContextCreditRefreshMs?: number;
     beforeContextRpcMs?: number;
     beforeContextEnrichMs?: number;
     beforeContextCacheWriteMs?: number;

--- a/apps/api/src/observability/events.test.ts
+++ b/apps/api/src/observability/events.test.ts
@@ -610,6 +610,32 @@ describe("emitGatewayRequestEvent", () => {
 		expect(JSON.stringify(event)).not.toContain("do-not-copy");
 	});
 
+	it("keeps provider header signals from error records when no result is available", async () => {
+		await emitGatewayRequestEvent({
+			requestId: "req_error_provider_headers_123",
+			workspaceId: "ws_error_provider_headers_123",
+			endpoint: "responses",
+			model: "openai/gpt-5-mini",
+			statusCode: 502,
+			success: false,
+			providerResponseHeaders: {
+				"OpenAI-Processing-Ms": "247.25",
+				"X-Request-ID": "req_openai_error",
+				"CF-Ray": "a216a79dcdd6722a-IAD",
+				"Server-Timing": "edge;dur=3.5, origin;dur=243.75",
+			},
+		});
+
+		expect(sendAxiomWideEventMock).toHaveBeenCalledTimes(1);
+		const event = sendAxiomWideEventMock.mock.calls[0]?.[0] as Record<string, unknown>;
+		expect(event).toMatchObject({
+			provider_processing_ms: 247.25,
+			provider_request_id: "req_openai_error",
+			provider_cf_ray: "a216a79dcdd6722a-IAD",
+			provider_server_timing: "edge;dur=3.5, origin;dur=243.75",
+		});
+	});
+
 	it("rejects malformed processing time and safely bounds provider header signals", async () => {
 		clearRuntime();
 		configureRuntime({

--- a/apps/api/src/observability/events.test.ts
+++ b/apps/api/src/observability/events.test.ts
@@ -552,6 +552,118 @@ describe("emitGatewayRequestEvent", () => {
 		expect(event.gateway_response_redacted_json).toBeUndefined();
 	});
 
+	it("keeps allowlisted provider timing headers on compact success events", async () => {
+		clearRuntime();
+		configureRuntime({
+			SUPABASE_URL: "https://example.supabase.co",
+			SUPABASE_SERVICE_ROLE_KEY: "service-role-key",
+			GATEWAY_CACHE: {} as KVNamespace,
+			NODE_ENV: "test",
+			AXIOM_API_KEY: "axiom_test_key",
+			AXIOM_DATASET: "gateway-wide",
+			AXIOM_SUCCESS_SAMPLE_RATE: "1",
+			AXIOM_DETAIL_SAMPLE_RATE: "0",
+			AXIOM_SLOW_REQUEST_MS: "999999",
+		} as any);
+
+		const result = {
+			kind: "stream",
+			provider: "openai",
+			upstream: new Response(null, {
+				status: 200,
+				headers: {
+					"openai-processing-ms": "386.5",
+					"x-request-id": "req_openai_primary",
+					"request-id": "req_openai_fallback",
+					"cf-ray": "a216a79dcdd6722a-ATL",
+					"server-timing": "edge;dur=4.2, origin;dur=382.3",
+					"set-cookie": "do-not-copy=this-header",
+				},
+			}),
+			generationTimeMs: 500,
+			bill: {
+				cost_cents: 0,
+				currency: "USD",
+			},
+		} as unknown as RequestResult;
+
+		await emitGatewayRequestEvent({
+			requestId: "req_compact_provider_headers_123",
+			workspaceId: "ws_compact_provider_headers_123",
+			endpoint: "responses",
+			model: "openai/gpt-5-mini",
+			statusCode: 200,
+			success: true,
+			result,
+		});
+
+		expect(sendAxiomWideEventMock).toHaveBeenCalledTimes(1);
+		const event = sendAxiomWideEventMock.mock.calls[0]?.[0] as Record<string, unknown>;
+		expect(event).toMatchObject({
+			observability_detail_level: "compact",
+			provider_processing_ms: 386.5,
+			provider_request_id: "req_openai_primary",
+			provider_cf_ray: "a216a79dcdd6722a-ATL",
+			provider_server_timing: "edge;dur=4.2, origin;dur=382.3",
+		});
+		expect(event.provider_response_headers_json).toBeUndefined();
+		expect(JSON.stringify(event)).not.toContain("do-not-copy");
+	});
+
+	it("rejects malformed processing time and safely bounds provider header signals", async () => {
+		clearRuntime();
+		configureRuntime({
+			SUPABASE_URL: "https://example.supabase.co",
+			SUPABASE_SERVICE_ROLE_KEY: "service-role-key",
+			GATEWAY_CACHE: {} as KVNamespace,
+			NODE_ENV: "test",
+			AXIOM_API_KEY: "axiom_test_key",
+			AXIOM_DATASET: "gateway-wide",
+			AXIOM_SUCCESS_SAMPLE_RATE: "1",
+			AXIOM_DETAIL_SAMPLE_RATE: "0",
+			AXIOM_SLOW_REQUEST_MS: "999999",
+		} as any);
+
+		const result = {
+			kind: "stream",
+			provider: "openai",
+			upstream: new Response(null, {
+				status: 200,
+				headers: {
+					"openai-processing-ms": "not-a-number",
+					"request-id": "r".repeat(400),
+					"cf-ray": "c".repeat(300),
+					"server-timing": "s".repeat(2_000),
+				},
+			}),
+			generationTimeMs: 500,
+			bill: {
+				cost_cents: 0,
+				currency: "USD",
+			},
+		} as unknown as RequestResult;
+
+		await emitGatewayRequestEvent({
+			requestId: "req_compact_bounded_headers_123",
+			workspaceId: "ws_compact_bounded_headers_123",
+			endpoint: "responses",
+			model: "openai/gpt-5-mini",
+			statusCode: 200,
+			success: true,
+			result,
+		});
+
+		const event = sendAxiomWideEventMock.mock.calls[0]?.[0] as Record<string, unknown>;
+		expect(event.provider_processing_ms).toBeUndefined();
+		expect(String(event.provider_request_id)).toHaveLength(256);
+		expect(String(event.provider_request_id)).toMatch(/\.\.\.\[truncated\]$/);
+		expect(String(event.provider_cf_ray)).toHaveLength(128);
+		expect(String(event.provider_cf_ray)).toMatch(/\.\.\.\[truncated\]$/);
+		expect(String(event.provider_server_timing)).toHaveLength(512);
+		expect(String(event.provider_server_timing)).toMatch(/\.\.\.\[truncated\]$/);
+		expect(event.provider_response_headers_json).toBeUndefined();
+	});
+
 	it("retains a safe provider snapshot and attempt timeline on compact success events", async () => {
 		clearRuntime();
 		configureRuntime({

--- a/apps/api/src/observability/events.ts
+++ b/apps/api/src/observability/events.ts
@@ -378,11 +378,28 @@ const PROVIDER_SERVER_TIMING_MAX_LENGTH = 512;
 const PROVIDER_PROCESSING_HEADER_MAX_LENGTH = 64;
 const TRUNCATED_HEADER_SUFFIX = "...[truncated]";
 
-function readProviderHeader(headers: Headers | null | undefined, names: string[]): string | null {
+type ProviderHeaderSource = Headers | Record<string, string>;
+
+function readProviderHeader(
+    headers: ProviderHeaderSource | null | undefined,
+    names: string[],
+): string | null {
     if (!headers) return null;
     try {
+        const getHeader = (headers as Headers).get;
+        if (typeof getHeader === "function") {
+            for (const name of names) {
+                const value = getHeader.call(headers, name)?.trim();
+                if (value) return value;
+            }
+            return null;
+        }
+
+        const entries = Object.entries(headers as Record<string, string>);
         for (const name of names) {
-            const value = headers.get(name)?.trim();
+            const normalizedName = name.toLowerCase();
+            const match = entries.find(([key]) => key.toLowerCase() === normalizedName);
+            const value = typeof match?.[1] === "string" ? match[1].trim() : null;
             if (value) return value;
         }
     } catch {
@@ -392,7 +409,7 @@ function readProviderHeader(headers: Headers | null | undefined, names: string[]
 }
 
 function readBoundedProviderHeader(
-    headers: Headers | null | undefined,
+    headers: ProviderHeaderSource | null | undefined,
     names: string[],
     maxLength: number,
 ): string | null {
@@ -403,7 +420,7 @@ function readBoundedProviderHeader(
     return `${value.slice(0, prefixLength)}${TRUNCATED_HEADER_SUFFIX}`;
 }
 
-function readProviderProcessingMs(headers: Headers | null | undefined): number | null {
+function readProviderProcessingMs(headers: ProviderHeaderSource | null | undefined): number | null {
     const value = readProviderHeader(headers, ["openai-processing-ms"]);
     if (!value || value.length > PROVIDER_PROCESSING_HEADER_MAX_LENGTH) return null;
     if (!/^\d+(?:\.\d+)?$/.test(value)) return null;
@@ -413,7 +430,7 @@ function readProviderProcessingMs(headers: Headers | null | undefined): number |
         : null;
 }
 
-function readProviderHeaderSignals(headers: Headers | null | undefined) {
+function readProviderHeaderSignals(headers: ProviderHeaderSource | null | undefined) {
     return {
         processingMs: readProviderProcessingMs(headers),
         requestId: readBoundedProviderHeader(
@@ -1151,7 +1168,9 @@ export async function emitGatewayRequestEvent(args: EventArgs) {
         const sanitizedProviderResponseHeaders = includeDetailedPayloads
             ? sanitizeForAxiom(args.providerResponseHeaders ?? headersToRecord(args.result?.upstream?.headers))
             : null;
-        const providerHeaderSignals = readProviderHeaderSignals(args.result?.upstream?.headers);
+        const providerHeaderSignals = readProviderHeaderSignals(
+            args.result?.upstream?.headers ?? args.providerResponseHeaders,
+        );
         const sanitizedGatewayResponse = includeDetailedPayloads
             ? sanitizeForAxiom(args.gatewayResponse ?? null)
             : null;

--- a/apps/api/src/observability/events.ts
+++ b/apps/api/src/observability/events.ts
@@ -372,6 +372,64 @@ function headersToRecord(headers: Headers | null | undefined): Record<string, st
     return Object.keys(out).length > 0 ? out : null;
 }
 
+const PROVIDER_REQUEST_ID_MAX_LENGTH = 256;
+const PROVIDER_CF_RAY_MAX_LENGTH = 128;
+const PROVIDER_SERVER_TIMING_MAX_LENGTH = 512;
+const PROVIDER_PROCESSING_HEADER_MAX_LENGTH = 64;
+const TRUNCATED_HEADER_SUFFIX = "...[truncated]";
+
+function readProviderHeader(headers: Headers | null | undefined, names: string[]): string | null {
+    if (!headers) return null;
+    try {
+        for (const name of names) {
+            const value = headers.get(name)?.trim();
+            if (value) return value;
+        }
+    } catch {
+        // Observability must never interfere with the gateway response path.
+    }
+    return null;
+}
+
+function readBoundedProviderHeader(
+    headers: Headers | null | undefined,
+    names: string[],
+    maxLength: number,
+): string | null {
+    const value = readProviderHeader(headers, names);
+    if (!value) return null;
+    if (value.length <= maxLength) return value;
+    const prefixLength = Math.max(0, maxLength - TRUNCATED_HEADER_SUFFIX.length);
+    return `${value.slice(0, prefixLength)}${TRUNCATED_HEADER_SUFFIX}`;
+}
+
+function readProviderProcessingMs(headers: Headers | null | undefined): number | null {
+    const value = readProviderHeader(headers, ["openai-processing-ms"]);
+    if (!value || value.length > PROVIDER_PROCESSING_HEADER_MAX_LENGTH) return null;
+    if (!/^\d+(?:\.\d+)?$/.test(value)) return null;
+    const parsed = Number(value);
+    return Number.isFinite(parsed) && parsed >= 0 && parsed <= Number.MAX_SAFE_INTEGER
+        ? parsed
+        : null;
+}
+
+function readProviderHeaderSignals(headers: Headers | null | undefined) {
+    return {
+        processingMs: readProviderProcessingMs(headers),
+        requestId: readBoundedProviderHeader(
+            headers,
+            ["x-request-id", "request-id"],
+            PROVIDER_REQUEST_ID_MAX_LENGTH,
+        ),
+        cfRay: readBoundedProviderHeader(headers, ["cf-ray"], PROVIDER_CF_RAY_MAX_LENGTH),
+        serverTiming: readBoundedProviderHeader(
+            headers,
+            ["server-timing"],
+            PROVIDER_SERVER_TIMING_MAX_LENGTH,
+        ),
+    };
+}
+
 type RoutingDrop = {
     stage: string;
     providerId: string | null;
@@ -1093,6 +1151,7 @@ export async function emitGatewayRequestEvent(args: EventArgs) {
         const sanitizedProviderResponseHeaders = includeDetailedPayloads
             ? sanitizeForAxiom(args.providerResponseHeaders ?? headersToRecord(args.result?.upstream?.headers))
             : null;
+        const providerHeaderSignals = readProviderHeaderSignals(args.result?.upstream?.headers);
         const sanitizedGatewayResponse = includeDetailedPayloads
             ? sanitizeForAxiom(args.gatewayResponse ?? null)
             : null;
@@ -1357,6 +1416,10 @@ export async function emitGatewayRequestEvent(args: EventArgs) {
             time_to_upstream_request_ms: toNum(ctx?.meta?.timeToUpstreamRequestMs),
 			time_to_latest_upstream_request_ms: toNum(ctx?.meta?.timeToLatestUpstreamRequestMs),
 			upstream_headers_ms: toNum(ctx?.meta?.upstreamHeadersMs),
+			provider_processing_ms: providerHeaderSignals.processingMs,
+			provider_request_id: providerHeaderSignals.requestId,
+			provider_cf_ray: providerHeaderSignals.cfRay,
+			provider_server_timing: providerHeaderSignals.serverTiming,
 			provider_duration_ms: toNum(ctx?.meta?.provider_duration_ms),
 			upstream_request_count: toNum(ctx?.meta?.upstreamRequestCount),
 			upstream_poll_count: toNum(ctx?.meta?.upstreamPollCount),

--- a/apps/api/src/observability/events.ts
+++ b/apps/api/src/observability/events.ts
@@ -1399,6 +1399,7 @@ export async function emitGatewayRequestEvent(args: EventArgs) {
             before_context_cache_status: ctx?.meta?.beforeContextCacheStatus ?? null,
             before_context_key_version_ms: toNum(ctx?.meta?.beforeContextKeyVersionMs),
             before_context_cache_read_ms: toNum(ctx?.meta?.beforeContextCacheReadMs),
+            before_context_credit_refresh_ms: toNum(ctx?.meta?.beforeContextCreditRefreshMs),
             before_context_rpc_ms: toNum(ctx?.meta?.beforeContextRpcMs),
             before_context_enrich_ms: toNum(ctx?.meta?.beforeContextEnrichMs),
             before_context_cache_write_ms: toNum(ctx?.meta?.beforeContextCacheWriteMs),

--- a/apps/api/src/pipeline/before/context.credit-refresh.test.ts
+++ b/apps/api/src/pipeline/before/context.credit-refresh.test.ts
@@ -3,7 +3,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 const runtime = vi.hoisted(() => {
 	const store = new Map<string, string>();
 	const background: Promise<unknown>[] = [];
-	const pendingWriteResolvers: Array<() => void> = [];
+	const pendingWrites: Array<{ key: string; resolve: () => void }> = [];
 	let deferWrites = false;
 	let walletResult: {
 		data: { balance_nanos: number; reserved_nanos: number } | null;
@@ -25,7 +25,7 @@ const runtime = vi.hoisted(() => {
 		}),
 		put: vi.fn(async (key: string, value: string) => {
 			if (deferWrites) {
-				await new Promise<void>((resolve) => pendingWriteResolvers.push(resolve));
+				await new Promise<void>((resolve) => pendingWrites.push({ key, resolve }));
 			}
 			store.set(key, value);
 		}),
@@ -90,7 +90,7 @@ const runtime = vi.hoisted(() => {
 	return {
 		store,
 		background,
-		pendingWriteResolvers,
+		pendingWrites,
 		cache,
 		supabase: { rpc, from },
 		get deferWrites() {
@@ -176,7 +176,7 @@ describe("fetchGatewayContext credit-only cache refresh", () => {
 	beforeEach(() => {
 		runtime.store.clear();
 		runtime.background.length = 0;
-		runtime.pendingWriteResolvers.length = 0;
+		runtime.pendingWrites.length = 0;
 		runtime.deferWrites = false;
 		runtime.walletResult = {
 			data: { balance_nanos: 5_000_000_000, reserved_nanos: 1_000_000_000 },
@@ -217,11 +217,35 @@ describe("fetchGatewayContext credit-only cache refresh", () => {
 		expect(runtime.supabase.rpc).not.toHaveBeenCalled();
 		expect(runtime.supabase.from).toHaveBeenCalledTimes(1);
 		expect(runtime.supabase.from).toHaveBeenCalledWith("wallets");
-		expect(runtime.background).toHaveLength(1);
-		await Promise.all(runtime.background);
+		expect(runtime.background).toHaveLength(0);
 		expect(JSON.parse(runtime.store.get(`gateway:credit:${workspaceId}`) ?? "null")).toMatchObject({
 			credit: { ok: true, balanceNanos: 4_000_000_000 },
 		});
+	});
+
+	it("awaits a refreshed credit snapshot write before returning cached context", async () => {
+		seedContextCache();
+		runtime.deferWrites = true;
+		const { fetchGatewayContext } = await import("./context");
+		let settled = false;
+		const fetchPromise = fetchGatewayContext({
+			workspaceId,
+			model,
+			endpoint,
+			apiKeyId,
+			disableCache: false,
+		}).then((context) => {
+			settled = true;
+			return context;
+		});
+
+		await vi.waitFor(() => expect(runtime.pendingWrites).toHaveLength(1));
+		expect(runtime.pendingWrites[0]?.key).toBe(`gateway:credit:${workspaceId}`);
+		expect(settled).toBe(false);
+
+		runtime.pendingWrites.shift()?.resolve();
+		await fetchPromise;
+		expect(settled).toBe(true);
 	});
 
 	it("ignores stale legacy credit and fails closed using reserved funds", async () => {
@@ -275,7 +299,7 @@ describe("fetchGatewayContext credit-only cache refresh", () => {
 		expect(runtime.supabase.from).not.toHaveBeenCalled();
 	});
 
-	it("does not await full-context KV writes", async () => {
+	it("awaits full-context credit writes but leaves unrelated cache writes in the background", async () => {
 		runtime.store.set(`gateway:keyver:id:${apiKeyId}`, "1");
 		runtime.deferWrites = true;
 		const { fetchGatewayContext } = await import("./context");
@@ -291,13 +315,24 @@ describe("fetchGatewayContext credit-only cache refresh", () => {
 			return context;
 		});
 
-		await vi.waitFor(() => expect(runtime.cache.put).toHaveBeenCalledTimes(3));
-		await Promise.resolve();
-		expect(settled).toBe(true);
-		expect(runtime.background).toHaveLength(1);
+		await vi.waitFor(() => expect(runtime.pendingWrites).toHaveLength(1));
+		expect(runtime.pendingWrites[0]?.key).toBe(`gateway:credit:${workspaceId}`);
+		expect(settled).toBe(false);
 
-		for (const resolve of runtime.pendingWriteResolvers.splice(0)) resolve();
-		await Promise.all(runtime.background);
+		runtime.pendingWrites.shift()?.resolve();
+		await vi.waitFor(() => expect(runtime.cache.put).toHaveBeenCalledTimes(3));
+		await vi.waitFor(() => expect(settled).toBe(true));
+		expect(runtime.background).toHaveLength(1);
+		expect(runtime.pendingWrites.map(({ key }) => key).sort()).toEqual([
+			`gateway:dynamic:default:${workspaceId}:${apiKeyId}:v1`,
+			`gateway:static:v2:default:${workspaceId}:${endpoint}:${model}`,
+		]);
+
 		await fetchPromise;
+		runtime.store.delete(`gateway:credit:${workspaceId}`);
+
+		for (const pending of runtime.pendingWrites.splice(0)) pending.resolve();
+		await Promise.all(runtime.background);
+		expect(runtime.store.has(`gateway:credit:${workspaceId}`)).toBe(false);
 	});
 });

--- a/apps/api/src/pipeline/before/context.credit-refresh.test.ts
+++ b/apps/api/src/pipeline/before/context.credit-refresh.test.ts
@@ -1,0 +1,303 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const runtime = vi.hoisted(() => {
+	const store = new Map<string, string>();
+	const background: Promise<unknown>[] = [];
+	const pendingWriteResolvers: Array<() => void> = [];
+	let deferWrites = false;
+	let walletResult: {
+		data: { balance_nanos: number; reserved_nanos: number } | null;
+		error: { message: string } | null;
+	} = {
+		data: { balance_nanos: 5_000_000_000, reserved_nanos: 1_000_000_000 },
+		error: null,
+	};
+
+	const cache = {
+		get: vi.fn(async (key: string | string[]) => {
+			if (Array.isArray(key)) {
+				return new Map(key.flatMap((entry) => {
+					const value = store.get(entry);
+					return value == null ? [] : [[entry, value] as const];
+				}));
+			}
+			return store.get(key) ?? null;
+		}),
+		put: vi.fn(async (key: string, value: string) => {
+			if (deferWrites) {
+				await new Promise<void>((resolve) => pendingWriteResolvers.push(resolve));
+			}
+			store.set(key, value);
+		}),
+		delete: vi.fn(async (key: string) => {
+			store.delete(key);
+		}),
+	};
+
+	const contextPayload = {
+		workspace_id: "workspace_credit",
+		resolved_model: "resolved/openai-gpt-5.4-nano",
+		key_ok: { ok: true, reason: null },
+		key_limit_ok: { ok: true, reason: null },
+		credit_ok: { ok: true, reason: null, balance_nanos: 4_000_000_000 },
+		providers: [],
+		pricing: {},
+	};
+	const rpc = vi.fn(async () => ({ data: [contextPayload], error: null }));
+	const from = vi.fn((table: string) => {
+		if (table === "wallets") {
+			return {
+				select: () => ({
+					eq: () => ({
+						maybeSingle: async () => walletResult,
+					}),
+				}),
+			};
+		}
+		if (table === "workspace_settings") {
+			return {
+				select: () => ({
+					eq: () => ({
+						maybeSingle: async () => ({
+							data: {
+								routing_mode: null,
+								byok_fallback_enabled: false,
+								beta_channel_enabled: false,
+								alpha_channel_enabled: false,
+								cache_aware_routing_enabled: true,
+							},
+							error: null,
+						}),
+					}),
+				}),
+			};
+		}
+		if (table === "workspaces") {
+			return {
+				select: () => ({
+					eq: () => ({
+						maybeSingle: async () => ({
+							data: { billing_mode: "wallet" },
+							error: null,
+						}),
+					}),
+				}),
+			};
+		}
+		throw new Error(`Unexpected table: ${table}`);
+	});
+
+	return {
+		store,
+		background,
+		pendingWriteResolvers,
+		cache,
+		supabase: { rpc, from },
+		get deferWrites() {
+			return deferWrites;
+		},
+		set deferWrites(value: boolean) {
+			deferWrites = value;
+		},
+		get walletResult() {
+			return walletResult;
+		},
+		set walletResult(value) {
+			walletResult = value;
+		},
+	};
+});
+
+vi.mock("@/runtime/env", () => ({
+	getCache: () => runtime.cache as unknown as KVNamespace,
+	getSupabaseAdmin: () => runtime.supabase,
+	dispatchBackground: (promise: Promise<unknown>) => {
+		runtime.background.push(promise);
+	},
+}));
+
+const workspaceId = "workspace_credit";
+const apiKeyId = "key_credit";
+const model = "openai/gpt-5.4-nano";
+const endpoint = "chat.completions";
+
+const teamEnrichment = {
+	tier: "basic",
+	created_at: "2026-01-01T00:00:00.000Z",
+	account_age_days: 1,
+	balance_nanos: 9_000_000_000,
+	balance_usd: 9,
+	balance_is_low: false,
+	total_requests: 10,
+	total_spend_nanos: 1,
+	total_spend_usd: 0,
+	spend_24h_nanos: 1,
+	spend_24h_usd: 0,
+	spend_7d_nanos: 1,
+	spend_7d_usd: 0,
+	spend_30d_nanos: 1,
+	spend_30d_usd: 0,
+	requests_1h: 1,
+	requests_24h: 1,
+};
+
+function seedContextCache(options: { legacyCredit?: boolean; credit?: unknown } = {}): void {
+	runtime.store.set(`gateway:keyver:id:${apiKeyId}`, "1");
+	runtime.store.set(
+		`gateway:dynamic:default:${workspaceId}:${apiKeyId}:v1`,
+		JSON.stringify({
+			workspaceId,
+			key: { ok: true, reason: null, resetAt: null },
+			keyLimit: { ok: true, reason: null, resetAt: null, buckets: null },
+			teamEnrichment,
+			teamSettings: { billingMode: "wallet" },
+			...(options.legacyCredit
+				? { credit: { ok: true, reason: null, resetAt: null, balanceNanos: 9_000_000_000 } }
+				: {}),
+		}),
+	);
+	runtime.store.set(
+		`gateway:static:v2:default:${workspaceId}:${endpoint}:${model}`,
+		JSON.stringify({
+			workspaceId,
+			resolvedModel: model,
+			preset: null,
+			providers: [],
+			pricing: {},
+			testingMode: false,
+		}),
+	);
+	if (options.credit) {
+		runtime.store.set(`gateway:credit:${workspaceId}`, JSON.stringify(options.credit));
+	}
+}
+
+describe("fetchGatewayContext credit-only cache refresh", () => {
+	beforeEach(() => {
+		runtime.store.clear();
+		runtime.background.length = 0;
+		runtime.pendingWriteResolvers.length = 0;
+		runtime.deferWrites = false;
+		runtime.walletResult = {
+			data: { balance_nanos: 5_000_000_000, reserved_nanos: 1_000_000_000 },
+			error: null,
+		};
+		runtime.cache.get.mockClear();
+		runtime.cache.put.mockClear();
+		runtime.cache.delete.mockClear();
+		runtime.supabase.rpc.mockClear();
+		runtime.supabase.from.mockClear();
+		vi.resetModules();
+	});
+
+	it("refreshes only wallet credit and preserves the cached gateway context", async () => {
+		seedContextCache();
+		const { fetchGatewayContext } = await import("./context");
+
+		const context = await fetchGatewayContext({
+			workspaceId,
+			model,
+			endpoint,
+			apiKeyId,
+			disableCache: false,
+		});
+
+		expect(context.credit).toMatchObject({ ok: true, balanceNanos: 4_000_000_000 });
+		expect(context.teamEnrichment).toMatchObject({
+			balance_nanos: 4_000_000_000,
+			balance_usd: 4,
+			balance_is_low: false,
+		});
+		expect(context.contextTelemetry).toMatchObject({
+			cacheStatus: "credit_refresh",
+			rpcMs: null,
+			enrichMs: null,
+		});
+		expect(context.contextTelemetry?.creditRefreshMs).toEqual(expect.any(Number));
+		expect(runtime.supabase.rpc).not.toHaveBeenCalled();
+		expect(runtime.supabase.from).toHaveBeenCalledTimes(1);
+		expect(runtime.supabase.from).toHaveBeenCalledWith("wallets");
+		expect(runtime.background).toHaveLength(1);
+		await Promise.all(runtime.background);
+		expect(JSON.parse(runtime.store.get(`gateway:credit:${workspaceId}`) ?? "null")).toMatchObject({
+			credit: { ok: true, balanceNanos: 4_000_000_000 },
+		});
+	});
+
+	it("ignores stale legacy credit and fails closed using reserved funds", async () => {
+		seedContextCache({ legacyCredit: true });
+		runtime.walletResult = {
+			data: { balance_nanos: 1_500_000_000, reserved_nanos: 750_000_001 },
+			error: null,
+		};
+		const { fetchGatewayContext } = await import("./context");
+
+		const context = await fetchGatewayContext({
+			workspaceId,
+			model,
+			endpoint,
+			apiKeyId,
+			disableCache: false,
+		});
+
+		expect(context.credit).toMatchObject({
+			ok: false,
+			reason: "insufficient_funds",
+			balanceNanos: 749_999_999,
+		});
+		expect(context.contextTelemetry?.cacheStatus).toBe("credit_refresh");
+		expect(runtime.supabase.rpc).not.toHaveBeenCalled();
+	});
+
+	it("uses a valid separate credit snapshot without querying the wallet", async () => {
+		seedContextCache({
+			credit: {
+				workspaceId,
+				credit: { ok: true, reason: null, resetAt: null, balanceNanos: 3_000_000_000 },
+				teamEnrichment,
+			},
+		});
+		const { fetchGatewayContext } = await import("./context");
+
+		const context = await fetchGatewayContext({
+			workspaceId,
+			model,
+			endpoint,
+			apiKeyId,
+			disableCache: false,
+		});
+
+		expect(context.credit.balanceNanos).toBe(3_000_000_000);
+		expect(context.contextTelemetry).toMatchObject({
+			cacheStatus: "hit",
+			creditRefreshMs: null,
+		});
+		expect(runtime.supabase.from).not.toHaveBeenCalled();
+	});
+
+	it("does not await full-context KV writes", async () => {
+		runtime.store.set(`gateway:keyver:id:${apiKeyId}`, "1");
+		runtime.deferWrites = true;
+		const { fetchGatewayContext } = await import("./context");
+		let settled = false;
+		const fetchPromise = fetchGatewayContext({
+			workspaceId,
+			model,
+			endpoint,
+			apiKeyId,
+			disableCache: false,
+		}).then((context) => {
+			settled = true;
+			return context;
+		});
+
+		await vi.waitFor(() => expect(runtime.cache.put).toHaveBeenCalledTimes(3));
+		await Promise.resolve();
+		expect(settled).toBe(true);
+		expect(runtime.background).toHaveLength(1);
+
+		for (const resolve of runtime.pendingWriteResolvers.splice(0)) resolve();
+		await Promise.all(runtime.background);
+		await fetchPromise;
+	});
+});

--- a/apps/api/src/pipeline/before/context.shared.test.ts
+++ b/apps/api/src/pipeline/before/context.shared.test.ts
@@ -3,11 +3,70 @@ import {
 	computeAdaptiveTtlForDynamic,
 	computeStaticTtl,
 	hasConfiguredKeyLimits,
+	mergeCachedContext,
 	normalizeCapabilityStatus,
 	normalizeProviderStatus,
 	normalizeRoutingStatus,
+	splitContextForCache,
 	supportsEndpointViaModalities,
 } from "./context.shared";
+
+describe("credit cache composition", () => {
+	const teamEnrichment = {
+		tier: "basic",
+		created_at: "2026-01-01T00:00:00.000Z",
+		account_age_days: 1,
+		balance_nanos: 5_000_000_000,
+		balance_usd: 5,
+		balance_is_low: false,
+		total_requests: 1,
+		total_spend_nanos: 1,
+		total_spend_usd: 0,
+		spend_24h_nanos: 1,
+		spend_24h_usd: 0,
+		spend_7d_nanos: 1,
+		spend_7d_usd: 0,
+		spend_30d_nanos: 1,
+		spend_30d_usd: 0,
+		requests_1h: 1,
+		requests_24h: 1,
+	};
+
+	it("keeps observational team enrichment in dynamic context", () => {
+		const split = splitContextForCache({
+			workspaceId: "workspace_123",
+			key: { ok: true, reason: null, resetAt: null },
+			keyLimit: { ok: true, reason: null, resetAt: null },
+			credit: { ok: true, reason: null, resetAt: null, balanceNanos: 5_000_000_000 },
+			providers: [],
+			pricing: {},
+			teamEnrichment,
+		} as any);
+
+		expect(split.dynamic.teamEnrichment).toEqual(teamEnrichment);
+	});
+
+	it("does not fall back to stale credit embedded in a legacy dynamic entry", () => {
+		expect(() => mergeCachedContext({
+			dynamic: {
+				workspaceId: "workspace_123",
+				key: { ok: true, reason: null, resetAt: null },
+				keyLimit: { ok: true, reason: null, resetAt: null },
+				credit: { ok: true, reason: null, resetAt: null, balanceNanos: 5_000_000_000 },
+			},
+			static: {
+				workspaceId: "workspace_123",
+				resolvedModel: "openai/gpt-5.4-nano",
+				preset: null,
+				providers: [],
+				pricing: {},
+				testingMode: false,
+			},
+			credit: null,
+			endpoint: "chat.completions",
+		})).toThrow("gateway_context_credit_cache_missing");
+	});
+});
 
 describe("key limit cache policy", () => {
 	it("detects request and spend caps across every supported window", () => {

--- a/apps/api/src/pipeline/before/context.shared.ts
+++ b/apps/api/src/pipeline/before/context.shared.ts
@@ -257,7 +257,10 @@ export function mergeCachedContext(args: {
 	credit?: CreditContextCacheEntry | null;
 	endpoint: string;
 }): GatewayContextData {
-	const credit = args.credit?.credit ?? args.dynamic.credit;
+	// Credit is invalidated independently after every wallet mutation. Never
+	// fall back to a legacy credit value embedded in the dynamic entry: that can
+	// re-admit a request using a pre-charge balance after the credit key is gone.
+	const credit = args.credit?.credit;
 	if (!credit) {
 		throw new Error("gateway_context_credit_cache_missing");
 	}
@@ -290,6 +293,10 @@ export function splitContextForCache(value: GatewayContextData): {
 			keyLimit: value.keyLimit,
 			keyEnrichment: value.keyEnrichment ?? null,
 			teamSettings: value.teamSettings ?? null,
+			// Aggregate enrichment is observational rather than an authorization
+			// input. Keep it with the dynamic context so a credit-only refresh can
+			// preserve it while replacing its balance fields authoritatively.
+			teamEnrichment: value.teamEnrichment ?? null,
 		},
 		static: {
 			workspaceId: value.workspaceId,

--- a/apps/api/src/pipeline/before/context.ts
+++ b/apps/api/src/pipeline/before/context.ts
@@ -3,7 +3,7 @@
 // Why: Keeps pre-execution logic centralized and consistent.
 // How: Calls RPC/SQL to fetch provider, pricing, and gating context.
 
-import { getSupabaseAdmin, getCache } from "@/runtime/env";
+import { dispatchBackground, getSupabaseAdmin, getCache } from "@/runtime/env";
 import { getProviderResidencyMetadata } from "@/lib/config/providerResidency";
 import { getTextMany, keyVersionToken } from "@/core/kv";
 import { gatewayCreditCacheKey } from "@/core/gateway-credit-cache";
@@ -69,8 +69,70 @@ const PRESET_TTL = 120;      // 2 minutes
 const CONTEXT_INFLIGHT_MAX_ENTRIES = 512;
 const CONTEXT_KEY_VERSION_L1_TTL_MS = 5_000;
 const FREE_ROUTER_MODEL_ID = "phaseo/free";
+const MIN_GATEWAY_CREDIT_NANOS = 1_000_000_000;
 
 const contextInflight = new Map<string, Promise<GatewayContextData>>();
+
+type CreditContextSnapshot = Pick<
+	GatewayContextData,
+	"workspaceId" | "credit" | "teamEnrichment"
+>;
+
+function finiteNonNegativeNanos(value: unknown): number {
+	const parsed = Number(value);
+	return Number.isFinite(parsed) ? Math.max(0, parsed) : 0;
+}
+
+async function fetchFreshCreditContext(args: {
+	workspaceId: string;
+	teamEnrichment?: GatewayContextData["teamEnrichment"];
+}): Promise<CreditContextSnapshot> {
+	const { data, error } = await getSupabaseAdmin()
+		.from("wallets")
+		.select("balance_nanos,reserved_nanos")
+		.eq("workspace_id", args.workspaceId)
+		.maybeSingle();
+	if (error) {
+		throw new Error(`gateway_credit_refresh_failed:${error.message ?? "unknown"}`);
+	}
+
+	if (!data) {
+		return {
+			workspaceId: args.workspaceId,
+			credit: {
+				ok: false,
+				reason: "wallet_missing",
+				resetAt: null,
+				balanceNanos: 0,
+			},
+			teamEnrichment: args.teamEnrichment ?? null,
+		};
+	}
+
+	const rawBalanceNanos = finiteNonNegativeNanos(data.balance_nanos);
+	const reservedNanos = finiteNonNegativeNanos(data.reserved_nanos);
+	const availableNanos = Math.max(rawBalanceNanos - reservedNanos, 0);
+	const hasMinimumCredit = availableNanos >= MIN_GATEWAY_CREDIT_NANOS;
+	const teamEnrichment = args.teamEnrichment
+		? {
+			...args.teamEnrichment,
+			balance_nanos: availableNanos,
+			balance_usd: Math.round((availableNanos / 1_000_000_000) * 100) / 100,
+			balance_is_low: !hasMinimumCredit,
+		}
+		: null;
+
+	return {
+		workspaceId: args.workspaceId,
+		credit: {
+			ok: hasMinimumCredit,
+			reason: hasMinimumCredit ? null : "insufficient_funds",
+			resetAt: null,
+			balanceNanos: availableNanos,
+		},
+		teamEnrichment,
+	};
+}
 
 async function hydrateByokKeys(
 	context: GatewayContextData,
@@ -827,6 +889,7 @@ export async function fetchGatewayContext(args: {
         totalMs: 0,
         keyVersionMs: null,
         cacheReadMs: null,
+        creditRefreshMs: null,
         rpcMs: null,
         enrichMs: null,
         cacheWriteMs: null,
@@ -877,9 +940,44 @@ export async function fetchGatewayContext(args: {
 					// Request/cost usage changes after every completion. A cached
 					// snapshot can admit subsequent requests past a configured cap,
 					// so only uncapped keys may use the dynamic context snapshot.
-                    const creditParsed = creditCachedRaw ? JSON.parse(creditCachedRaw) : null;
-                    const creditContext = isCreditContextLike(creditParsed) ? creditParsed : null;
-                    const merged = mergeCachedContext({
+					let cacheStatus: ContextFetchTelemetry["cacheStatus"] = "hit";
+					let creditContext: CreditContextSnapshot | null = null;
+					if (creditCachedRaw) {
+						try {
+							const creditParsed = JSON.parse(creditCachedRaw);
+							creditContext = isCreditContextLike(creditParsed) ? creditParsed : null;
+						} catch {
+							creditContext = null;
+						}
+					}
+					if (!creditContext) {
+						const creditRefreshStartedAt = performance.now();
+						creditContext = await fetchFreshCreditContext({
+							workspaceId: args.workspaceId,
+							teamEnrichment: dynamicParsed.teamEnrichment ?? null,
+						});
+						telemetry.creditRefreshMs = round3(
+							performance.now() - creditRefreshStartedAt,
+						);
+						cacheStatus = "credit_refresh";
+						const creditOnlyContext = mergeCachedContext({
+							dynamic: dynamicParsed,
+							static: staticParsed,
+							credit: creditContext,
+							endpoint: args.endpoint,
+						});
+						const creditTtl = clampTtl(
+							computeCreditSnapshotTtlForContext(creditOnlyContext),
+						);
+						dispatchBackground(
+							cache.put(
+								creditCacheKey,
+								JSON.stringify(creditContext),
+								{ expirationTtl: creditTtl },
+							).catch(() => undefined),
+						);
+					}
+					const merged = mergeCachedContext({
                         dynamic: dynamicParsed,
                         static: staticParsed,
                         credit: creditContext,
@@ -889,7 +987,7 @@ export async function fetchGatewayContext(args: {
                         ...merged,
                         contextTelemetry: {
                             ...telemetry,
-                            cacheStatus: "hit",
+                            cacheStatus,
                             totalMs: round3(performance.now() - fetchStartedAt),
                         },
 					}, args.workspaceId);
@@ -1554,7 +1652,11 @@ export async function fetchGatewayContext(args: {
                         cache.put(staticCacheKey, JSON.stringify(split.static), { expirationTtl: staticTtl }),
                     );
                 }
-                await Promise.all(cacheWrites);
+				dispatchBackground(
+					Promise.all(cacheWrites)
+						.then(() => undefined)
+						.catch(() => undefined),
+				);
             } catch {
                 // ignore cache write failures
             } finally {

--- a/apps/api/src/pipeline/before/context.ts
+++ b/apps/api/src/pipeline/before/context.ts
@@ -969,13 +969,11 @@ export async function fetchGatewayContext(args: {
 						const creditTtl = clampTtl(
 							computeCreditSnapshotTtlForContext(creditOnlyContext),
 						);
-						dispatchBackground(
-							cache.put(
-								creditCacheKey,
-								JSON.stringify(creditContext),
-								{ expirationTtl: creditTtl },
-							).catch(() => undefined),
-						);
+						await cache.put(
+							creditCacheKey,
+							JSON.stringify(creditContext),
+							{ expirationTtl: creditTtl },
+						).catch(() => undefined);
 					}
 					const merged = mergeCachedContext({
                         dynamic: dynamicParsed,
@@ -1641,22 +1639,28 @@ export async function fetchGatewayContext(args: {
                     ? null
                     : clampTtl(isPreset ? Math.min(PRESET_TTL, pricingAwareStaticTtl) : pricingAwareStaticTtl);
                 const creditTtl = clampTtl(computeCreditSnapshotTtlForContext(parsed));
-                const cacheWrites: Promise<void>[] = [
-					...(hasConfiguredKeyLimits(parsed.keyLimit)
-						? []
-						: [cache.put(dynamicCacheKey, JSON.stringify(split.dynamic), { expirationTtl: dynamicTtl })]),
-                    cache.put(creditCacheKey, JSON.stringify(split.credit), { expirationTtl: creditTtl }),
+                await cache.put(
+                    creditCacheKey,
+                    JSON.stringify(split.credit),
+                    { expirationTtl: creditTtl },
+                );
+                const backgroundCacheWrites: Promise<void>[] = [
+                    ...(hasConfiguredKeyLimits(parsed.keyLimit)
+                        ? []
+                        : [cache.put(dynamicCacheKey, JSON.stringify(split.dynamic), { expirationTtl: dynamicTtl })]),
                 ];
                 if (staticTtl !== null) {
-                    cacheWrites.push(
+                    backgroundCacheWrites.push(
                         cache.put(staticCacheKey, JSON.stringify(split.static), { expirationTtl: staticTtl }),
                     );
                 }
-				dispatchBackground(
-					Promise.all(cacheWrites)
-						.then(() => undefined)
-						.catch(() => undefined),
-				);
+                if (backgroundCacheWrites.length > 0) {
+                    dispatchBackground(
+                        Promise.all(backgroundCacheWrites)
+                            .then(() => undefined)
+                            .catch(() => undefined),
+                    );
+                }
             } catch {
                 // ignore cache write failures
             } finally {

--- a/apps/api/src/pipeline/before/guards.ts
+++ b/apps/api/src/pipeline/before/guards.ts
@@ -574,9 +574,10 @@ export function makeMeta(input: {
     providerCapabilitiesBeta?: boolean;
     beta?: RequestBetaOptions;
     beforeContextMs?: number | null;
-    beforeContextCacheStatus?: "hit" | "miss" | "bypass" | null;
+    beforeContextCacheStatus?: "hit" | "miss" | "bypass" | "credit_refresh" | null;
     beforeContextKeyVersionMs?: number | null;
     beforeContextCacheReadMs?: number | null;
+    beforeContextCreditRefreshMs?: number | null;
     beforeContextRpcMs?: number | null;
     beforeContextEnrichMs?: number | null;
     beforeContextCacheWriteMs?: number | null;
@@ -652,6 +653,7 @@ export function makeMeta(input: {
         beforeContextCacheStatus: input.beforeContextCacheStatus ?? undefined,
         beforeContextKeyVersionMs: input.beforeContextKeyVersionMs ?? undefined,
         beforeContextCacheReadMs: input.beforeContextCacheReadMs ?? undefined,
+        beforeContextCreditRefreshMs: input.beforeContextCreditRefreshMs ?? undefined,
         beforeContextRpcMs: input.beforeContextRpcMs ?? undefined,
         beforeContextEnrichMs: input.beforeContextEnrichMs ?? undefined,
         beforeContextCacheWriteMs: input.beforeContextCacheWriteMs ?? undefined,

--- a/apps/api/src/pipeline/before/index.ts
+++ b/apps/api/src/pipeline/before/index.ts
@@ -726,6 +726,7 @@ export async function beforeRequest(
         beforeContextCacheStatus: contextTelemetry?.cacheStatus ?? null,
         beforeContextKeyVersionMs: contextTelemetry?.keyVersionMs ?? null,
         beforeContextCacheReadMs: contextTelemetry?.cacheReadMs ?? null,
+        beforeContextCreditRefreshMs: contextTelemetry?.creditRefreshMs ?? null,
         beforeContextRpcMs: contextTelemetry?.rpcMs ?? null,
         beforeContextEnrichMs: contextTelemetry?.enrichMs ?? null,
         beforeContextCacheWriteMs: contextTelemetry?.cacheWriteMs ?? null,

--- a/apps/api/src/pipeline/before/schemas.capability-params.test.ts
+++ b/apps/api/src/pipeline/before/schemas.capability-params.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from "vitest";
+import { contextSchema } from "./schemas";
+
+function contextPayload(capabilityParams: unknown) {
+	return {
+		workspace_id: "ws_capability_params",
+		resolved_model: "openai/gpt-5.4-nano",
+		key_ok: { ok: true, reason: null },
+		key_limit_ok: { ok: true, reason: null },
+		credit_ok: { ok: true, reason: null },
+		providers: [
+			{
+				provider_id: "openai",
+				api_model_id: "openai/gpt-5.4-nano",
+				provider_model_slug: "gpt-5.4-nano-2026-03-17",
+				capability_params: capabilityParams,
+			},
+		],
+		pricing: {},
+	};
+}
+
+describe("contextSchema provider capability params", () => {
+	it("normalizes empty descriptor arrays to an empty capability record", () => {
+		const parsed = contextSchema.parse(contextPayload([]));
+
+		expect(parsed.providers[0]?.capabilityParams).toEqual({});
+	});
+
+	it("normalizes catalog descriptor arrays into a record keyed by param_id", () => {
+		const parsed = contextSchema.parse(contextPayload([
+			{
+				param_id: "seed",
+				provider_min: null,
+				provider_max: null,
+				provider_default: null,
+				notes: null,
+			},
+			{
+				param_id: "max_tokens",
+				provider_min: 1,
+				provider_max: 128_000,
+				provider_default: 4_096,
+				notes: "Provider output-token limit",
+			},
+		]));
+
+		expect(parsed.providers[0]?.capabilityParams).toEqual({
+			seed: {
+				provider_min: null,
+				provider_max: null,
+				provider_default: null,
+				notes: null,
+			},
+			max_tokens: {
+				provider_min: 1,
+				provider_max: 128_000,
+				provider_default: 4_096,
+				notes: "Provider output-token limit",
+			},
+		});
+		expect(Object.keys(parsed.providers[0]?.capabilityParams ?? {})).toEqual([
+			"seed",
+			"max_tokens",
+		]);
+	});
+
+	it("normalizes string entries and resolves duplicate param_id descriptors last-wins", () => {
+		const parsed = contextSchema.parse(contextPayload([
+			"temperature",
+			{ param_id: "seed", provider_default: 1, notes: "older row" },
+			{ param_id: "seed", provider_default: 2, notes: "newer row" },
+		]));
+
+		expect(parsed.providers[0]?.capabilityParams).toEqual({
+			temperature: {},
+			seed: {
+				provider_default: 2,
+				notes: "newer row",
+			},
+		});
+	});
+
+	it("preserves the existing record form", () => {
+		const params = {
+			request: { allowlist: ["temperature", "max_tokens"] },
+			reasoning: { maxReasoningTokens: 8_192 },
+		};
+		const parsed = contextSchema.parse(contextPayload(params));
+
+		expect(parsed.providers[0]?.capabilityParams).toEqual(params);
+	});
+
+	it.each([
+		["non-object/non-string entries", [42]],
+		["missing param_id", [{ provider_min: 0 }]],
+		["blank param_id", [{ param_id: "   ", provider_min: 0 }]],
+	])("rejects malformed descriptor arrays with %s", (_description, capabilityParams) => {
+		const parsed = contextSchema.safeParse(contextPayload(capabilityParams));
+
+		expect(parsed.success).toBe(false);
+	});
+});

--- a/apps/api/src/pipeline/before/schemas.ts
+++ b/apps/api/src/pipeline/before/schemas.ts
@@ -189,6 +189,32 @@ function toModalityList(value: unknown): string[] | null {
     return null;
 }
 
+const capabilityParamDescriptorSchema = z
+    .object({
+        param_id: z.string().trim().min(1),
+    })
+    .passthrough();
+
+const capabilityParamsSchema = z
+    .union([
+        z.record(z.string(), z.any()),
+        z.array(z.union([z.string().trim().min(1), capabilityParamDescriptorSchema])),
+    ])
+    .transform<Record<string, any>>((value) => {
+        if (!Array.isArray(value)) return value;
+
+        const params: Record<string, any> = {};
+        for (const entry of value) {
+            if (typeof entry === "string") {
+                params[entry] = {};
+                continue;
+            }
+            const { param_id: paramId, ...config } = entry;
+            params[paramId] = config;
+        }
+        return params;
+    });
+
 const providerSchema = z
     .object({
         provider_id: z.string(),
@@ -239,7 +265,7 @@ const providerSchema = z
         supports_endpoint: z.boolean().optional().default(true),
         base_weight: z.coerce.number().optional().default(1),
         byok_meta: z.array(byokMetaSchema).optional().default([]),
-        capability_params: z.record(z.string(), z.any()).optional().default({}),
+        capability_params: capabilityParamsSchema.optional().default({}),
         max_input_tokens: z.coerce.number().nullable().optional(),
         max_output_tokens: z.coerce.number().nullable().optional(),
     })

--- a/apps/api/src/pipeline/before/textParamPolicy.test.ts
+++ b/apps/api/src/pipeline/before/textParamPolicy.test.ts
@@ -52,6 +52,18 @@ describe("textParamPolicy", () => {
 		]);
 	});
 
+	it("accepts OpenAI-compatible stream options on chat completions", () => {
+		const body = {
+			model: "openai/gpt-5.4-nano",
+			messages: [{ role: "user", content: "Hello" }],
+			stream: true,
+			stream_options: { include_usage: true },
+		};
+
+		expect(getUnknownTopLevelParams("chat.completions", body)).toEqual([]);
+		expect(extractRequestedParams("chat.completions", body)).toEqual([]);
+	});
+
 	it("extracts documented AION responses parameters", () => {
 		const body = {
 			model: "aion-labs/aion-3.0",

--- a/apps/api/src/pipeline/before/textParamPolicy.ts
+++ b/apps/api/src/pipeline/before/textParamPolicy.ts
@@ -33,6 +33,7 @@ const TEXT_ENDPOINT_REGISTRY: Record<TextEndpoint, EndpointParamRegistry> = {
 			"presence_penalty",
 			"seed",
 			"stream",
+			"stream_options",
 			"temperature",
 			"tools",
 			"max_tool_calls",

--- a/apps/api/src/pipeline/before/types.ts
+++ b/apps/api/src/pipeline/before/types.ts
@@ -279,10 +279,11 @@ export type KeyEnrichment = {
 };
 
 export type ContextFetchTelemetry = {
-    cacheStatus: "hit" | "miss" | "bypass";
+    cacheStatus: "hit" | "miss" | "bypass" | "credit_refresh";
     totalMs: number;
     keyVersionMs?: number | null;
     cacheReadMs?: number | null;
+    creditRefreshMs?: number | null;
     rpcMs?: number | null;
     enrichMs?: number | null;
     cacheWriteMs?: number | null;


### PR DESCRIPTION
## Summary

- normalize catalogue capability parameter arrays at the gateway context schema boundary
- retain the efficient credit-only refresh path used by the latency benchmark
- accept OpenAI-compatible chat completion stream options
- emit a bounded allowlist of provider processing and trace headers on compact observability events

## Production failure

GPT-5.4 Nano context loading failed because the RPC returned descriptor arrays for both OpenAI provider offers while the Worker required a record. After that was repaired, chat completions rejected the benchmark's standard stream_options field. Both paths now have focused regression coverage.

## Validation

- 34/34 focused context, schema, cache and observability tests passed
- 9/9 text parameter policy tests passed
- API TypeScript typecheck passed
- Wrangler production dry-run completed successfully
- production Worker version ea145dbc-afb1-4043-a9d7-79c8db83ef57 deployed from this clean branch
- two normal-path GPT-5.4 Nano probes completed successfully

## Notes

This branch is based on the latest origin/main. It restores the credit-context optimization that two overlapping main-branch deployments had overwritten.