### PR TITLE
fix: show DigitalOcean Kimi K3 as external availability

### DIFF
--- a/packages/data/catalog/src/data/api_providers/digitalocean/models.json
+++ b/packages/data/catalog/src/data/api_providers/digitalocean/models.json
@@ -555,7 +555,7 @@
         "modes": []
       }
     ],
-    "routing_status": "disabled",
+    "routing_status": "active",
     "routable": false,
     "regions": {
       "execution": null,


### PR DESCRIPTION
## Summary

- mark DigitalOcean's Kimi K3 provider offer as an active catalogue route
- keep `is_active_gateway: false` and `routable: false`
- allow the V2 model pricing/provider projection to include DigitalOcean without making it callable through Phaseo

## Root cause

The original catalogue-only addition used `routing_status: "disabled"`. V2 correctly separates provider availability from Phaseo gateway enablement, but its public model projection deliberately hides disabled routes. This meant the verified DigitalOcean offer was imported yet omitted from the Kimi K3 page.

## Resulting semantics

- DigitalOcean offers Kimi K3: yes
- visible in Phaseo's provider catalogue: yes
- Phaseo gateway routing enabled: no
- selectable for Phaseo inference: no

## Validation

- exactly one `digitalocean:kimi-k3` record remains
- `routing_status` is `active`
- `is_active_gateway` remains `false`
- `routable` remains `false`
- no runtime executor, credentials or routing configuration changed

After merge and the main importer run, purge `moonshotai/kimi-k3` to show DigitalOcean immediately.