### PR TITLE
Unify the chat playground experience

### DIFF
--- a/apps/web/src/app/(dashboard)/chat/audio/page.tsx
+++ b/apps/web/src/app/(dashboard)/chat/audio/page.tsx
@@ -1,27 +1,5 @@
-import type { Metadata } from "next";
-import { Suspense } from "react";
-import { buildMetadata } from "@/lib/seo";
-import { fetchFrontendGatewayModels } from "@/lib/fetchers/frontend/fetchFrontendGatewayModels";
-import { RoomScaffold } from "@/components/(chat)/RoomScaffold";
-import { AudioRoom } from "@/components/(chat)/rooms/AudioRoom";
-
-export const metadata: Metadata = buildMetadata({
-	title: "Audio Studio",
-	description:
-		"Audio workspace for speech synthesis, transcription, and translation.",
-	path: "/chat/audio",
-	keywords: ["AI audio", "speech synthesis", "transcription", "translation"],
-});
+import { redirect } from "next/navigation";
 
 export default function ChatAudioPage() {
-	return <Suspense fallback={null}><ChatAudioContent /></Suspense>;
-}
-
-async function ChatAudioContent() {
-	const models = await fetchFrontendGatewayModels();
-	return (
-		<RoomScaffold>
-			<AudioRoom models={models} />
-		</RoomScaffold>
-	);
+	redirect("/chat/speech");
 }

