### PR TITLE
data: add DeepInfra and activate Together for Kimi K3

### DIFF
--- a/packages/data/catalog/src/data/api_providers/deepinfra/models.json
+++ b/packages/data/catalog/src/data/api_providers/deepinfra/models.json
@@ -3655,6 +3655,149 @@
     "rate_limits": []
   },
   {
-    "api_model_id":"thinking-machines/inkling","provider_api_model_id":"deepinfra:thinking-machines/inkling","provider_model_slug":"thinkingmachines/Inkling","internal_model_id":"thinking-machines/inkling","is_active_gateway":true,"quantization_scheme":null,"input_modalities":"text,image,audio","output_modalities":"text","context_length":524288,"max_output_tokens":524288,"effective_from":"2026-07-21T00:00:00","effective_to":null,"capabilities":[{"capability_id":"text.generate","status":"active","params":[],"reasoning":null,"tool_call":null,"structured_output":null,"temperature":null,"attachment":null,"input_modalities":null,"output_modalities":null,"modes":[]}],"routing_status":"active","routable":true,"regions":{"execution":null,"data":null},"service_tiers":[],"api":{"formats":[],"endpoint":null,"deployment":null},"sources":[{"url":"https://api.deepinfra.com/models/list","kind":"api"}],"verification":{"status":"verified","checked_at":"2026-07-24T00:00:00Z","notes":"Official DeepInfra model list; created 2026-07-21."},"rate_limits":[]
+    "api_model_id": "thinking-machines/inkling",
+    "provider_api_model_id": "deepinfra:thinking-machines/inkling",
+    "provider_model_slug": "thinkingmachines/Inkling",
+    "internal_model_id": "thinking-machines/inkling",
+    "is_active_gateway": true,
+    "quantization_scheme": null,
+    "input_modalities": "text,image,audio",
+    "output_modalities": "text",
+    "context_length": 524288,
+    "max_output_tokens": 524288,
+    "effective_from": "2026-07-21T00:00:00",
+    "effective_to": null,
+    "capabilities": [
+      {
+        "capability_id": "text.generate",
+        "status": "active",
+        "params": [],
+        "reasoning": null,
+        "tool_call": null,
+        "structured_output": null,
+        "temperature": null,
+        "attachment": null,
+        "input_modalities": null,
+        "output_modalities": null,
+        "modes": []
+      }
+    ],
+    "routing_status": "active",
+    "routable": true,
+    "regions": {
+      "execution": null,
+      "data": null
+    },
+    "service_tiers": [],
+    "api": {
+      "formats": [],
+      "endpoint": null,
+      "deployment": null
+    },
+    "sources": [
+      {
+        "url": "https://api.deepinfra.com/models/list",
+        "kind": "api"
+      }
+    ],
+    "verification": {
+      "status": "verified",
+      "checked_at": "2026-07-24T00:00:00Z",
+      "notes": "Official DeepInfra model list; created 2026-07-21."
+    },
+    "rate_limits": []
+  },
+  {
+    "api_model_id": "moonshotai/kimi-k3",
+    "provider_api_model_id": "deepinfra:moonshotai/kimi-k3",
+    "provider_model_slug": "moonshotai/Kimi-K3",
+    "internal_model_id": "moonshotai/kimi-k3",
+    "is_active_gateway": true,
+    "quantization_scheme": null,
+    "input_modalities": "text,image",
+    "output_modalities": "text",
+    "context_length": 1048576,
+    "max_output_tokens": null,
+    "effective_from": "2026-07-27T15:00:00Z",
+    "effective_to": null,
+    "capabilities": [
+      {
+        "capability_id": "text.generate",
+        "status": "active",
+        "params": [
+          {
+            "param_id": "max_tokens",
+            "provider_min": null,
+            "provider_max": null,
+            "provider_default": null,
+            "notes": null
+          },
+          {
+            "param_id": "temperature",
+            "provider_min": null,
+            "provider_max": null,
+            "provider_default": null,
+            "notes": null
+          },
+          {
+            "param_id": "top_p",
+            "provider_min": null,
+            "provider_max": null,
+            "provider_default": null,
+            "notes": null
+          },
+          {
+            "param_id": "tools",
+            "provider_min": null,
+            "provider_max": null,
+            "provider_default": null,
+            "notes": null
+          },
+          {
+            "param_id": "tool_choice",
+            "provider_min": null,
+            "provider_max": null,
+            "provider_default": null,
+            "notes": null
+          }
+        ],
+        "reasoning": true,
+        "tool_call": true,
+        "structured_output": null,
+        "temperature": true,
+        "attachment": true,
+        "input_modalities": null,
+        "output_modalities": null,
+        "modes": []
+      }
+    ],
+    "routing_status": "active",
+    "routable": true,
+    "regions": {
+      "execution": null,
+      "data": null
+    },
+    "service_tiers": [],
+    "api": {
+      "formats": [
+        "openai"
+      ],
+      "endpoint": null,
+      "deployment": null
+    },
+    "sources": [
+      {
+        "kind": "api_reference",
+        "url": "https://deepinfra.com/moonshotai/Kimi-K3",
+        "accessed_at": "2026-07-27T19:30:00Z",
+        "notes": "DeepInfra lists live Kimi K3 inference with a 1,024K context window and public token pricing."
+      }
+    ],
+    "verification": {
+      "status": "verified",
+      "checked_at": "2026-07-27T19:30:00Z",
+      "notes": "DeepInfra lists live Kimi K3 inference with a 1,024K context window and public token pricing."
+    },
+    "rate_limits": []
   }
 ]

