### PR TITLE
Add Phaseo mission to July ICYMI recap

### DIFF
--- a/apps/web/src/content/announcements/icymi-july-2026-what-we-shipped.mdx
+++ b/apps/web/src/content/announcements/icymi-july-2026-what-we-shipped.mdx
@@ -149,4 +149,4 @@ The July changelog includes these model releases and returns to availability:
 
 July built the platform foundations for the next stage of Phaseo: deeper observability, broader multimodal and async support, more dependable automated catalogue updates, and a developer experience that works consistently across the web, CLI, MCP, and language SDKs.
 
-Our mission is to build the broadest AI gateway at the lowest sustainable price—not to maximise margins, but because we want to build the best possible product with the people who use it. That is why Phaseo will remain open source, why we will keep working to drive our own costs down, and why the community will always have a place in shaping what we build next.
+Our mission is to build the broadest AI gateway at the lowest sustainable price. We are doing this because we want to build the best possible product with the people who use it, not to maximise margins. That is why Phaseo will remain open source, why we will keep working to drive our own costs down, and why the community will always have a place in shaping what we build next.

--- a/apps/web/src/content/announcements/icymi-july-2026-what-we-shipped.mdx
+++ b/apps/web/src/content/announcements/icymi-july-2026-what-we-shipped.mdx
@@ -148,3 +148,5 @@ The July changelog includes these model releases and returns to availability:
 ## Next Up
 
 July built the platform foundations for the next stage of Phaseo: deeper observability, broader multimodal and async support, more dependable automated catalogue updates, and a developer experience that works consistently across the web, CLI, MCP, and language SDKs.
+
+Our mission is to build the broadest AI gateway at the lowest sustainable price—not to maximise margins, but because we want to build the best possible product with the people who use it. That is why Phaseo will remain open source, why we will keep working to drive our own costs down, and why the community will always have a place in shaping what we build next.

--- a/apps/web/src/content/announcements/icymi-july-2026-what-we-shipped.mdx
+++ b/apps/web/src/content/announcements/icymi-july-2026-what-we-shipped.mdx
@@ -149,4 +149,6 @@ The July changelog includes these model releases and returns to availability:
 
 July built the platform foundations for the next stage of Phaseo: deeper observability, broader multimodal and async support, more dependable automated catalogue updates, and a developer experience that works consistently across the web, CLI, MCP, and language SDKs.
 
-Our mission is to build the broadest AI gateway at the lowest sustainable price. We are doing this because we want to build the best possible product with the people who use it, not to maximise margins. That is why Phaseo will remain open source, why we will keep working to drive our own costs down, and why the community will always have a place in shaping what we build next.
+On [30 July 2026](https://x.com/sama/status/2082880720989532597), OpenAI cut GPT-5.6 Luna API prices by 80% and Terra prices by 20%, describing its goal as offering the best price-to-intelligence trade-off at every level. This is the direction we want the industry to move in. Improvements to models, inference, routing and production software should deliver more intelligence per dollar for everyone.
+
+Our mission is to build the broadest AI gateway and offer the best price-to-intelligence trade-off at every level. We will keep driving down our own costs and pass those savings on through lower prices. Our aim is not to maximise margins. It is to build the best possible product with the people who use it. Phaseo will remain open source, and the community will always have a place in shaping what we build next.


### PR DESCRIPTION
## Summary

- adds a short mission statement to the end of the July ICYMI post
- frames Phaseo's ambition as building the broadest AI gateway at the lowest sustainable price
- reiterates the commitment to open source development, lower underlying costs, and community participation

## Wording

The statement is deliberately framed as a mission rather than a current market-leadership claim.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a concluding note to the July 2026 announcement highlighting Phaseo’s open-source commitment, cost-reduction goals, and continued community input.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->