--- a/apps/web/src/app/(dashboard)/chat/realtime/page.tsx
+++ b/apps/web/src/app/(dashboard)/chat/realtime/page.tsx
@@ -26,7 +26,7 @@ function RealtimeFlagDisabled() {
 				</div>
 			</header>
 			<section className="flex min-h-0 flex-1 items-center justify-center px-4">
-				<div className="w-full max-w-lg rounded-lg border border-border bg-background px-5 py-6 text-center shadow-sm">
+				<div className="w-full max-w-lg rounded-2xl border border-border bg-background px-5 py-6 text-center shadow-sm">
 					<h2 className="text-base font-semibold">Realtime voice is gated</h2>
 					<p className="mt-2 text-sm leading-6 text-muted-foreground">
 						Realtime voice is not enabled for this account yet.

--- a/apps/web/src/app/(dashboard)/layout.tsx
+++ b/apps/web/src/app/(dashboard)/layout.tsx
@@ -1,13 +1,16 @@
 // app/(dashboard)/layout.tsx
 import Header from "@/components/header/header";
 import Footer from "@/components/footer";
+import DashboardFooterGate from "@/components/layout/DashboardFooterGate";
 
 function DashboardFrame({ children }: { children: React.ReactNode }) {
 	return (
 		<div id="dashboard-shell" className="flex min-h-dvh flex-col">
 			<Header />
 			<main className="flex-1 min-h-0 flex flex-col">{children}</main>
-			<Footer />
+			<DashboardFooterGate>
+				<Footer />
+			</DashboardFooterGate>
 		</div>
 	);
 }

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -121,12 +121,6 @@
 	body {
 		@apply bg-background text-foreground;
 	}
-	body[data-hide-footer="true"] #dashboard-shell > footer {
-		display: none !important;
-	}
-	#dashboard-shell:has([data-chat-viewport-root="true"]) > footer {
-		display: none !important;
-	}
 	a[href],
 	button:not(:disabled),
 	[role="button"]:not(:disabled) {

--- a/apps/web/src/components/(chat)/ChatConversationComposer.tsx
+++ b/apps/web/src/components/(chat)/ChatConversationComposer.tsx
@@ -676,7 +676,7 @@ function ComposerModelSelectField({
 							onChange={(event) => setSearch(event.target.value)}
 							onKeyDown={(event) => event.stopPropagation()}
 							placeholder="Search models..."
-							className="h-8 rounded-xl bg-input/50 text-xs"
+							className="h-8 rounded-md bg-input/50 text-xs"
 						/>
 					</div>
 					<ScrollArea className="h-72" viewportClassName="pr-2">
@@ -797,7 +797,7 @@ function ComposerTimezoneSelectField({
 							onChange={(event) => setSearch(event.target.value)}
 							onKeyDown={(event) => event.stopPropagation()}
 							placeholder="Search timezones..."
-							className="h-8 rounded-xl bg-input/50 text-xs"
+							className="h-8 rounded-md bg-input/50 text-xs"
 						/>
 					</div>
 					<div className="grid gap-0.5 px-1 pb-1">
@@ -2107,7 +2107,7 @@ export function ChatConversationComposer(props: ChatConversationComposerProps) {
 				) : null}
 				{toolType === "phaseo:advisor" ? (
 					<>
-						<div className="flex flex-wrap items-center gap-1 rounded-xl border border-border bg-muted/50 p-1">
+						<div className="flex flex-wrap items-center gap-1 rounded-md border border-border bg-muted/50 p-1">
 							<div className="flex min-w-0 flex-1 flex-wrap gap-1">
 								{advisorConfigs.map((advisor, index) => {
 									const selected = index === advisorIndex;
@@ -2264,7 +2264,7 @@ export function ChatConversationComposer(props: ChatConversationComposerProps) {
 				) : null}
 				{toolType === "phaseo:fusion" ? (
 					<div className="grid gap-2">
-						<div className="rounded-xl border border-border bg-muted px-3 py-2 text-xs text-muted-foreground">
+						<div className="rounded-md border border-border bg-muted px-3 py-2 text-xs text-muted-foreground">
 							<span className="block font-medium text-foreground">
 								Fusion Settings
 							</span>
@@ -2923,7 +2923,10 @@ export function ChatConversationComposer(props: ChatConversationComposerProps) {
 	);
 
 	return (
-		<div className="border-t border-border bg-background px-4 py-[17px] md:px-8">
+		<div
+			data-chat-composer-footer="true"
+			className="border-t border-border bg-background px-4 py-[17px] md:px-8"
+		>
 			<div className="mx-auto flex w-full max-w-3xl flex-col gap-3">
 				{queuedPrompts.length > 0 ? (
 					<div className="rounded-2xl border border-border bg-card/95 p-1.5">
@@ -2948,7 +2951,7 @@ export function ChatConversationComposer(props: ChatConversationComposerProps) {
 										}
 										onDragEnd={() => setDraggingQueuedPromptId(null)}
 										className={cn(
-											"group grid grid-cols-[auto_auto_minmax(0,1fr)_auto_auto] items-center gap-1.5 rounded-xl px-1.5 py-1.5 text-sm text-muted-foreground transition-colors hover:bg-muted/55",
+											"group grid grid-cols-[auto_auto_minmax(0,1fr)_auto_auto] items-center gap-1.5 rounded-md px-1.5 py-1.5 text-sm text-muted-foreground transition-colors hover:bg-muted/55",
 											draggingQueuedPromptId === prompt.id &&
 												"bg-muted/60 opacity-70",
 										)}
@@ -2995,7 +2998,7 @@ export function ChatConversationComposer(props: ChatConversationComposerProps) {
 					</div>
 				) : null}
 				{sendGateType === "auth" ? (
-					<div className="flex flex-wrap items-center justify-between gap-3 rounded-xl border border-amber-300/70 bg-amber-50 px-3 py-2 text-amber-900 dark:border-amber-700/70 dark:bg-amber-950/30 dark:text-amber-100">
+					<div className="flex flex-wrap items-center justify-between gap-3 rounded-md border border-amber-300/70 bg-amber-50 px-3 py-2 text-amber-900 dark:border-amber-700/70 dark:bg-amber-950/30 dark:text-amber-100">
 						<div className="flex items-start gap-2 text-sm">
 							<Info className="mt-0.5 h-4 w-4 shrink-0" />
 							<div className="space-y-0.5">
@@ -3080,7 +3083,7 @@ export function ChatConversationComposer(props: ChatConversationComposerProps) {
 				<div ref={composerCommandRootRef} className="relative">
 					{slashMenuOpen ? (
 						<div
-							className="absolute right-0 bottom-full left-0 z-30 mb-2 overflow-hidden rounded-xl border border-border bg-popover text-popover-foreground shadow-none"
+							className="absolute right-0 bottom-full left-0 z-30 mb-2 overflow-hidden rounded-md border border-border bg-popover text-popover-foreground shadow-none"
 							aria-label="Chat commands"
 						>
 							{showSlashSearch ? (

--- a/apps/web/src/components/(chat)/ChatHeader.tsx
+++ b/apps/web/src/components/(chat)/ChatHeader.tsx
@@ -96,12 +96,13 @@ import {
 	ArrowRight,
 	ChevronsLeft,
 	ChevronDown,
-	ChevronRight,
 	Check,
 	CircleCheck,
 	CircleQuestionMark,
 	Columns2,
 	Database,
+	PanelLeftClose,
+	PanelLeftOpen,
 	Keyboard,
 	List,
 	MessageCircleDashed,
@@ -1380,15 +1381,13 @@ export function ChatHeader({
 							size="icon"
 							className="group -ml-1"
 							onClick={toggleSidebar}
-							aria-label="Toggle sidebar"
+							aria-label={sidebarState === "expanded" ? "Collapse sidebar" : "Open sidebar"}
 						>
-							<ChevronRight
-								className={`h-5 w-5 transition-transform duration-200 ${
-									sidebarState === "expanded"
-										? "rotate-180 group-hover:-translate-x-1"
-										: "group-hover:translate-x-1"
-								}`}
-							/>
+							{sidebarState === "expanded" ? (
+								<PanelLeftClose className="h-5 w-5" />
+							) : (
+								<PanelLeftOpen className="h-5 w-5" />
+							)}
 						</Button>
 					</TooltipTrigger>
 					<TooltipContent
@@ -1396,7 +1395,7 @@ export function ChatHeader({
 						align="center"
 						sideOffset={8}
 					>
-						Toggle sidebar
+						{sidebarState === "expanded" ? "Collapse sidebar" : "Open sidebar"}
 					</TooltipContent>
 				</Tooltip>
 				{selectedModelIds.length > 0 ? (
@@ -1562,7 +1561,7 @@ export function ChatHeader({
 								</div>
 							</TooltipContent>
 						</Tooltip>
-						<DropdownMenuContent align="end" sideOffset={8} className="w-72">
+						<DropdownMenuContent align="end" sideOffset={8} className="w-72 rounded-[8px]! [&_[data-slot=dropdown-menu-item]]:rounded-[8px]!">
 							<DropdownMenuItem
 								onClick={() => onResponseLayoutChange("sequential")}
 								className="items-start gap-2"
@@ -2205,7 +2204,7 @@ export function ChatHeader({
 													models, and the composer.
 												</p>
 											</div>
-											<div className="rounded-xl border border-border bg-card p-3">
+											<div className="rounded-2xl border border-border bg-card p-3">
 												<ChatShortcutReference />
 											</div>
 										</div>

--- a/apps/web/src/components/(chat)/ChatMessagesEmptyState.tsx
+++ b/apps/web/src/components/(chat)/ChatMessagesEmptyState.tsx
@@ -334,7 +334,7 @@ export function ChatMessagesEmptyState({
 										: `Use ${collection.label}`
 								}
 								className={cn(
-									"group h-full rounded-xl border border-border bg-card p-2 text-left shadow-sm transition sm:p-3 2xl:p-3.5",
+									"group h-full rounded-2xl border border-border bg-card p-2 text-left shadow-sm transition sm:p-3 2xl:p-3.5",
 									"hover:border-foreground/20 hover:bg-muted/30 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
 									allAdded &&
 										"cursor-default border-foreground/20 bg-muted/20 hover:border-foreground/20 hover:bg-muted/20",
@@ -384,7 +384,7 @@ export function ChatMessagesEmptyState({
 						);
 					})}
 					{collections.length === 0 ? (
-						<div className="rounded-xl border border-dashed border-border bg-muted/30 p-4 text-sm text-muted-foreground sm:col-span-3">
+						<div className="rounded-2xl border border-dashed border-border bg-muted/30 p-4 text-sm text-muted-foreground sm:col-span-3">
 							Model sets will appear once the model cache has loaded.
 						</div>
 					) : null}

--- a/apps/web/src/components/(chat)/ChatPlaygroundShell.tsx
+++ b/apps/web/src/components/(chat)/ChatPlaygroundShell.tsx
@@ -2,18 +2,24 @@ export default function ChatPlaygroundShell() {
     return (
         <div className="flex h-full min-h-0 w-full">
             <aside className="hidden h-full w-64 flex-col border-r border-border bg-background md:flex">
-                <div className="flex flex-1 flex-col gap-4 px-4 py-5">
-                    <div className="h-8 w-28 rounded-md bg-muted/50" />
-                    <div className="h-9 w-full rounded-md bg-muted/40" />
-                    <div className="h-9 w-full rounded-md bg-muted/40" />
-                    <div className="h-9 w-full rounded-md bg-muted/40" />
-                    <div className="mt-2 h-px w-full bg-border" />
-                    <div className="space-y-2">
+                <div className="flex h-[57px] items-center border-b border-border px-2">
+                    <div className="h-8 w-full rounded-md bg-muted/50" />
+                </div>
+                <div className="flex min-h-0 flex-1 flex-col">
+                    <div className="space-y-1 border-b border-border px-2 py-1.5">
+                        <div className="h-8 w-full rounded-md bg-muted/40" />
+                        <div className="h-8 w-full rounded-md bg-muted/40" />
+                        <div className="h-8 w-full rounded-md bg-muted/40" />
+                    </div>
+                    <div className="space-y-2 px-4 py-3">
                         <div className="h-6 w-24 rounded bg-muted/40" />
                         <div className="h-8 w-full rounded-md bg-muted/30" />
                         <div className="h-8 w-full rounded-md bg-muted/30" />
                         <div className="h-8 w-full rounded-md bg-muted/30" />
                     </div>
+                </div>
+                <div className="border-t border-border px-2 py-2">
+                    <div className="h-14 w-full rounded-lg bg-muted/40" />
                 </div>
             </aside>
             <div className="flex min-w-0 flex-1 flex-col">

--- a/apps/web/src/components/(chat)/ChatRoomSwitcher.tsx
+++ b/apps/web/src/components/(chat)/ChatRoomSwitcher.tsx
@@ -58,7 +58,7 @@ function isRoomActive(pathname: string, route: string): boolean {
 	return pathname === route || pathname.startsWith(`${route}/`);
 }
 
-export function ChatRoomSwitcher() {
+export function ChatRoomSwitcher({ className }: { className?: string } = {}) {
 	const { realtimeEnabled, videoEnabled } = useChatFeatureFlags();
 	const pathname = usePathname() ?? "/chat";
 	const { state: sidebarState, isMobile } = useSidebar();
@@ -71,71 +71,47 @@ export function ChatRoomSwitcher() {
 	const collapsed = sidebarState === "collapsed" && !isMobile;
 
 	return (
-		<div className="px-2 py-1.5">
+		<div className={cn("px-2 py-1.5", className)}>
 			<DropdownMenu>
-				{collapsed ? (
-					<Tooltip>
-						<TooltipTrigger asChild>
-							<DropdownMenuTrigger render={<Button
-									variant="ghost"
-									className={cn(
-										"h-8 gap-0 px-2 text-sm font-medium",
-										collapsed
-											? "w-8 justify-center px-0"
-											: "w-full justify-between px-2",
-									)}
-									aria-label={activeRoom.label} />}>
+				<Tooltip>
+					<TooltipTrigger asChild>
+						<DropdownMenuTrigger render={<Button
+								variant="ghost"
+								className="relative h-8 w-full min-w-0 justify-start gap-0 overflow-hidden rounded-[8px]! px-2 text-sm font-medium group-data-[state=collapsed]:rounded-full!"
+								aria-label={activeRoom.label} />}>
 
-									<span className="inline-flex items-center gap-2">
-										<ActiveIcon className="h-4 w-4 shrink-0" />
-										{!collapsed ? activeRoom.label : null}
-										{!collapsed && activeRoom.beta ? (
-											<Badge variant="outline" className="h-4 px-1.5 text-[9px] uppercase tracking-wide">
-												Beta
-											</Badge>
-										) : null}
-									</span>
-									{!collapsed ? (
-										<ChevronsUpDown className="h-4 w-4 text-muted-foreground" />
-									) : null}
-
-							</DropdownMenuTrigger>
-						</TooltipTrigger>
-						<TooltipContent side="right" align="center" sideOffset={10}>
-							{activeRoom.label}
-						</TooltipContent>
-					</Tooltip>
-				) : (
-					<DropdownMenuTrigger render={<Button
-							variant="ghost"
-							className={cn(
-								"h-8 gap-0 px-2 text-sm font-medium",
-								collapsed
-									? "w-8 justify-center px-0"
-									: "w-full justify-between px-2",
-							)}
-							aria-label={activeRoom.label} />}>
-
-							<span className="inline-flex items-center gap-2">
 								<ActiveIcon className="h-4 w-4 shrink-0" />
-								{!collapsed ? activeRoom.label : null}
-								{!collapsed && activeRoom.beta ? (
-									<Badge variant="outline" className="h-4 px-1.5 text-[9px] uppercase tracking-wide">
-										Beta
-									</Badge>
-								) : null}
-							</span>
-							{!collapsed ? (
-								<ChevronsUpDown className="h-4 w-4 text-muted-foreground" />
-							) : null}
+								<span className="ml-2 inline-flex min-w-0 items-center gap-2 whitespace-nowrap group-data-[collapsible=icon]:hidden">
+									<span>
+										{activeRoom.label}
+									</span>
+									{activeRoom.beta ? (
+										<Badge
+											variant="outline"
+										className="h-4 rounded-[4px]! px-1.5 text-[10px] font-medium"
+										>
+											Beta
+										</Badge>
+									) : null}
+								</span>
+								<ChevronsUpDown className="absolute right-2 h-4 w-4 shrink-0 text-muted-foreground group-data-[collapsible=icon]:hidden" />
 
-					</DropdownMenuTrigger>
-				)}
+						</DropdownMenuTrigger>
+					</TooltipTrigger>
+					<TooltipContent
+						side="right"
+						align="center"
+						sideOffset={10}
+						hidden={!collapsed || isMobile}
+					>
+						{activeRoom.label}
+					</TooltipContent>
+				</Tooltip>
 				<DropdownMenuContent
 					side={collapsed ? "right" : "bottom"}
 					align="start"
 					sideOffset={8}
-					className="z-[90] w-56"
+					className={cn("z-[90] rounded-[8px]! [&_[data-slot=dropdown-menu-item]]:rounded-[8px]!", collapsed && "w-56")}
 				>
 					{availableRooms.map((room) => {
 						const Icon = ICONS[room.id];
@@ -157,7 +133,7 @@ export function ChatRoomSwitcher() {
 												<span>{room.label}</span>
 												<Badge
 													variant="outline"
-													className="ml-auto h-4 px-1.5 text-[9px] uppercase tracking-wide"
+											className="ml-auto h-4 rounded-[4px]! px-1.5 text-[10px] font-medium"
 												>
 													Coming soon
 												</Badge>
@@ -180,7 +156,7 @@ export function ChatRoomSwitcher() {
 									<Icon className="h-4 w-4" />
 									<span>{room.label}</span>
 									{room.beta ? (
-										<Badge variant="outline" className="ml-auto h-4 px-1.5 text-[9px] uppercase tracking-wide">
+										<Badge variant="outline" className="ml-auto h-4 rounded-[4px]! px-1.5 text-[10px] font-medium">
 											Beta
 										</Badge>
 									) : null}

--- a/apps/web/src/components/(chat)/ChatSidebar.tsx
+++ b/apps/web/src/components/(chat)/ChatSidebar.tsx
@@ -38,6 +38,11 @@ import {
 } from "@/components/(chat)/playground/use-grouped-chat-threads";
 import type { ChatTag, ChatThread } from "@/lib/indexeddb/chats";
 import { ChatRoomSwitcher } from "@/components/(chat)/ChatRoomSwitcher";
+import { useChatCredits } from "@/components/(chat)/use-chat-credits";
+import {
+	CHAT_SIDEBAR_ACTIONS_CLASS,
+	CHAT_SIDEBAR_HISTORY_GROUP_CLASS,
+} from "@/components/(chat)/chatSidebarStyles";
 import { ThemeSelector } from "@/components/theme-toggle";
 import { cn } from "@/lib/utils";
 import {
@@ -59,7 +64,6 @@ import {
 	Trash2,
 	UserRound,
 } from "lucide-react";
-import { createClient } from "@/utils/supabase/client";
 
 export type GroupedThreads = {
 	pinned: ChatThread[];
@@ -102,20 +106,6 @@ type ThreadDateGroup = {
 	label: string;
 	threads: ChatThread[];
 };
-
-type CreditsBalanceResponse = {
-	initialBalance?: number | null;
-};
-
-function formatCreditsBalance(value: number | null) {
-	if (value === null || !Number.isFinite(value)) return null;
-	return new Intl.NumberFormat("en-US", {
-		style: "currency",
-		currency: "USD",
-		minimumFractionDigits: 2,
-		maximumFractionDigits: 2,
-	}).format(value);
-}
 
 function getOrdinalDay(day: number) {
 	const remainder = day % 100;
@@ -218,11 +208,8 @@ export function ChatSidebar({
 	const [selectedThreadIds, setSelectedThreadIds] = useState<Set<string>>(
 		() => new Set(),
 	);
-	const [creditsBalance, setCreditsBalance] = useState<number | null>(null);
-	const [creditsLoading, setCreditsLoading] = useState(false);
+	const { creditsLabel, creditsLoading } = useChatCredits(authUser?.id);
 	const collapsed = sidebarState === "collapsed" && !isMobile;
-	const brandLightSrc = collapsed ? "/logo_light.svg" : "/wordmark_light.svg";
-	const brandDarkSrc = collapsed ? "/logo_dark.svg" : "/wordmark_dark.svg";
 	const withCollapsedTooltip = (label: string, button: ReactElement) =>
 		collapsed ? (
 			<Tooltip>
@@ -241,7 +228,6 @@ export function ChatSidebar({
 		.join("")
 		.slice(0, 2)
 		.toUpperCase();
-	const creditsLabel = formatCreditsBalance(creditsBalance);
 	const activeTag = tags.find((tag) => tag.id === activeTagId) ?? null;
 	const dateThreadGroups = buildThreadDateGroups(groupedThreads);
 	const tagsByRecentUse = useMemo(() => {
@@ -270,60 +256,6 @@ export function ChatSidebar({
 		[threads, selectedThreadIds],
 	);
 	const selectedCount = selectedThreads.length;
-	useEffect(() => {
-		if (!authUser?.id) {
-			setCreditsBalance(null);
-			setCreditsLoading(false);
-			return;
-		}
-
-		let active = true;
-		const controller = new AbortController();
-		const timeoutId = window.setTimeout(() => controller.abort(), 8000);
-		setCreditsLoading(true);
-		createClient().auth.getSession()
-			.then(({ data }) => {
-				const accessToken = data.session?.access_token;
-				if (!accessToken) throw new Error("Credits request requires a session");
-				return fetch("/api/account/credits/balance", {
-					headers: {
-						accept: "application/json",
-						authorization: `Bearer ${accessToken}`,
-					},
-					signal: controller.signal,
-				});
-			})
-			.then(async (response) => {
-				if (!response.ok) throw new Error(`Credits request failed: ${response.status}`);
-				return (await response.json()) as CreditsBalanceResponse;
-			})
-			.then((data) => {
-				if (!active) return;
-				const rawBalance = data.initialBalance;
-				const balance =
-					rawBalance === null || rawBalance === undefined
-						? null
-						: Number(rawBalance);
-				setCreditsBalance(balance !== null && Number.isFinite(balance) ? balance : null);
-			})
-			.catch((error) => {
-				if (active && (error as Error).name !== "AbortError") {
-					setCreditsBalance(null);
-				}
-			})
-			.finally(() => {
-				window.clearTimeout(timeoutId);
-				if (active) {
-					setCreditsLoading(false);
-				}
-			});
-
-		return () => {
-			active = false;
-			window.clearTimeout(timeoutId);
-			controller.abort();
-		};
-	}, [authUser?.id]);
 	const toggleThreadSelection = (threadId: string) => {
 		setSelectedThreadIds((prev) => {
 			const next = new Set(prev);
@@ -374,7 +306,7 @@ export function ChatSidebar({
 							<MoreHorizontal className="h-4 w-4" />
 
 					</DropdownMenuTrigger>
-					<DropdownMenuContent side="right">
+					<DropdownMenuContent side="right" className="rounded-[8px]! [&_[data-slot=dropdown-menu-item]]:rounded-[8px]!">
 						<DropdownMenuItem onClick={() => onRenameThread(thread)}>
 							<PencilLine className="mr-2 h-4 w-4" />
 							Rename
@@ -410,34 +342,8 @@ export function ChatSidebar({
 	return (
 		<>
 			<SidebarHeader className="h-[57px] gap-0 border-b border-border px-0 py-0">
-				<div
-					className={cn(
-						"flex h-full w-full items-center gap-2 px-2",
-						collapsed ? "justify-center" : "ml-2",
-					)}
-				>
-					<Link href="/" aria-label="Phaseo">
-						<img
-							src={brandLightSrc}
-							alt=""
-							aria-hidden="true"
-							className={cn(
-								"select-none",
-								collapsed ? "h-5" : "h-6",
-								"block dark:hidden",
-							)}
-						/>
-						<img
-							src={brandDarkSrc}
-							alt=""
-							aria-hidden="true"
-							className={cn(
-								"select-none",
-								collapsed ? "h-5" : "h-6",
-								"hidden dark:block",
-							)}
-						/>
-					</Link>
+				<div className="flex h-full min-w-0 items-center px-0">
+					<ChatRoomSwitcher className="min-w-0 flex-1" />
 					<Button
 						variant="ghost"
 						size="icon"
@@ -450,9 +356,7 @@ export function ChatSidebar({
 				</div>
 			</SidebarHeader>
 			<SidebarContent className="gap-0">
-				<ChatRoomSwitcher />
-				<SidebarSeparator className="my-0" />
-				<div className="px-2 py-1.5">
+				<div data-chat-sidebar-actions="true" className={CHAT_SIDEBAR_ACTIONS_CLASS}>
 					{withCollapsedTooltip(
 						"New Chat",
 						<Button
@@ -460,7 +364,7 @@ export function ChatSidebar({
 							className={cn(
 								"h-8 min-w-0 w-full gap-2 text-sm font-medium",
 								collapsed
-									? "justify-center px-0"
+									? "justify-start px-2"
 									: "w-full flex-1 justify-start px-2",
 							)}
 							onClick={onCreateThread}
@@ -479,7 +383,7 @@ export function ChatSidebar({
 							className={cn(
 								"h-8 min-w-0 w-full gap-2 text-sm font-medium",
 								collapsed
-									? "justify-center px-0"
+									? "justify-start px-2"
 									: "w-full flex-1 justify-start px-2",
 							)}
 							asChild
@@ -489,7 +393,7 @@ export function ChatSidebar({
 								href="/"
 								className={cn(
 									"group/db flex w-full min-w-0 items-center gap-2",
-									collapsed && "justify-center",
+									collapsed && "justify-start",
 								)}
 							>
 								<Database className="h-4 w-4 shrink-0" />
@@ -511,7 +415,7 @@ export function ChatSidebar({
 							className={cn(
 								"h-8 min-w-0 w-full gap-2 text-sm font-medium",
 								collapsed
-									? "justify-center px-0"
+									? "justify-start px-2"
 									: "w-full flex-1 justify-start px-2",
 							)}
 							onClick={onSearch}
@@ -524,9 +428,9 @@ export function ChatSidebar({
 						</Button>,
 					)}
 				</div>
-				<SidebarSeparator className="my-0" />
+				<SidebarSeparator className="mx-0 my-0 w-full" />
 				<ScrollArea className="h-full group-data-[collapsible=icon]:hidden">
-					<SidebarGroup className="px-2 pb-2 pt-1">
+					<SidebarGroup className={CHAT_SIDEBAR_HISTORY_GROUP_CLASS}>
 						{tags.length > 0 ? (
 							<Collapsible
 								open={tagsOpen}
@@ -690,19 +594,21 @@ export function ChatSidebar({
 					</SidebarGroup>
 				</ScrollArea>
 			</SidebarContent>
-			<SidebarFooter className="border-t border-border px-3 py-3">
+			<SidebarFooter
+				className="h-[57px] shrink-0 justify-center border-t border-border px-2 py-2"
+			>
 				{authUser ? (
 					<div className="grid gap-2">
 						<DropdownMenu>
 							<DropdownMenuTrigger render={<Button
 									variant="ghost"
 									className={cn(
-										"h-auto min-h-14 w-full touch-manipulation items-center gap-3 rounded-2xl py-2 active:bg-muted data-open:bg-muted",
-										collapsed ? "justify-center px-0" : "justify-start",
+										"h-10 min-h-0 w-full touch-manipulation items-center gap-2 py-1 active:bg-muted data-open:bg-muted",
+										collapsed ? "justify-center rounded-full px-0" : "justify-start rounded-md px-2",
 									)}
 									aria-label="Open account menu" />}>
 
-									<Avatar className="pointer-events-none h-8 w-8 rounded-lg border border-zinc-200/70 dark:border-zinc-800/70">
+									<Avatar className="pointer-events-none h-7 w-7 rounded-full border border-zinc-200/70 dark:border-zinc-800/70">
 										{authUser.avatarUrl && (
 											<AvatarImage
 												src={authUser.avatarUrl}
@@ -710,7 +616,7 @@ export function ChatSidebar({
 												className="object-cover"
 											/>
 										)}
-										<AvatarFallback className="rounded-lg text-[11px] font-semibold">
+										<AvatarFallback className="rounded-full text-[10px] font-semibold">
 											{initials || "U"}
 										</AvatarFallback>
 									</Avatar>
@@ -735,7 +641,7 @@ export function ChatSidebar({
 								side={collapsed ? "right" : "top"}
 								align="start"
 								sideOffset={8}
-								className="w-56 z-[90]"
+								className="z-[90] w-56 rounded-[8px]! [&_[data-slot=dropdown-menu-item]]:rounded-[8px]!"
 							>
 								<DropdownMenuItem render={<Link href="/settings/account" />}>
 
@@ -787,7 +693,7 @@ export function ChatSidebar({
 				) : (
 					<Button
 						variant="ghost"
-						className="w-full justify-start"
+						className="w-full justify-start rounded-md"
 						asChild
 					>
 						<Link href="/sign-in">Sign in to chat</Link>

--- a/apps/web/src/components/(chat)/ChatTagsDialog.tsx
+++ b/apps/web/src/components/(chat)/ChatTagsDialog.tsx
@@ -140,7 +140,7 @@ export function ChatTagsDialog({
 								</span>
 							</div>
 							<ScrollArea
-								className="max-h-36 rounded-xl border border-border bg-muted/20"
+								className="max-h-36 rounded-md border border-border bg-muted/20"
 								viewportClassName="flex flex-wrap gap-2 p-2"
 							>
 								{availableTags.map((tag) => {
@@ -197,7 +197,7 @@ export function ChatTagsDialog({
 						{matchingExistingTag ? null : (
 							<div className="grid gap-1.5">
 								<span className="text-xs text-muted-foreground">Color</span>
-								<div className="grid grid-cols-9 gap-1.5 rounded-xl border border-border bg-muted/20 p-2">
+								<div className="grid grid-cols-9 gap-1.5 rounded-md border border-border bg-muted/20 p-2">
 									{TAG_COLORS.map((option) => (
 										<button
 											key={option}
@@ -258,7 +258,7 @@ export function ChatTagsDialog({
 								))}
 							</div>
 						) : (
-							<p className="rounded-xl border border-dashed border-border px-3 py-4 text-sm text-muted-foreground">
+							<p className="rounded-md border border-dashed border-border px-3 py-4 text-sm text-muted-foreground">
 								No tags assigned.
 							</p>
 						)}

--- a/apps/web/src/components/(chat)/ModelSettingsDialog.tsx
+++ b/apps/web/src/components/(chat)/ModelSettingsDialog.tsx
@@ -530,7 +530,7 @@ export function ModelSettingsDialog({
                                                         setModelPickerSearch("");
                                                         setModelPickerOpen(false);
                                                     }}
-                                                    className="flex min-h-7 w-full items-center gap-2 rounded-xl px-2 py-1.5 text-left text-sm text-foreground outline-none transition-colors hover:bg-muted focus-visible:bg-muted focus-visible:ring-2 focus-visible:ring-ring"
+															className="flex min-h-7 w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-sm text-foreground outline-none transition-colors hover:bg-muted focus-visible:bg-muted focus-visible:ring-2 focus-visible:ring-ring"
                                                 >
                                                     <Logo
                                                         id={choice.orgId}
@@ -567,7 +567,7 @@ export function ModelSettingsDialog({
                                                         setModelPickerSearch("");
                                                         setModelPickerOpen(false);
                                                     }}
-                                                    className="flex min-h-7 w-full items-center gap-2 rounded-xl px-2 py-1.5 text-left text-sm text-foreground outline-none transition-colors hover:bg-muted focus-visible:bg-muted focus-visible:ring-2 focus-visible:ring-ring"
+															className="flex min-h-7 w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-sm text-foreground outline-none transition-colors hover:bg-muted focus-visible:bg-muted focus-visible:ring-2 focus-visible:ring-ring"
                                                 >
                                                     <Logo
                                                         id={choice.orgId}

--- a/apps/web/src/components/(chat)/RoomComposer.tsx
+++ b/apps/web/src/components/(chat)/RoomComposer.tsx
@@ -1,0 +1,93 @@
+import type { ComponentProps } from "react";
+import { Check, Plus, type LucideIcon } from "lucide-react";
+import { AIGeneratedNotice } from "@/components/(chat)/AIGeneratedNotice";
+import { Button } from "@/components/ui/button";
+import {
+	DropdownMenu,
+	DropdownMenuContent,
+	DropdownMenuItem,
+	DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { cn } from "@/lib/utils";
+
+export type RoomComposerTool = {
+	id: string;
+	label: string;
+	icon: LucideIcon;
+	active?: boolean;
+	disabled?: boolean;
+	onSelect: () => void;
+};
+
+export function RoomComposerToolsMenu({ tools }: { tools: RoomComposerTool[] }) {
+	if (tools.length === 0) return null;
+
+	return (
+		<DropdownMenu>
+			<DropdownMenuTrigger render={<Button
+					type="button"
+					variant="ghost"
+					size="icon"
+					className="h-8 w-8"
+					aria-label="Open action menu"
+					data-chat-room-tools-trigger="true" />}>
+
+					<Plus className="h-4 w-4" />
+
+			</DropdownMenuTrigger>
+			<DropdownMenuContent side="top" align="start" sideOffset={8} className="w-52 rounded-[8px]! [&_[data-slot=dropdown-menu-item]]:rounded-[8px]!">
+				{tools.map((tool) => {
+					const Icon = tool.icon;
+					return (
+						<DropdownMenuItem
+							key={tool.id}
+							disabled={tool.disabled}
+							onClick={tool.onSelect}
+							className="gap-2"
+						>
+							<Icon className="h-4 w-4 text-muted-foreground" />
+							<span>{tool.label}</span>
+							{tool.active ? <Check className="ml-auto h-4 w-4" /> : null}
+						</DropdownMenuItem>
+					);
+				})}
+			</DropdownMenuContent>
+		</DropdownMenu>
+	);
+}
+
+export function RoomComposerFooter({
+	children,
+	className,
+	...props
+}: ComponentProps<"footer">) {
+	return (
+		<footer
+			data-chat-composer-footer="true"
+			className={cn(
+				"border-t border-border bg-background px-4 py-[15px] md:px-8",
+				className,
+			)}
+			{...props}
+		>
+			{children}
+			<AIGeneratedNotice className="mt-1" />
+		</footer>
+	);
+}
+
+export function RoomComposerSurface({
+	className,
+	...props
+}: ComponentProps<"div">) {
+	return (
+		<div
+			data-chat-composer-surface="true"
+			className={cn(
+				"rounded-2xl border border-border bg-card shadow-sm transition-colors duration-200 ease-[cubic-bezier(0.23,1,0.32,1)] motion-reduce:transition-none",
+				className,
+			)}
+			{...props}
+		/>
+	);
+}

--- a/apps/web/src/components/(chat)/RoomModelSelector.tsx
+++ b/apps/web/src/components/(chat)/RoomModelSelector.tsx
@@ -462,13 +462,13 @@ export function RoomModelSelector({
 		const modelEnabled = modelEnabledById?.[modelId] !== false;
 		const canRemoveModel = Boolean(onRemoveModel);
 		return (
-			<div key={modelId} className="relative shrink-0">
+			<div key={modelId} className="relative shrink-0 rounded-2xl">
 				<Button
 					variant="ghost"
 					size="sm"
 					onClick={() => onOpenModelSettingsForModel?.(modelId)}
 					className={cn(
-						"h-8 max-w-[220px] gap-1.5 pl-2",
+						"h-8 max-w-[220px] gap-1.5 rounded-2xl pl-2",
 						!modelEnabled && "opacity-55",
 						canRemoveModel ? "pr-7" : "pr-2",
 					)}
@@ -610,7 +610,7 @@ export function RoomModelSelector({
 						variant="ghost"
 						size="sm"
 						className={cn(
-							"h-8 gap-1.5",
+							"h-8 gap-1.5 rounded-2xl",
 							selectedModelIds.length === 0 ? "px-2 text-xs" : "w-8 px-0",
 						)}
 					>

--- a/apps/web/src/components/(chat)/RoomScaffold.tsx
+++ b/apps/web/src/components/(chat)/RoomScaffold.tsx
@@ -2,11 +2,14 @@
 
 import Link from "next/link";
 import { useEffect, useState, type ReactNode } from "react";
-import { Database, Gauge, LogOut, UserRound } from "lucide-react";
+import { Coins, Database, Gauge, LogOut, UserRound } from "lucide-react";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { ChatRoomSwitcher } from "@/components/(chat)/ChatRoomSwitcher";
+import { useChatCredits } from "@/components/(chat)/use-chat-credits";
+import { CHAT_SIDEBAR_ACTIONS_CLASS } from "@/components/(chat)/chatSidebarStyles";
 import { ThemeSelector } from "@/components/theme-toggle";
 import { Button } from "@/components/ui/button";
+import { Skeleton } from "@/components/ui/skeleton";
 import { useChatAuth } from "@/components/(chat)/playground/use-chat-auth";
 import {
 	DropdownMenu,
@@ -34,31 +37,6 @@ type RoomScaffoldProps = {
 
 export const ROOM_SIDEBAR_SLOT_ID = "room-scaffold-sidebar-slot";
 
-function RoomSidebarBrand() {
-	const { state: sidebarState, isMobile } = useSidebar();
-	const collapsed = sidebarState === "collapsed" && !isMobile;
-	const brandLightSrc = collapsed ? "/logo_light.svg" : "/wordmark_light.svg";
-	const brandDarkSrc = collapsed ? "/logo_dark.svg" : "/wordmark_dark.svg";
-	const brandClassName = collapsed ? "h-5 select-none" : "h-6 select-none";
-
-	return (
-		<>
-			<img
-				src={brandLightSrc}
-				alt=""
-				aria-hidden="true"
-				className={`${brandClassName} block dark:hidden`}
-			/>
-			<img
-				src={brandDarkSrc}
-				alt=""
-				aria-hidden="true"
-				className={`${brandClassName} hidden dark:block`}
-			/>
-		</>
-	);
-}
-
 function RoomSidebarDatabaseButton() {
 	const { state: sidebarState, isMobile } = useSidebar();
 	const collapsed = sidebarState === "collapsed" && !isMobile;
@@ -66,12 +44,12 @@ function RoomSidebarDatabaseButton() {
 		<Button
 			variant="ghost"
 			asChild
-			className="h-8 min-w-0 w-full flex-1 justify-start gap-0 px-2 text-sm font-medium group-data-[collapsible=icon]:justify-center group-data-[collapsible=icon]:px-0"
+			className="h-8 min-w-0 w-full flex-1 justify-start gap-0 px-2 text-sm font-medium"
 			aria-label="Database"
 		>
 			<Link
 				href="/"
-				className="group/db flex w-full min-w-0 items-center gap-2 group-data-[collapsible=icon]:justify-center"
+				className="group/db flex w-full min-w-0 items-center justify-start gap-2"
 			>
 				<Database className="h-4 w-4 shrink-0" />
 				<span className="truncate group-data-[collapsible=icon]:hidden">Database</span>
@@ -96,6 +74,7 @@ function RoomSidebarDatabaseButton() {
 export function RoomScaffold({ children }: RoomScaffoldProps) {
 	const [hasCustomSidebarContent, setHasCustomSidebarContent] = useState(false);
 	const { authUser, authLoading, handleSignOut } = useChatAuth();
+	const { creditsLabel, creditsLoading } = useChatCredits(authUser?.id);
 
 	useEffect(() => {
 		const slot = document.getElementById(ROOM_SIDEBAR_SLOT_ID);
@@ -125,21 +104,17 @@ export function RoomScaffold({ children }: RoomScaffoldProps) {
 		<SidebarProvider defaultOpen contained className="h-full overflow-hidden">
 			<Sidebar collapsible="icon" className="border-r border-border bg-background">
 				<SidebarHeader className="h-[57px] gap-0 border-b border-border px-0 py-0">
-					<div className="flex h-full w-full items-center gap-2 px-4 group-data-[collapsible=icon]:justify-center group-data-[collapsible=icon]:px-2">
-						<Link href="/" aria-label="Phaseo">
-							<RoomSidebarBrand />
-						</Link>
+					<div className="flex h-full min-w-0 items-center">
+						<ChatRoomSwitcher className="min-w-0 flex-1" />
 					</div>
 				</SidebarHeader>
 				<SidebarContent className="gap-0">
-					<ChatRoomSwitcher />
-					<SidebarSeparator className="my-0" />
 					{!hasCustomSidebarContent ? (
 						<>
-							<div className="px-2 pb-1 pt-1.5">
+							<div data-chat-sidebar-actions="true" className={CHAT_SIDEBAR_ACTIONS_CLASS}>
 								<RoomSidebarDatabaseButton />
 							</div>
-							<SidebarSeparator className="my-0" />
+							<SidebarSeparator className="mx-0 my-0 w-full" />
 						</>
 					) : null}
 					<div
@@ -147,16 +122,18 @@ export function RoomScaffold({ children }: RoomScaffoldProps) {
 						className="flex min-h-0 flex-1 flex-col gap-0"
 					/>
 				</SidebarContent>
-				<SidebarFooter className="border-t border-border px-3 py-3">
+				<SidebarFooter
+					className="h-[57px] shrink-0 justify-center border-t border-border px-2 py-2"
+				>
 					{authUser ? (
 						<div className="grid gap-2">
 							<DropdownMenu>
 								<DropdownMenuTrigger render={<Button
 										variant="ghost"
 										aria-label="Open account menu"
-										className="h-auto min-h-14 w-full touch-manipulation justify-start gap-3 rounded-2xl py-2 active:bg-muted data-open:bg-muted group-data-[collapsible=icon]:justify-center group-data-[collapsible=icon]:px-0" />}>
+										className="h-10 min-h-0 w-full touch-manipulation justify-start gap-2 rounded-md px-2 py-1 active:bg-muted data-open:bg-muted group-data-[collapsible=icon]:justify-center group-data-[collapsible=icon]:rounded-full group-data-[collapsible=icon]:px-0" />}>
 
-										<Avatar className="pointer-events-none h-8 w-8 rounded-lg border border-zinc-200/70 dark:border-zinc-800/70">
+									<Avatar className="pointer-events-none h-7 w-7 rounded-full border border-zinc-200/70 dark:border-zinc-800/70">
 											{authUser.avatarUrl ? (
 												<AvatarImage
 													src={authUser.avatarUrl}
@@ -164,7 +141,7 @@ export function RoomScaffold({ children }: RoomScaffoldProps) {
 													className="object-cover"
 												/>
 											) : null}
-											<AvatarFallback className="rounded-lg text-[11px] font-semibold">
+										<AvatarFallback className="rounded-full text-[10px] font-semibold">
 												{initials || "U"}
 											</AvatarFallback>
 										</Avatar>
@@ -182,7 +159,7 @@ export function RoomScaffold({ children }: RoomScaffoldProps) {
 									side="right"
 									align="start"
 									sideOffset={8}
-									className="w-56 z-[90]"
+									className="z-[90] w-56 rounded-[8px]! [&_[data-slot=dropdown-menu-item]]:rounded-[8px]!"
 								>
 									<DropdownMenuItem render={<Link href="/settings/account" />}>
 
@@ -194,6 +171,21 @@ export function RoomScaffold({ children }: RoomScaffoldProps) {
 
 											<Gauge className="mr-2 h-4 w-4" />
 											Usage
+
+									</DropdownMenuItem>
+									<DropdownMenuItem render={<Link
+											href="/settings/credits"
+											aria-label={creditsLabel ? `Credits balance: ${creditsLabel}` : "Credits"} />}>
+
+											<Coins className="mr-2 h-4 w-4" />
+											<span>Credits</span>
+											{creditsLoading ? (
+												<Skeleton className="ml-auto h-3.5 w-16 rounded-sm" />
+											) : creditsLabel ? (
+												<span className="ml-auto font-mono text-xs tabular-nums text-muted-foreground">
+													{creditsLabel}
+												</span>
+											) : null}
 
 									</DropdownMenuItem>
 									<DropdownMenuSeparator />
@@ -212,7 +204,7 @@ export function RoomScaffold({ children }: RoomScaffoldProps) {
 					) : authLoading ? (
 						<div className="h-9 w-full rounded-md bg-muted/40" />
 					) : (
-						<Button variant="ghost" className="w-full justify-start" asChild>
+						<Button variant="ghost" className="w-full justify-start rounded-md" asChild>
 							<Link href="/sign-in">Sign in to chat</Link>
 						</Button>
 					)}

--- a/apps/web/src/components/(chat)/VirtualizedModelCatalog.tsx
+++ b/apps/web/src/components/(chat)/VirtualizedModelCatalog.tsx
@@ -148,7 +148,7 @@ export function VirtualizedModelCatalog<T>({
 											: undefined
 									}
 									className={cn(
-										"relative flex min-h-8 cursor-default select-none items-center gap-2 rounded-xl px-2 py-1 text-sm outline-hidden",
+										"relative flex min-h-8 cursor-default select-none items-center gap-2 rounded-md px-2 py-1 text-sm outline-hidden",
 										"data-[selected=true]:bg-muted data-[selected=true]:text-foreground",
 										isItemDisabled(row.item) &&
 											"pointer-events-none opacity-50",

--- a/apps/web/src/components/(chat)/chatSidebarStyles.ts
+++ b/apps/web/src/components/(chat)/chatSidebarStyles.ts
@@ -1,0 +1,4 @@
+export const CHAT_SIDEBAR_ACTIONS_CLASS =
+	"px-2 py-1.5 [&_button]:rounded-[8px]! group-data-[state=collapsed]:[&_button]:rounded-full!";
+
+export const CHAT_SIDEBAR_HISTORY_GROUP_CLASS = "px-2 pb-2 pt-1";

--- a/apps/web/src/components/(chat)/rooms/AudioRoom.tsx
+++ b/apps/web/src/components/(chat)/rooms/AudioRoom.tsx
@@ -7,6 +7,7 @@ import { Logo } from "@/components/Logo";
 import type { GatewaySupportedModel } from "@/lib/fetchers/gateway/getGatewaySupportedModelIds";
 import { filterModelsForRoom } from "@/lib/chat/rooms";
 import { fetchChatWebApi } from "@/lib/web-api/client";
+import { cn } from "@/lib/utils";
 import { getModelDetailsHref } from "@/lib/models/modelHref";
 import { APP_HEADERS } from "@/components/(chat)/playground/chat-playground-core";
 import { inferAudioMimeType } from "@/components/(chat)/chatConversationHelpers";
@@ -50,6 +51,10 @@ import { RoomSearchDialog } from "@/components/(chat)/RoomSearchDialog";
 import { useSidebar } from "@/components/ui/sidebar";
 import { ROOM_SIDEBAR_SLOT_ID } from "@/components/(chat)/RoomScaffold";
 import {
+	CHAT_SIDEBAR_ACTIONS_CLASS,
+	CHAT_SIDEBAR_HISTORY_GROUP_CLASS,
+} from "@/components/(chat)/chatSidebarStyles";
+import {
 	Tooltip,
 	TooltipContent,
 	TooltipTrigger,
@@ -77,21 +82,26 @@ import {
 import { AudioModelSettingsDialog } from "@/components/(chat)/rooms/settings/AudioModelSettingsDialog";
 import { RoomErrorNotice } from "@/components/(chat)/rooms/RoomErrorNotice";
 import {
-	AudioLines,
+	RoomComposerFooter,
+	RoomComposerSurface,
+	RoomComposerToolsMenu,
+} from "@/components/(chat)/RoomComposer";
+import {
 	ArrowUpRight,
 	Check,
-	ChevronRight,
+	PanelLeftClose,
+	PanelLeftOpen,
 	Copy,
 	Cpu,
 	Database,
 	Download,
 	Info,
-	Languages,
+	FileText,
+	Link2,
 	Loader2,
 	MessageCircleDashed,
-	Mic,
 	MoreHorizontal,
-	Music2,
+	Paperclip,
 	Pencil,
 	PencilLine,
 	Pin,
@@ -183,12 +193,6 @@ const AUDIO_MODE_SUPPORT_FALLBACK: AudioModeSupport = {
 	music: false,
 };
 
-const AUDIO_MODE_OPTIONS: AudioMode[] = [
-	"speech",
-	"music",
-	"transcription",
-	"translation",
-];
 const MUSIC_POLL_INTERVAL_MS = 2_500;
 const MUSIC_POLL_MAX_ATTEMPTS = 36;
 
@@ -220,11 +224,18 @@ function modeBusyLabel(mode: AudioMode): string {
 	return "Translating audio...";
 }
 
-function modeIcon(mode: AudioMode) {
-	if (mode === "speech") return <Mic className="h-3.5 w-3.5" />;
-	if (mode === "music") return <Music2 className="h-3.5 w-3.5" />;
-	if (mode === "transcription") return <AudioLines className="h-3.5 w-3.5" />;
-	return <Languages className="h-3.5 w-3.5" />;
+function modeActionLabel(mode: AudioMode): string {
+	if (mode === "speech") return "Generate speech";
+	if (mode === "music") return "Generate music";
+	if (mode === "transcription") return "Transcribe";
+	return "Translate";
+}
+
+function modeEmptyDescription(mode: AudioMode): string {
+	if (mode === "speech") return "Type text to generate spoken audio.";
+	if (mode === "music") return "Describe the track you want to generate.";
+	if (mode === "transcription") return "Upload audio to produce a transcript.";
+	return "Upload audio to translate it into English.";
 }
 
 function readFileAsBase64(file: File): Promise<string> {
@@ -963,9 +974,9 @@ function modeSupportFromModes(modes: AudioMode[]): AudioModeSupport {
 
 export function AudioRoom({
 	models,
-	roomId = "audio",
+	roomId = "speech",
 	initialMode = "speech",
-	allowedModes = ["speech", "music"],
+	allowedModes = ["speech"],
 }: AudioRoomProps) {
 	const { toggleSidebar, state: sidebarState, isMobile } = useSidebar();
 	const collapsed = sidebarState === "collapsed" && !isMobile;
@@ -1004,7 +1015,9 @@ export function AudioRoom({
 	const [temporaryMode, setTemporaryMode] = useState(false);
 	const [textInput, setTextInput] = useState("");
 	const [musicLyricsInput, setMusicLyricsInput] = useState("");
+	const [showMusicLyricsInput, setShowMusicLyricsInput] = useState(false);
 	const [audioUrlInput, setAudioUrlInput] = useState("");
+	const [showAudioUrlInput, setShowAudioUrlInput] = useState(false);
 	const [audioFile, setAudioFile] = useState<File | null>(null);
 	const [isLoading, setIsLoading] = useState(false);
 	const [error, setError] = useState<string | null>(null);
@@ -1021,6 +1034,7 @@ export function AudioRoom({
 		null,
 	);
 	const copiedPromptTimeoutRef = useRef<number | null>(null);
+	const audioFileInputRef = useRef<HTMLInputElement | null>(null);
 	const pinnedStorageKey = `${roomId}-room-pinned-conversations-v1`;
 
 	const modelSettings = useRoomModelSettings({
@@ -1035,35 +1049,6 @@ export function AudioRoom({
 		modelSettingsCompat.selectedProfile ?? modelSettingsCompat.activeModelSettings ?? null;
 	const selectedModelEnabled = selectedProfile?.enabled !== false;
 	const selectedProviderId = selectedProfile?.providerId;
-	const composerSelectedModel = useMemo(
-		() =>
-			filteredModels.find(
-				(model) =>
-					model.modelId === modelId &&
-					(!selectedProviderId || model.providerId === selectedProviderId),
-			) ??
-			filteredModels.find((model) => model.modelId === modelId) ??
-			null,
-		[filteredModels, modelId, selectedProviderId],
-	);
-	const composerModelLogoId =
-		composerSelectedModel?.organisationId?.trim() ||
-		composerSelectedModel?.providerId ||
-		(modelId.split("/")[0] || "phaseo");
-	const composerModelLabel =
-		(modelId &&
-			(modelSettings.modelDisplayNameById[modelId] ||
-				composerSelectedModel?.modelName ||
-				modelId)) ||
-		"Select model";
-	const openComposerModelPicker = () => {
-		const targetModelId = modelId || filteredModels[0]?.modelId;
-		if (!targetModelId) return;
-		if (targetModelId !== modelId) {
-			setModelId(targetModelId);
-		}
-		modelSettings.openModelSettingsForModel(targetModelId);
-	};
 
 	const selectedModeSupport = useMemo(
 		() => getModelModeSupport(allAudioModels, modelId, selectedProviderId),
@@ -1073,22 +1058,6 @@ export function AudioRoom({
 		() => intersectAudioModeSupport(selectedModeSupport, roomModeSupport),
 		[selectedModeSupport, roomModeSupport],
 	);
-	const availableModes = useMemo(() => {
-		const supported: AudioMode[] = [];
-		if (effectiveModeSupport.speech) supported.push("speech");
-		if (effectiveModeSupport.music) supported.push("music");
-		if (effectiveModeSupport.transcription) supported.push("transcription");
-		if (effectiveModeSupport.translation) supported.push("translation");
-		return supported.length ? supported : (["speech"] as AudioMode[]);
-	}, [effectiveModeSupport]);
-	const uiAvailableModes = useMemo(() => {
-		const enabled: AudioMode[] = [];
-		if (roomModeSupport.speech) enabled.push("speech");
-		if (roomModeSupport.music) enabled.push("music");
-		if (roomModeSupport.transcription) enabled.push("transcription");
-		if (roomModeSupport.translation) enabled.push("translation");
-		return enabled.length ? enabled : (["speech"] as AudioMode[]);
-	}, [roomModeSupport]);
 	const conversations = useMemo(
 		() => buildConversations(entries, pinnedConversationIds),
 		[entries, pinnedConversationIds],
@@ -1189,33 +1158,15 @@ export function AudioRoom({
 	}, [filteredModels]);
 
 	useEffect(() => {
-		if (uiAvailableModes.includes(mode)) return;
-		setMode(uiAvailableModes[0] ?? "speech");
-	}, [mode, uiAvailableModes]);
+		if (normalizedAllowedModes.includes(mode)) return;
+		setMode(normalizedAllowedModes[0] ?? "speech");
+	}, [mode, normalizedAllowedModes]);
 
 	useEffect(() => {
 		if (!activeConversationMode) return;
 		if (mode === activeConversationMode) return;
 		setMode(activeConversationMode);
 	}, [activeConversationMode, mode]);
-
-	const handleModeSelect = (targetMode: AudioMode) => {
-		if (activeConversationMode) return;
-		if (!uiAvailableModes.includes(targetMode)) return;
-		if (!availableModes.includes(targetMode)) {
-			const fallbackModel = allAudioModels.find((model) => {
-				const support = intersectAudioModeSupport(
-					getAudioModeSupportForCapabilities(model.capabilities),
-					roomModeSupport,
-				);
-				return support[targetMode];
-			});
-			if (fallbackModel) {
-				setModelId(fallbackModel.modelId);
-			}
-		}
-		setMode(targetMode);
-	};
 
 	useEffect(() => {
 		setSidebarSlotEl(document.getElementById(ROOM_SIDEBAR_SLOT_ID));
@@ -1287,7 +1238,9 @@ export function AudioRoom({
 		setActiveConversationId(createConversationId(roomId));
 		setTextInput("");
 		setMusicLyricsInput("");
+		setShowMusicLyricsInput(false);
 		setAudioUrlInput("");
+		setShowAudioUrlInput(false);
 		setAudioFile(null);
 		setError(null);
 	};
@@ -1298,7 +1251,9 @@ export function AudioRoom({
 			setActiveConversationId(createConversationId(roomId));
 			setTextInput("");
 			setMusicLyricsInput("");
+			setShowMusicLyricsInput(false);
 			setAudioUrlInput("");
+			setShowAudioUrlInput(false);
 			setAudioFile(null);
 			setError(null);
 			return;
@@ -1316,7 +1271,9 @@ export function AudioRoom({
 		);
 		setTextInput("");
 		setMusicLyricsInput("");
+		setShowMusicLyricsInput(false);
 		setAudioUrlInput("");
+		setShowAudioUrlInput(false);
 		setAudioFile(null);
 		setError(null);
 	};
@@ -1502,12 +1459,13 @@ export function AudioRoom({
 	const retryEntry = async (entry: AudioEntry) => {
 		const prompt = entry.inputText?.trim();
 		if (!prompt || !selectedModelEnabled || isLoading) return;
-		const retryMode: AudioMode = entry.mode === "music" ? "music" : "speech";
+		const retryMode = entry.mode;
 		setModelId(entry.modelId);
 		setMode(retryMode);
 		setTextInput(prompt);
 		if (retryMode === "music") {
 			setMusicLyricsInput(entry.musicLyrics ?? "");
+			setShowMusicLyricsInput(Boolean(entry.musicLyrics));
 		}
 		requestAnimationFrame(() => {
 			void submit({
@@ -1877,9 +1835,11 @@ export function AudioRoom({
 				setTextInput("");
 				if (targetMode === "music") {
 					setMusicLyricsInput("");
+					setShowMusicLyricsInput(false);
 				}
 			} else {
 				setAudioUrlInput("");
+				setShowAudioUrlInput(false);
 				setAudioFile(null);
 			}
 		} catch (err) {
@@ -1916,9 +1876,6 @@ export function AudioRoom({
 								setError(null);
 							}}
 						>
-							<span className="shrink-0 text-muted-foreground">
-								{modeIcon(conversation.mode)}
-							</span>
 							<span className="w-0 grow overflow-hidden text-ellipsis whitespace-nowrap">
 								{conversation.title}
 							</span>
@@ -1929,7 +1886,7 @@ export function AudioRoom({
 									<MoreHorizontal className="h-4 w-4" />
 
 							</DropdownMenuTrigger>
-							<DropdownMenuContent side="right">
+							<DropdownMenuContent side="right" className="rounded-[8px]! [&_[data-slot=dropdown-menu-item]]:rounded-[8px]!">
 								<DropdownMenuItem
 									onClick={() => {
 										void renameConversation(conversation);
@@ -1969,7 +1926,7 @@ export function AudioRoom({
 	const sidebarHistory = sidebarSlotEl
 		? createPortal(
 				<>
-					<div className="px-2 py-1.5">
+					<div data-chat-sidebar-actions="true" className={CHAT_SIDEBAR_ACTIONS_CLASS}>
 						{collapsed ? (
 							<Tooltip>
 								<TooltipTrigger asChild>
@@ -1977,7 +1934,7 @@ export function AudioRoom({
 										variant="ghost"
 										className={`h-8 min-w-0 w-full text-sm font-medium ${
 											collapsed
-												? "justify-center px-0"
+												? "justify-start px-2"
 												: "flex-1 justify-start gap-2 px-2"
 										}`}
 										onClick={startNewConversation}
@@ -2009,13 +1966,13 @@ export function AudioRoom({
 								<TooltipTrigger asChild>
 									<Button
 										variant="ghost"
-										className="h-8 min-w-0 w-full justify-center px-0 text-sm font-medium"
+										className="h-8 min-w-0 w-full justify-start px-2 text-sm font-medium"
 										asChild
 										aria-label="Database"
 									>
 										<Link
 											href="/"
-											className="group/db flex w-full min-w-0 items-center justify-center"
+											className="group/db flex w-full min-w-0 items-center justify-start"
 										>
 											<Database className="h-4 w-4 shrink-0" />
 										</Link>
@@ -2044,7 +2001,7 @@ export function AudioRoom({
 								<TooltipTrigger asChild>
 									<Button
 										variant="ghost"
-										className="h-8 min-w-0 w-full justify-center px-0 text-sm font-medium"
+										className="h-8 min-w-0 w-full justify-start px-2 text-sm font-medium"
 										onClick={() => setConversationSearchOpen(true)}
 										aria-label="Search Chats"
 									>
@@ -2067,9 +2024,9 @@ export function AudioRoom({
 							</Button>
 						)}
 					</div>
-					<SidebarSeparator className="my-0" />
+					<SidebarSeparator className="mx-0 my-0 w-full" />
 					<ScrollArea className="h-full group-data-[collapsible=icon]:hidden">
-						<SidebarGroup className="pt-0 px-2 pb-2">
+						<SidebarGroup className={CHAT_SIDEBAR_HISTORY_GROUP_CLASS}>
 							<SidebarGroupLabel>Chats</SidebarGroupLabel>
 							<SidebarGroupContent className="overflow-hidden">
 								<SidebarMenu>
@@ -2098,6 +2055,13 @@ export function AudioRoom({
 				sidebarSlotEl,
 			)
 		: null;
+	const isAudioSourceMode = mode === "transcription" || mode === "translation";
+	const audioComposerExpanded = Boolean(
+		error ||
+			(mode === "music" && (showMusicLyricsInput || musicLyricsInput.trim())) ||
+			(isAudioSourceMode &&
+				(showAudioUrlInput || audioUrlInput.trim() || audioFile)),
+	);
 
 	return (
 		<div className="flex min-h-0 flex-1 flex-col overflow-hidden">
@@ -2110,16 +2074,15 @@ export function AudioRoom({
 								<Button
 									variant="ghost"
 									size="icon"
-									className="group -ml-1 h-8 w-8"
-									onClick={toggleSidebar}
+								className="-ml-1 h-8 w-8"
+								onClick={toggleSidebar}
+								aria-label={sidebarState === "expanded" ? "Collapse sidebar" : "Open sidebar"}
 								>
-									<ChevronRight
-										className={`h-4 w-4 transition-transform duration-200 ${
-											sidebarState === "expanded"
-												? "rotate-180 group-hover:-translate-x-1"
-												: "group-hover:translate-x-1"
-										}`}
-									/>
+								{sidebarState === "expanded" ? (
+									<PanelLeftClose className="h-4 w-4" />
+								) : (
+									<PanelLeftOpen className="h-4 w-4" />
+								)}
 								</Button>
 							</TooltipTrigger>
 							<TooltipContent side={sidebarState === "collapsed" ? "right" : "bottom"} align="center" sideOffset={8}>Toggle sidebar</TooltipContent>
@@ -2173,9 +2136,7 @@ export function AudioRoom({
 							<div>
 								<p className="text-base font-semibold">Start a new conversation</p>
 								<p className="text-sm text-muted-foreground">
-									{mode === "music"
-										? "Describe the track you want to generate."
-										: "Type your prompt and convert it to speech."}
+									{modeEmptyDescription(mode)}
 								</p>
 							</div>
 						</div>
@@ -2459,49 +2420,15 @@ export function AudioRoom({
 				</div>
 			</main>
 
-			<footer className="border-t border-border px-4 py-3 md:px-6">
+			<RoomComposerFooter>
 				<div className="mx-auto w-full max-w-3xl">
-					<div className="rounded-2xl border border-border bg-background px-3 py-2">
-						{activeConversationMode ? (
-							<div className="flex items-center px-1 py-1 text-xs text-muted-foreground">
-								<span className="inline-flex items-center gap-1.5 rounded-md border border-border bg-muted px-2 py-1">
-									{modeIcon(activeConversationMode)}
-									{modeLabel(activeConversationMode)}
-								</span>
-							</div>
-						) : (
-							<div className="flex flex-wrap gap-2 px-1 py-1">
-								{AUDIO_MODE_OPTIONS.map((option) => {
-									const isDisabled = !uiAvailableModes.includes(option);
-									const showComingSoon = isDisabled && option !== "speech";
-									const button = (
-										<Button
-											key={option}
-											type="button"
-											variant={mode === option ? "default" : "outline"}
-											size="sm"
-											onClick={() => handleModeSelect(option)}
-											className="h-7 gap-1.5 text-xs"
-											disabled={isDisabled}
-										>
-											{modeIcon(option)}
-											{modeLabel(option)}
-										</Button>
-									);
-									if (!showComingSoon) return button;
-									return (
-										<Tooltip key={option}>
-											<TooltipTrigger asChild>
-												<span className="inline-flex cursor-not-allowed">
-													{button}
-												</span>
-											</TooltipTrigger>
-											<TooltipContent side="top">Coming Soon</TooltipContent>
-										</Tooltip>
-									);
-								})}
-							</div>
+					<RoomComposerSurface
+						className={cn(
+							audioComposerExpanded
+								? "px-3 py-2"
+								: "flex flex-col gap-1 px-2 py-1 sm:flex-row sm:items-center",
 						)}
+					>
 						{mode === "speech" ? (
 							<Textarea
 								value={textInput}
@@ -2512,31 +2439,32 @@ export function AudioRoom({
 										void submit();
 									}
 								}}
-								rows={3}
+								rows={1}
 								placeholder="Type text to generate speech..."
-								className="min-h-[72px] resize-none border-0 bg-transparent px-1 py-2 shadow-none focus-visible:ring-0"
+								className="order-1 min-h-9 w-full resize-none border-0 !bg-transparent px-2 py-2 shadow-none focus-visible:ring-0 sm:order-2 sm:flex-1 dark:!bg-transparent"
 							/>
 						) : mode === "music" ? (
-							<div className="grid gap-2 px-1 py-2">
-								<div className="grid gap-1">
-									<p className="text-[11px] font-medium uppercase tracking-wide text-muted-foreground">
-										Prompt
-									</p>
-									<Textarea
-										value={textInput}
-										onChange={(event) => setTextInput(event.target.value)}
-										onKeyDown={(event) => {
-											if (event.key === "Enter" && !event.shiftKey) {
-												event.preventDefault();
-												void submit();
-											}
-										}}
-										rows={3}
-										placeholder="Describe the music style, mood, instruments, and structure..."
-										className="min-h-[72px] max-h-40 overflow-y-auto resize-none border-0 bg-transparent px-1 py-1 shadow-none focus-visible:ring-0"
-									/>
-								</div>
-								<div className="grid gap-1">
+							<>
+								<Textarea
+									value={textInput}
+									onChange={(event) => setTextInput(event.target.value)}
+									onKeyDown={(event) => {
+										if (event.key === "Enter" && !event.shiftKey) {
+											event.preventDefault();
+											void submit();
+										}
+									}}
+									rows={audioComposerExpanded ? 3 : 1}
+									placeholder="Describe the music style, mood, instruments, and structure..."
+									className={cn(
+										"resize-none border-0 !bg-transparent shadow-none focus-visible:ring-0 dark:!bg-transparent",
+										audioComposerExpanded
+											? "min-h-[72px] max-h-40 overflow-y-auto px-1 py-2"
+											: "order-1 min-h-9 w-full px-2 py-2 sm:order-2 sm:flex-1",
+									)}
+								/>
+								{showMusicLyricsInput || musicLyricsInput.trim() ? (
+								<div className="grid gap-1 px-1 pb-1">
 									<p className="text-[11px] font-medium uppercase tracking-wide text-muted-foreground">
 										Lyrics (Optional)
 									</p>
@@ -2548,53 +2476,110 @@ export function AudioRoom({
 										className="min-h-[72px] max-h-40 overflow-y-auto resize-none border-0 bg-transparent px-1 py-1 shadow-none focus-visible:ring-0"
 									/>
 								</div>
-							</div>
+								) : null}
+							</>
 						) : (
-							<div className="grid gap-2 px-1 py-2 md:grid-cols-2">
-								<Input
-									value={audioUrlInput}
-									onChange={(event) => setAudioUrlInput(event.target.value)}
-									placeholder="Audio URL (optional if file is attached)"
-								/>
-								<Input
+							<>
+								<input
+									ref={audioFileInputRef}
 									type="file"
 									accept="audio/*"
-									onChange={(event) =>
-										setAudioFile(event.target.files?.[0] ?? null)
-									}
+									className="hidden"
+									onChange={(event) => {
+										setAudioFile(event.target.files?.[0] ?? null);
+										event.target.value = "";
+									}}
 								/>
-							</div>
+								<div
+									className={cn(
+										"text-sm text-muted-foreground",
+										audioComposerExpanded
+											? "px-1 py-2"
+											: "order-1 min-h-9 w-full px-2 py-2 sm:order-2 sm:flex-1",
+									)}
+								>
+									{audioFile?.name || audioUrlInput.trim() ||
+										(mode === "transcription"
+											? "Add audio to transcribe..."
+											: "Add audio to translate...")}
+								</div>
+								{showAudioUrlInput ? (
+									<div className="px-1 pb-1">
+										<Input
+											value={audioUrlInput}
+											onChange={(event) => setAudioUrlInput(event.target.value)}
+											placeholder="Audio URL"
+											className="h-8"
+										/>
+									</div>
+								) : null}
+								{audioUrlInput.trim() || audioFile ? (
+									<div className="flex flex-wrap gap-1 px-1 pb-1">
+										{audioUrlInput.trim() ? (
+											<button
+												type="button"
+												className="inline-flex items-center gap-1 rounded-full border border-border bg-muted px-1.5 py-0.5 text-[11px] text-muted-foreground"
+												onClick={() => setAudioUrlInput("")}
+											>
+												<span className="max-w-[220px] truncate">Audio URL</span>
+												<X className="h-3 w-3" />
+											</button>
+										) : null}
+										{audioFile ? (
+											<button
+												type="button"
+												className="inline-flex items-center gap-1 rounded-full border border-border bg-muted px-1.5 py-0.5 text-[11px] text-muted-foreground"
+												onClick={() => setAudioFile(null)}
+											>
+												<span className="max-w-[220px] truncate">{audioFile.name}</span>
+												<X className="h-3 w-3" />
+											</button>
+										) : null}
+									</div>
+								) : null}
+							</>
 						)}
 						{error ? <RoomErrorNotice error={error} className="mb-2" /> : null}
-						<div className="flex items-center justify-between pt-2">
-							<div className="flex items-center gap-1.5">
-								<Tooltip>
-									<TooltipTrigger asChild>
-										<Button
-											type="button"
-											variant="ghost"
-											className="h-8 gap-1.5 px-2"
-											onClick={openComposerModelPicker}
-											disabled={!modelId && filteredModels.length === 0}
-										>
-											{modelId ? (
-												<Logo
-													id={composerModelLogoId}
-													alt={composerModelLabel}
-													width={16}
-													height={16}
-													className="shrink-0 rounded-none"
-												/>
-											) : (
-												<Cpu className="h-4 w-4 text-muted-foreground" />
-											)}
-										</Button>
-									</TooltipTrigger>
-									<TooltipContent side="top">{composerModelLabel}</TooltipContent>
-								</Tooltip>
-							</div>
+						<div
+							className={cn(
+								"flex items-center justify-between",
+								audioComposerExpanded ? "pt-2" : "order-2 w-full sm:contents",
+							)}
+						>
+							{mode === "music" ? (
+								<RoomComposerToolsMenu
+									tools={[
+										{
+											id: "lyrics",
+											label: "Add lyrics",
+											icon: FileText,
+											active: Boolean(showMusicLyricsInput || musicLyricsInput.trim()),
+											onSelect: () => setShowMusicLyricsInput((prev) => !prev),
+										},
+									]}
+								/>
+							) : isAudioSourceMode ? (
+								<RoomComposerToolsMenu
+									tools={[
+										{
+											id: "audio-url",
+											label: "Add audio URL",
+											icon: Link2,
+											active: Boolean(showAudioUrlInput || audioUrlInput.trim()),
+											onSelect: () => setShowAudioUrlInput((prev) => !prev),
+										},
+										{
+											id: "upload-audio",
+											label: "Upload audio",
+											icon: Paperclip,
+											active: Boolean(audioFile),
+											onSelect: () => audioFileInputRef.current?.click(),
+										},
+									]}
+								/>
+							) : null}
 							<Button
-								className="ml-auto"
+								className={cn("ml-auto", !audioComposerExpanded && "order-3")}
 								onClick={() => {
 									void submit();
 								}}
@@ -2602,14 +2587,12 @@ export function AudioRoom({
 							>
 								{isLoading
 									? <Loader2 className="h-4 w-4 animate-spin" />
-									: mode === "music"
-										? "Generate"
-										: "Convert"}
+									: modeActionLabel(mode)}
 							</Button>
 						</div>
-					</div>
+					</RoomComposerSurface>
 				</div>
-			</footer>
+			</RoomComposerFooter>
 			{dialogProfile ? (
 				<AudioModelSettingsDialog
 					open={modelSettings.modelSettingsOpen}

--- a/apps/web/src/components/(chat)/rooms/EmbeddingsRoom.tsx
+++ b/apps/web/src/components/(chat)/rooms/EmbeddingsRoom.tsx
@@ -8,6 +8,7 @@ import type { GatewaySupportedModel } from "@/lib/fetchers/gateway/getGatewaySup
 import { filterModelsForRoom } from "@/lib/chat/rooms";
 import { fetchChatWebApi } from "@/lib/web-api/client";
 import { getModelDetailsHref } from "@/lib/models/modelHref";
+import { cn } from "@/lib/utils";
 import { APP_HEADERS } from "@/components/(chat)/playground/chat-playground-core";
 import {
 	buildEmbeddingsMultimodalInput,
@@ -29,6 +30,10 @@ import { RoomModelSelector } from "@/components/(chat)/RoomModelSelector";
 import { RoomSearchDialog } from "@/components/(chat)/RoomSearchDialog";
 import { useSidebar } from "@/components/ui/sidebar";
 import { ROOM_SIDEBAR_SLOT_ID } from "@/components/(chat)/RoomScaffold";
+import {
+	CHAT_SIDEBAR_ACTIONS_CLASS,
+	CHAT_SIDEBAR_HISTORY_GROUP_CLASS,
+} from "@/components/(chat)/chatSidebarStyles";
 import {
 	Popover,
 	PopoverContent,
@@ -66,10 +71,16 @@ import {
 import { EmbeddingsModelSettingsDialog } from "@/components/(chat)/rooms/settings/EmbeddingsModelSettingsDialog";
 import { RoomErrorNotice } from "@/components/(chat)/rooms/RoomErrorNotice";
 import {
+	RoomComposerFooter,
+	RoomComposerSurface,
+	RoomComposerToolsMenu,
+} from "@/components/(chat)/RoomComposer";
+import {
 	AudioLines,
 	ArrowUpRight,
 	Check,
-	ChevronRight,
+	PanelLeftClose,
+	PanelLeftOpen,
 	Clapperboard,
 	Copy,
 	Cpu,
@@ -464,35 +475,6 @@ export function EmbeddingsRoom({ models }: { models: GatewaySupportedModel[] }) 
 		modelSettingsCompat.selectedProfile ?? modelSettingsCompat.activeModelSettings ?? null;
 	const selectedModelEnabled = selectedProfile?.enabled !== false;
 	const selectedProviderId = selectedProfile?.providerId;
-	const composerSelectedModel = useMemo(
-		() =>
-			filteredModels.find(
-				(model) =>
-					model.modelId === modelId &&
-					(!selectedProviderId || model.providerId === selectedProviderId),
-			) ??
-			filteredModels.find((model) => model.modelId === modelId) ??
-			null,
-		[filteredModels, modelId, selectedProviderId],
-	);
-	const composerModelLogoId =
-		composerSelectedModel?.organisationId?.trim() ||
-		composerSelectedModel?.providerId ||
-		(modelId.split("/")[0] || "phaseo");
-	const composerModelLabel =
-		(modelId &&
-			(modelSettings.modelDisplayNameById[modelId] ||
-				composerSelectedModel?.modelName ||
-				modelId)) ||
-		"Select model";
-	const openComposerModelPicker = () => {
-		const targetModelId = modelId || filteredModels[0]?.modelId;
-		if (!targetModelId) return;
-		if (targetModelId !== modelId) {
-			setModelId(targetModelId);
-		}
-		modelSettings.openModelSettingsForModel(targetModelId);
-	};
 	const dialogModelId: string | null = modelSettingsCompat.modelSettingsModelId ?? null;
 	const dialogProfile =
 		dialogModelId && typeof modelSettingsCompat.getProfileForModel === "function"
@@ -1100,7 +1082,7 @@ export function EmbeddingsRoom({ models }: { models: GatewaySupportedModel[] }) 
 									<MoreHorizontal className="h-4 w-4" />
 
 							</DropdownMenuTrigger>
-							<DropdownMenuContent side="right">
+							<DropdownMenuContent side="right" className="rounded-[8px]! [&_[data-slot=dropdown-menu-item]]:rounded-[8px]!">
 								<DropdownMenuItem
 									onClick={() => {
 										void renameConversation(conversation);
@@ -1138,13 +1120,13 @@ export function EmbeddingsRoom({ models }: { models: GatewaySupportedModel[] }) 
 	const sidebarHistory = sidebarSlotEl
 		? createPortal(
 				<>
-					<div className="px-2 py-1.5">
+					<div data-chat-sidebar-actions="true" className={CHAT_SIDEBAR_ACTIONS_CLASS}>
 						{collapsed ? (
 							<Tooltip>
 								<TooltipTrigger asChild>
 									<Button
 										variant="ghost"
-										className="h-8 min-w-0 w-full justify-center px-0 text-sm font-medium"
+										className="h-8 min-w-0 w-full justify-start px-2 text-sm font-medium"
 										onClick={startNewConversation}
 										aria-label="New Chat"
 									>
@@ -1171,13 +1153,13 @@ export function EmbeddingsRoom({ models }: { models: GatewaySupportedModel[] }) 
 								<TooltipTrigger asChild>
 									<Button
 										variant="ghost"
-										className="h-8 min-w-0 w-full justify-center px-0 text-sm font-medium"
+										className="h-8 min-w-0 w-full justify-start px-2 text-sm font-medium"
 										asChild
 										aria-label="Database"
 									>
 										<Link
 											href="/"
-											className="group/db flex w-full min-w-0 items-center justify-center"
+											className="group/db flex w-full min-w-0 items-center justify-start"
 										>
 											<Database className="h-4 w-4 shrink-0" />
 										</Link>
@@ -1206,7 +1188,7 @@ export function EmbeddingsRoom({ models }: { models: GatewaySupportedModel[] }) 
 								<TooltipTrigger asChild>
 									<Button
 										variant="ghost"
-										className="h-8 min-w-0 w-full justify-center px-0 text-sm font-medium"
+										className="h-8 min-w-0 w-full justify-start px-2 text-sm font-medium"
 										onClick={() => setConversationSearchOpen(true)}
 										aria-label="Search Chats"
 									>
@@ -1229,9 +1211,9 @@ export function EmbeddingsRoom({ models }: { models: GatewaySupportedModel[] }) 
 							</Button>
 						)}
 					</div>
-					<SidebarSeparator className="my-0" />
+					<SidebarSeparator className="mx-0 my-0 w-full" />
 					<ScrollArea className="h-full group-data-[collapsible=icon]:hidden">
-						<SidebarGroup className="pt-0 px-2 pb-2">
+						<SidebarGroup className={CHAT_SIDEBAR_HISTORY_GROUP_CLASS}>
 							<SidebarGroupLabel>Chats</SidebarGroupLabel>
 							<SidebarGroupContent className="overflow-hidden">
 								<SidebarMenu>
@@ -1266,16 +1248,15 @@ export function EmbeddingsRoom({ models }: { models: GatewaySupportedModel[] }) 
 							<Button
 								variant="ghost"
 								size="icon"
-								className="group -ml-1 h-8 w-8"
-								onClick={toggleSidebar}
+							className="-ml-1 h-8 w-8"
+							onClick={toggleSidebar}
+							aria-label={sidebarState === "expanded" ? "Collapse sidebar" : "Open sidebar"}
 							>
-								<ChevronRight
-									className={`h-4 w-4 transition-transform duration-200 ${
-										sidebarState === "expanded"
-											? "rotate-180 group-hover:-translate-x-1"
-											: "group-hover:translate-x-1"
-									}`}
-								/>
+							{sidebarState === "expanded" ? (
+								<PanelLeftClose className="h-4 w-4" />
+							) : (
+								<PanelLeftOpen className="h-4 w-4" />
+							)}
 							</Button>
 						</TooltipTrigger>
 						<TooltipContent side={sidebarState === "collapsed" ? "right" : "bottom"} align="center" sideOffset={8}>Toggle sidebar</TooltipContent>
@@ -1325,7 +1306,7 @@ export function EmbeddingsRoom({ models }: { models: GatewaySupportedModel[] }) 
 			<main className="min-h-0 flex-1 overflow-auto overscroll-contain px-4 py-5 md:px-6">
 				<div className="mx-auto flex w-full max-w-5xl flex-col gap-5">
 					{activeEntries.length === 0 ? (
-						<div className="rounded-xl border border-dashed border-border bg-card p-6 text-sm text-muted-foreground">
+						<div className="rounded-2xl border border-dashed border-border bg-card p-6 text-sm text-muted-foreground">
 							No embeddings history yet.
 						</div>
 					) : (
@@ -1691,9 +1672,13 @@ export function EmbeddingsRoom({ models }: { models: GatewaySupportedModel[] }) 
 				</div>
 			</main>
 
-			<footer className="border-t border-border px-4 py-3 md:px-6">
+			<RoomComposerFooter>
 				<div className="mx-auto w-full max-w-3xl">
-					<div className="rounded-2xl border border-border bg-background px-3 py-2">
+					<RoomComposerSurface className={cn(
+						showImageUrlInput || showAudioUrlInput || showVideoUrlInput || imageUrl.trim() || audioUrl.trim() || videoUrl.trim() || files.length || splitTextModeActive || error
+							? "px-3 py-2"
+							: "flex flex-col gap-1 px-2 py-1 sm:flex-row sm:items-center",
+					)}>
 						<input
 							ref={fileInputRef}
 							type="file"
@@ -1711,9 +1696,14 @@ export function EmbeddingsRoom({ models }: { models: GatewaySupportedModel[] }) 
 						<Textarea
 							value={textInput}
 							onChange={(event) => setTextInput(event.target.value)}
-							rows={3}
+							rows={1}
 							placeholder="Text input for embeddings (optional if using URLs/files)..."
-							className="min-h-[64px] resize-none border-0 bg-transparent px-1 py-2 shadow-none focus-visible:ring-0"
+							className={cn(
+								"resize-none border-0 !bg-transparent shadow-none focus-visible:ring-0 dark:!bg-transparent",
+								showImageUrlInput || showAudioUrlInput || showVideoUrlInput || imageUrl.trim() || audioUrl.trim() || videoUrl.trim() || files.length || splitTextModeActive || error
+									? "min-h-[64px] px-1 py-2"
+									: "order-1 min-h-9 w-full px-2 py-2 sm:order-2 sm:flex-1",
+							)}
 						/>
 						{splitTextModeActive ? (
 							<p className="px-1 pb-1 text-[11px] text-muted-foreground">
@@ -1801,103 +1791,43 @@ export function EmbeddingsRoom({ models }: { models: GatewaySupportedModel[] }) 
 							</div>
 						) : null}
 						{error ? <RoomErrorNotice error={error} className="mb-2" /> : null}
-						<div className="flex items-center justify-between pt-2">
-							<div className="flex items-center gap-1.5">
-								<Tooltip>
-									<TooltipTrigger asChild>
-										<Button
-											type="button"
-											variant="ghost"
-											className="h-8 gap-1.5 px-2"
-											onClick={openComposerModelPicker}
-											disabled={!modelId && filteredModels.length === 0}
-										>
-											{modelId ? (
-												<Logo
-													id={composerModelLogoId}
-													alt={composerModelLabel}
-													width={16}
-													height={16}
-													className="shrink-0 rounded-none"
-												/>
-											) : (
-												<Cpu className="h-4 w-4 text-muted-foreground" />
-											)}
-										</Button>
-									</TooltipTrigger>
-									<TooltipContent side="top">{composerModelLabel}</TooltipContent>
-								</Tooltip>
-								<Tooltip>
-									<TooltipTrigger asChild>
-										<Button
-											type="button"
-											variant="ghost"
-											size="icon"
-											className={`h-8 w-8 ${
-												showImageUrlInput || imageUrl.trim()
-													? "bg-muted text-foreground"
-													: ""
-											}`}
-											onClick={() => setShowImageUrlInput((prev) => !prev)}
-										>
-											<ImagePlus className="h-4 w-4" />
-										</Button>
-									</TooltipTrigger>
-									<TooltipContent side="top">Add image URL</TooltipContent>
-								</Tooltip>
-								<Tooltip>
-									<TooltipTrigger asChild>
-										<Button
-											type="button"
-											variant="ghost"
-											size="icon"
-											className={`h-8 w-8 ${
-												showAudioUrlInput || audioUrl.trim()
-													? "bg-muted text-foreground"
-													: ""
-											}`}
-											onClick={() => setShowAudioUrlInput((prev) => !prev)}
-										>
-											<AudioLines className="h-4 w-4" />
-										</Button>
-									</TooltipTrigger>
-									<TooltipContent side="top">Add audio URL</TooltipContent>
-								</Tooltip>
-								<Tooltip>
-									<TooltipTrigger asChild>
-										<Button
-											type="button"
-											variant="ghost"
-											size="icon"
-											className={`h-8 w-8 ${
-												showVideoUrlInput || videoUrl.trim()
-													? "bg-muted text-foreground"
-													: ""
-											}`}
-											onClick={() => setShowVideoUrlInput((prev) => !prev)}
-										>
-											<Clapperboard className="h-4 w-4" />
-										</Button>
-									</TooltipTrigger>
-									<TooltipContent side="top">Add video URL</TooltipContent>
-								</Tooltip>
-								<Tooltip>
-									<TooltipTrigger asChild>
-										<Button
-											type="button"
-											variant="ghost"
-											size="icon"
-											className={`h-8 w-8 ${files.length ? "bg-muted text-foreground" : ""}`}
-											onClick={() => fileInputRef.current?.click()}
-										>
-											<Paperclip className="h-4 w-4" />
-										</Button>
-									</TooltipTrigger>
-									<TooltipContent side="top">Upload files</TooltipContent>
-								</Tooltip>
+						<div className={cn("flex items-center justify-between", showImageUrlInput || showAudioUrlInput || showVideoUrlInput || imageUrl.trim() || audioUrl.trim() || videoUrl.trim() || files.length || splitTextModeActive || error ? "pt-2" : "order-2 w-full sm:contents")}>
+							<div className={cn("flex items-center gap-1.5", !(showImageUrlInput || showAudioUrlInput || showVideoUrlInput || imageUrl.trim() || audioUrl.trim() || videoUrl.trim() || files.length || splitTextModeActive || error) && "order-1")}>
+								<RoomComposerToolsMenu
+									tools={[
+										{
+											id: "image-url",
+											label: "Add image URL",
+											icon: ImagePlus,
+											active: Boolean(showImageUrlInput || imageUrl.trim()),
+											onSelect: () => setShowImageUrlInput((prev) => !prev),
+										},
+										{
+											id: "audio-url",
+											label: "Add audio URL",
+											icon: AudioLines,
+											active: Boolean(showAudioUrlInput || audioUrl.trim()),
+											onSelect: () => setShowAudioUrlInput((prev) => !prev),
+										},
+										{
+											id: "video-url",
+											label: "Add video URL",
+											icon: Clapperboard,
+											active: Boolean(showVideoUrlInput || videoUrl.trim()),
+											onSelect: () => setShowVideoUrlInput((prev) => !prev),
+										},
+										{
+											id: "upload-files",
+											label: "Upload files",
+											icon: Paperclip,
+											active: files.length > 0,
+											onSelect: () => fileInputRef.current?.click(),
+										},
+									]}
+								/>
 							</div>
 							<Button
-								className="ml-auto"
+								className={cn("ml-auto", !(showImageUrlInput || showAudioUrlInput || showVideoUrlInput || imageUrl.trim() || audioUrl.trim() || videoUrl.trim() || files.length || splitTextModeActive || error) && "order-3")}
 								onClick={() => {
 									void submit();
 								}}
@@ -1906,9 +1836,9 @@ export function EmbeddingsRoom({ models }: { models: GatewaySupportedModel[] }) 
 								{isLoading ? "Embedding..." : "Embed"}
 							</Button>
 						</div>
-					</div>
+					</RoomComposerSurface>
 				</div>
-			</footer>
+			</RoomComposerFooter>
 			{dialogProfile ? (
 				<EmbeddingsModelSettingsDialog
 					open={modelSettings.modelSettingsOpen}

--- a/apps/web/src/components/(chat)/rooms/MediaStudioRoom.tsx
+++ b/apps/web/src/components/(chat)/rooms/MediaStudioRoom.tsx
@@ -78,7 +78,12 @@ import { ImageModelSettingsDialog } from "@/components/(chat)/rooms/settings/Ima
 import { VideoModelSettingsDialog } from "@/components/(chat)/rooms/settings/VideoModelSettingsDialog";
 import { RoomErrorNotice } from "@/components/(chat)/rooms/RoomErrorNotice";
 import {
-	ChevronRight,
+	RoomComposerFooter,
+	RoomComposerSurface,
+} from "@/components/(chat)/RoomComposer";
+import {
+	PanelLeftClose,
+	PanelLeftOpen,
 	CircleAlert,
 	Cpu,
 	Download,
@@ -893,42 +898,6 @@ export function MediaStudioRoom({ roomId, models }: MediaStudioRoomProps) {
 	const modelSettingsCompat = modelSettings as any;
 	const selectedProfile =
 		modelSettingsCompat.selectedProfile ?? modelSettingsCompat.activeModelSettings ?? null;
-	const selectedProviderId = selectedProfile?.providerId;
-	const composerSelectedModel = useMemo(
-		() =>
-			filteredModels.find(
-				(model) =>
-					model.modelId === activeModelId &&
-					(!selectedProviderId || model.providerId === selectedProviderId),
-			) ??
-			filteredModels.find((model) => model.modelId === activeModelId) ??
-			null,
-		[activeModelId, filteredModels, selectedProviderId],
-	);
-	const composerModelLogoId =
-		composerSelectedModel?.organisationId?.trim() ||
-		composerSelectedModel?.providerId ||
-		(activeModelId.split("/")[0] || "phaseo");
-	const composerModelLabel =
-		(activeModelId &&
-			(modelSettings.modelDisplayNameById[activeModelId] ||
-				composerSelectedModel?.modelName ||
-				activeModelId)) ||
-		"Select model";
-	const openComposerModelPicker = () => {
-		const targetModelId =
-			activeModelId || selectedModelIds[0] || filteredModels[0]?.modelId;
-		if (!targetModelId) return;
-		if (!selectedModelIds.includes(targetModelId)) {
-			setSelectedModelIds((prev) =>
-				roomId === "video" ? [targetModelId] : [...prev, targetModelId],
-			);
-		}
-		if (targetModelId !== activeModelId) {
-			setActiveModelId(targetModelId);
-		}
-		modelSettings.openModelSettingsForModel(targetModelId);
-	};
 	const dialogModelId: string | null = modelSettingsCompat.modelSettingsModelId ?? null;
 	const dialogProfile =
 		dialogModelId && typeof modelSettingsCompat.getProfileForModel === "function"
@@ -1821,16 +1790,15 @@ export function MediaStudioRoom({ roomId, models }: MediaStudioRoomProps) {
 							<Button
 								variant="ghost"
 								size="icon"
-								className="group -ml-1 h-8 w-8"
-								onClick={toggleSidebar}
+							className="-ml-1 h-8 w-8"
+							onClick={toggleSidebar}
+							aria-label={sidebarState === "expanded" ? "Collapse sidebar" : "Open sidebar"}
 							>
-								<ChevronRight
-									className={`h-4 w-4 transition-transform duration-200 ${
-										sidebarState === "expanded"
-											? "rotate-180 group-hover:-translate-x-1"
-											: "group-hover:translate-x-1"
-									}`}
-								/>
+							{sidebarState === "expanded" ? (
+								<PanelLeftClose className="h-4 w-4" />
+							) : (
+								<PanelLeftOpen className="h-4 w-4" />
+							)}
 							</Button>
 						</TooltipTrigger>
 						<TooltipContent side={sidebarState === "collapsed" ? "right" : "bottom"} align="center" sideOffset={8}>Toggle sidebar</TooltipContent>
@@ -1890,7 +1858,7 @@ export function MediaStudioRoom({ roomId, models }: MediaStudioRoomProps) {
 					</div>
 				) : null}
 				{entries.length === 0 ? (
-					<div className="flex min-h-[240px] items-center justify-center rounded-xl border border-dashed border-border bg-muted/15 px-6 text-center text-sm text-muted-foreground">
+					<div className="flex min-h-[240px] items-center justify-center rounded-2xl border border-dashed border-border bg-muted/15 px-6 text-center text-sm text-muted-foreground">
 						{isImageRoom ? "Your generated images will appear here." : "Your generated videos will appear here."}
 					</div>
 				) : isImageRoom ? (
@@ -1901,7 +1869,7 @@ export function MediaStudioRoom({ roomId, models }: MediaStudioRoomProps) {
 							return (
 								<div
 									key={entry.id}
-									className="overflow-hidden rounded-xl border border-border bg-card"
+									className="overflow-hidden rounded-2xl border border-border bg-card"
 								>
 									<div className="relative aspect-[4/5] bg-muted/20">
 										{entry.status === "failed" ? (
@@ -2042,7 +2010,7 @@ export function MediaStudioRoom({ roomId, models }: MediaStudioRoomProps) {
 							const modelLabel = modelLabelById.get(entry.modelId) ?? entry.modelId;
 							const pendingState = getPendingGenerationState(entry, "video");
 							return (
-								<div className="flex min-h-[460px] flex-col overflow-hidden rounded-xl border border-border bg-card">
+								<div className="flex min-h-[460px] flex-col overflow-hidden rounded-2xl border border-border bg-card">
 									<div className="flex items-start justify-between gap-3 border-b border-border px-4 py-3">
 										<div className="min-w-0">
 											<p className="truncate text-sm font-medium text-foreground" title={modelLabel}>
@@ -2137,7 +2105,7 @@ export function MediaStudioRoom({ roomId, models }: MediaStudioRoomProps) {
 										) : entry.url ? (
 											<MediaPlayer
 												theme="surface"
-												className="h-full w-full overflow-hidden rounded-xl border border-border/70 bg-gradient-to-b from-muted/80 to-background shadow-sm"
+										className="h-full w-full overflow-hidden rounded-2xl border border-border/70 bg-gradient-to-b from-muted/80 to-background shadow-sm"
 											>
 												<div className="flex h-full min-h-[320px] items-center justify-center px-3 pb-2 pt-3">
 													<MediaPlayerVideo
@@ -2189,13 +2157,13 @@ export function MediaStudioRoom({ roomId, models }: MediaStudioRoomProps) {
 						})()}
 					</div>
 				) : (
-					<div className="flex min-h-[240px] items-center justify-center rounded-xl border border-dashed border-border bg-muted/15 px-6 text-center text-sm text-muted-foreground">
+					<div className="flex min-h-[240px] items-center justify-center rounded-2xl border border-dashed border-border bg-muted/15 px-6 text-center text-sm text-muted-foreground">
 						Your generated videos will appear here.
 					</div>
 				)}
 			</main>
 
-			<footer className="border-t border-border px-4 py-3 md:px-6">
+			<RoomComposerFooter>
 				<div className="mx-auto w-full max-w-3xl space-y-2">
 					{roomId === "video" && hasPendingEntries ? (
 						<p className="text-xs text-muted-foreground">
@@ -2211,7 +2179,7 @@ export function MediaStudioRoom({ roomId, models }: MediaStudioRoomProps) {
 						</div>
 					) : null}
 					{error ? <RoomErrorNotice error={error} /> : null}
-					<div className="rounded-2xl border border-border bg-background px-3 py-2">
+					<RoomComposerSurface className="flex flex-col gap-1 px-2 py-1 sm:flex-row sm:items-center">
 						<Textarea
 							value={prompt}
 							onChange={(event) => setPrompt(event.target.value)}
@@ -2227,38 +2195,12 @@ export function MediaStudioRoom({ roomId, models }: MediaStudioRoomProps) {
 									: "Describe the video you want to create..."
 							}
 							disabled={roomId === "video" && hasPendingEntries}
-							rows={3}
-							className="min-h-[64px] resize-none border-0 bg-transparent px-1 py-2 shadow-none focus-visible:ring-0"
+							rows={1}
+							className="order-1 min-h-9 w-full resize-none border-0 !bg-transparent px-2 py-2 shadow-none focus-visible:ring-0 sm:order-2 sm:flex-1 dark:!bg-transparent"
 						/>
-						<div className="flex items-center justify-between pt-2">
-							<div className="flex items-center gap-1.5">
-								<Tooltip>
-									<TooltipTrigger asChild>
-										<Button
-											type="button"
-											variant="ghost"
-											className="h-8 gap-1.5 px-2"
-											onClick={openComposerModelPicker}
-											disabled={filteredModels.length === 0 || (roomId === "video" && hasPendingEntries)}
-										>
-											{activeModelId ? (
-												<Logo
-													id={composerModelLogoId}
-													alt={composerModelLabel}
-													width={16}
-													height={16}
-													className="shrink-0 rounded-none"
-												/>
-											) : (
-												<Cpu className="h-4 w-4 text-muted-foreground" />
-											)}
-										</Button>
-									</TooltipTrigger>
-									<TooltipContent side="top">{composerModelLabel}</TooltipContent>
-								</Tooltip>
-							</div>
+						<div className="order-2 flex w-full items-center justify-between sm:contents">
 							<Button
-								className="ml-auto"
+								className="order-3 ml-auto"
 								onClick={submit}
 								disabled={
 									!prompt.trim() ||
@@ -2276,9 +2218,9 @@ export function MediaStudioRoom({ roomId, models }: MediaStudioRoomProps) {
 										: "Create"}
 							</Button>
 						</div>
-					</div>
+					</RoomComposerSurface>
 				</div>
-			</footer>
+			</RoomComposerFooter>
 			<Dialog
 				open={Boolean(previewEntryId)}
 				onOpenChange={(open) => {
@@ -2301,7 +2243,7 @@ export function MediaStudioRoom({ roomId, models }: MediaStudioRoomProps) {
 									</DialogHeader>
 								</div>
 								<div className="bg-muted/20 p-4">
-									<div className="flex max-h-[62vh] min-h-[320px] items-center justify-center overflow-hidden rounded-lg border border-border bg-background/60">
+									<div className="flex max-h-[62vh] min-h-[320px] items-center justify-center overflow-hidden rounded-2xl border border-border bg-background/60">
 										<img
 											src={previewEntry.url}
 											alt={previewEntry.prompt || "Generated image"}
@@ -2411,11 +2353,11 @@ export function MediaStudioRoom({ roomId, models }: MediaStudioRoomProps) {
 									</DialogHeader>
 								</div>
 								<div className="bg-muted/20 p-4">
-									<div className="flex min-h-[260px] items-center justify-center overflow-hidden rounded-lg border border-border bg-background/60 p-2">
+									<div className="flex min-h-[260px] items-center justify-center overflow-hidden rounded-2xl border border-border bg-background/60 p-2">
 										{previewEntry.url ? (
 											<MediaPlayer
 												theme="surface"
-												className="w-full overflow-hidden rounded-xl border border-border/70 bg-gradient-to-b from-muted/80 to-background shadow-sm"
+											className="w-full overflow-hidden rounded-2xl border border-border/70 bg-gradient-to-b from-muted/80 to-background shadow-sm"
 											>
 												<div className="flex items-center justify-center px-3 pb-2 pt-3">
 													<div

--- a/apps/web/src/components/(chat)/rooms/ModerationRoom.tsx
+++ b/apps/web/src/components/(chat)/rooms/ModerationRoom.tsx
@@ -8,6 +8,7 @@ import type { GatewaySupportedModel } from "@/lib/fetchers/gateway/getGatewaySup
 import { filterModelsForRoom } from "@/lib/chat/rooms";
 import { fetchChatWebApi } from "@/lib/web-api/client";
 import { getModelDetailsHref } from "@/lib/models/modelHref";
+import { cn } from "@/lib/utils";
 import { APP_HEADERS } from "@/components/(chat)/playground/chat-playground-core";
 import {
 	buildModerationInput,
@@ -27,6 +28,10 @@ import { RoomModelSelector } from "@/components/(chat)/RoomModelSelector";
 import { RoomSearchDialog } from "@/components/(chat)/RoomSearchDialog";
 import { useSidebar } from "@/components/ui/sidebar";
 import { ROOM_SIDEBAR_SLOT_ID } from "@/components/(chat)/RoomScaffold";
+import {
+	CHAT_SIDEBAR_ACTIONS_CLASS,
+	CHAT_SIDEBAR_HISTORY_GROUP_CLASS,
+} from "@/components/(chat)/chatSidebarStyles";
 import {
 	Tooltip,
 	TooltipContent,
@@ -64,9 +69,15 @@ import {
 import { ModerationModelSettingsDialog } from "@/components/(chat)/rooms/settings/ModerationModelSettingsDialog";
 import { RoomErrorNotice } from "@/components/(chat)/rooms/RoomErrorNotice";
 import {
+	RoomComposerFooter,
+	RoomComposerSurface,
+	RoomComposerToolsMenu,
+} from "@/components/(chat)/RoomComposer";
+import {
 	ArrowUpRight,
 	Check,
-	ChevronRight,
+	PanelLeftClose,
+	PanelLeftOpen,
 	Copy,
 	Cpu,
 	Database,
@@ -590,35 +601,6 @@ export function ModerationRoom({ models }: { models: GatewaySupportedModel[] }) 
 		modelSettingsCompat.selectedProfile ?? modelSettingsCompat.activeModelSettings ?? null;
 	const selectedModelEnabled = selectedProfile?.enabled !== false;
 	const selectedProviderId = selectedProfile?.providerId;
-	const composerSelectedModel = useMemo(
-		() =>
-			filteredModels.find(
-				(model) =>
-					model.modelId === modelId &&
-					(!selectedProviderId || model.providerId === selectedProviderId),
-			) ??
-			filteredModels.find((model) => model.modelId === modelId) ??
-			null,
-		[filteredModels, modelId, selectedProviderId],
-	);
-	const composerModelLogoId =
-		composerSelectedModel?.organisationId?.trim() ||
-		composerSelectedModel?.providerId ||
-		(modelId.split("/")[0] || "phaseo");
-	const composerModelLabel =
-		(modelId &&
-			(modelSettings.modelDisplayNameById[modelId] ||
-				composerSelectedModel?.modelName ||
-				modelId)) ||
-		"Select model";
-	const openComposerModelPicker = () => {
-		const targetModelId = modelId || filteredModels[0]?.modelId;
-		if (!targetModelId) return;
-		if (targetModelId !== modelId) {
-			setModelId(targetModelId);
-		}
-		modelSettings.openModelSettingsForModel(targetModelId);
-	};
 	const dialogModelId: string | null = modelSettingsCompat.modelSettingsModelId ?? null;
 	const dialogProfile =
 		dialogModelId && typeof modelSettingsCompat.getProfileForModel === "function"
@@ -1192,7 +1174,7 @@ export function ModerationRoom({ models }: { models: GatewaySupportedModel[] }) 
 									<MoreHorizontal className="h-4 w-4" />
 
 							</DropdownMenuTrigger>
-							<DropdownMenuContent side="right">
+							<DropdownMenuContent side="right" className="rounded-[8px]! [&_[data-slot=dropdown-menu-item]]:rounded-[8px]!">
 								<DropdownMenuItem
 									onClick={() => {
 										void renameConversation(conversation);
@@ -1230,13 +1212,13 @@ export function ModerationRoom({ models }: { models: GatewaySupportedModel[] }) 
 	const sidebarHistory = sidebarSlotEl
 		? createPortal(
 				<>
-					<div className="px-2 py-1.5">
+					<div data-chat-sidebar-actions="true" className={CHAT_SIDEBAR_ACTIONS_CLASS}>
 						{collapsed ? (
 							<Tooltip>
 								<TooltipTrigger asChild>
 									<Button
 										variant="ghost"
-										className="h-8 min-w-0 w-full justify-center px-0 text-sm font-medium"
+										className="h-8 min-w-0 w-full justify-start px-2 text-sm font-medium"
 										onClick={startNewConversation}
 										aria-label="New Chat"
 									>
@@ -1263,13 +1245,13 @@ export function ModerationRoom({ models }: { models: GatewaySupportedModel[] }) 
 								<TooltipTrigger asChild>
 									<Button
 										variant="ghost"
-										className="h-8 min-w-0 w-full justify-center px-0 text-sm font-medium"
+										className="h-8 min-w-0 w-full justify-start px-2 text-sm font-medium"
 										asChild
 										aria-label="Database"
 									>
 										<Link
 											href="/"
-											className="group/db flex w-full min-w-0 items-center justify-center"
+											className="group/db flex w-full min-w-0 items-center justify-start"
 										>
 											<Database className="h-4 w-4 shrink-0" />
 										</Link>
@@ -1298,7 +1280,7 @@ export function ModerationRoom({ models }: { models: GatewaySupportedModel[] }) 
 								<TooltipTrigger asChild>
 									<Button
 										variant="ghost"
-										className="h-8 min-w-0 w-full justify-center px-0 text-sm font-medium"
+										className="h-8 min-w-0 w-full justify-start px-2 text-sm font-medium"
 										onClick={() => setConversationSearchOpen(true)}
 										aria-label="Search Chats"
 									>
@@ -1321,9 +1303,9 @@ export function ModerationRoom({ models }: { models: GatewaySupportedModel[] }) 
 							</Button>
 						)}
 					</div>
-					<SidebarSeparator className="my-0" />
+					<SidebarSeparator className="mx-0 my-0 w-full" />
 					<ScrollArea className="h-full group-data-[collapsible=icon]:hidden">
-						<SidebarGroup className="pt-0 px-2 pb-2">
+						<SidebarGroup className={CHAT_SIDEBAR_HISTORY_GROUP_CLASS}>
 							<SidebarGroupLabel>Chats</SidebarGroupLabel>
 							<SidebarGroupContent className="overflow-hidden">
 								<SidebarMenu>
@@ -1358,16 +1340,15 @@ export function ModerationRoom({ models }: { models: GatewaySupportedModel[] }) 
 								<Button
 									variant="ghost"
 									size="icon"
-									className="group -ml-1 h-8 w-8"
-									onClick={toggleSidebar}
+								className="-ml-1 h-8 w-8"
+								onClick={toggleSidebar}
+								aria-label={sidebarState === "expanded" ? "Collapse sidebar" : "Open sidebar"}
 								>
-									<ChevronRight
-										className={`h-4 w-4 transition-transform duration-200 ${
-											sidebarState === "expanded"
-												? "rotate-180 group-hover:-translate-x-1"
-												: "group-hover:translate-x-1"
-										}`}
-									/>
+								{sidebarState === "expanded" ? (
+									<PanelLeftClose className="h-4 w-4" />
+								) : (
+									<PanelLeftOpen className="h-4 w-4" />
+								)}
 								</Button>
 							</TooltipTrigger>
 							<TooltipContent side={sidebarState === "collapsed" ? "right" : "bottom"} align="center" sideOffset={8}>Toggle sidebar</TooltipContent>
@@ -1654,7 +1635,7 @@ export function ModerationRoom({ models }: { models: GatewaySupportedModel[] }) 
 											</div>
 											{entry.result ? (
 												<div className="space-y-3">
-													<div className="rounded-xl border border-border bg-muted/20 p-3">
+											<div className="rounded-md border border-border bg-muted/20 p-3">
 														<div className="mb-2 flex items-center justify-between">
 															<p className="text-xs font-semibold uppercase text-muted-foreground">
 																Top signal
@@ -1710,7 +1691,7 @@ export function ModerationRoom({ models }: { models: GatewaySupportedModel[] }) 
 																					: "Image Only"}
 
 																	</DropdownMenuTrigger>
-																	<DropdownMenuContent align="end" className="w-28">
+																	<DropdownMenuContent align="end" className="w-28 rounded-[8px]! [&_[data-slot=dropdown-menu-item]]:rounded-[8px]!">
 																		<DropdownMenuItem
 																			onClick={() =>
 																				setCategoryViewByEntryId((prev) => ({
@@ -1920,9 +1901,13 @@ export function ModerationRoom({ models }: { models: GatewaySupportedModel[] }) 
 				</div>
 			</main>
 
-			<footer className="border-t border-border px-4 py-3 md:px-6">
+			<RoomComposerFooter>
 				<div className="mx-auto w-full max-w-3xl">
-					<div className="rounded-2xl border border-border bg-background px-3 py-2">
+					<RoomComposerSurface className={cn(
+						showImageUrlInput || imageUrl.trim() || imageFile || error
+							? "px-3 py-2"
+							: "flex flex-col gap-1 px-2 py-1 sm:flex-row sm:items-center",
+					)}>
 						<input
 							ref={imageFileInputRef}
 							type="file"
@@ -1941,9 +1926,14 @@ export function ModerationRoom({ models }: { models: GatewaySupportedModel[] }) 
 									void submit();
 								}
 							}}
-							rows={3}
+							rows={1}
 							placeholder="Text to moderate..."
-							className="min-h-[64px] resize-none border-0 bg-transparent px-1 py-2 shadow-none focus-visible:ring-0"
+							className={cn(
+								"resize-none border-0 !bg-transparent shadow-none focus-visible:ring-0 dark:!bg-transparent",
+								showImageUrlInput || imageUrl.trim() || imageFile || error
+									? "min-h-[64px] px-1 py-2"
+									: "order-1 min-h-9 w-full px-2 py-2 sm:order-2 sm:flex-1",
+							)}
 						/>
 						{showImageUrlInput ? (
 							<div className="px-1 pb-1">
@@ -1986,69 +1976,29 @@ export function ModerationRoom({ models }: { models: GatewaySupportedModel[] }) 
 							</div>
 						) : null}
 						{error ? <RoomErrorNotice error={error} className="mb-2" /> : null}
-						<div className="flex items-center justify-between pt-2">
-							<div className="flex items-center gap-1.5">
-								<Tooltip>
-									<TooltipTrigger asChild>
-										<Button
-											type="button"
-											variant="ghost"
-											className="h-8 gap-1.5 px-2"
-											onClick={openComposerModelPicker}
-											disabled={!modelId && filteredModels.length === 0}
-										>
-											{modelId ? (
-												<Logo
-													id={composerModelLogoId}
-													alt={composerModelLabel}
-													width={16}
-													height={16}
-													className="shrink-0 rounded-none"
-												/>
-											) : (
-												<Cpu className="h-4 w-4 text-muted-foreground" />
-											)}
-										</Button>
-									</TooltipTrigger>
-									<TooltipContent side="top">{composerModelLabel}</TooltipContent>
-								</Tooltip>
-								<Tooltip>
-									<TooltipTrigger asChild>
-										<Button
-											type="button"
-											variant="ghost"
-											size="icon"
-											className={`h-8 w-8 ${
-												showImageUrlInput || imageUrl.trim()
-													? "bg-muted text-foreground"
-													: ""
-											}`}
-											onClick={() =>
-												setShowImageUrlInput((prev) => !prev)
-											}
-										>
-											<Link2 className="h-4 w-4" />
-										</Button>
-									</TooltipTrigger>
-									<TooltipContent side="top">Add image URL</TooltipContent>
-								</Tooltip>
-								<Tooltip>
-									<TooltipTrigger asChild>
-										<Button
-											type="button"
-											variant="ghost"
-											size="icon"
-											className={`h-8 w-8 ${imageFile ? "bg-muted text-foreground" : ""}`}
-											onClick={() => imageFileInputRef.current?.click()}
-										>
-											<ImagePlus className="h-4 w-4" />
-										</Button>
-									</TooltipTrigger>
-									<TooltipContent side="top">Upload image</TooltipContent>
-								</Tooltip>
+						<div className={cn("flex items-center justify-between", showImageUrlInput || imageUrl.trim() || imageFile || error ? "pt-2" : "order-2 w-full sm:contents")}>
+							<div className={cn("flex items-center gap-1.5", !(showImageUrlInput || imageUrl.trim() || imageFile || error) && "order-1")}>
+								<RoomComposerToolsMenu
+									tools={[
+										{
+											id: "image-url",
+											label: "Add image URL",
+											icon: Link2,
+											active: Boolean(showImageUrlInput || imageUrl.trim()),
+											onSelect: () => setShowImageUrlInput((prev) => !prev),
+										},
+										{
+											id: "upload-image",
+											label: "Upload image",
+											icon: ImagePlus,
+											active: Boolean(imageFile),
+											onSelect: () => imageFileInputRef.current?.click(),
+										},
+									]}
+								/>
 							</div>
 							<Button
-								className="ml-auto"
+								className={cn("ml-auto", !(showImageUrlInput || imageUrl.trim() || imageFile || error) && "order-3")}
 								onClick={() => {
 									void submit();
 								}}
@@ -2057,9 +2007,9 @@ export function ModerationRoom({ models }: { models: GatewaySupportedModel[] }) 
 								{isLoading ? "Moderating..." : "Moderate"}
 							</Button>
 						</div>
-					</div>
+					</RoomComposerSurface>
 				</div>
-			</footer>
+			</RoomComposerFooter>
 			{dialogProfile ? (
 				<ModerationModelSettingsDialog
 					open={modelSettings.modelSettingsOpen}

--- a/apps/web/src/components/(chat)/rooms/RealtimeRoom.tsx
+++ b/apps/web/src/components/(chat)/rooms/RealtimeRoom.tsx
@@ -9,7 +9,8 @@ import {
 	BadgeDollarSign,
 	Check,
 	ChevronDown,
-	ChevronRight,
+	PanelLeftClose,
+	PanelLeftOpen,
 	Clock3,
 	Mic,
 	Settings,
@@ -46,6 +47,10 @@ import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip
 import type { GatewaySupportedModel } from "@/lib/fetchers/gateway/getGatewaySupportedModelIds";
 import { filterModelsForRoom } from "@/lib/chat/rooms";
 import { groupModelsByReleaseMonth } from "@/components/(chat)/playgroundConfig";
+import {
+	RoomComposerFooter,
+	RoomComposerSurface,
+} from "@/components/(chat)/RoomComposer";
 import { cn } from "@/lib/utils";
 import { fetchChatWebApi } from "@/lib/web-api/client";
 
@@ -2916,16 +2921,15 @@ export function RealtimeRoom({ models = [] }: RealtimeRoomProps) {
 								<Button
 									variant="ghost"
 									size="icon"
-									className="group -ml-1 h-8 w-8"
+									className="-ml-1 h-8 w-8"
 									onClick={toggleSidebar}
+									aria-label={sidebarState === "expanded" ? "Collapse sidebar" : "Open sidebar"}
 								>
-									<ChevronRight
-										className={`h-4 w-4 transition-transform duration-200 ${
-											sidebarState === "expanded"
-												? "rotate-180 group-hover:-translate-x-1"
-												: "group-hover:translate-x-1"
-										}`}
-									/>
+									{sidebarState === "expanded" ? (
+										<PanelLeftClose className="h-4 w-4" />
+									) : (
+										<PanelLeftOpen className="h-4 w-4" />
+									)}
 								</Button>
 							</TooltipTrigger>
 							<TooltipContent
@@ -2996,7 +3000,7 @@ export function RealtimeRoom({ models = [] }: RealtimeRoomProps) {
 											)}
 										</div>
 									) : (
-										<div className="flex min-h-24 w-full max-w-sm items-center justify-center rounded-lg border border-border bg-muted/20 px-6 py-5">
+										<div className="flex min-h-24 w-full max-w-sm items-center justify-center rounded-2xl border border-border bg-muted/20 px-6 py-5">
 											<div className="flex items-center gap-3">
 												<div className="flex h-9 w-9 items-center justify-center rounded-full bg-background ring-1 ring-border">
 													<Volume2 className="h-4 w-4 text-muted-foreground" />
@@ -3107,7 +3111,7 @@ export function RealtimeRoom({ models = [] }: RealtimeRoomProps) {
 											key={model.id}
 											type="button"
 											onClick={() => setSelectedModelId(model.id)}
-											className="group min-h-32 rounded-lg border border-border bg-background px-4 py-3 text-left transition hover:border-foreground/30 hover:bg-muted/30"
+											className="group min-h-32 rounded-2xl border border-border bg-background px-4 py-3 text-left transition hover:border-foreground/30 hover:bg-muted/30"
 										>
 											<div className="flex items-center gap-2">
 												<Logo
@@ -3134,8 +3138,9 @@ export function RealtimeRoom({ models = [] }: RealtimeRoomProps) {
 						)}
 					</div>
 
-					<div className="flex min-h-20 items-center border-t border-border bg-background px-4">
-						<div className="mx-auto flex w-full max-w-3xl gap-2">
+					<RoomComposerFooter>
+						<div className="mx-auto w-full max-w-3xl">
+							<RoomComposerSurface className="p-1">
 							{sessionActive ? (
 								<Button
 									type="button"
@@ -3158,8 +3163,9 @@ export function RealtimeRoom({ models = [] }: RealtimeRoomProps) {
 									{selectedModel ? "Start realtime session" : "Select a model to start"}
 								</Button>
 							)}
+							</RoomComposerSurface>
 						</div>
-					</div>
+					</RoomComposerFooter>
 				</div>
 
 				<aside className="flex min-h-0 flex-col bg-muted/10">
@@ -3180,7 +3186,7 @@ export function RealtimeRoom({ models = [] }: RealtimeRoomProps) {
 								<div
 									key={line.id}
 									className={cn(
-										"rounded-lg border px-3 py-2 text-sm",
+										"rounded-2xl border px-3 py-2 text-sm",
 										line.role === "assistant"
 											? "border-primary/20 bg-primary/5"
 											: line.role === "user"

--- a/apps/web/src/components/(chat)/use-chat-credits.ts
+++ b/apps/web/src/components/(chat)/use-chat-credits.ts
@@ -1,0 +1,83 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { createClient } from "@/utils/supabase/client";
+
+type CreditsBalanceResponse = {
+	initialBalance?: number | null;
+};
+
+function formatCreditsBalance(value: number | null) {
+	if (value === null || !Number.isFinite(value)) return null;
+	return new Intl.NumberFormat("en-US", {
+		style: "currency",
+		currency: "USD",
+		minimumFractionDigits: 2,
+		maximumFractionDigits: 2,
+	}).format(value);
+}
+
+export function useChatCredits(userId?: string) {
+	const [balance, setBalance] = useState<number | null>(null);
+	const [loading, setLoading] = useState(false);
+
+	useEffect(() => {
+		if (!userId) {
+			setBalance(null);
+			setLoading(false);
+			return;
+		}
+
+		let active = true;
+		const controller = new AbortController();
+		const timeoutId = window.setTimeout(() => controller.abort(), 8000);
+		setLoading(true);
+		createClient().auth.getSession()
+			.then(({ data }) => {
+				const accessToken = data.session?.access_token;
+				if (!accessToken) throw new Error("Credits request requires a session");
+				return fetch("/api/account/credits/balance", {
+					headers: {
+						accept: "application/json",
+						authorization: `Bearer ${accessToken}`,
+					},
+					signal: controller.signal,
+				});
+			})
+			.then(async (response) => {
+				if (!response.ok) throw new Error(`Credits request failed: ${response.status}`);
+				return (await response.json()) as CreditsBalanceResponse;
+			})
+			.then((data) => {
+				if (!active) return;
+				const rawBalance = data.initialBalance;
+				const nextBalance =
+					rawBalance === null || rawBalance === undefined
+						? null
+						: Number(rawBalance);
+				setBalance(
+					nextBalance !== null && Number.isFinite(nextBalance)
+						? nextBalance
+						: null,
+				);
+			})
+			.catch((error) => {
+				if (active && (error as Error).name !== "AbortError") setBalance(null);
+			})
+			.finally(() => {
+				window.clearTimeout(timeoutId);
+				if (active) setLoading(false);
+			});
+
+		return () => {
+			active = false;
+			window.clearTimeout(timeoutId);
+			controller.abort();
+		};
+	}, [userId]);
+
+	return {
+		creditsLabel: formatCreditsBalance(balance),
+		creditsLoading: loading,
+	};
+}

--- a/apps/web/src/components/layout/DashboardFooterGate.test.ts
+++ b/apps/web/src/components/layout/DashboardFooterGate.test.ts
@@ -1,0 +1,17 @@
+import { shouldShowDashboardFooter } from "./DashboardFooterGate";
+
+describe("shouldShowDashboardFooter", () => {
+	it.each(["/chat", "/chat/fusion", "/chat/image/session-1"])(
+		"keeps the dashboard footer out of %s",
+		(pathname) => {
+			expect(shouldShowDashboardFooter(pathname)).toBe(false);
+		},
+	);
+
+	it.each(["/", "/models", "/settings/account", "/chats"])(
+		"keeps the dashboard footer on %s",
+		(pathname) => {
+			expect(shouldShowDashboardFooter(pathname)).toBe(true);
+		},
+	);
+});

--- a/apps/web/src/components/layout/DashboardFooterGate.tsx
+++ b/apps/web/src/components/layout/DashboardFooterGate.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import { usePathname } from "next/navigation";
+import { useSyncExternalStore, type ReactNode } from "react";
+import {
+	getFooterVisibilitySnapshot,
+	subscribeFooterVisibility,
+} from "@/components/layout/footerVisibility";
+
+const FOOTERLESS_ROUTE_PREFIXES = ["/chat"] as const;
+
+export function shouldShowDashboardFooter(pathname: string): boolean {
+	return !FOOTERLESS_ROUTE_PREFIXES.some(
+		(prefix) => pathname === prefix || pathname.startsWith(`${prefix}/`),
+	);
+}
+
+export default function DashboardFooterGate({ children }: { children: ReactNode }) {
+	const pathname = usePathname() ?? "/";
+	const overridesAllowFooter = useSyncExternalStore(
+		subscribeFooterVisibility,
+		getFooterVisibilitySnapshot,
+		() => true,
+	);
+
+	return shouldShowDashboardFooter(pathname) && overridesAllowFooter
+		? children
+		: null;
+}

--- a/apps/web/src/components/layout/HideGlobalFooter.tsx
+++ b/apps/web/src/components/layout/HideGlobalFooter.tsx
@@ -1,10 +1,10 @@
 "use client";
 
-import { useEffect } from "react";
+import { useLayoutEffect } from "react";
 import { registerHideFooter } from "@/components/layout/footerVisibility";
 
 export default function HideGlobalFooter() {
-	useEffect(() => {
+	useLayoutEffect(() => {
 		return registerHideFooter();
 	}, []);
 

--- a/apps/web/src/components/layout/NoFooterStyle.tsx
+++ b/apps/web/src/components/layout/NoFooterStyle.tsx
@@ -1,10 +1,10 @@
 "use client";
 
-import { useEffect } from "react";
+import { useLayoutEffect } from "react";
 import { registerHideFooter } from "@/components/layout/footerVisibility";
 
 export default function NoFooterStyle() {
-	useEffect(() => {
+	useLayoutEffect(() => {
 		return registerHideFooter();
 	}, []);
 

--- a/apps/web/src/components/layout/ShowFooterStyle.tsx
+++ b/apps/web/src/components/layout/ShowFooterStyle.tsx
@@ -1,10 +1,10 @@
 "use client";
 
-import { useEffect } from "react";
+import { useLayoutEffect } from "react";
 import { registerShowFooter } from "@/components/layout/footerVisibility";
 
 export default function ShowFooterStyle() {
-	useEffect(() => {
+	useLayoutEffect(() => {
 		return registerShowFooter();
 	}, []);
 

--- a/apps/web/src/components/layout/ShowGlobalFooter.tsx
+++ b/apps/web/src/components/layout/ShowGlobalFooter.tsx
@@ -1,10 +1,10 @@
 "use client";
 
-import { useEffect } from "react";
+import { useLayoutEffect } from "react";
 import { registerShowFooter } from "@/components/layout/footerVisibility";
 
 export default function ShowGlobalFooter() {
-	useEffect(() => {
+	useLayoutEffect(() => {
 		return registerShowFooter();
 	}, []);
 

--- a/apps/web/src/components/layout/footerVisibility.test.ts
+++ b/apps/web/src/components/layout/footerVisibility.test.ts
@@ -1,0 +1,29 @@
+import {
+	getFooterVisibilitySnapshot,
+	registerHideFooter,
+	registerShowFooter,
+	subscribeFooterVisibility,
+} from "./footerVisibility";
+
+describe("footer visibility overrides", () => {
+	it("supports nested hide and show overrides with idempotent cleanup", () => {
+		const listener = jest.fn();
+		const unsubscribe = subscribeFooterVisibility(listener);
+		const removeHide = registerHideFooter();
+
+		expect(getFooterVisibilitySnapshot()).toBe(false);
+
+		const removeShow = registerShowFooter();
+		expect(getFooterVisibilitySnapshot()).toBe(true);
+
+		removeShow();
+		expect(getFooterVisibilitySnapshot()).toBe(false);
+
+		removeHide();
+		removeHide();
+		expect(getFooterVisibilitySnapshot()).toBe(true);
+		expect(listener).toHaveBeenCalledTimes(4);
+
+		unsubscribe();
+	});
+});

--- a/apps/web/src/components/layout/footerVisibility.ts
+++ b/apps/web/src/components/layout/footerVisibility.ts
@@ -1,47 +1,41 @@
-const HIDE_DEPTH_ATTR = "data-hide-footer-depth";
-const SHOW_DEPTH_ATTR = "data-show-footer-depth";
-const HIDE_FLAG_ATTR = "data-hide-footer";
+type FooterVisibilityListener = () => void;
 
-function readCounter(attr: string): number {
-	const raw = document.body.getAttribute(attr);
-	const parsed = Number.parseInt(raw ?? "0", 10);
-	return Number.isFinite(parsed) && parsed > 0 ? parsed : 0;
+const listeners = new Set<FooterVisibilityListener>();
+let hideDepth = 0;
+let showDepth = 0;
+
+function emitVisibilityChange() {
+	for (const listener of listeners) listener();
 }
 
-function writeCounter(attr: string, value: number) {
-	if (value > 0) {
-		document.body.setAttribute(attr, String(value));
-		return;
-	}
-	document.body.removeAttribute(attr);
+export function getFooterVisibilitySnapshot(): boolean {
+	return hideDepth === 0 || showDepth > 0;
 }
 
-function updateFooterVisibility() {
-	const hideDepth = readCounter(HIDE_DEPTH_ATTR);
-	const showDepth = readCounter(SHOW_DEPTH_ATTR);
-	if (hideDepth > 0 && showDepth === 0) {
-		document.body.setAttribute(HIDE_FLAG_ATTR, "true");
-		return;
-	}
-	document.body.removeAttribute(HIDE_FLAG_ATTR);
+export function subscribeFooterVisibility(listener: FooterVisibilityListener) {
+	listeners.add(listener);
+	return () => listeners.delete(listener);
+}
+
+function registerVisibilityOverride(type: "hide" | "show") {
+	if (type === "hide") hideDepth += 1;
+	else showDepth += 1;
+	emitVisibilityChange();
+
+	let active = true;
+	return () => {
+		if (!active) return;
+		active = false;
+		if (type === "hide") hideDepth = Math.max(0, hideDepth - 1);
+		else showDepth = Math.max(0, showDepth - 1);
+		emitVisibilityChange();
+	};
 }
 
 export function registerHideFooter() {
-	writeCounter(HIDE_DEPTH_ATTR, readCounter(HIDE_DEPTH_ATTR) + 1);
-	updateFooterVisibility();
-
-	return () => {
-		writeCounter(HIDE_DEPTH_ATTR, readCounter(HIDE_DEPTH_ATTR) - 1);
-		updateFooterVisibility();
-	};
+	return registerVisibilityOverride("hide");
 }
 
 export function registerShowFooter() {
-	writeCounter(SHOW_DEPTH_ATTR, readCounter(SHOW_DEPTH_ATTR) + 1);
-	updateFooterVisibility();
-
-	return () => {
-		writeCounter(SHOW_DEPTH_ATTR, readCounter(SHOW_DEPTH_ATTR) - 1);
-		updateFooterVisibility();
-	};
+	return registerVisibilityOverride("show");
 }

--- a/apps/web/src/lib/chat/rooms.ts
+++ b/apps/web/src/lib/chat/rooms.ts
@@ -97,7 +97,7 @@ export const CHAT_ROOMS: ChatRoomConfig[] = [
 		id: "speech-to-text",
 		label: "Speech to Text",
 		route: "/chat/speech-to-text",
-		description: "Speech transcription and translation workspace.",
+		description: "Speech transcription workspace.",
 		capabilityHints: SPEECH_TO_TEXT_CAPABILITY_HINTS,
 	},
 	{
@@ -144,9 +144,9 @@ export const CHAT_ROOM_BY_ID: Record<ChatRoomId, ChatRoomConfig> = {
 	video: CHAT_ROOMS[2],
 	audio: {
 		id: "audio",
-		label: "Audio",
-		route: "/chat/audio",
-		description: "Legacy audio workspace.",
+		label: "Text to Speech",
+		route: "/chat/speech",
+		description: "Audio model compatibility mapping for focused audio rooms.",
 		capabilityHints: AUDIO_CAPABILITY_HINTS,
 	},
 	speech: CHAT_ROOMS[3],


### PR DESCRIPTION
## Summary

- integrate Chat and Fusion into the dashboard shell so the global header remains consistent
- add the AI-generated-content notice across chat rooms
- move Fusion into the room switcher with a Beta badge and keep it at the bottom
- gate unreleased Video and Realtime rooms behind Statsig feature flags with Coming soon states
- standardize room composers, tool menus, model selection placement, spacing, and control radii
- centralize dashboard footer visibility so Chat routes do not flash or retain footer artifacts
- align the expanded and collapsed sidebar motion, separators, header, and profile area
- show the authenticated Credits balance in every chat profile menu
- enforce 8px radii for chat dropdown triggers, panels, and rows; 4px for status badges; full circles only for icon-only collapsed controls

## Why

The chat experience had evolved through separate room-specific implementations. That caused duplicated composer and profile behavior, inconsistent footer state, mismatched sidebar geometry, and radius tokens that changed meaning inside the sidebar. In particular, the sidebar locally redefines its radius token, so semantic `rounded-md` controls could render more rounded than their dropdown equivalents.

This consolidates the shared behavior and uses explicit chat radii where the inherited token is unsafe.

## User impact

Chat now feels like one connected dashboard experience across Text, Images, Audio, Moderation, Embeddings, and Fusion. Navigation, composer tools, profile information, feature availability, and footer behavior remain consistent when switching rooms or collapsing the sidebar.

## Validation

- `pnpm --filter @phaseo/web typecheck`
- `pnpm --filter @phaseo/web test` — 112 suites, 547 tests passed
- ESLint `--quiet` across all 25 changed web source files
- `git diff --check`
- live authenticated checks on `/chat` and `/chat/embeddings`
  - room trigger, dropdown panel, and rows: 8px
  - room status badges: 4px
  - collapsed icon controls: fully circular
  - Credits visible in Text and room profile menus

The repository-wide lint invocation exceeded its four-minute local bound; the complete changed-file lint set passed.

Created with Codex

Closes #1138

Related to #846