### PR TITLE
Coordinate immediate Worker and website cache purges

### DIFF
--- a/apps/web/src/app/(dashboard)/internal/cache/CacheOpsClient.tsx
+++ b/apps/web/src/app/(dashboard)/internal/cache/CacheOpsClient.tsx
@@ -22,11 +22,11 @@ import { Checkbox } from "@/components/ui/checkbox";
 import { Input } from "@/components/ui/input";
 import {
 	fetchCacheControlState,
-	purgeCacheScope,
 	type CacheControlState,
 	type CachePurgeResult,
 	type CacheScope,
 } from "@/lib/fetchers/internal/cacheControlClient";
+import { purgeCacheScopeAction } from "./actions";
 
 type PendingPurge = { scope: CacheScope; targetId: string };
 
@@ -94,8 +94,8 @@ export default function CacheOpsClient() {
 		const { scope, targetId } = pendingPurge;
 		startTransition(async () => {
 			try {
-				const result = await purgeCacheScope({
-					scope: scope.id,
+				const result = await purgeCacheScopeAction({
+					scope: scope.id as Parameters<typeof purgeCacheScopeAction>[0]["scope"],
 					targetId: targetId || undefined,
 					bumpBrowserGeneration,
 				});
@@ -118,7 +118,7 @@ export default function CacheOpsClient() {
 						{generation ? <Badge variant="secondary">Search generation {generation.generation}</Badge> : null}
 					</div>
 					<p className="max-w-2xl text-sm text-muted-foreground">
-						Purge named Cloudflare Worker cache families without redeploying or exposing Cloudflare credentials.
+						Purge the matching Cloudflare Worker and website cache families in one operation.
 					</p>
 				</div>
 				<div className="flex gap-2">
@@ -148,9 +148,9 @@ export default function CacheOpsClient() {
 			{lastResult ? (
 				<Alert>
 					<CheckCircle2 className="size-4 text-emerald-600" />
-					<AlertTitle>Cloudflare purge completed</AlertTitle>
+					<AlertTitle>Full cache purge completed</AlertTitle>
 					<AlertDescription>
-						Purged {lastResult.tags.length} tags at {formatTimestamp(lastResult.purgedAt)}.
+						Purged {lastResult.tags.length} Worker tags and invalidated the matching website cache at {formatTimestamp(lastResult.purgedAt)}.
 						{lastResult.generation ? ` Search generation is now ${lastResult.generation}.` : ""}
 						{lastResult.generationWarning ? ` ${lastResult.generationWarning}` : ""}
 					</AlertDescription>
@@ -250,7 +250,7 @@ export default function CacheOpsClient() {
 						<AlertDialogTitle>Purge {pendingPurge?.scope.label}?</AlertDialogTitle>
 						<AlertDialogDescription>
 							Cloudflare will evict {pendingPurge?.scope.tagCount ?? 0} named cache tags
-							{pendingPurge?.targetId ? ` for ${pendingPurge.targetId}` : ""}. The next request in each region may rebuild the affected data.
+							{pendingPurge?.targetId ? ` for ${pendingPurge.targetId}` : ""}, and the matching website data and page caches will be expired immediately.
 						</AlertDialogDescription>
 					</AlertDialogHeader>
 					{pendingPurge?.scope.affectsSearch ? (

--- a/apps/web/src/app/(dashboard)/internal/cache/actions.ts
+++ b/apps/web/src/app/(dashboard)/internal/cache/actions.ts
@@ -11,6 +11,8 @@ import {
 	revalidateProviderDataTags,
 } from "@/lib/cache/revalidateDataTags";
 import { fetchInternalAuthStatus } from "@/lib/fetchers/internal/fetchInternalAuthStatus";
+import { getServerAccountContext } from "@/lib/fetchers/internal/serverAccountContext";
+import { fetchInternalWebApi } from "@/lib/web-api/client";
 import {
 	revalidateSingleModelAllAction,
 	revalidateSingleModelApiInfoAction,
@@ -115,6 +117,31 @@ type GatewayCachePurgeResult =
 	| { ok: true; message: string }
 	| { ok: false; message: string };
 
+type CacheScopeId =
+	| "search"
+	| "catalogue"
+	| "model"
+	| "provider"
+	| "organisation"
+	| "benchmark"
+	| "apps"
+	| "landing"
+	| "rankings"
+	| "updates"
+	| "pricing"
+	| "all-public";
+
+type CachePurgeResult = {
+	success: true;
+	scope: string;
+	targetId: string | null;
+	tags: string[];
+	generation: number | null;
+	generationWarning: string | null;
+	browserRefreshEnabled: boolean;
+	purgedAt: string;
+};
+
 async function requireAdmin() {
 	const status = await fetchInternalAuthStatus();
 	if (!status.signedIn || !status.isAdmin) throw new Error("Unauthorized");
@@ -205,6 +232,131 @@ async function runAdminAction(
 					: `${label} failed.`,
 		};
 	}
+}
+
+function expireNextCacheScope(scope: CacheScopeId, targetId: string | null) {
+	switch (scope) {
+		case "catalogue":
+			expirePublicModelCatalogueCache();
+			break;
+		case "model":
+			expirePublicModelCatalogueCache({ modelId: targetId });
+			break;
+		case "provider":
+			revalidateProviderDataTags(
+				targetId ? { providerId: targetId } : {}
+			);
+			revalidatePath("/api-providers", "layout");
+			revalidatePath("/models", "layout");
+			if (targetId) {
+				revalidatePath(`/api-providers/${targetId}`);
+				revalidatePath(`/api-providers/${targetId}/models`);
+			}
+			break;
+		case "organisation":
+			revalidateOrganisationDataTags(
+				targetId ? { organisationId: targetId } : {}
+			);
+			revalidatePath("/organisations", "layout");
+			revalidatePath("/models", "layout");
+			if (targetId) {
+				revalidatePath(`/organisations/${targetId}`);
+				revalidatePath(`/organisations/${targetId}/models`);
+			}
+			break;
+		case "benchmark":
+			revalidateBenchmarkDataTags(
+				targetId ? { benchmarkId: targetId } : {}
+			);
+			revalidatePath("/benchmarks");
+			revalidatePath("/models", "layout");
+			if (targetId) revalidatePath(`/benchmarks/${targetId}`);
+			break;
+		case "apps":
+			revalidateAppDataTags(targetId ? [targetId] : []);
+			revalidatePath("/apps");
+			revalidatePath("/rankings");
+			if (targetId) revalidatePath(`/apps/${targetId}`);
+			break;
+		case "landing":
+			for (const tag of LANDING_TAGS) {
+				revalidateTag(tag, EXPIRE_NOW);
+			}
+			revalidatePath("/");
+			break;
+		case "rankings":
+			for (const tag of RANKINGS_TAGS) {
+				revalidateTag(tag, EXPIRE_NOW);
+			}
+			revalidatePath("/rankings");
+			break;
+		case "updates":
+			for (const tag of [
+				"data:model-updates",
+				"frontend:model-updates",
+				"frontend:model-update-cards",
+				"frontend:update-cards",
+				"frontend:web-updates",
+				"frontend:youtube-updates",
+			] as const) {
+				revalidateTag(tag, EXPIRE_NOW);
+			}
+			revalidatePath("/updates");
+			revalidatePath("/updates/models");
+			break;
+		case "pricing":
+			revalidateModelDataTags();
+			for (const tag of [
+				"data:subscription_plans",
+				"frontend:subscription-plans",
+			] as const) {
+				revalidateTag(tag, EXPIRE_NOW);
+			}
+			revalidatePath("/pricing");
+			revalidatePath("/subscription-plans");
+			revalidatePath("/models", "layout");
+			break;
+		case "all-public":
+			expirePublicModelCatalogueCache();
+			for (const tag of [
+				...APP_FRONTEND_TAGS,
+				...LANDING_TAGS,
+				...RANKINGS_TAGS,
+				...SEARCH_TAGS,
+				...SIGN_IN_TAGS,
+			]) {
+				revalidateTag(tag, EXPIRE_NOW);
+			}
+			revalidatePath("/", "layout");
+			break;
+		case "search":
+			for (const tag of SEARCH_TAGS) {
+				revalidateTag(tag, EXPIRE_NOW);
+			}
+			revalidatePath("/search");
+			break;
+	}
+}
+
+export async function purgeCacheScopeAction(input: {
+	scope: CacheScopeId;
+	targetId?: string;
+	bumpBrowserGeneration: boolean;
+}): Promise<CachePurgeResult> {
+	const { accessToken } = await getServerAccountContext();
+	if (!accessToken) throw new Error("Your admin session is no longer available. Sign in again.");
+
+	const result = await fetchInternalWebApi<CachePurgeResult>(
+		"/api/internal/cache/purge",
+		accessToken,
+		{
+			method: "POST",
+			body: JSON.stringify(input),
+		}
+	);
+
+	expireNextCacheScope(input.scope, result.targetId);
+	return result;
 }
 
 export async function revalidateModelsGlobalDataAction(): Promise<CacheOpResult> {

--- a/apps/web/src/app/(dashboard)/internal/cache/actions.ts
+++ b/apps/web/src/app/(dashboard)/internal/cache/actions.ts
@@ -1,6 +1,6 @@
 "use server";
 
-import { revalidatePath, revalidateTag } from "next/cache";
+import { revalidatePath, updateTag } from "next/cache";
 import {
 	expirePublicModelCatalogueCache,
 	revalidateAppDataTags,
@@ -18,8 +18,6 @@ import {
 	revalidateSingleModelApiInfoAction,
 	revalidateSingleModelDataAction,
 } from "@/app/(dashboard)/internal/data/actions";
-
-const EXPIRE_NOW = { expire: 0 } as const;
 
 const SEARCH_TAGS = [
 	"search:data",
@@ -280,13 +278,13 @@ function expireNextCacheScope(scope: CacheScopeId, targetId: string | null) {
 			break;
 		case "landing":
 			for (const tag of LANDING_TAGS) {
-				revalidateTag(tag, EXPIRE_NOW);
+				updateTag(tag);
 			}
 			revalidatePath("/");
 			break;
 		case "rankings":
 			for (const tag of RANKINGS_TAGS) {
-				revalidateTag(tag, EXPIRE_NOW);
+				updateTag(tag);
 			}
 			revalidatePath("/rankings");
 			break;
@@ -299,7 +297,7 @@ function expireNextCacheScope(scope: CacheScopeId, targetId: string | null) {
 				"frontend:web-updates",
 				"frontend:youtube-updates",
 			] as const) {
-				revalidateTag(tag, EXPIRE_NOW);
+				updateTag(tag);
 			}
 			revalidatePath("/updates");
 			revalidatePath("/updates/models");
@@ -310,7 +308,7 @@ function expireNextCacheScope(scope: CacheScopeId, targetId: string | null) {
 				"data:subscription_plans",
 				"frontend:subscription-plans",
 			] as const) {
-				revalidateTag(tag, EXPIRE_NOW);
+				updateTag(tag);
 			}
 			revalidatePath("/pricing");
 			revalidatePath("/subscription-plans");
@@ -325,13 +323,13 @@ function expireNextCacheScope(scope: CacheScopeId, targetId: string | null) {
 				...SEARCH_TAGS,
 				...SIGN_IN_TAGS,
 			]) {
-				revalidateTag(tag, EXPIRE_NOW);
+				updateTag(tag);
 			}
 			revalidatePath("/", "layout");
 			break;
 		case "search":
 			for (const tag of SEARCH_TAGS) {
-				revalidateTag(tag, EXPIRE_NOW);
+				updateTag(tag);
 			}
 			revalidatePath("/search");
 			break;
@@ -371,7 +369,7 @@ export async function revalidatePublicModelCatalogueAction(): Promise<CacheOpRes
 	return runAdminAction("Public catalogue", async () => {
 		expirePublicModelCatalogueCache();
 		for (const tag of APP_FRONTEND_TAGS) {
-			revalidateTag(tag, EXPIRE_NOW);
+			updateTag(tag);
 		}
 		const gatewayPurge = await purgeGatewayCatalogueCache(["models"]);
 		return {
@@ -448,7 +446,7 @@ export async function revalidateGlobalModelAndProviderAction(): Promise<CacheOpR
 export async function revalidateSearchDataAction(): Promise<CacheOpResult> {
 	return runAdminAction("Search", async () => {
 		for (const tag of SEARCH_TAGS) {
-			revalidateTag(tag, EXPIRE_NOW);
+			updateTag(tag);
 		}
 		revalidatePath("/search");
 	});
@@ -457,7 +455,7 @@ export async function revalidateSearchDataAction(): Promise<CacheOpResult> {
 export async function revalidateLandingDataAction(): Promise<CacheOpResult> {
 	return runAdminAction("Landing", async () => {
 		for (const tag of LANDING_TAGS) {
-			revalidateTag(tag, EXPIRE_NOW);
+			updateTag(tag);
 		}
 		revalidatePath("/");
 	});
@@ -466,7 +464,7 @@ export async function revalidateLandingDataAction(): Promise<CacheOpResult> {
 export async function revalidateSignInCatalogAction(): Promise<CacheOpResult> {
 	return runAdminAction("Sign-in catalog", async () => {
 		for (const tag of SIGN_IN_TAGS) {
-			revalidateTag(tag, EXPIRE_NOW);
+			updateTag(tag);
 		}
 		revalidatePath("/sign-in");
 	});
@@ -475,9 +473,9 @@ export async function revalidateSignInCatalogAction(): Promise<CacheOpResult> {
 export async function revalidateSubscriptionPlansAction(): Promise<CacheOpResult> {
 	return runAdminAction("Subscription plans", async () => {
 		for (const tag of ["data:subscription_plans", "frontend:subscription-plans"] as const) {
-			revalidateTag(tag, EXPIRE_NOW);
+			updateTag(tag);
 		}
-		revalidateTag("search:data", EXPIRE_NOW);
+		updateTag("search:data");
 		revalidatePath("/subscription-plans");
 		revalidatePath("/search");
 	});
@@ -486,7 +484,7 @@ export async function revalidateSubscriptionPlansAction(): Promise<CacheOpResult
 export async function revalidateRankingsAction(): Promise<CacheOpResult> {
 	return runAdminAction("Rankings", async () => {
 		for (const tag of RANKINGS_TAGS) {
-			revalidateTag(tag, EXPIRE_NOW);
+			updateTag(tag);
 		}
 		revalidatePath("/rankings");
 	});
@@ -531,11 +529,11 @@ export async function revalidateCountryDataAction(
 		trimmedIso ? `Country (${trimmedIso})` : "Countries (global)",
 		async () => {
 			for (const tag of COUNTRY_FRONTEND_TAGS) {
-				revalidateTag(tag, EXPIRE_NOW);
+				updateTag(tag);
 			}
 			revalidatePath("/countries");
 			if (trimmedIso) {
-				revalidateTag(`frontend:countries:${trimmedIso}`, EXPIRE_NOW);
+				updateTag(`frontend:countries:${trimmedIso}`);
 				revalidatePath(`/countries/${trimmedIso.toLowerCase()}`);
 				revalidatePath(`/countries/${trimmedIso.toLowerCase()}/models`);
 			}
@@ -558,10 +556,10 @@ export async function revalidateProfileDataAction(
 		trimmedSlug ? `Profile (${trimmedSlug})` : "Profiles (global)",
 		async () => {
 			for (const tag of PROFILE_FRONTEND_TAGS) {
-				revalidateTag(tag, EXPIRE_NOW);
+				updateTag(tag);
 			}
 			if (trimmedSlug) {
-				revalidateTag(`frontend:profile:${trimmedSlug}`, EXPIRE_NOW);
+				updateTag(`frontend:profile:${trimmedSlug}`);
 				revalidatePath(`/profile/${trimmedSlug}`);
 			}
 		}
@@ -640,7 +638,7 @@ export async function revalidateCustomScopeAction(input: {
 
 	return runAdminAction("Custom scope", async () => {
 		for (const tag of tags) {
-			revalidateTag(tag, EXPIRE_NOW);
+			updateTag(tag);
 		}
 		for (const path of paths) {
 			revalidatePath(path);

--- a/apps/web/src/app/(dashboard)/internal/data/actions.ts
+++ b/apps/web/src/app/(dashboard)/internal/data/actions.ts
@@ -773,7 +773,7 @@ export async function revalidateSingleModelDataAction(modelId: string) {
 	await revalidateCloudflare(["web-api-models", "web-api-model-details", "web-api-model-benchmarks", "web-api-model-timelines", "web-api-model-subscriptions", "web-api-model-notices", "web-api-search"]);
 	revalidatePath(`/internal/data/models/edit/${modelId}`);
 	revalidatePath("/models");
-	revalidatePath("/models/**");
+	revalidatePath(`/models/${modelId}`);
 
 	return { ok: true as const, message: "Model data cache revalidated." };
 }
@@ -783,7 +783,7 @@ export async function revalidateSingleModelApiInfoAction(modelId: string) {
 	await revalidateCloudflare(["web-api-models", "web-api-model-pricing", "web-api-model-performance", "web-api-model-provider-health", "web-api-provider-routing-health", "web-api-providers"]);
 	revalidatePath(`/internal/data/models/edit/${modelId}`);
 	revalidatePath("/models");
-	revalidatePath("/models/**");
+	revalidatePath(`/models/${modelId}`);
 	revalidatePath("/api-providers");
 	revalidatePath("/api-providers/**");
 
@@ -795,7 +795,7 @@ export async function revalidateSingleModelAllAction(modelId: string) {
 	await revalidateCloudflare(["web-api-models", "web-api-model-details", "web-api-model-benchmarks", "web-api-model-timelines", "web-api-model-subscriptions", "web-api-model-pricing", "web-api-model-performance", "web-api-model-notices", "web-api-providers", "web-api-organisations", "web-api-reference-data", "web-api-search"]);
 	revalidatePath(`/internal/data/models/edit/${modelId}`);
 	revalidatePath("/models");
-	revalidatePath("/models/**");
+	revalidatePath(`/models/${modelId}`);
 	revalidatePath("/api-providers");
 	revalidatePath("/api-providers/**");
 

--- a/apps/web/src/app/(dashboard)/internal/data/actions.ts
+++ b/apps/web/src/app/(dashboard)/internal/data/actions.ts
@@ -22,6 +22,11 @@ import {
 import { normalizeHttpUrl } from "@/lib/utils/urlSafety";
 import { getServerAccountContext } from "@/lib/fetchers/internal/serverAccountContext";
 import { fetchAccountWebApi, fetchInternalWebApi } from "@/lib/web-api/client";
+import {
+	revalidateModelApiInfoTags,
+	revalidateModelDataOnlyTags,
+	revalidateModelDataTags,
+} from "@/lib/cache/revalidateDataTags";
 
 async function callCatalogMutation(path: `/api/account/models/catalog/${string}`, method: "POST" | "PUT" | "DELETE", body?: unknown) {
 	const { accessToken } = await getServerAccountContext();
@@ -771,6 +776,7 @@ export async function deleteModelAction(modelId: string) {
 // react-doctor-disable-next-line
 export async function revalidateSingleModelDataAction(modelId: string) {
 	await revalidateCloudflare(["web-api-models", "web-api-model-details", "web-api-model-benchmarks", "web-api-model-timelines", "web-api-model-subscriptions", "web-api-model-notices", "web-api-search"]);
+	revalidateModelDataOnlyTags({ modelId });
 	revalidatePath(`/internal/data/models/edit/${modelId}`);
 	revalidatePath("/models");
 	revalidatePath(`/models/${modelId}`);
@@ -781,11 +787,11 @@ export async function revalidateSingleModelDataAction(modelId: string) {
 // react-doctor-disable-next-line
 export async function revalidateSingleModelApiInfoAction(modelId: string) {
 	await revalidateCloudflare(["web-api-models", "web-api-model-pricing", "web-api-model-performance", "web-api-model-provider-health", "web-api-provider-routing-health", "web-api-providers"]);
+	revalidateModelApiInfoTags({ modelId });
 	revalidatePath(`/internal/data/models/edit/${modelId}`);
 	revalidatePath("/models");
 	revalidatePath(`/models/${modelId}`);
-	revalidatePath("/api-providers");
-	revalidatePath("/api-providers/**");
+	revalidatePath("/api-providers", "layout");
 
 	return { ok: true as const, message: "Model API info cache revalidated." };
 }
@@ -793,11 +799,11 @@ export async function revalidateSingleModelApiInfoAction(modelId: string) {
 // react-doctor-disable-next-line
 export async function revalidateSingleModelAllAction(modelId: string) {
 	await revalidateCloudflare(["web-api-models", "web-api-model-details", "web-api-model-benchmarks", "web-api-model-timelines", "web-api-model-subscriptions", "web-api-model-pricing", "web-api-model-performance", "web-api-model-notices", "web-api-providers", "web-api-organisations", "web-api-reference-data", "web-api-search"]);
+	revalidateModelDataTags({ modelId });
 	revalidatePath(`/internal/data/models/edit/${modelId}`);
 	revalidatePath("/models");
 	revalidatePath(`/models/${modelId}`);
-	revalidatePath("/api-providers");
-	revalidatePath("/api-providers/**");
+	revalidatePath("/api-providers", "layout");
 
 	return { ok: true as const, message: "All model caches revalidated." };
 }

--- a/apps/web/src/lib/cache/revalidateDataTags.ts
+++ b/apps/web/src/lib/cache/revalidateDataTags.ts
@@ -1,7 +1,4 @@
-import { revalidatePath, revalidateTag, updateTag } from "next/cache";
-
-const STALE_WHILE_REVALIDATE = { expire: 0 } as const;
-const EXPIRE_IMMEDIATELY = { expire: 0 } as const;
+import { revalidatePath, updateTag } from "next/cache";
 
 type RevalidateModelDataTagOptions = {
 	modelId?: string | null;
@@ -163,12 +160,6 @@ const PUBLIC_MODEL_CATALOGUE_GLOBAL_TAGS = [
 	"frontend:og-payload",
 ] as const;
 
-function revalidateTagList(tags: readonly string[]) {
-	for (const tag of tags) {
-		revalidateTag(tag, STALE_WHILE_REVALIDATE);
-	}
-}
-
 function expireTagList(tags: readonly string[]) {
 	for (const tag of new Set(tags)) {
 		updateTag(tag);
@@ -245,86 +236,63 @@ export function expirePublicModelCatalogueCache(
 export function revalidateModelDataOnlyTags(
 	options: RevalidateModelDataTagOptions = {}
 ) {
-	revalidateTagList(MODEL_DATA_GLOBAL_TAGS);
+	const tags: string[] = [...MODEL_DATA_GLOBAL_TAGS];
 
 	for (const organisationId of options.organisationIds ?? []) {
 		if (!organisationId) continue;
-		revalidateTag(
+		tags.push(
 			`organisation:header:${organisationId}`,
-			STALE_WHILE_REVALIDATE
-		);
-		revalidateTag(
 			`data:organisations:${organisationId}`,
-			STALE_WHILE_REVALIDATE
 		);
 	}
 
 	if (options.modelId) {
-		revalidateTag(`model:data:${options.modelId}`, STALE_WHILE_REVALIDATE);
-		revalidateTag(`model:header:${options.modelId}`, STALE_WHILE_REVALIDATE);
-		revalidateTag(`data:models:${options.modelId}`, STALE_WHILE_REVALIDATE);
-		revalidateTag(
+		tags.push(
+			`model:data:${options.modelId}`,
+			`model:header:${options.modelId}`,
+			`data:models:${options.modelId}`,
 			`data:benchmarks:model:${options.modelId}`,
-			STALE_WHILE_REVALIDATE
-		);
-		revalidateTag(
 			`model:benchmarks:highlights:${options.modelId}`,
-			STALE_WHILE_REVALIDATE
-		);
-		revalidateTag(
 			`model:benchmarks:table:${options.modelId}`,
-			STALE_WHILE_REVALIDATE
-		);
-		revalidateTag(
 			`model:benchmarks:comparisons:${options.modelId}`,
-			STALE_WHILE_REVALIDATE
 		);
 	}
 
 	for (const benchmarkId of options.benchmarkIds ?? []) {
 		if (!benchmarkId) continue;
-		revalidateTag(`data:benchmarks:${benchmarkId}`, STALE_WHILE_REVALIDATE);
+		tags.push(`data:benchmarks:${benchmarkId}`);
 		if (options.modelId) {
-			revalidateTag(
+			tags.push(
 				`data:benchmarks:model:${options.modelId}:benchmark:${benchmarkId}`,
-				STALE_WHILE_REVALIDATE
 			);
 		}
 	}
+
+	expireTagList(tags);
 }
 
 export function revalidateModelApiInfoTags(
 	options: RevalidateModelDataTagOptions = {}
 ) {
 	const hasModelScope = Boolean(options.modelId);
+	const tags: string[] = [];
 	if (!hasModelScope) {
-		revalidateTagList(MODEL_API_GLOBAL_TAGS);
-		for (const tag of MODEL_CANONICAL_RESOLVER_TAGS) {
-			revalidateTag(tag, EXPIRE_IMMEDIATELY);
-		}
+		tags.push(...MODEL_API_GLOBAL_TAGS, ...MODEL_CANONICAL_RESOLVER_TAGS);
 	}
 
 	if (options.modelId) {
-		revalidateTag(`model:canonical:${options.modelId}`, EXPIRE_IMMEDIATELY);
-		revalidateTag(`model:api:${options.modelId}`, STALE_WHILE_REVALIDATE);
-		revalidateTag(
+		tags.push(
+			`model:canonical:${options.modelId}`,
+			`model:api:${options.modelId}`,
 			`model:pricing-history:${options.modelId}`,
-			STALE_WHILE_REVALIDATE
-		);
-		revalidateTag(
 			`model:performance:${options.modelId}`,
-			STALE_WHILE_REVALIDATE
-		);
-		revalidateTag(`data:model_apps:${options.modelId}`, STALE_WHILE_REVALIDATE);
-		revalidateTag(
+			`data:model_apps:${options.modelId}`,
 			`data:gateway_requests:model:${options.modelId}`,
-			STALE_WHILE_REVALIDATE
-		);
-		revalidateTag(
 			`data:gateway_usage_rollups:model:${options.modelId}`,
-			STALE_WHILE_REVALIDATE
 		);
 	}
+
+	expireTagList(tags);
 }
 
 /**
@@ -341,24 +309,13 @@ export function revalidateModelDataTags(
 export function revalidateBenchmarkDataTags(
 	options: RevalidateBenchmarkTagOptions = {}
 ) {
-	revalidateTag("data:benchmarks", STALE_WHILE_REVALIDATE);
-	revalidateTag("data:benchmarks:list", STALE_WHILE_REVALIDATE);
+	const tags = ["data:benchmarks", "data:benchmarks:list"];
 	if (options.modelId) {
-		revalidateTag(
+		tags.push(
 			`data:benchmarks:model:${options.modelId}`,
-			STALE_WHILE_REVALIDATE
-		);
-		revalidateTag(
 			`model:benchmarks:highlights:${options.modelId}`,
-			STALE_WHILE_REVALIDATE
-		);
-		revalidateTag(
 			`model:benchmarks:table:${options.modelId}`,
-			STALE_WHILE_REVALIDATE
-		);
-		revalidateTag(
 			`model:benchmarks:comparisons:${options.modelId}`,
-			STALE_WHILE_REVALIDATE
 		);
 	}
 
@@ -370,20 +327,21 @@ export function revalidateBenchmarkDataTags(
 	}
 
 	for (const benchmarkId of benchmarkIds) {
-		revalidateTag(`data:benchmarks:${benchmarkId}`, STALE_WHILE_REVALIDATE);
+		tags.push(`data:benchmarks:${benchmarkId}`);
 		if (options.modelId) {
-			revalidateTag(
+			tags.push(
 				`data:benchmarks:model:${options.modelId}:benchmark:${benchmarkId}`,
-				STALE_WHILE_REVALIDATE
 			);
 		}
 	}
+
+	expireTagList(tags);
 }
 
 export function revalidateProviderDataTags(
 	options: RevalidateProviderTagOptions = {}
 ) {
-	revalidateTagList(MODEL_API_GLOBAL_TAGS);
+	const tags: string[] = [...MODEL_API_GLOBAL_TAGS];
 
 	const providerIds = new Set<string>();
 	if (options.providerId) providerIds.add(options.providerId);
@@ -393,29 +351,23 @@ export function revalidateProviderDataTags(
 	}
 
 	for (const providerId of providerIds) {
-		revalidateTag(`data:api_providers:${providerId}`, STALE_WHILE_REVALIDATE);
-		revalidateTag(`api_provider:header:${providerId}`, STALE_WHILE_REVALIDATE);
-		revalidateTag(
+		tags.push(
+			`data:api_providers:${providerId}`,
+			`api_provider:header:${providerId}`,
 			`data:gateway_usage_rollups:provider:${providerId}`,
-			STALE_WHILE_REVALIDATE
-		);
-		revalidateTag(
 			`data:gateway_provider_health_states:provider:${providerId}`,
-			STALE_WHILE_REVALIDATE
-		);
-		revalidateTag(`data:top_apps:provider:${providerId}`, STALE_WHILE_REVALIDATE);
-		revalidateTag(
+			`data:top_apps:provider:${providerId}`,
 			`data:top_models:provider:${providerId}`,
-			STALE_WHILE_REVALIDATE
 		);
 	}
+
+	expireTagList(tags);
 }
 
 export function revalidateOrganisationDataTags(
 	options: RevalidateOrganisationTagOptions = {}
 ) {
-	revalidateTag("data:organisations", STALE_WHILE_REVALIDATE);
-	revalidateTag("data:organisations:list", STALE_WHILE_REVALIDATE);
+	const tags = ["data:organisations", "data:organisations:list"];
 
 	const organisationIds = new Set<string>();
 	if (options.organisationId) organisationIds.add(options.organisationId);
@@ -425,27 +377,28 @@ export function revalidateOrganisationDataTags(
 	}
 
 	for (const organisationId of organisationIds) {
-		revalidateTag(
+		tags.push(
 			`organisation:header:${organisationId}`,
-			STALE_WHILE_REVALIDATE
-		);
-		revalidateTag(
 			`data:organisations:${organisationId}`,
-			STALE_WHILE_REVALIDATE
 		);
 	}
+
+	expireTagList(tags);
 }
 
 export function revalidateAppDataTags(appIds: string[] = []) {
-	revalidateTag("data:apps", STALE_WHILE_REVALIDATE);
-	revalidateTag("data:app_details", STALE_WHILE_REVALIDATE);
-	revalidateTag("data:app_usage", STALE_WHILE_REVALIDATE);
-	revalidateTag("data:top_apps", STALE_WHILE_REVALIDATE);
-	revalidateTag("public-top-apps", STALE_WHILE_REVALIDATE);
+	const tags = [
+		"data:apps",
+		"data:app_details",
+		"data:app_usage",
+		"data:top_apps",
+		"public-top-apps",
+	];
 
 	for (const appId of appIds) {
 		if (!appId) continue;
-		revalidateTag(`data:app_details:${appId}`, STALE_WHILE_REVALIDATE);
-		revalidateTag(`data:app_usage:${appId}`, STALE_WHILE_REVALIDATE);
+		tags.push(`data:app_details:${appId}`, `data:app_usage:${appId}`);
 	}
+
+	expireTagList(tags);
 }

--- a/apps/web/src/lib/cache/revalidateDataTags.ts
+++ b/apps/web/src/lib/cache/revalidateDataTags.ts
@@ -1,6 +1,6 @@
 import { revalidatePath, revalidateTag, updateTag } from "next/cache";
 
-const STALE_WHILE_REVALIDATE = "max" as const;
+const STALE_WHILE_REVALIDATE = { expire: 0 } as const;
 const EXPIRE_IMMEDIATELY = { expire: 0 } as const;
 
 type RevalidateModelDataTagOptions = {


### PR DESCRIPTION
## Summary

- preserve Cloudflare caching for API data and Next.js caching for rendered public pages
- give both layers one Cache Control Centre operation
- purge Worker cache tags first, then immediately expire the matching Next.js data tags and routes
- use `updateTag()` for manual administrative refreshes so the next request blocks for fresh content instead of receiving stale-while-revalidate data
- expire exact model detail routes for targeted model operations
- make the model editor's Data, API info, and All controls clear their matching Worker and Next.js caches

## Architecture

Cloudflare remains the authoritative cache for reusable API responses. Next.js continues caching rendered public pages to minimise server renders and Worker calls. Manual purges coordinate both layers rather than converting public pages to dynamic rendering, preserving fast loads and low usage.

Client-side SWR behaviour is unchanged; this PR does not add duplicate browser revalidation requests.

## Root cause

The Cache Control Centre called the Cloudflare web API directly from the browser, so it purged Worker cache tags but never invoked Next.js cache invalidation. The model-editor actions also used stale-while-revalidate helpers and previously targeted `/models/**` instead of the concrete model page.

This allowed imported catalogue changes—such as removing the Kimi K3 notice—to remain visible from the rendered website cache after an apparently successful purge.

## Behaviour after this change

A manual purge now waits for the Worker purge, immediately expires the matching Next.js data tags, revalidates the relevant layouts or exact detail paths, and only then reports success. Targeting `moonshotai/kimi-k3` explicitly invalidates `/models/moonshotai/kimi-k3`.

Normal visitors continue receiving cached rendered pages. Only the first request after an administrative purge blocks while fresh content is regenerated.

## Validation

- `git diff --check` passes
- reviewed every Cache Control Centre scope and mapped it to matching Next.js tags and paths
- verified all manual tag helpers use `updateTag()` with no remaining `revalidateTag(..., "max")` path
- verified all three model-editor refresh actions expire scoped model tags and the exact model route
- local TypeScript validation could not start because the current lockfile is rejected by the repository's minimum-release-age policy; CI remains the dependency-backed validation path

## UI impact

Text-only clarification in the internal Cache Control Centre; no public UI change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added more targeted cache purging for models, providers, organisations, benchmarks, apps, countries, and profiles.
  * Cache purge results now provide clearer confirmation messaging, including Worker tag updates and expected website cache timing.

* **Bug Fixes**
  * Improved cache invalidation reliability across catalogue, search, landing pages, subscriptions, rankings, and model data.
  * Updated purge confirmations to clarify that matching website data and page caches expire immediately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->