### PR TITLE
Fix duplicate watcher Discord alerts

### DIFF
--- a/apps/api/src/pipeline/model-discovery/helpers.test.ts
+++ b/apps/api/src/pipeline/model-discovery/helpers.test.ts
@@ -2,6 +2,7 @@ import { afterAll, afterEach, describe, expect, it } from "vitest";
 import {
 	assertSafeDiscoverySnapshot,
 	buildDiscordMessage,
+	computeDiscordNotificationFingerprint,
 	extractDiscoveredModels,
 	extractProviderApiModelSnapshot,
 	fetchProviderModels,
@@ -282,6 +283,63 @@ describe("buildDiscordMessage", () => {
 			baseUrl: "https://gateway.example/v1",
 			authStyle: "none",
 		})).toBe("https://catalog.example/models.json");
+	});
+});
+
+describe("extractProviderApiModelSnapshot pricing comparisons", () => {
+	it("ignores volatile raw metadata when canonical prices are unchanged", () => {
+		const previous = extractProviderApiModelSnapshot(
+			"chutes",
+			{ price: { input: { usd: 0.2 }, output: { usd: 0.8 } } },
+			{ price: { input: { usd: 0.2 }, output: { usd: 0.8 } }, refreshed_at: "first" },
+		);
+		const current = extractProviderApiModelSnapshot(
+			"chutes",
+			{ price: { input: { usd: 0.2 }, output: { usd: 0.8 } } },
+			{ price: { input: { usd: 0.2 }, output: { usd: 0.8 } }, refreshed_at: "second" },
+		);
+
+		expect(current.pricingFingerprint).toBe(previous.pricingFingerprint);
+		expect(current.pricingDetails).not.toEqual(previous.pricingDetails);
+	});
+
+	it("detects a changed canonical provider price", () => {
+		const previous = extractProviderApiModelSnapshot(
+			"chutes",
+			{ price: { input: { usd: 0.2 }, output: { usd: 0.8 } } },
+			null,
+		);
+		const current = extractProviderApiModelSnapshot(
+			"chutes",
+			{ price: { input: { usd: 0.25 }, output: { usd: 0.8 } } },
+			null,
+		);
+
+		expect(current.pricingFingerprint).not.toBe(previous.pricingFingerprint);
+	});
+});
+
+describe("computeDiscordNotificationFingerprint", () => {
+	it("is stable for an identical notification and changes with its payload", async () => {
+		setupRuntimeFromEnv({} as any);
+		const input = {
+			modelChanges: [],
+			pricing: { updatesDetected: 0, providerChanges: [] },
+			providerApiPricing: { updatesDetected: 1, providerChanges: [{ providerId: "openrouter", updates: 1, samples: ["model | price changed"] }] },
+			pricingTable: { updatesDetected: 0, providerChanges: [], errors: [] },
+			configuredModelCoverage: { updatesDetected: 0, providerChanges: [] },
+		} as any;
+
+		const first = await computeDiscordNotificationFingerprint(input);
+		const repeated = await computeDiscordNotificationFingerprint(input);
+		const changed = await computeDiscordNotificationFingerprint({
+			...input,
+			providerApiPricing: { updatesDetected: 2, providerChanges: [{ providerId: "openrouter", updates: 2, samples: ["two prices changed"] }] },
+		});
+
+		expect(first).toMatch(/^[0-9a-f]{64}$/);
+		expect(repeated).toBe(first);
+		expect(changed).not.toBe(first);
 	});
 });
 

--- a/apps/api/src/pipeline/model-discovery/helpers.test.ts
+++ b/apps/api/src/pipeline/model-discovery/helpers.test.ts
@@ -317,6 +317,21 @@ describe("extractProviderApiModelSnapshot pricing comparisons", () => {
 
 		expect(current.pricingFingerprint).not.toBe(previous.pricingFingerprint);
 	});