--- a/packages/data/catalog/src/data/api_providers/together/models.json
+++ b/packages/data/catalog/src/data/api_providers/together/models.json
@@ -1396,8 +1396,8 @@
     "provider_api_model_id": "together:moonshotai/kimi-k3",
     "provider_model_slug": "moonshotai/Kimi-K3",
     "internal_model_id": "moonshotai/kimi-k3",
-    "is_active_gateway": false,
-    "quantization_scheme": null,
+    "is_active_gateway": true,
+    "quantization_scheme": "FP4",
     "input_modalities": "text,image",
     "output_modalities": "text",
     "context_length": 1048576,
@@ -1407,42 +1407,87 @@
     "capabilities": [
       {
         "capability_id": "text.generate",
-        "status": "coming_soon",
-        "params": [],
+        "status": "active",
+        "params": [
+          {
+            "param_id": "max_tokens",
+            "provider_min": null,
+            "provider_max": null,
+            "provider_default": null,
+            "notes": null
+          },
+          {
+            "param_id": "temperature",
+            "provider_min": null,
+            "provider_max": null,
+            "provider_default": null,
+            "notes": null
+          },
+          {
+            "param_id": "top_p",
+            "provider_min": null,
+            "provider_max": null,
+            "provider_default": null,
+            "notes": null
+          },
+          {
+            "param_id": "tools",
+            "provider_min": null,
+            "provider_max": null,
+            "provider_default": null,
+            "notes": null
+          },
+          {
+            "param_id": "tool_choice",
+            "provider_min": null,
+            "provider_max": null,
+            "provider_default": null,
+            "notes": null
+          },
+          {
+            "param_id": "response_format",
+            "provider_min": null,
+            "provider_max": null,
+            "provider_default": null,
+            "notes": "Together documents JSON mode for Kimi K3."
+          }
+        ],
         "reasoning": true,
-        "tool_call": null,
-        "structured_output": null,
-        "temperature": null,
+        "tool_call": true,
+        "structured_output": true,
+        "temperature": true,
         "attachment": true,
         "input_modalities": null,
         "output_modalities": null,
         "modes": []
       }
     ],
-    "routing_status": null,
-    "routable": false,
+    "routing_status": "active",
+    "routable": true,
     "regions": {
       "execution": null,
       "data": null
     },
     "service_tiers": [],
     "api": {
-      "formats": [],
+      "formats": [
+        "openai"
+      ],
       "endpoint": null,
       "deployment": null
     },
     "sources": [
       {
+        "kind": "api_reference",
         "url": "https://www.together.ai/models/kimi-k3",
-        "kind": "announcement",
-        "accessed_at": "2026-07-26T00:00:00Z",
-        "notes": "Together explicitly lists Kimi K3 as coming soon to its Serverless API."
+        "accessed_at": "2026-07-27T19:30:00Z",
+        "notes": "Together documents Kimi K3 as live on serverless and dedicated infrastructure with vision, JSON mode and function calling."
       }
     ],
     "verification": {
       "status": "verified",
-      "checked_at": "2026-07-26T00:00:00Z",
-      "notes": "Official Together model page confirms planned Serverless API availability; production route details remain pending."
+      "checked_at": "2026-07-27T19:30:00Z",
+      "notes": "Together documents Kimi K3 as live on serverless and dedicated infrastructure with vision, JSON mode and function calling."
     },
     "rate_limits": []
   }

