### PR TITLE
Fix Kimi K3 Baseten routing and remove stale notice

### DIFF
--- a/apps/api/tests/aimock/cross-provider-models.spec.ts
+++ b/apps/api/tests/aimock/cross-provider-models.spec.ts
@@ -92,9 +92,9 @@ describe("cross-provider model deployment matrix", () => {
         }).toMatchObject({
 			models: 352,
             providers: 49,
-			deployments: 794,
+			deployments: 795,
 			multiProviderModels: 127,
-			multiProviderDeployments: 566,
+			multiProviderDeployments: 567,
             missing: [],
         });
     });

--- a/packages/data/catalog/src/data/api_providers/baseten/models.json
+++ b/packages/data/catalog/src/data/api_providers/baseten/models.json
@@ -976,7 +976,7 @@
     "provider_api_model_id": "baseten:moonshotai/kimi-k3",
     "provider_model_slug": "moonshotai/Kimi-K3",
     "internal_model_id": "moonshotai/kimi-k3",
-    "is_active_gateway": false,
+    "is_active_gateway": true,
     "quantization_scheme": null,
     "input_modalities": "text,image",
     "output_modalities": "text",

--- a/packages/data/catalog/src/data/models/moonshotai/kimi-k3/model.json
+++ b/packages/data/catalog/src/data/models/moonshotai/kimi-k3/model.json
@@ -14,10 +14,6 @@
   "output_types": "text",
   "api_model_id": "moonshotai/kimi-k3",
   "family_id": "moonshotai/kimi-k3",
-  "page_notice": {
-    "tone": "info",
-    "markdown": "Kimi K3's full model weights are scheduled for release on **July 27, 2026 at 15:00 UTC**. As the weights become available, confirmed inference providers will be onboarded as soon as their hosted endpoints go live. Together AI, Baseten, and Fireworks are currently marked **Coming Soon**."
-  },
   "links": [
     {
       "title": "Kimi K3 Tech Blog",


### PR DESCRIPTION
## Summary

- enable Baseten as a gateway route for `moonshotai/kimi-k3`
- remove the obsolete pre-release notice from the canonical Kimi K3 model page
- leave Fireworks routing unchanged and disabled
- update the catalogue-derived AIMock deployment totals for the newly active route

## Root cause

PR #1317 activated Baseten's Kimi K3 capability and marked the row routable, but the row's `is_active_gateway` field remained `false`. The V2 importer correctly persisted that value as `routing_enabled = false`, so Baseten was excluded by the gateway context query.

## Independent verification

Baseten's official Kimi K3 changelog confirms the live `moonshotai/Kimi-K3` OpenAI-compatible route, a 1M-token context window, and tool calling.

## Validation

- parsed both edited catalogue files as JSON
- Baseten Kimi K3 changes by one field: `is_active_gateway: false` → `true`
- Kimi K3 model changes only remove the four-line `page_notice` block
- updated expected AIMock totals from 794 to 795 deployments and 566 to 567 multi-provider deployments
- data validation passes
- full AIMock matrix passes (1,693 tests)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enabled gateway access for the MoonshotAI Kimi K3 model.
  * Removed the informational notice previously shown on the model’s details page.

* **Tests**
  * Updated deployment coverage expectations to reflect the newly available model deployment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->