+
+	it("detects supplemental non-token price changes", () => {
+		const previous = extractProviderApiModelSnapshot(
+			"deepinfra",
+			{ metadata: { pricing: { input_tokens: 0.2, output_tokens: 0.8, per_image_unit: 0.04 } } },
+			{ metadata: { pricing: { input_tokens: 0.2, output_tokens: 0.8, per_image_unit: 0.04 } } },
+		);
+		const current = extractProviderApiModelSnapshot(
+			"deepinfra",
+			{ metadata: { pricing: { input_tokens: 0.2, output_tokens: 0.8, per_image_unit: 0.05 } } },
+			{ metadata: { pricing: { input_tokens: 0.2, output_tokens: 0.8, per_image_unit: 0.05 } } },
+		);
+
+		expect(current.pricingFingerprint).not.toBe(previous.pricingFingerprint);
+	});
 });
 
 describe("computeDiscordNotificationFingerprint", () => {

--- a/apps/api/src/pipeline/model-discovery/helpers.ts
+++ b/apps/api/src/pipeline/model-discovery/helpers.ts
@@ -316,6 +316,14 @@ function normalizeProviderApiPricingDetails(
 	return record?.pricing ? normalizeJson(record.pricing) : pricingDetails ?? null;
 }
 
+export function toProviderApiPricingFingerprint(pricingDetails: unknown): string | null {
+	const record = asRecord(pricingDetails);
+	// When a provider has a canonical normalization, compare only that stable shape.
+	// Raw provider payloads are retained for diagnostics, but may include volatile
+	// metadata that is unrelated to the billable rates.
+	return toPricingFingerprint(record?.normalized ?? pricingDetails);
+}
+
 export function toNullableInteger(value: unknown): number | null {
 	if (typeof value === "number") {
 		if (!Number.isFinite(value)) return null;
@@ -340,7 +348,7 @@ export function extractProviderApiModelSnapshot(
 			contextLength: null,
 			maxCompletionTokens: null,
 			pricingDetails: normalizedPricingDetails,
-			pricingFingerprint: toPricingFingerprint(normalizedPricingDetails),
+			pricingFingerprint: toProviderApiPricingFingerprint(normalizedPricingDetails),
 		};
 	}
 
@@ -354,7 +362,7 @@ export function extractProviderApiModelSnapshot(
 		contextLength,
 		maxCompletionTokens,
 		pricingDetails: normalizedPricingDetails,
-		pricingFingerprint: toPricingFingerprint(normalizedPricingDetails),
+		pricingFingerprint: toProviderApiPricingFingerprint(normalizedPricingDetails),
 	};
 }
 
@@ -939,6 +947,29 @@ export async function loadLatestConfiguredCoverageState(source?: string): Promis
 	return null;
 }
 
+export async function loadLatestDiscordNotificationFingerprint(source?: string): Promise<string | null> {
+	const supabase = getSupabaseAdmin();
+	let query = supabase
+		.from("model_discovery_runs")
+		.select("summary,status,started_at")
+		.in("status", ["completed", "completed_with_errors"])
+		.order("started_at", { ascending: false });
+	const sourceValue = typeof source === "string" ? source.trim() : "";
+	if (sourceValue) query = query.eq("source", sourceValue);
+
+	const { data, error } = await query.limit(200);
+	if (error) throw new Error(error.message || "Failed to load Discord notification fingerprint");
+
+	for (const row of data ?? []) {
+		const summary = asRecord((row as Record<string, unknown>).summary);
+		const fingerprint = typeof summary?.notificationFingerprint === "string"
+			? summary.notificationFingerprint.trim()
+			: "";
+		if (fingerprint) return fingerprint;
+	}
+	return null;
+}
+
 export function parsePricingTableStateFromSummary(summary: unknown): PricingTableSnapshotState[] {
 	const summaryRecord = asRecord(summary);
 	const tableMonitor = asRecord(summaryRecord?.pricingTableMonitor);
@@ -1360,6 +1391,13 @@ export function buildDiscordMessage(args: {
 	const text = sections.join("\n\n").trim();
 	if (text.length <= 1900) return text;
 	return `${text.slice(0, 1888)}\n...[truncated]`;
+}
+
+export async function computeDiscordNotificationFingerprint(args: Parameters<typeof buildDiscordMessage>[0]): Promise<string | null> {
+	const message = buildDiscordMessage(args).trim();
+	if (!message) return null;
+	const digest = await crypto.subtle.digest("SHA-256", new TextEncoder().encode(message));
+	return Array.from(new Uint8Array(digest), (byte) => byte.toString(16).padStart(2, "0")).join("");
 }
 
 export async function sendDiscordNotification(args: {

--- a/apps/api/src/pipeline/model-discovery/helpers.ts
+++ b/apps/api/src/pipeline/model-discovery/helpers.ts
@@ -316,12 +316,52 @@ function normalizeProviderApiPricingDetails(
 	return record?.pricing ? normalizeJson(record.pricing) : pricingDetails ?? null;
 }
 
+const CANONICAL_PROVIDER_PRICE_KEYS = new Set([
+	"prompt", "input", "completion", "output", "cache_prompt", "input_cache_read",
+	"input_cache_reads", "cache_input", "cached_input", "input_cache_write",
+	"input_cache_writes", "cache_creation", "cache_write", "input_tokens",
+	"cache_read_tokens", "output_tokens", "input_price_per_million",
+	"cache_read_input_price_per_million", "output_price_per_million",
+	"prompt_text_token_price", "cached_prompt_text_token_price",
+	"completion_text_token_price", "input_token_price_per_m", "output_token_price_per_m",
+	"input_price", "cache_price", "output_price", "cache_read",
+]);
+const VOLATILE_PROVIDER_PRICE_KEYS = new Set([
+	"created", "created_at", "createdat", "updated", "updated_at", "updatedat",
+	"last_updated", "lastupdated", "refreshed_at", "refreshedat", "timestamp",
+	"request_id", "requestid", "generated_at", "generatedat", "fetched_at", "fetchedat",
+]);
+
+function supplementalProviderPricing(value: unknown, key = ""): unknown | null {
+	const normalizedKey = key.trim().toLowerCase();
+	if (CANONICAL_PROVIDER_PRICE_KEYS.has(normalizedKey) || VOLATILE_PROVIDER_PRICE_KEYS.has(normalizedKey)) {
+		return null;
+	}
+	if (Array.isArray(value)) {
+		const entries = value
+			.map((entry) => supplementalProviderPricing(entry))
+			.filter((entry): entry is unknown => entry !== null)
+			.sort((left, right) => JSON.stringify(left).localeCompare(JSON.stringify(right)));
+		return entries.length > 0 ? entries : null;
+	}
+	if (value && typeof value === "object") {
+		const entries = Object.entries(value as Record<string, unknown>)
+			.map(([nestedKey, nestedValue]) => [nestedKey, supplementalProviderPricing(nestedValue, nestedKey)] as const)
+			.filter((entry): entry is readonly [string, unknown] => entry[1] !== null)
+			.sort(([left], [right]) => left.localeCompare(right));
+		return entries.length > 0 ? Object.fromEntries(entries) : null;
+	}
+	return value ?? null;
+}
+
 export function toProviderApiPricingFingerprint(pricingDetails: unknown): string | null {
 	const record = asRecord(pricingDetails);
-	// When a provider has a canonical normalization, compare only that stable shape.
-	// Raw provider payloads are retained for diagnostics, but may include volatile
-	// metadata that is unrelated to the billable rates.
-	return toPricingFingerprint(record?.normalized ?? pricingDetails);
+	if (!record?.normalized) return toPricingFingerprint(pricingDetails);
+	const supplemental = supplementalProviderPricing(record.sourcePricing);
+	return toPricingFingerprint({
+		normalized: record.normalized,
+		...(supplemental === null ? {} : { supplemental }),
+	});
 }
 
 export function toNullableInteger(value: unknown): number | null {

--- a/apps/api/src/pipeline/model-discovery/index.test.ts
+++ b/apps/api/src/pipeline/model-discovery/index.test.ts
@@ -1,0 +1,72 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const getSupabaseAdminMock = vi.fn();
+
+vi.mock("@/runtime/env", () => ({
+	getBindings: () => ({}),
+	getSupabaseAdmin: () => getSupabaseAdminMock(),
+}));
+
+import { fetchPreviousModelsByProviders } from "./index";
+
+type SeenModelRow = {
+	provider_id: string;
+	model_id: string;
+	model_details: Record<string, unknown>;
+	pricing_details: null;
+};
+
+function buildPagedSupabase(rows: SeenModelRow[]) {
+	const ranges: Array<[number, number]> = [];
+	const query = {
+		select: vi.fn(() => query),
+		in: vi.fn(() => query),
+		order: vi.fn(() => query),
+		range: vi.fn(async (from: number, to: number) => {
+			ranges.push([from, to]);
+			return { data: rows.slice(from, to + 1), error: null };
+		}),
+	};
+	return {
+		ranges,
+		client: { from: vi.fn(() => query) },
+	};
+}
+
+describe("fetchPreviousModelsByProviders", () => {
+	beforeEach(() => {
+		getSupabaseAdminMock.mockReset();
+	});
+
+	it("loads every page when a shard has more than 1,000 stored models", async () => {
+		const rows = Array.from({ length: 1_093 }, (_, index) => ({
+			provider_id: "large-provider",
+			model_id: `model-${index.toString().padStart(4, "0")}`,
+			model_details: {},
+			pricing_details: null,
+		}));
+		const supabase = buildPagedSupabase(rows);
+		getSupabaseAdminMock.mockReturnValue(supabase.client);
+
+		const state = await fetchPreviousModelsByProviders(["large-provider"]);
+
+		expect(state.byProvider.get("large-provider")?.modelIds).toHaveLength(1_093);
+		expect(supabase.ranges).toEqual([[0, 999], [1_000, 1_999]]);
+	});
+
+	it("requests an empty final page when the row count is an exact page multiple", async () => {
+		const rows = Array.from({ length: 1_000 }, (_, index) => ({
+			provider_id: "exact-provider",
+			model_id: `model-${index.toString().padStart(4, "0")}`,
+			model_details: {},
+			pricing_details: null,
+		}));
+		const supabase = buildPagedSupabase(rows);
+		getSupabaseAdminMock.mockReturnValue(supabase.client);
+
+		const state = await fetchPreviousModelsByProviders(["exact-provider"]);
+
+		expect(state.byProvider.get("exact-provider")?.modelIds).toHaveLength(1_000);
+		expect(supabase.ranges).toEqual([[0, 999], [1_000, 1_999]]);
+	});
+});

--- a/apps/api/src/pipeline/model-discovery/index.ts
+++ b/apps/api/src/pipeline/model-discovery/index.ts
@@ -7,6 +7,7 @@ import {
 	asRecord,
 	assertSafeDiscoverySnapshot,
 	buildProviderApiModelSnapshotDiff,
+	computeDiscordNotificationFingerprint,
 	computeConfiguredModelCoverageFingerprint,
 	diffModelIds,
 	extractProviderApiModelSnapshot,
@@ -15,6 +16,7 @@ import {
 	hasProviderApiSnapshotValue,
 	loadConfiguredProviderModelIds,
 	loadLatestConfiguredCoverageState,
+	loadLatestDiscordNotificationFingerprint,
 	loadLatestPricingTableState,
 	readBindingEnv,
 	runPricingMonitorCheck,
@@ -199,6 +201,7 @@ type DiscoveryRunSummary = {
 	providerApiPricingMonitor: ProviderApiPricingMonitorSummary;
 	pricingTableMonitor: PricingTableMonitorSummary;
 	configuredModelCoverageMonitor: ConfiguredModelCoverageMonitorSummary;
+	notificationFingerprint: string | null;
 };
 
 type SupabaseSeenModelRow = {
@@ -228,6 +231,7 @@ const MAX_PRICING_PROVIDER_LINES = 20;
 const MAX_PRICING_SAMPLE_LINES = 6;
 const MAX_PRICING_ROWS = 5_000;
 const PRICING_PAGE_SIZE = 500;
+const SEEN_MODELS_PAGE_SIZE = 1_000;
 const RUNS_RETENTION_DAYS = 5;
 const PRICING_KEY_PATTERN = /(price|pricing|cost|billing|currency|rate|meter|unit|token)/i;
 const PRICING_EXTRACTION_MAX_DEPTH = 4;
@@ -328,6 +332,7 @@ function compactSummary(summary: DiscoveryRunSummary, extra: { notificationError
 	return {
 		statePersisted: summary.statePersisted,
 		persistenceDeferredReason: summary.persistenceDeferredReason ?? undefined,
+		notificationFingerprint: summary.notificationFingerprint ?? undefined,
 		results: summary.results.map((result) => ({
 			providerId: result.providerId,
 			status: result.status,
@@ -461,7 +466,7 @@ type PreviousModelsState = {
 	providerApiSnapshotReadyByProvider: Set<string>;
 };
 
-async function fetchPreviousModelsByProviders(providerIds: string[]): Promise<PreviousModelsState> {
+export async function fetchPreviousModelsByProviders(providerIds: string[]): Promise<PreviousModelsState> {
 	const map = new Map<string, PreviousProviderModels>();
 	for (const providerId of providerIds) {
 		map.set(providerId, {
@@ -475,18 +480,28 @@ async function fetchPreviousModelsByProviders(providerIds: string[]): Promise<Pr
 	}
 
 	const supabase = getSupabaseAdmin();
-	const { data, error } = await supabase
-		.from("model_discovery_seen_models")
-		.select("provider_id,model_id,model_details,pricing_details")
-		.in("provider_id", providerIds);
+	const rows: SupabaseSeenModelRow[] = [];
+	for (let offset = 0; ; offset += SEEN_MODELS_PAGE_SIZE) {
+		const { data, error } = await supabase
+			.from("model_discovery_seen_models")
+			.select("provider_id,model_id,model_details,pricing_details")
+			.in("provider_id", providerIds)
+			.order("provider_id", { ascending: true })
+			.order("model_id", { ascending: true })
+			.range(offset, offset + SEEN_MODELS_PAGE_SIZE - 1);
 
-	if (error) {
-		throw new Error(error.message || "Failed to load previous discovered models");
+		if (error) {
+			throw new Error(error.message || "Failed to load previous discovered models");
+		}
+
+		const page = (data ?? []) as SupabaseSeenModelRow[];
+		rows.push(...page);
+		if (page.length < SEEN_MODELS_PAGE_SIZE) break;
 	}
 
 	const providerApiSnapshotReadyByProvider = new Set<string>();
 
-	for (const row of (data ?? []) as SupabaseSeenModelRow[]) {
+	for (const row of rows) {
 		if (typeof row.provider_id !== "string" || typeof row.model_id !== "string") continue;
 		const state = map.get(row.provider_id);
 		if (!state) continue;
@@ -882,6 +897,7 @@ export async function runModelDiscoveryJob(args: RunArgs): Promise<DiscoveryRunS
 		}
 
 		let notificationError: string | null = null;
+		let notificationFingerprint: string | null = null;
 		let notificationSummary: {
 			delivered: boolean;
 			skipped: boolean;
@@ -891,28 +907,41 @@ export async function runModelDiscoveryJob(args: RunArgs): Promise<DiscoveryRunS
 			skipped: true,
 			reason: shouldNotify ? "not attempted" : "notifications disabled",
 		};
-		if (shouldNotify) {
-			try {
-				notificationSummary = await sendDiscordNotification({
-					modelChanges: changes,
-					pricing: pricingMonitor,
-					providerApiPricing: providerApiPricingMonitor,
-					pricingTable: pricingTableMonitor,
-					configuredModelCoverage: configuredModelCoverageNotificationSummary,
-				});
-			} catch (error) {
-				notificationError = error instanceof Error ? error.message : String(error);
-				console.error("[model-discovery] Discord notification failed:", notificationError);
-			}
-		}
-
-		const hasNotifiableChanges = hasDiscordNotifiableChanges({
+		const notificationInput = {
 			modelChanges: changes,
 			pricing: pricingMonitor,
 			providerApiPricing: providerApiPricingMonitor,
 			pricingTable: pricingTableMonitor,
 			configuredModelCoverage: configuredModelCoverageNotificationSummary,
-		});
+		};
+		const hasNotifiableChanges = hasDiscordNotifiableChanges(notificationInput);
+		if (shouldNotify && hasNotifiableChanges) {
+			try {
+				notificationFingerprint = await computeDiscordNotificationFingerprint(notificationInput);
+				let previousFingerprint: string | null = null;
+				try {
+					previousFingerprint = await loadLatestDiscordNotificationFingerprint(args.source);
+				} catch (error) {
+					console.error(
+						"[model-discovery] Failed to compare Discord notification fingerprint:",
+						error instanceof Error ? error.message : String(error),
+					);
+				}
+
+				if (notificationFingerprint && notificationFingerprint === previousFingerprint) {
+					notificationSummary = { delivered: true, skipped: true, reason: "duplicate notification fingerprint" };
+					console.log("[model-discovery] Discord notification skipped: duplicate notification fingerprint");
+				} else {
+					notificationSummary = await sendDiscordNotification(notificationInput);
+					if (!notificationSummary.delivered) notificationFingerprint = null;
+				}
+			} catch (error) {
+				notificationFingerprint = null;
+				notificationError = error instanceof Error ? error.message : String(error);
+				console.error("[model-discovery] Discord notification failed:", notificationError);
+			}
+		}
+
 		const requiresNotificationDelivery = shouldNotify && hasNotifiableChanges;
 		const notificationDelivered = !requiresNotificationDelivery || notificationSummary.delivered;
 		const persistenceDeferredReason = !notificationDelivered
@@ -1048,6 +1077,7 @@ export async function runModelDiscoveryJob(args: RunArgs): Promise<DiscoveryRunS
 			providerApiPricingMonitor,
 			pricingTableMonitor,
 			configuredModelCoverageMonitor,
+			notificationFingerprint,
 		};
 
 		const status: RunStatus =
@@ -1134,6 +1164,7 @@ export async function runModelDiscoveryJob(args: RunArgs): Promise<DiscoveryRunS
 				providerChanges: [],
 				fingerprint: null,
 			},
+			notificationFingerprint: null,
 		};
 		try {
 			await updateRunFinish(failedSummary, "failed", { error: reason });


### PR DESCRIPTION
## Summary
- paginate model-discovery state reads so shards larger than Supabase's 1,000-row response cap are compared against their complete baseline
- fingerprint canonical normalized provider pricing while retaining raw upstream pricing payloads for diagnostics
- persist a deterministic Discord payload fingerprint and suppress identical notifications from the same watcher shard
- add regression coverage for 1,093-row and exact-1,000-row model snapshots, stable pricing fingerprints, and Discord payload fingerprints

## Root cause
Shard 1 currently contains 1,093 discovered models, but the previous-state query was unpaginated. The missing rows were repeatedly classified as new models, producing recurring alerts such as Together 25 → 271 and Venice ~20 → 106. Provider pricing fingerprints also included volatile raw metadata, causing unchanged canonical rates to be reported repeatedly.

## Validation
- `pnpm exec vitest run src/pipeline/model-discovery/index.test.ts src/pipeline/model-discovery/helpers.test.ts src/pipeline/model-discovery/pricing-normalizers.test.ts` (30 passed)
- `pnpm run typecheck`
- targeted ESLint (0 errors; existing max-lines warnings only)
- `pnpm validate:pricing`
- `pnpm validate:gateway`
- `pnpm --filter @phaseo/gateway-api build` (Wrangler deploy dry-run)

## Repository-wide test note
`pnpm --filter @phaseo/gateway-api test` is not currently green on `main`; it reports hundreds of unrelated existing failures across OAuth, routing, video, provider configuration, and shared runtime-state suites. The watcher-focused suites above pass.

Created with Codex