### PR TITLE
Add Google Lyria 3.5

### DIFF
--- a/packages/data/catalog/src/data/models/google/lyria-3.5/model.json
+++ b/packages/data/catalog/src/data/models/google/lyria-3.5/model.json
@@ -1,0 +1,107 @@
+{
+  "model_id": "google/lyria-3.5",
+  "organisation_id": "google",
+  "name": "Lyria 3.5",
+  "status": "Available",
+  "previous_model_id": "google/lyria-3",
+  "description": "Lyria 3.5 is Google's music generation model with improved musicality, lyrics, vocal quality, and support for variable-length tracks up to three minutes.",
+  "announced_date": "2026-07-29T00:00:00",
+  "release_date": "2026-07-29T00:00:00",
+  "deprecation_date": null,
+  "retirement_date": null,
+  "license": "Proprietary",
+  "input_types": "text,image",
+  "output_types": "text,audio_music",
+  "api_model_id": "google/lyria-3.5",
+  "family_id": "google/lyria-3",
+  "links": [
+    {
+      "title": "Lyria 3.5",
+      "kind": "homepage",
+      "url": "https://deepmind.google/models/lyria/"
+    },
+    {
+      "title": "Lyria 3 model card",
+      "kind": "model_card",
+      "url": "https://deepmind.google/models/model-cards/lyria-3-5/"
+    }
+  ],
+  "details": [
+    {
+      "name": "maximum_track_length",
+      "value": "Up to 3 minutes"
+    },
+    {
+      "name": "availability_note",
+      "value": "Available in Google Flow Music. Google has not published a Gemini API or Vertex AI model identifier for Lyria 3.5."
+    },
+    {
+      "name": "capability_note",
+      "value": "Google describes improved vocals, musicality, lyrics, and variable song lengths."
+    }
+  ],
+  "benchmarks": [],
+  "page_notice": {
+    "tone": "info",
+    "markdown": "Lyria 3.5 is currently available in Google Flow Music, but Google has not yet documented a public API model identifier. Phaseo routing will remain disabled until an official endpoint is available."
+  },
+  "model_type": "audio",
+  "knowledge_cutoff": null,
+  "limits": {
+    "context": null,
+    "input": null,
+    "output": null
+  },
+  "modalities": {
+    "input": [
+      "text",
+      "image/*"
+    ],
+    "output": [
+      "text",
+      "audio/*"
+    ]
+  },
+  "reasoning": {
+    "supported": null,
+    "options": []
+  },
+  "capabilities": {
+    "attachment": null,
+    "tool_call": null,
+    "structured_output": null,
+    "temperature": null,
+    "streaming": null,
+    "web_search": null
+  },
+  "open_weights": false,
+  "sources": [
+    {
+      "kind": "official",
+      "url": "https://deepmind.google/models/lyria/",
+      "accessed_at": "2026-07-29T00:00:00",
+      "notes": "Official product page describing Lyria 3.5 capabilities and Flow Music availability."
+    },
+    {
+      "kind": "model_card",
+      "url": "https://deepmind.google/models/model-cards/lyria-3-5/",
+      "accessed_at": "2026-07-29T00:00:00",
+      "notes": "Official Google DeepMind model card supplied with the release."
+    },
+    {
+      "kind": "documentation",
+      "url": "https://docs.cloud.google.com/gemini-enterprise-agent-platform/models/music/generate-music",
+      "accessed_at": "2026-07-29T00:00:00",
+      "notes": "The public API documentation currently lists only lyria-3-clip-preview and lyria-3-pro-preview."
+    }
+  ],
+  "verification": {
+    "status": "verified",
+    "checked_at": "2026-07-29T00:00:00",
+    "notes": "Model identity and capabilities verified against Google DeepMind. No public API model identifier was documented at verification time."
+  },
+  "last_updated": "2026-07-29T00:00:00",
+  "removal_date": null,
+  "replacement_model_id": null,
+  "license_url": null
+}


### PR DESCRIPTION
## Summary

- adds `google/lyria-3.5` to the canonical model catalogue
- records text and image inputs, lyrics and music outputs, improved vocals and musicality, and variable tracks up to three minutes
- links the official Google DeepMind product page and model card
- clearly marks routing as unavailable because Google has not published a Gemini API or Vertex AI model identifier for Lyria 3.5

## Why

Google has released Lyria 3.5 in Flow Music, but its public developer documentation still lists only `lyria-3-clip-preview` and `lyria-3-pro-preview`. Adding a provider mapping for an inferred 3.5 slug would make the gateway advertise an endpoint that is not documented to exist.

The existing Phaseo Lyria 3 music executor remains unchanged and ready for an official 3.5 model slug when Google exposes one.

## Validation

- `jq empty packages/data/catalog/src/data/models/google/lyria-3.5/model.json`
- `git diff --check`
- reviewed against the repository's model and page-notice schemas
- full `pnpm validate:data` could not run locally because the npm registry proxy terminated while installing dependencies