--- a/packages/data/catalog/src/data/models/moonshotai/kimi-k3/model.json
+++ b/packages/data/catalog/src/data/models/moonshotai/kimi-k3/model.json
@@ -16,7 +16,7 @@
   "family_id": "moonshotai/kimi-k3",
   "page_notice": {
     "tone": "info",
-    "markdown": "Kimi K3's full model weights are scheduled for release on **July 27, 2026 at 15:00 UTC**. As the weights become available, confirmed inference providers will be onboarded as soon as their hosted endpoints go live. Together AI, Baseten, and Fireworks are currently marked **Coming Soon**."
+    "markdown": "Kimi K3 weights were released on **July 27, 2026**. Hosted API access is now available from multiple providers, including Baseten, Cloudflare AI Gateway, DeepInfra, Fireworks, Modal, Moonshot AI, Nebius Token Factory, Novita, SiliconFlow, Together AI, and Venice."
   },
   "links": [
     {
@@ -38,6 +38,21 @@
       "title": "SiliconFlow pricing",
       "kind": "pricing",
       "url": "https://siliconflow.cn/pricing"
+    },
+    {
+      "title": "Cloudflare AI Gateway Kimi K3",
+      "kind": "api_reference",
+      "url": "https://developers.cloudflare.com/ai/models/moonshotai/kimi-k3/"
+    },
+    {
+      "title": "DeepInfra Kimi K3",
+      "kind": "pricing",
+      "url": "https://deepinfra.com/moonshotai/Kimi-K3"
+    },
+    {
+      "title": "Together AI Kimi K3",
+      "kind": "pricing",
+      "url": "https://www.together.ai/models/kimi-k3"
     }
   ],
   "details": [
@@ -99,7 +114,7 @@
     },
     {
       "name": "availability_note",
-      "value": "Baseten, Fireworks, Moonshot AI, GMI Cloud, Nebius Token Factory, Novita, SiliconFlow, and Venice provide Kimi K3 API access. Baseten exposes a text-and-image Model API route with a 1,048,576-token context window at $0.30 per million cached input tokens, $3.00 per million input tokens, and $15.00 per million output tokens. Fireworks exposes a serverless vision route with function calling and a 1,048,576-token context window; standard pricing is $0.30 cached input, $3.00 input, and $15.00 output per million tokens, while priority pricing is $0.375 cached input, $3.75 input, and $18.75 output. Nebius Token Factory advertises an FP4 text route in eu-north1 with a 1,048,576-token context window at $3.00 per million input tokens and $15.00 per million output tokens. GMI Cloud currently advertises an FP8 route with a 262,144-token context window; Novita advertises text, image, and video input with a 1,048,576-token context and output limit; SiliconFlow advertises text and image input with a 1,048,576-token context and online pricing of $0.30 per million cached input tokens, $3.00 per million input tokens, and $15.00 per million output tokens. Venice exposes the standard kimi-k3 route at $3.75 per million input tokens, $0.375 per million cached input tokens, and $18.75 per million output tokens. Venice's live catalog does not expose an E2EE Kimi K3 model ID, so no E2EE route or pricing is listed. Full model weights are scheduled for July 27, 2026 at 15:00 UTC. Together AI has announced planned hosted inference availability and remains listed as coming soon until its endpoint goes live."
+      "value": "Kimi K3 is available from Baseten, Cloudflare AI Gateway, DeepInfra, Fireworks, GMI Cloud, Modal, Moonshot AI, Nebius Token Factory, Novita, SiliconFlow, Together AI, and Venice. DeepInfra lists $2.70 per million input tokens, $0.27 per million cached input tokens, and $13.50 per million output tokens. Together AI lists $3.00 input, $0.30 cached input, and $15.00 output per million tokens. Cloudflare AI Gateway exposes the model through its OpenAI-compatible Chat Completions endpoint; its public documentation directs users to the Cloudflare dashboard for pricing."
     }
   ],
   "benchmarks": [
@@ -454,6 +469,24 @@
       "url": "https://siliconflow.cn/pricing",
       "accessed_at": null,
       "notes": null
+    },
+    {
+      "kind": "api_reference",
+      "url": "https://developers.cloudflare.com/ai/models/moonshotai/kimi-k3/",
+      "accessed_at": "2026-07-27T19:30:00Z",
+      "notes": "Official provider Kimi K3 listing."
+    },
+    {
+      "kind": "pricing",
+      "url": "https://deepinfra.com/moonshotai/Kimi-K3",
+      "accessed_at": "2026-07-27T19:30:00Z",
+      "notes": "Official provider Kimi K3 listing."
+    },
+    {
+      "kind": "pricing",
+      "url": "https://www.together.ai/models/kimi-k3",
+      "accessed_at": "2026-07-27T19:30:00Z",
+      "notes": "Official provider Kimi K3 listing."
     }
   ],
   "verification": {

--- a/packages/data/catalog/src/data/pricing/deepinfra/moonshotai-kimi-k3/text.generate/pricing.json
+++ b/packages/data/catalog/src/data/pricing/deepinfra/moonshotai-kimi-k3/text.generate/pricing.json
@@ -1,0 +1,74 @@
+{
+  "key": "deepinfra:moonshotai/kimi-k3:text.generate",
+  "api_provider_id": "deepinfra",
+  "provider_slug": "deepinfra",
+  "api_model_id": "moonshotai/kimi-k3",
+  "capability_id": "text.generate",
+  "rules": [
+    {
+      "meter": "input_text_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 2.7,
+      "currency": "USD",
+      "pricing_plan": "standard",
+      "note": "DeepInfra reports $2.70 per 1M input tokens.",
+      "match": [],
+      "priority": 100,
+      "effective_from": "2026-07-27T15:00:00Z",
+      "region": null,
+      "cache_duration_seconds": null,
+      "conditions": [],
+      "source": "https://deepinfra.com/moonshotai/Kimi-K3"
+    },
+    {
+      "meter": "cached_read_text_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 0.27,
+      "currency": "USD",
+      "pricing_plan": "standard",
+      "note": "DeepInfra reports $0.27 per 1M cached input tokens.",
+      "match": [],
+      "priority": 100,
+      "effective_from": "2026-07-27T15:00:00Z",
+      "region": null,
+      "cache_duration_seconds": null,
+      "conditions": [],
+      "source": "https://deepinfra.com/moonshotai/Kimi-K3"
+    },
+    {
+      "meter": "output_text_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 13.5,
+      "currency": "USD",
+      "pricing_plan": "standard",
+      "note": "DeepInfra reports $13.50 per 1M output tokens.",
+      "match": [],
+      "priority": 100,
+      "effective_from": "2026-07-27T15:00:00Z",
+      "region": null,
+      "cache_duration_seconds": null,
+      "conditions": [],
+      "source": "https://deepinfra.com/moonshotai/Kimi-K3"
+    }
+  ],
+  "regions": [],
+  "service_tiers": [
+    "standard"
+  ],
+  "sources": [
+    {
+      "kind": "pricing",
+      "url": "https://deepinfra.com/moonshotai/Kimi-K3",
+      "accessed_at": "2026-07-27T19:30:00Z",
+      "notes": "Live Kimi K3 pricing published by DeepInfra."
+    }
+  ],
+  "verification": {
+    "status": "verified",
+    "checked_at": "2026-07-27T19:30:00Z",
+    "notes": "Pricing transcribed from DeepInfra's live Kimi K3 listing."
+  }
+}

--- a/packages/data/catalog/src/data/pricing/together/moonshotai-kimi-k3/text.generate/pricing.json
+++ b/packages/data/catalog/src/data/pricing/together/moonshotai-kimi-k3/text.generate/pricing.json
@@ -1,0 +1,74 @@
+{
+  "key": "together:moonshotai/kimi-k3:text.generate",
+  "api_provider_id": "together",
+  "provider_slug": "together",
+  "api_model_id": "moonshotai/kimi-k3",
+  "capability_id": "text.generate",
+  "rules": [
+    {
+      "meter": "input_text_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 3.0,
+      "currency": "USD",
+      "pricing_plan": "standard",
+      "note": "Together AI reports $3.00 per 1M input tokens.",
+      "match": [],
+      "priority": 100,
+      "effective_from": "2026-07-27T15:00:00Z",
+      "region": null,
+      "cache_duration_seconds": null,
+      "conditions": [],
+      "source": "https://www.together.ai/models/kimi-k3"
+    },
+    {
+      "meter": "cached_read_text_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 0.3,
+      "currency": "USD",
+      "pricing_plan": "standard",
+      "note": "Together AI reports $0.30 per 1M cached input tokens.",
+      "match": [],
+      "priority": 100,
+      "effective_from": "2026-07-27T15:00:00Z",
+      "region": null,
+      "cache_duration_seconds": null,
+      "conditions": [],
+      "source": "https://www.together.ai/models/kimi-k3"
+    },
+    {
+      "meter": "output_text_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 15.0,
+      "currency": "USD",
+      "pricing_plan": "standard",
+      "note": "Together AI reports $15.00 per 1M output tokens.",
+      "match": [],
+      "priority": 100,
+      "effective_from": "2026-07-27T15:00:00Z",
+      "region": null,
+      "cache_duration_seconds": null,
+      "conditions": [],
+      "source": "https://www.together.ai/models/kimi-k3"
+    }
+  ],
+  "regions": [],
+  "service_tiers": [
+    "standard"
+  ],
+  "sources": [
+    {
+      "kind": "pricing",
+      "url": "https://www.together.ai/models/kimi-k3",
+      "accessed_at": "2026-07-27T19:30:00Z",
+      "notes": "Live Kimi K3 pricing published by Together AI."
+    }
+  ],
+  "verification": {
+    "status": "verified",
+    "checked_at": "2026-07-27T19:30:00Z",
+    "notes": "Pricing transcribed from Together AI's live Kimi K3 listing."
+  }
+}


### PR DESCRIPTION
## Summary

- add Kimi K3 as an active DeepInfra route
- promote Together AI's existing Kimi K3 entry from `coming_soon` to active
- record DeepInfra pricing at $2.70 input, $0.27 cached input, and $13.50 output per million tokens
- record Together AI pricing at $3.00 input, $0.30 cached input, and $15.00 output per million tokens
- refresh the canonical Kimi K3 provider availability notice and source links
- clarify that Cloudflare's existing Kimi K3 entry belongs to Cloudflare AI Gateway rather than Workers AI

## Provider details

### DeepInfra

- provider model ID: `moonshotai/Kimi-K3`
- OpenAI-compatible inference
- 1,048,576-token context
- text and image input
- reasoning and tool calling
- verified public token pricing from the live model listing

### Together AI

- provider model ID: `moonshotai/Kimi-K3`
- live serverless and dedicated availability
- FP4 with a 1,048,576-token context
- text and image input
- reasoning, JSON mode and function calling
- existing coming-soon row updated in place rather than duplicated

## Audit notes

- Cloudflare AI Gateway already contained Kimi K3, so no duplicate Cloudflare provider row is added.
- DigitalOcean support remains tracked separately in #1320 because making it routable requires provider integration work.
- No runtime executor code is modified because DeepInfra and Together already have active Phaseo provider integrations.

## Validation

- reviewed the complete branch diff against `main`
- confirmed only the DeepInfra and Together model lists, their two pricing files, and the canonical Kimi K3 model record changed
- verified all JSON sources and provider IDs against the official live provider listings
- repository CI pending


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added hosted API availability for the MoonshotAI Kimi K3 model through Cloudflare AI Gateway, DeepInfra, and Together AI.
  - Enabled OpenAI-compatible access, tool calling, structured output, JSON response formatting, and configurable generation parameters.
  - Added token-based pricing details for DeepInfra and Together AI, including input, cached, and output token rates.
- **Documentation**
  - Updated the model page with release information, provider links, availability details, and official source references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->