### PR TITLE
data: add disabled DigitalOcean Kimi K3 route

### DIFF
--- a/packages/data/catalog/src/data/api_providers/digitalocean/models.json
+++ b/packages/data/catalog/src/data/api_providers/digitalocean/models.json
@@ -528,6 +528,69 @@
     "rate_limits": []
   },
   {
+    "api_model_id": "moonshotai/kimi-k3",
+    "provider_api_model_id": "digitalocean:kimi-k3",
+    "provider_model_slug": "kimi-k3",
+    "internal_model_id": "moonshotai/kimi-k3",
+    "is_active_gateway": false,
+    "quantization_scheme": null,
+    "input_modalities": "text,image",
+    "output_modalities": "text",
+    "context_length": null,
+    "max_output_tokens": null,
+    "effective_from": "2026-07-27T00:00:00Z",
+    "effective_to": null,
+    "capabilities": [
+      {
+        "capability_id": "text.generate",
+        "status": "active",
+        "params": [],
+        "reasoning": true,
+        "tool_call": true,
+        "structured_output": true,
+        "temperature": null,
+        "attachment": true,
+        "input_modalities": null,
+        "output_modalities": null,
+        "modes": []
+      }
+    ],
+    "routing_status": "disabled",
+    "routable": false,
+    "regions": {
+      "execution": null,
+      "data": null
+    },
+    "service_tiers": [
+      "standard"
+    ],
+    "api": {
+      "formats": [],
+      "endpoint": null,
+      "deployment": null
+    },
+    "sources": [
+      {
+        "url": "https://docs.digitalocean.com/products/inference/details/models/",
+        "kind": "documentation",
+        "accessed_at": "2026-07-28T00:00:00Z",
+        "notes": "DigitalOcean lists kimi-k3 for serverless inference with native vision and prompt caching."
+      },
+      {
+        "url": "https://docs.digitalocean.com/products/inference/details/pricing/",
+        "kind": "pricing",
+        "accessed_at": "2026-07-28T00:00:00Z",
+        "notes": "DigitalOcean publishes Kimi K3 token pricing for input, cached input, and output."
+      }
+    ],
+    "verification": {
+      "status": "verified",
+      "checked_at": "2026-07-28T00:00:00Z",
+      "notes": "DigitalOcean's official model catalogue confirms the kimi-k3 serverless route with vision, streaming, tool calling, structured output, and prompt caching. Phaseo routing remains disabled until the DigitalOcean gateway integration is implemented and authenticated."
+    },
+    "rate_limits": []
+  },
+  {
     "api_model_id": "nvidia/nemotron-3-nano-omni",
     "provider_api_model_id": "digitalocean:nemotron-3-nano-omni",
     "provider_model_slug": "nemotron-3-nano-omni",

--- a/packages/data/catalog/src/data/pricing/digitalocean/moonshotai-kimi-k3/text.generate/pricing.json
+++ b/packages/data/catalog/src/data/pricing/digitalocean/moonshotai-kimi-k3/text.generate/pricing.json
@@ -1,0 +1,74 @@
+{
+  "key": "digitalocean:moonshotai/kimi-k3:text.generate",
+  "api_provider_id": "digitalocean",
+  "provider_slug": "digitalocean",
+  "api_model_id": "moonshotai/kimi-k3",
+  "capability_id": "text.generate",
+  "rules": [
+    {
+      "meter": "input_text_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 3,
+      "currency": "USD",
+      "pricing_plan": "standard",
+      "note": "DigitalOcean Kimi K3 uncached input pricing.",
+      "match": [],
+      "priority": 100,
+      "effective_from": "2026-07-27T00:00:00Z",
+      "region": null,
+      "cache_duration_seconds": null,
+      "conditions": [],
+      "source": null
+    },
+    {
+      "meter": "cached_read_text_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 0.6,
+      "currency": "USD",
+      "pricing_plan": "standard",
+      "note": "DigitalOcean Kimi K3 cached input pricing.",
+      "match": [],
+      "priority": 100,
+      "effective_from": "2026-07-27T00:00:00Z",
+      "region": null,
+      "cache_duration_seconds": null,
+      "conditions": [],
+      "source": null
+    },
+    {
+      "meter": "output_text_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 15,
+      "currency": "USD",
+      "pricing_plan": "standard",
+      "note": "DigitalOcean Kimi K3 output pricing.",
+      "match": [],
+      "priority": 100,
+      "effective_from": "2026-07-27T00:00:00Z",
+      "region": null,
+      "cache_duration_seconds": null,
+      "conditions": [],
+      "source": null
+    }
+  ],
+  "regions": [],
+  "service_tiers": [
+    "standard"
+  ],
+  "sources": [
+    {
+      "url": "https://docs.digitalocean.com/products/inference/details/pricing/",
+      "kind": "pricing",
+      "accessed_at": "2026-07-28T00:00:00Z",
+      "notes": "Official DigitalOcean serverless inference pricing."
+    }
+  ],
+  "verification": {
+    "status": "verified",
+    "checked_at": "2026-07-28T00:00:00Z",
+    "notes": "Pricing transcribed from DigitalOcean's official inference pricing documentation."
+  }
+}


### PR DESCRIPTION
## Summary

- add DigitalOcean's `kimi-k3` serverless model to the provider catalogue
- record the official text, vision, reasoning, tool-calling, structured-output, streaming and prompt-caching capabilities
- add published pricing of $3.00 input, $0.60 cached input, and $15.00 output per million tokens
- keep the Phaseo gateway route explicitly disabled

## Routing state

DigitalOcean offers Kimi K3, but Phaseo does not yet have a verified DigitalOcean gateway executor. This PR therefore uses:

- `is_active_gateway: false`
- `routing_status: "disabled"`
- `routable: false`

It does not add credentials, runtime configuration, or an executor, and does not claim the model is callable through Phaseo.

## Verification

The model and pricing were checked against DigitalOcean's official inference model and pricing documentation.

## Validation

- parsed both changed files as JSON
- confirmed exactly one DigitalOcean Kimi K3 model row exists
- confirmed the branch changes exactly two files
- confirmed the branch is based directly on `main`

Related to #1320. This catalogue-only PR does not close the provider-integration issue.