### PR TITLE
fix(web): complete models catalogue V2 cutover

### DIFF
--- a/apps/web/src/app/(dashboard)/models/page.tsx
+++ b/apps/web/src/app/(dashboard)/models/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from "next";
 import ModelsPageClient from "@/components/(data)/models/Models/ModelsPageClient";
-import { resolveModelsCatalogueVersion } from "@/lib/flags";
+import { resolveModelsCatalogueVersion } from "@/lib/models/catalogueVersion";
 import { buildMetadata } from "@/lib/seo";
 
 export const metadata: Metadata = buildMetadata({

--- a/apps/web/src/app/(dashboard)/models/table/page.tsx
+++ b/apps/web/src/app/(dashboard)/models/table/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from "next";
 import ModelsTablePageClient from "@/components/(data)/models/Models/ModelsTablePageClient";
-import { resolveModelsCatalogueVersion } from "@/lib/flags";
+import { resolveModelsCatalogueVersion } from "@/lib/models/catalogueVersion";
 
 export const metadata: Metadata = {
 	title: "Models table view",
@@ -19,4 +19,3 @@ export default async function ModelsTablePage() {
 		/>
 	);
 }
-

--- a/apps/web/src/lib/flags/index.ts
+++ b/apps/web/src/lib/flags/index.ts
@@ -3,15 +3,13 @@ import "server-only";
 import { flag } from "flags/next";
 import type { StatsigUser } from "@flags-sdk/statsig";
 
-import { isAdminViewer } from "@/lib/auth/getViewerRole";
-import { getServerStatsigUser, getStatsigFlagsAdapter } from "@/lib/statsig/server";
+import { getStatsigFlagsAdapter } from "@/lib/statsig/server";
 import {
 	BATCH_API_GATE,
 	VIDEO_API_GATE,
 	REALTIME_VOICE_GATE,
 	GATEWAY_IO_LOGGING_GATE,
 	SAML_SSO_GATE,
-	MODELS_CATALOGUE_V2_BETA_KEY,
 	NEW_LANDING_PAGE_EXPERIMENT,
 	NEW_LANDING_PAGE_GATE,
 	type GatewayHeroVariant,
@@ -20,28 +18,6 @@ import {
 import { identify } from "./identify";
 
 const statsigAdapter = getStatsigFlagsAdapter();
-
-export const modelsCatalogueV2Flag = flag<boolean>({
-	key: MODELS_CATALOGUE_V2_BETA_KEY,
-	description: "Use the parallel V2 models catalogue tables.",
-	defaultValue: false,
-	decide: async () => {
-		const user = await getServerStatsigUser();
-		const custom = user.custom as Record<string, unknown> | undefined;
-		const enabledKeys = custom?.betaFeatureKeys;
-		return (
-			Array.isArray(enabledKeys) &&
-			enabledKeys.includes(MODELS_CATALOGUE_V2_BETA_KEY)
-		);
-	},
-});
-
-export async function resolveModelsCatalogueVersion(): Promise<"v1" | "v2"> {
-	// This branch treats local development as the V2 cutover environment so the
-	// catalogue cannot silently fall back to V1 while it is being validated.
-	if (process.env.NODE_ENV === "development") return "v2";
-	return (await isAdminViewer()) && (await modelsCatalogueV2Flag()) ? "v2" : "v1";
-}
 
 export const gatewayNewHeroFlag = statsigAdapter
 	? flag<boolean, StatsigUser>({

--- a/apps/web/src/lib/models/catalogueVersion.test.ts
+++ b/apps/web/src/lib/models/catalogueVersion.test.ts
@@ -1,7 +1,7 @@
-import { resolveModelsCatalogueVersion } from "./catalogueVersion";
+import { resolveModelsCatalogueVersion } from "@/lib/models/catalogueVersion";
 
 describe("resolveModelsCatalogueVersion", () => {
-	it("uses the V2 catalogue after the hard cutover", async () => {
-		await expect(resolveModelsCatalogueVersion()).resolves.toBe("v2");
-	});
+    it("uses the V2 catalogue after the hard cutover", async () => {
+        await expect(resolveModelsCatalogueVersion()).resolves.toBe("v2");
+    });
 });

--- a/apps/web/src/lib/models/catalogueVersion.test.ts
+++ b/apps/web/src/lib/models/catalogueVersion.test.ts
@@ -1,0 +1,7 @@
+import { resolveModelsCatalogueVersion } from "./catalogueVersion";
+
+describe("resolveModelsCatalogueVersion", () => {
+	it("uses the V2 catalogue after the hard cutover", async () => {
+		await expect(resolveModelsCatalogueVersion()).resolves.toBe("v2");
+	});
+});

--- a/apps/web/src/lib/models/catalogueVersion.ts
+++ b/apps/web/src/lib/models/catalogueVersion.ts
@@ -1,3 +1,3 @@
 export async function resolveModelsCatalogueVersion(): Promise<"v2"> {
-	return "v2";
+    return "v2";
 }

--- a/apps/web/src/lib/models/catalogueVersion.ts
+++ b/apps/web/src/lib/models/catalogueVersion.ts
@@ -1,0 +1,3 @@
+export async function resolveModelsCatalogueVersion(): Promise<"v2"> {
+	return "v2";
+}


### PR DESCRIPTION
## Summary

- make the models catalogue resolver return V2 for every visitor after the hard cutover
- remove the obsolete admin/Statsig V2 rollout gate
- use the dedicated catalogue-version resolver from both models routes
- add a regression test for the V2-only contract

## Root cause

The web API was changed to always return `catalogue_version: "v2"`, while the production web page still selected V1 for ordinary visitors. The SWR fetcher correctly rejected the mismatched response and the page error boundary rendered “Something went wrong”.

## Impact

The public `/models` catalogue and internal table route now request the same V2 contract returned by the API.

## Validation

- direct resolver runtime assertion: returned `v2`
- `git diff --check`: passed
- live production reproduction confirmed the previous V1/V2 mismatch
- full local Jest/type-check could not run because npm returned repeated 502 responses while installing the isolated worktree dependencies; CI is the authoritative validation gate

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The models catalogue now consistently uses the latest version across model views and tables.

* **Bug Fixes**
  * Removed outdated catalogue-version selection logic to ensure users see the intended catalogue experience.

* **Tests**
  * Added coverage confirming the latest catalogue version is selected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->