### PR TITLE
Keep Priority naming while supporting OpenAI Fast

### DIFF
--- a/apps/docs/v1/api-reference/parameters.mdx
+++ b/apps/docs/v1/api-reference/parameters.mdx
@@ -44,7 +44,7 @@ Parameter support still varies by endpoint, model, and provider. The model quick
 | [`reasoning_effort`](#reasoning_effort) | `string` | Lowering or increasing reasoning budget. |
 | [`reasoning_tokens`](#reasoning_tokens) | `integer` | Reasoning-specific token limit or accounting field. |
 | [`include_reasoning`](#include_reasoning) | `boolean` | Returning reasoning content or summaries where supported. |
-| [`service_tier`](#service_tier) | `string` | Choosing a supported request tier such as `fast`, `priority`, or `flex`. |
+| [`service_tier`](#service_tier) | `string` | Choosing a supported request tier such as `priority` or `flex`; OpenAI also accepts `fast` as an alias. |
 | [`prompt_cache_key`](#prompt_cache_key) | `string` | Keeping cache-aware routing sticky for related requests. |
 | [`cache_control`](#cache_control) | `object` | Applying provider-neutral prompt cache hints or breakpoints. |
 | [`prompt_cache_retention`](#prompt_cache_retention) | `string` | Setting OpenAI-compatible prompt cache retention. |
@@ -61,13 +61,13 @@ Parameter support still varies by endpoint, model, and provider. The model quick
 - [Chat Completions](./endpoint/chat-completions.mdx)
 - [Responses](/v1/api-reference/endpoint/responses)
 
-Use `fast`, `priority`, or `flex` only when the selected model and provider combination supports them. OpenAI accepts `priority` as a legacy alias for `fast`. `standard` is the default when `service_tier` is omitted.
+Use `priority` or `flex` only when the selected model and provider combination supports them. Phaseo keeps `priority` as the canonical premium tier; OpenAI routes also accept `fast` as an alias. `standard` is the default when `service_tier` is omitted.
 
 `Batch` is not a `service_tier` value. Batch requests use the separate Batch API.
 
 For Anthropic-compatible Messages requests, Anthropic's native upstream values are `auto` and `standard_only`. Phaseo may normalize or map these values across providers while preserving Anthropic-compatible behavior on `/v1/messages`.
 
-If you are using an official Anthropic SDK with a custom base URL pointed at Phaseo, prefer Anthropic-native values on `/v1/messages`. For normalized cross-provider tier controls such as `fast`, `priority`, and `flex`, prefer raw HTTP requests or the gateway-native / OpenAI-style text APIs.
+If you are using an official Anthropic SDK with a custom base URL pointed at Phaseo, prefer Anthropic-native values on `/v1/messages`. For normalized cross-provider tier controls such as `priority` and `flex`, or OpenAI's `fast` alias, prefer raw HTTP requests or the gateway-native / OpenAI-style text APIs.
 
 ## Parameter reference
 
@@ -427,7 +427,7 @@ Selects a supported routing or pricing tier on compatible text APIs.
 | Supported values | `standard`, `fast`, `priority`, `flex` |
 | Default | `standard` |
 
-Use `fast`, `priority`, or `flex` only when the chosen model and provider combination supports them. For OpenAI, `priority` remains a legacy alias for `fast`. Omit the field to stay on the default standard tier.
+Use `priority` or `flex` only when the chosen model and provider combination supports them. Phaseo keeps `priority` as the canonical premium tier; supported OpenAI routes also accept `fast` as an alias with identical routing and pricing. Omit the field to stay on the default standard tier.
 
 Phaseo maps these gateway-normalized tier values to provider-native controls internally, so callers can use the same `service_tier` values across supported text surfaces.
 

--- a/apps/docs/v1/guides/service-tiers.mdx
+++ b/apps/docs/v1/guides/service-tiers.mdx
@@ -23,8 +23,7 @@ Service tiers are currently available only for supported text models on supporte
 | Tier | How to request it | Typical use |
 | --- | --- | --- |
 | `Standard` | Default behavior. No extra field required. | General production traffic. |
-| `Fast` | Set `service_tier: "fast"` on the request. | Faster or premium routing where supported. |
-| `Priority` | Legacy alias for `fast`; set `service_tier: "priority"`. | Backwards-compatible faster routing where supported. |
+| `Priority` | Set `service_tier: "priority"` on the request. | Faster or premium routing where supported. OpenAI also accepts `fast`. |
 | `Flex` | Set `service_tier: "flex"` on the request. | Lower-cost routing where supported. |
 | `Batch` | Use the Batch API rather than `service_tier`. | Large deferred workloads where latency is less important. |
 
@@ -37,7 +36,7 @@ Use the same `service_tier` field when you call any supported synchronous text A
 - [Responses API reference](../api-reference/endpoint/responses.mdx)
 - [Shared parameter reference](../api-reference/parameters.mdx)
 
-The accepted `service_tier` values are `standard`, `fast`, `priority`, `flex`, and `batch`. `Standard` is the default behavior when `service_tier` is omitted. `Fast` and `Flex` are opt-in request modes, `Priority` remains a backwards-compatible alias for `Fast`, and `Batch` is handled by the Batch API rather than synchronous text requests.
+The accepted `service_tier` values are `standard`, `fast`, `priority`, `flex`, and `batch`. `Standard` is the default behavior when `service_tier` is omitted. Phaseo uses `Priority` as the canonical premium tier name. For OpenAI routes, `fast` is accepted as a provider-compatible alias and uses the same routing and pricing. `Batch` is handled by the Batch API rather than synchronous text requests.
 
 <Note>
 Phaseo maps the normalized gateway values to provider-native controls internally. For example, an Anthropic route may receive Anthropic-native tier fields upstream, but the client-facing request still uses the gateway values listed here.
@@ -54,15 +53,15 @@ Phaseo maps the normalized gateway values to provider-native controls internally
 }
 ```
 
-## Fast
+## Priority
 
-Use `Fast` when you want the provider's premium or higher-priority offer. OpenAI renamed Priority processing to Fast mode on 30 July 2026 and continues to accept `priority` as an alias.
+Use `Priority` when you want the provider's premium or higher-priority offer. Phaseo keeps `priority` as its provider-neutral name. OpenAI calls this Fast mode and accepts both `priority` and `fast` on supported models.
 
 ```json
 {
   "model": "openai/gpt-5.5",
   "input": "Summarise this incident report.",
-  "service_tier": "fast"
+  "service_tier": "priority"
 }
 ```
 

--- a/apps/web/src/components/(data)/model/quickstart/Quickstart.tsx
+++ b/apps/web/src/components/(data)/model/quickstart/Quickstart.tsx
@@ -71,7 +71,7 @@ type LanguageFamilyId =
 	| "php"
 	| "ruby";
 
-type ServiceTier = "standard" | "fast" | "priority" | "flex";
+type ServiceTier = "standard" | "priority" | "flex";
 
 const LANGUAGE_FAMILY_ORDER: LanguageFamilyId[] = [
 	"typescript",
@@ -163,8 +163,7 @@ const LANGUAGE_VARIANT_LABELS: Partial<Record<string, string>> = {
 
 const SERVICE_TIER_LABELS: Record<ServiceTier, string> = {
 	standard: "Standard",
-	fast: "Fast",
-	priority: "Priority (legacy alias)",
+	priority: "Priority",
 	flex: "Flex",
 };
 const STREAMING_SNIPPET_LANGUAGES = new Set([

--- a/apps/web/src/components/(data)/model/quickstart/QuickstartUsageSection.tsx
+++ b/apps/web/src/components/(data)/model/quickstart/QuickstartUsageSection.tsx
@@ -54,7 +54,7 @@ type QuickstartVisual =
 	| { kind: "icon"; icon: LucideIcon; className?: string };
 
 type ServiceTierOption = {
-	value: "standard" | "fast" | "priority" | "flex" | "batch";
+	value: "standard" | "priority" | "flex" | "batch";
 	label: string;
 	disabled?: boolean;
 	hint?: string;
@@ -62,8 +62,7 @@ type ServiceTierOption = {
 
 const SERVICE_TIER_OPTIONS: ServiceTierOption[] = [
 	{ value: "standard", label: "Standard" },
-	{ value: "fast", label: "Fast" },
-	{ value: "priority", label: "Priority (legacy alias)" },
+	{ value: "priority", label: "Priority" },
 	{ value: "flex", label: "Flex" },
 	{ value: "batch", label: "Batch", disabled: true, hint: "Coming soon" },
 ];
@@ -97,7 +96,7 @@ type QuickstartUsageSectionProps = {
 	showStreamingControl?: boolean;
 	supportsServiceTier: boolean;
 	streamingEnabled: boolean;
-	selectedServiceTier: "standard" | "fast" | "priority" | "flex";
+	selectedServiceTier: "standard" | "priority" | "flex";
 	requestModeLabel?: string;
 	serviceTierDocsHref?: string | null;
 	streamingDocsHref?: string | null;
@@ -105,7 +104,7 @@ type QuickstartUsageSectionProps = {
 	onSelectEndpoint: (value: string) => void;
 	onSelectLanguageFamily: (familyId: string) => void;
 	onSelectLanguage: (value: string) => void;
-	onSelectServiceTier: (value: "standard" | "fast" | "priority" | "flex") => void;
+	onSelectServiceTier: (value: "standard" | "priority" | "flex") => void;
 	onToggleStreaming: (enabled: boolean) => void;
 	curlQuickstart: string;
 	typescriptSdkUsage: string | null;
@@ -661,7 +660,7 @@ export function QuickstartUsageSection({
 								<Select
 									value={selectedServiceTier}
 									onValueChange={(value) =>
-										onSelectServiceTier(value as "standard" | "fast" | "priority" | "flex")
+										onSelectServiceTier(value as "standard" | "priority" | "flex")
 									}
 								>
 									<SelectTrigger className="h-8 w-full rounded-lg bg-muted/60 text-xs">

--- a/apps/web/src/lib/parameters/reference.ts
+++ b/apps/web/src/lib/parameters/reference.ts
@@ -155,7 +155,7 @@ const PARAMETER_REFERENCE: Record<string, ParameterReference> = {
 		type: "string",
 		defaultValue: "standard",
 		description:
-			"Chooses a supported request tier such as fast, priority, or flex when the route supports it.",
+			"Chooses a supported request tier such as priority or flex. OpenAI routes also accept fast as an alias for Priority.",
 	},
 	stream: {
 		type: "boolean",

--- a/packages/data/catalog/src/data/pricing/openai/openai-gpt-5.3-codex/text.generate/pricing.json
+++ b/packages/data/catalog/src/data/pricing/openai/openai-gpt-5.3-codex/text.generate/pricing.json
@@ -19,7 +19,7 @@
       "region": null,
       "cache_duration_seconds": null,
       "conditions": [],
-      "source": null
+      "source": "https://developers.openai.com/api/docs/pricing"
     },
     {
       "meter": "cached_read_text_tokens",
@@ -35,7 +35,7 @@
       "region": null,
       "cache_duration_seconds": null,
       "conditions": [],
-      "source": null
+      "source": "https://developers.openai.com/api/docs/pricing"
     },
     {
       "meter": "output_text_tokens",
@@ -51,7 +51,7 @@
       "region": null,
       "cache_duration_seconds": null,
       "conditions": [],
-      "source": null
+      "source": "https://developers.openai.com/api/docs/pricing"
     },
     {
       "meter": "input_text_tokens",
@@ -67,7 +67,8 @@
       "region": null,
       "cache_duration_seconds": null,
       "conditions": [],
-      "source": null
+      "source": null,
+      "effective_to": "2026-07-30T00:00:00Z"
     },
     {
       "meter": "cached_read_text_tokens",
@@ -83,7 +84,8 @@
       "region": null,
       "cache_duration_seconds": null,
       "conditions": [],
-      "source": null
+      "source": null,
+      "effective_to": "2026-07-30T00:00:00Z"
     },
     {
       "meter": "output_text_tokens",
@@ -99,7 +101,59 @@
       "region": null,
       "cache_duration_seconds": null,
       "conditions": [],
-      "source": null
+      "source": null,
+      "effective_to": "2026-07-30T00:00:00Z"
+    },
+    {
+      "meter": "input_text_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 3.5,
+      "currency": "USD",
+      "pricing_plan": "priority",
+      "note": "OpenAI Fast mode pricing, exposed as Phaseo Priority. Requests may use service_tier \"priority\" or \"fast\".",
+      "match": [],
+      "priority": 100,
+      "effective_from": "2026-07-30T00:00:00Z",
+      "region": null,
+      "cache_duration_seconds": null,
+      "conditions": [],
+      "source": "https://developers.openai.com/api/docs/pricing",
+      "effective_to": null
+    },
+    {
+      "meter": "cached_read_text_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 0.35,
+      "currency": "USD",
+      "pricing_plan": "priority",
+      "note": "OpenAI Fast mode pricing, exposed as Phaseo Priority. Requests may use service_tier \"priority\" or \"fast\".",
+      "match": [],
+      "priority": 100,
+      "effective_from": "2026-07-30T00:00:00Z",
+      "region": null,
+      "cache_duration_seconds": null,
+      "conditions": [],
+      "source": "https://developers.openai.com/api/docs/pricing",
+      "effective_to": null
+    },
+    {
+      "meter": "output_text_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 28,
+      "currency": "USD",
+      "pricing_plan": "priority",
+      "note": "OpenAI Fast mode pricing, exposed as Phaseo Priority. Requests may use service_tier \"priority\" or \"fast\".",
+      "match": [],
+      "priority": 100,
+      "effective_from": "2026-07-30T00:00:00Z",
+      "region": null,
+      "cache_duration_seconds": null,
+      "conditions": [],
+      "source": "https://developers.openai.com/api/docs/pricing",
+      "effective_to": null
     }
   ],
   "regions": [],
@@ -107,10 +161,12 @@
     "standard",
     "priority"
   ],
-  "sources": [],
+  "sources": [
+    "https://developers.openai.com/api/docs/pricing"
+  ],
   "verification": {
-    "status": "unverified",
-    "checked_at": null,
-    "notes": null
+    "status": "verified",
+    "checked_at": "2026-07-30T00:00:00Z",
+    "notes": "Verified against OpenAI's July 30, 2026 pricing. Phaseo keeps Priority as the canonical tier name and accepts fast as an OpenAI-compatible alias."
   }
 }

--- a/packages/data/catalog/src/data/pricing/openai/openai-gpt-5.4-mini/text.generate/pricing.json
+++ b/packages/data/catalog/src/data/pricing/openai/openai-gpt-5.4-mini/text.generate/pricing.json
@@ -19,7 +19,7 @@
       "region": null,
       "cache_duration_seconds": null,
       "conditions": [],
-      "source": null
+      "source": "https://developers.openai.com/api/docs/pricing"
     },
     {
       "meter": "cached_read_text_tokens",
@@ -35,7 +35,7 @@
       "region": null,
       "cache_duration_seconds": null,
       "conditions": [],
-      "source": null
+      "source": "https://developers.openai.com/api/docs/pricing"
     },
     {
       "meter": "output_text_tokens",
@@ -51,7 +51,7 @@
       "region": null,
       "cache_duration_seconds": null,
       "conditions": [],
-      "source": null
+      "source": "https://developers.openai.com/api/docs/pricing"
     },
     {
       "meter": "input_text_tokens",
@@ -67,7 +67,7 @@
       "region": null,
       "cache_duration_seconds": null,
       "conditions": [],
-      "source": null
+      "source": "https://developers.openai.com/api/docs/pricing"
     },
     {
       "meter": "cached_read_text_tokens",
@@ -83,7 +83,7 @@
       "region": null,
       "cache_duration_seconds": null,
       "conditions": [],
-      "source": null
+      "source": "https://developers.openai.com/api/docs/pricing"
     },
     {
       "meter": "output_text_tokens",
@@ -99,7 +99,7 @@
       "region": null,
       "cache_duration_seconds": null,
       "conditions": [],
-      "source": null
+      "source": "https://developers.openai.com/api/docs/pricing"
     },
     {
       "meter": "input_text_tokens",
@@ -115,7 +115,7 @@
       "region": null,
       "cache_duration_seconds": null,
       "conditions": [],
-      "source": null
+      "source": "https://developers.openai.com/api/docs/pricing"
     },
     {
       "meter": "cached_read_text_tokens",
@@ -131,7 +131,7 @@
       "region": null,
       "cache_duration_seconds": null,
       "conditions": [],
-      "source": null
+      "source": "https://developers.openai.com/api/docs/pricing"
     },
     {
       "meter": "output_text_tokens",
@@ -147,7 +147,7 @@
       "region": null,
       "cache_duration_seconds": null,
       "conditions": [],
-      "source": null
+      "source": "https://developers.openai.com/api/docs/pricing"
     },
     {
       "meter": "input_text_tokens",
@@ -163,7 +163,8 @@
       "region": null,
       "cache_duration_seconds": null,
       "conditions": [],
-      "source": null
+      "source": null,
+      "effective_to": "2026-07-30T00:00:00Z"
     },
     {
       "meter": "cached_read_text_tokens",
@@ -179,7 +180,8 @@
       "region": null,
       "cache_duration_seconds": null,
       "conditions": [],
-      "source": null
+      "source": null,
+      "effective_to": "2026-07-30T00:00:00Z"
     },
     {
       "meter": "output_text_tokens",
@@ -195,7 +197,59 @@
       "region": null,
       "cache_duration_seconds": null,
       "conditions": [],
-      "source": null
+      "source": null,
+      "effective_to": "2026-07-30T00:00:00Z"
+    },
+    {
+      "meter": "input_text_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 1.5,
+      "currency": "USD",
+      "pricing_plan": "priority",
+      "note": "OpenAI Fast mode pricing, exposed as Phaseo Priority. Requests may use service_tier \"priority\" or \"fast\".",
+      "match": [],
+      "priority": 100,
+      "effective_from": "2026-07-30T00:00:00Z",
+      "region": null,
+      "cache_duration_seconds": null,
+      "conditions": [],
+      "source": "https://developers.openai.com/api/docs/pricing",
+      "effective_to": null
+    },
+    {
+      "meter": "cached_read_text_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 0.15,
+      "currency": "USD",
+      "pricing_plan": "priority",
+      "note": "OpenAI Fast mode pricing, exposed as Phaseo Priority. Requests may use service_tier \"priority\" or \"fast\".",
+      "match": [],
+      "priority": 100,
+      "effective_from": "2026-07-30T00:00:00Z",
+      "region": null,
+      "cache_duration_seconds": null,
+      "conditions": [],
+      "source": "https://developers.openai.com/api/docs/pricing",
+      "effective_to": null
+    },
+    {
+      "meter": "output_text_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 9,
+      "currency": "USD",
+      "pricing_plan": "priority",
+      "note": "OpenAI Fast mode pricing, exposed as Phaseo Priority. Requests may use service_tier \"priority\" or \"fast\".",
+      "match": [],
+      "priority": 100,
+      "effective_from": "2026-07-30T00:00:00Z",
+      "region": null,
+      "cache_duration_seconds": null,
+      "conditions": [],
+      "source": "https://developers.openai.com/api/docs/pricing",
+      "effective_to": null
     }
   ],
   "regions": [],
@@ -205,10 +259,12 @@
     "flex",
     "priority"
   ],
-  "sources": [],
+  "sources": [
+    "https://developers.openai.com/api/docs/pricing"
+  ],
   "verification": {
-    "status": "unverified",
-    "checked_at": null,
-    "notes": null
+    "status": "verified",
+    "checked_at": "2026-07-30T00:00:00Z",
+    "notes": "Verified against OpenAI's July 30, 2026 pricing. Phaseo keeps Priority as the canonical tier name and accepts fast as an OpenAI-compatible alias."
   }
 }

--- a/packages/data/catalog/src/data/pricing/openai/openai-gpt-5.4/text.generate/pricing.json
+++ b/packages/data/catalog/src/data/pricing/openai/openai-gpt-5.4/text.generate/pricing.json
@@ -35,7 +35,7 @@
           "value": 272000
         }
       ],
-      "source": null
+      "source": "https://developers.openai.com/api/docs/pricing"
     },
     {
       "meter": "cached_read_text_tokens",
@@ -67,7 +67,7 @@
           "value": 272000
         }
       ],
-      "source": null
+      "source": "https://developers.openai.com/api/docs/pricing"
     },
     {
       "meter": "output_text_tokens",
@@ -99,7 +99,7 @@
           "value": 272000
         }
       ],
-      "source": null
+      "source": "https://developers.openai.com/api/docs/pricing"
     },
     {
       "meter": "input_text_tokens",
@@ -131,7 +131,7 @@
           "value": 272000
         }
       ],
-      "source": null
+      "source": "https://developers.openai.com/api/docs/pricing"
     },
     {
       "meter": "cached_read_text_tokens",
@@ -163,7 +163,7 @@
           "value": 272000
         }
       ],
-      "source": null
+      "source": "https://developers.openai.com/api/docs/pricing"
     },
     {
       "meter": "output_text_tokens",
@@ -195,7 +195,7 @@
           "value": 272000
         }
       ],
-      "source": null
+      "source": "https://developers.openai.com/api/docs/pricing"
     },
     {
       "meter": "input_text_tokens",
@@ -227,7 +227,7 @@
           "value": 272000
         }
       ],
-      "source": null
+      "source": "https://developers.openai.com/api/docs/pricing"
     },
     {
       "meter": "cached_read_text_tokens",
@@ -259,7 +259,7 @@
           "value": 272000
         }
       ],
-      "source": null
+      "source": "https://developers.openai.com/api/docs/pricing"
     },
     {
       "meter": "output_text_tokens",
@@ -291,7 +291,7 @@
           "value": 272000
         }
       ],
-      "source": null
+      "source": "https://developers.openai.com/api/docs/pricing"
     },
     {
       "meter": "input_text_tokens",
@@ -323,7 +323,7 @@
           "value": 272000
         }
       ],
-      "source": null
+      "source": "https://developers.openai.com/api/docs/pricing"
     },
     {
       "meter": "cached_read_text_tokens",
@@ -355,7 +355,8 @@
           "value": 272000
         }
       ],
-      "source": null
+      "source": null,
+      "effective_to": "2026-07-30T00:00:00Z"
     },
     {
       "meter": "output_text_tokens",
@@ -387,7 +388,7 @@
           "value": 272000
         }
       ],
-      "source": null
+      "source": "https://developers.openai.com/api/docs/pricing"
     },
     {
       "meter": "input_text_tokens",
@@ -419,7 +420,8 @@
           "value": 272000
         }
       ],
-      "source": null
+      "source": null,
+      "effective_to": "2026-07-30T00:00:00Z"
     },
     {
       "meter": "cached_read_text_tokens",
@@ -451,7 +453,8 @@
           "value": 272000
         }
       ],
-      "source": null
+      "source": null,
+      "effective_to": "2026-07-30T00:00:00Z"
     },
     {
       "meter": "output_text_tokens",
@@ -483,7 +486,8 @@
           "value": 272000
         }
       ],
-      "source": null
+      "source": null,
+      "effective_to": "2026-07-30T00:00:00Z"
     },
     {
       "meter": "input_text_tokens",
@@ -515,7 +519,8 @@
           "value": 272000
         }
       ],
-      "source": null
+      "source": null,
+      "effective_to": "2026-07-30T00:00:00Z"
     },
     {
       "meter": "cached_read_text_tokens",
@@ -547,7 +552,8 @@
           "value": 272000
         }
       ],
-      "source": null
+      "source": null,
+      "effective_to": "2026-07-30T00:00:00Z"
     },
     {
       "meter": "output_text_tokens",
@@ -579,7 +585,140 @@
           "value": 272000
         }
       ],
-      "source": null
+      "source": null,
+      "effective_to": "2026-07-30T00:00:00Z"
+    },
+    {
+      "meter": "input_text_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 5,
+      "currency": "USD",
+      "pricing_plan": "priority",
+      "note": "OpenAI Fast mode pricing, exposed as Phaseo Priority. Requests may use service_tier \"priority\" or \"fast\".",
+      "match": [
+        {
+          "path": "input_tokens",
+          "op": "lt",
+          "or_group": 1,
+          "and_index": 1,
+          "value": 272000
+        }
+      ],
+      "priority": 100,
+      "effective_from": "2026-07-30T00:00:00Z",
+      "region": null,
+      "cache_duration_seconds": null,
+      "conditions": [
+        {
+          "path": "input_tokens",
+          "op": "lt",
+          "or_group": 1,
+          "and_index": 1,
+          "value": 272000
+        }
+      ],
+      "source": "https://developers.openai.com/api/docs/pricing",
+      "effective_to": null
+    },
+    {
+      "meter": "cached_read_text_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 0.5,
+      "currency": "USD",
+      "pricing_plan": "priority",
+      "note": "OpenAI Fast mode pricing, exposed as Phaseo Priority. Requests may use service_tier \"priority\" or \"fast\".",
+      "match": [
+        {
+          "path": "input_tokens",
+          "op": "lt",
+          "or_group": 1,
+          "and_index": 1,
+          "value": 272000
+        }
+      ],
+      "priority": 100,
+      "effective_from": "2026-07-30T00:00:00Z",
+      "region": null,
+      "cache_duration_seconds": null,
+      "conditions": [
+        {
+          "path": "input_tokens",
+          "op": "lt",
+          "or_group": 1,
+          "and_index": 1,
+          "value": 272000
+        }
+      ],
+      "source": "https://developers.openai.com/api/docs/pricing",
+      "effective_to": null
+    },
+    {
+      "meter": "output_text_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 30,
+      "currency": "USD",
+      "pricing_plan": "priority",
+      "note": "OpenAI Fast mode pricing, exposed as Phaseo Priority. Requests may use service_tier \"priority\" or \"fast\".",
+      "match": [
+        {
+          "path": "input_tokens",
+          "op": "lt",
+          "or_group": 1,
+          "and_index": 1,
+          "value": 272000
+        }
+      ],
+      "priority": 100,
+      "effective_from": "2026-07-30T00:00:00Z",
+      "region": null,
+      "cache_duration_seconds": null,
+      "conditions": [
+        {
+          "path": "input_tokens",
+          "op": "lt",
+          "or_group": 1,
+          "and_index": 1,
+          "value": 272000
+        }
+      ],
+      "source": "https://developers.openai.com/api/docs/pricing",
+      "effective_to": null
+    },
+    {
+      "meter": "cached_read_text_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 0.25,
+      "currency": "USD",
+      "pricing_plan": "flex",
+      "note": "Long-context Flex cached-input pricing from OpenAI's current pricing table.",
+      "match": [
+        {
+          "path": "input_tokens",
+          "op": "gte",
+          "or_group": 1,
+          "and_index": 1,
+          "value": 272000
+        }
+      ],
+      "priority": 100,
+      "effective_from": "2026-07-30T00:00:00Z",
+      "region": null,
+      "cache_duration_seconds": null,
+      "conditions": [
+        {
+          "path": "input_tokens",
+          "op": "gte",
+          "or_group": 1,
+          "and_index": 1,
+          "value": 272000
+        }
+      ],
+      "source": "https://developers.openai.com/api/docs/pricing",
+      "effective_to": null
     }
   ],
   "regions": [],
@@ -588,10 +727,12 @@
     "flex",
     "priority"
   ],
-  "sources": [],
+  "sources": [
+    "https://developers.openai.com/api/docs/pricing"
+  ],
   "verification": {
-    "status": "unverified",
-    "checked_at": null,
-    "notes": null
+    "status": "verified",
+    "checked_at": "2026-07-30T00:00:00Z",
+    "notes": "Verified against OpenAI's July 30, 2026 pricing. Phaseo keeps Priority as the canonical tier name and accepts fast as an OpenAI-compatible alias."
   }
 }

--- a/packages/data/catalog/src/data/pricing/openai/openai-gpt-5.5/text.generate/pricing.json
+++ b/packages/data/catalog/src/data/pricing/openai/openai-gpt-5.5/text.generate/pricing.json
@@ -35,7 +35,7 @@
           "value": 272000
         }
       ],
-      "source": null
+      "source": "https://developers.openai.com/api/docs/pricing"
     },
     {
       "meter": "cached_read_text_tokens",
@@ -67,7 +67,7 @@
           "value": 272000
         }
       ],
-      "source": null
+      "source": "https://developers.openai.com/api/docs/pricing"
     },
     {
       "meter": "output_text_tokens",
@@ -99,7 +99,7 @@
           "value": 272000
         }
       ],
-      "source": null
+      "source": "https://developers.openai.com/api/docs/pricing"
     },
     {
       "meter": "input_text_tokens",
@@ -131,7 +131,7 @@
           "value": 272000
         }
       ],
-      "source": null
+      "source": "https://developers.openai.com/api/docs/pricing"
     },
     {
       "meter": "cached_read_text_tokens",
@@ -163,7 +163,7 @@
           "value": 272000
         }
       ],
-      "source": null
+      "source": "https://developers.openai.com/api/docs/pricing"
     },
     {
       "meter": "output_text_tokens",
@@ -195,7 +195,7 @@
           "value": 272000
         }
       ],
-      "source": null
+      "source": "https://developers.openai.com/api/docs/pricing"
     },
     {
       "meter": "input_text_tokens",
@@ -227,7 +227,7 @@
           "value": 272000
         }
       ],
-      "source": null
+      "source": "https://developers.openai.com/api/docs/pricing"
     },
     {
       "meter": "cached_read_text_tokens",
@@ -259,7 +259,7 @@
           "value": 272000
         }
       ],
-      "source": null
+      "source": "https://developers.openai.com/api/docs/pricing"
     },
     {
       "meter": "output_text_tokens",
@@ -291,7 +291,7 @@
           "value": 272000
         }
       ],
-      "source": null
+      "source": "https://developers.openai.com/api/docs/pricing"
     },
     {
       "meter": "input_text_tokens",
@@ -323,7 +323,7 @@
           "value": 272000
         }
       ],
-      "source": null
+      "source": "https://developers.openai.com/api/docs/pricing"
     },
     {
       "meter": "cached_read_text_tokens",
@@ -355,7 +355,7 @@
           "value": 272000
         }
       ],
-      "source": null
+      "source": "https://developers.openai.com/api/docs/pricing"
     },
     {
       "meter": "output_text_tokens",
@@ -387,7 +387,7 @@
           "value": 272000
         }
       ],
-      "source": null
+      "source": "https://developers.openai.com/api/docs/pricing"
     },
     {
       "meter": "input_text_tokens",
@@ -419,7 +419,8 @@
           "value": 272000
         }
       ],
-      "source": null
+      "source": null,
+      "effective_to": "2026-07-30T00:00:00Z"
     },
     {
       "meter": "cached_read_text_tokens",
@@ -451,7 +452,8 @@
           "value": 272000
         }
       ],
-      "source": null
+      "source": null,
+      "effective_to": "2026-07-30T00:00:00Z"
     },
     {
       "meter": "output_text_tokens",
@@ -483,7 +485,107 @@
           "value": 272000
         }
       ],
-      "source": null
+      "source": null,
+      "effective_to": "2026-07-30T00:00:00Z"
+    },
+    {
+      "meter": "input_text_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 12.5,
+      "currency": "USD",
+      "pricing_plan": "priority",
+      "note": "OpenAI Fast mode pricing, exposed as Phaseo Priority. Requests may use service_tier \"priority\" or \"fast\".",
+      "match": [
+        {
+          "path": "input_tokens",
+          "op": "lt",
+          "or_group": 1,
+          "and_index": 1,
+          "value": 272000
+        }
+      ],
+      "priority": 100,
+      "effective_from": "2026-07-30T00:00:00Z",
+      "region": null,
+      "cache_duration_seconds": null,
+      "conditions": [
+        {
+          "path": "input_tokens",
+          "op": "lt",
+          "or_group": 1,
+          "and_index": 1,
+          "value": 272000
+        }
+      ],
+      "source": "https://developers.openai.com/api/docs/pricing",
+      "effective_to": null
+    },
+    {
+      "meter": "cached_read_text_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 1.25,
+      "currency": "USD",
+      "pricing_plan": "priority",
+      "note": "OpenAI Fast mode pricing, exposed as Phaseo Priority. Requests may use service_tier \"priority\" or \"fast\".",
+      "match": [
+        {
+          "path": "input_tokens",
+          "op": "lt",
+          "or_group": 1,
+          "and_index": 1,
+          "value": 272000
+        }
+      ],
+      "priority": 100,
+      "effective_from": "2026-07-30T00:00:00Z",
+      "region": null,
+      "cache_duration_seconds": null,
+      "conditions": [
+        {
+          "path": "input_tokens",
+          "op": "lt",
+          "or_group": 1,
+          "and_index": 1,
+          "value": 272000
+        }
+      ],
+      "source": "https://developers.openai.com/api/docs/pricing",
+      "effective_to": null
+    },
+    {
+      "meter": "output_text_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 75,
+      "currency": "USD",
+      "pricing_plan": "priority",
+      "note": "OpenAI Fast mode pricing, exposed as Phaseo Priority. Requests may use service_tier \"priority\" or \"fast\".",
+      "match": [
+        {
+          "path": "input_tokens",
+          "op": "lt",
+          "or_group": 1,
+          "and_index": 1,
+          "value": 272000
+        }
+      ],
+      "priority": 100,
+      "effective_from": "2026-07-30T00:00:00Z",
+      "region": null,
+      "cache_duration_seconds": null,
+      "conditions": [
+        {
+          "path": "input_tokens",
+          "op": "lt",
+          "or_group": 1,
+          "and_index": 1,
+          "value": 272000
+        }
+      ],
+      "source": "https://developers.openai.com/api/docs/pricing",
+      "effective_to": null
     }
   ],
   "regions": [],
@@ -492,10 +594,12 @@
     "flex",
     "priority"
   ],
-  "sources": [],
+  "sources": [
+    "https://developers.openai.com/api/docs/pricing"
+  ],
   "verification": {
-    "status": "unverified",
-    "checked_at": null,
-    "notes": null
+    "status": "verified",
+    "checked_at": "2026-07-30T00:00:00Z",
+    "notes": "Verified against OpenAI's July 30, 2026 pricing. Phaseo keeps Priority as the canonical tier name and accepts fast as an OpenAI-compatible alias."
   }
 }

--- a/packages/data/catalog/src/data/pricing/openai/openai-gpt-5.6-luna-pro/text.generate/pricing.json
+++ b/packages/data/catalog/src/data/pricing/openai/openai-gpt-5.6-luna-pro/text.generate/pricing.json
@@ -744,7 +744,7 @@
       "price_per_unit": 0.4,
       "currency": "USD",
       "pricing_plan": "priority",
-      "note": "OpenAI Fast mode pricing; service_tier \"priority\" remains a supported alias.",
+      "note": "OpenAI Fast mode pricing, exposed as Phaseo Priority. Requests may use service_tier \"priority\" or \"fast\".",
       "match": [],
       "priority": 100,
       "effective_from": "2026-07-30T00:00:00Z",
@@ -761,7 +761,7 @@
       "price_per_unit": 0.04,
       "currency": "USD",
       "pricing_plan": "priority",
-      "note": "OpenAI Fast mode pricing; service_tier \"priority\" remains a supported alias.",
+      "note": "OpenAI Fast mode pricing, exposed as Phaseo Priority. Requests may use service_tier \"priority\" or \"fast\".",
       "match": [],
       "priority": 100,
       "effective_from": "2026-07-30T00:00:00Z",
@@ -778,7 +778,7 @@
       "price_per_unit": 0.5,
       "currency": "USD",
       "pricing_plan": "priority",
-      "note": "OpenAI Fast mode pricing; service_tier \"priority\" remains a supported alias.",
+      "note": "OpenAI Fast mode pricing, exposed as Phaseo Priority. Requests may use service_tier \"priority\" or \"fast\".",
       "match": [],
       "priority": 100,
       "effective_from": "2026-07-30T00:00:00Z",
@@ -795,7 +795,7 @@
       "price_per_unit": 2.4,
       "currency": "USD",
       "pricing_plan": "priority",
-      "note": "OpenAI Fast mode pricing; service_tier \"priority\" remains a supported alias.",
+      "note": "OpenAI Fast mode pricing, exposed as Phaseo Priority. Requests may use service_tier \"priority\" or \"fast\".",
       "match": [],
       "priority": 100,
       "effective_from": "2026-07-30T00:00:00Z",
@@ -810,7 +810,6 @@
   "service_tiers": [
     "standard",
     "flex",
-    "fast",
     "priority"
   ],
   "sources": [
@@ -819,6 +818,6 @@
   "verification": {
     "status": "verified",
     "checked_at": "2026-07-30T00:00:00Z",
-    "notes": "Updated from OpenAI's pricing page for the July 30, 2026 GPT-5.6 price change and Fast mode launch."
+    "notes": "Verified against OpenAI's July 30, 2026 pricing. Phaseo keeps Priority as the canonical tier name and accepts fast as an OpenAI-compatible alias."
   }
 }

--- a/packages/data/catalog/src/data/pricing/openai/openai-gpt-5.6-luna/text.generate/pricing.json
+++ b/packages/data/catalog/src/data/pricing/openai/openai-gpt-5.6-luna/text.generate/pricing.json
@@ -744,7 +744,7 @@
       "price_per_unit": 0.4,
       "currency": "USD",
       "pricing_plan": "priority",
-      "note": "OpenAI Fast mode pricing; service_tier \"priority\" remains a supported alias.",
+      "note": "OpenAI Fast mode pricing, exposed as Phaseo Priority. Requests may use service_tier \"priority\" or \"fast\".",
       "match": [],
       "priority": 100,
       "effective_from": "2026-07-30T00:00:00Z",
@@ -761,7 +761,7 @@
       "price_per_unit": 0.04,
       "currency": "USD",
       "pricing_plan": "priority",
-      "note": "OpenAI Fast mode pricing; service_tier \"priority\" remains a supported alias.",
+      "note": "OpenAI Fast mode pricing, exposed as Phaseo Priority. Requests may use service_tier \"priority\" or \"fast\".",
       "match": [],
       "priority": 100,
       "effective_from": "2026-07-30T00:00:00Z",
@@ -778,7 +778,7 @@
       "price_per_unit": 0.5,
       "currency": "USD",
       "pricing_plan": "priority",
-      "note": "OpenAI Fast mode pricing; service_tier \"priority\" remains a supported alias.",
+      "note": "OpenAI Fast mode pricing, exposed as Phaseo Priority. Requests may use service_tier \"priority\" or \"fast\".",
       "match": [],
       "priority": 100,
       "effective_from": "2026-07-30T00:00:00Z",
@@ -795,7 +795,7 @@
       "price_per_unit": 2.4,
       "currency": "USD",
       "pricing_plan": "priority",
-      "note": "OpenAI Fast mode pricing; service_tier \"priority\" remains a supported alias.",
+      "note": "OpenAI Fast mode pricing, exposed as Phaseo Priority. Requests may use service_tier \"priority\" or \"fast\".",
       "match": [],
       "priority": 100,
       "effective_from": "2026-07-30T00:00:00Z",
@@ -810,7 +810,6 @@
   "service_tiers": [
     "standard",
     "flex",
-    "fast",
     "priority"
   ],
   "sources": [
@@ -819,6 +818,6 @@
   "verification": {
     "status": "verified",
     "checked_at": "2026-07-30T00:00:00Z",
-    "notes": "Updated from OpenAI's pricing page for the July 30, 2026 GPT-5.6 price change and Fast mode launch."
+    "notes": "Verified against OpenAI's July 30, 2026 pricing. Phaseo keeps Priority as the canonical tier name and accepts fast as an OpenAI-compatible alias."
   }
 }

--- a/packages/data/catalog/src/data/pricing/openai/openai-gpt-5.6-sol-pro/text.generate/pricing.json
+++ b/packages/data/catalog/src/data/pricing/openai/openai-gpt-5.6-sol-pro/text.generate/pricing.json
@@ -1092,7 +1092,7 @@
       "price_per_unit": 10,
       "currency": "USD",
       "pricing_plan": "priority",
-      "note": "OpenAI Fast mode pricing; service_tier \"priority\" remains a supported alias.",
+      "note": "OpenAI Fast mode pricing, exposed as Phaseo Priority. Requests may use service_tier \"priority\" or \"fast\".",
       "match": [],
       "priority": 100,
       "effective_from": "2026-07-30T00:00:00Z",
@@ -1109,7 +1109,7 @@
       "price_per_unit": 1,
       "currency": "USD",
       "pricing_plan": "priority",
-      "note": "OpenAI Fast mode pricing; service_tier \"priority\" remains a supported alias.",
+      "note": "OpenAI Fast mode pricing, exposed as Phaseo Priority. Requests may use service_tier \"priority\" or \"fast\".",
       "match": [],
       "priority": 100,
       "effective_from": "2026-07-30T00:00:00Z",
@@ -1126,7 +1126,7 @@
       "price_per_unit": 12.5,
       "currency": "USD",
       "pricing_plan": "priority",
-      "note": "OpenAI Fast mode pricing; service_tier \"priority\" remains a supported alias.",
+      "note": "OpenAI Fast mode pricing, exposed as Phaseo Priority. Requests may use service_tier \"priority\" or \"fast\".",
       "match": [],
       "priority": 100,
       "effective_from": "2026-07-30T00:00:00Z",
@@ -1143,7 +1143,7 @@
       "price_per_unit": 60,
       "currency": "USD",
       "pricing_plan": "priority",
-      "note": "OpenAI Fast mode pricing; service_tier \"priority\" remains a supported alias.",
+      "note": "OpenAI Fast mode pricing, exposed as Phaseo Priority. Requests may use service_tier \"priority\" or \"fast\".",
       "match": [],
       "priority": 100,
       "effective_from": "2026-07-30T00:00:00Z",
@@ -1158,7 +1158,6 @@
   "service_tiers": [
     "standard",
     "flex",
-    "fast",
     "priority"
   ],
   "sources": [
@@ -1167,6 +1166,6 @@
   "verification": {
     "status": "verified",
     "checked_at": "2026-07-30T00:00:00Z",
-    "notes": "Updated from OpenAI's pricing page for the July 30, 2026 GPT-5.6 price change and Fast mode launch."
+    "notes": "Verified against OpenAI's July 30, 2026 pricing. Phaseo keeps Priority as the canonical tier name and accepts fast as an OpenAI-compatible alias."
   }
 }

--- a/packages/data/catalog/src/data/pricing/openai/openai-gpt-5.6-sol/text.generate/pricing.json
+++ b/packages/data/catalog/src/data/pricing/openai/openai-gpt-5.6-sol/text.generate/pricing.json
@@ -1092,7 +1092,7 @@
       "price_per_unit": 10,
       "currency": "USD",
       "pricing_plan": "priority",
-      "note": "OpenAI Fast mode pricing; service_tier \"priority\" remains a supported alias.",
+      "note": "OpenAI Fast mode pricing, exposed as Phaseo Priority. Requests may use service_tier \"priority\" or \"fast\".",
       "match": [],
       "priority": 100,
       "effective_from": "2026-07-30T00:00:00Z",
@@ -1109,7 +1109,7 @@
       "price_per_unit": 1,
       "currency": "USD",
       "pricing_plan": "priority",
-      "note": "OpenAI Fast mode pricing; service_tier \"priority\" remains a supported alias.",
+      "note": "OpenAI Fast mode pricing, exposed as Phaseo Priority. Requests may use service_tier \"priority\" or \"fast\".",
       "match": [],
       "priority": 100,
       "effective_from": "2026-07-30T00:00:00Z",
@@ -1126,7 +1126,7 @@
       "price_per_unit": 12.5,
       "currency": "USD",
       "pricing_plan": "priority",
-      "note": "OpenAI Fast mode pricing; service_tier \"priority\" remains a supported alias.",
+      "note": "OpenAI Fast mode pricing, exposed as Phaseo Priority. Requests may use service_tier \"priority\" or \"fast\".",
       "match": [],
       "priority": 100,
       "effective_from": "2026-07-30T00:00:00Z",
@@ -1143,7 +1143,7 @@
       "price_per_unit": 60,
       "currency": "USD",
       "pricing_plan": "priority",
-      "note": "OpenAI Fast mode pricing; service_tier \"priority\" remains a supported alias.",
+      "note": "OpenAI Fast mode pricing, exposed as Phaseo Priority. Requests may use service_tier \"priority\" or \"fast\".",
       "match": [],
       "priority": 100,
       "effective_from": "2026-07-30T00:00:00Z",
@@ -1158,7 +1158,6 @@
   "service_tiers": [
     "standard",
     "flex",
-    "fast",
     "priority"
   ],
   "sources": [
@@ -1167,6 +1166,6 @@
   "verification": {
     "status": "verified",
     "checked_at": "2026-07-30T00:00:00Z",
-    "notes": "Updated from OpenAI's pricing page for the July 30, 2026 GPT-5.6 price change and Fast mode launch."
+    "notes": "Verified against OpenAI's July 30, 2026 pricing. Phaseo keeps Priority as the canonical tier name and accepts fast as an OpenAI-compatible alias."
   }
 }

--- a/packages/data/catalog/src/data/pricing/openai/openai-gpt-5.6-terra-pro/text.generate/pricing.json
+++ b/packages/data/catalog/src/data/pricing/openai/openai-gpt-5.6-terra-pro/text.generate/pricing.json
@@ -744,7 +744,7 @@
       "price_per_unit": 4,
       "currency": "USD",
       "pricing_plan": "priority",
-      "note": "OpenAI Fast mode pricing; service_tier \"priority\" remains a supported alias.",
+      "note": "OpenAI Fast mode pricing, exposed as Phaseo Priority. Requests may use service_tier \"priority\" or \"fast\".",
       "match": [],
       "priority": 100,
       "effective_from": "2026-07-30T00:00:00Z",
@@ -761,7 +761,7 @@
       "price_per_unit": 0.4,
       "currency": "USD",
       "pricing_plan": "priority",
-      "note": "OpenAI Fast mode pricing; service_tier \"priority\" remains a supported alias.",
+      "note": "OpenAI Fast mode pricing, exposed as Phaseo Priority. Requests may use service_tier \"priority\" or \"fast\".",
       "match": [],
       "priority": 100,
       "effective_from": "2026-07-30T00:00:00Z",
@@ -778,7 +778,7 @@
       "price_per_unit": 5,
       "currency": "USD",
       "pricing_plan": "priority",
-      "note": "OpenAI Fast mode pricing; service_tier \"priority\" remains a supported alias.",
+      "note": "OpenAI Fast mode pricing, exposed as Phaseo Priority. Requests may use service_tier \"priority\" or \"fast\".",
       "match": [],
       "priority": 100,
       "effective_from": "2026-07-30T00:00:00Z",
@@ -795,7 +795,7 @@
       "price_per_unit": 24,
       "currency": "USD",
       "pricing_plan": "priority",
-      "note": "OpenAI Fast mode pricing; service_tier \"priority\" remains a supported alias.",
+      "note": "OpenAI Fast mode pricing, exposed as Phaseo Priority. Requests may use service_tier \"priority\" or \"fast\".",
       "match": [],
       "priority": 100,
       "effective_from": "2026-07-30T00:00:00Z",
@@ -810,7 +810,6 @@
   "service_tiers": [
     "standard",
     "flex",
-    "fast",
     "priority"
   ],
   "sources": [
@@ -819,6 +818,6 @@
   "verification": {
     "status": "verified",
     "checked_at": "2026-07-30T00:00:00Z",
-    "notes": "Updated from OpenAI's pricing page for the July 30, 2026 GPT-5.6 price change and Fast mode launch."
+    "notes": "Verified against OpenAI's July 30, 2026 pricing. Phaseo keeps Priority as the canonical tier name and accepts fast as an OpenAI-compatible alias."
   }
 }

--- a/packages/data/catalog/src/data/pricing/openai/openai-gpt-5.6-terra/text.generate/pricing.json
+++ b/packages/data/catalog/src/data/pricing/openai/openai-gpt-5.6-terra/text.generate/pricing.json
@@ -744,7 +744,7 @@
       "price_per_unit": 4,
       "currency": "USD",
       "pricing_plan": "priority",
-      "note": "OpenAI Fast mode pricing; service_tier \"priority\" remains a supported alias.",
+      "note": "OpenAI Fast mode pricing, exposed as Phaseo Priority. Requests may use service_tier \"priority\" or \"fast\".",
       "match": [],
       "priority": 100,
       "effective_from": "2026-07-30T00:00:00Z",
@@ -761,7 +761,7 @@
       "price_per_unit": 0.4,
       "currency": "USD",
       "pricing_plan": "priority",
-      "note": "OpenAI Fast mode pricing; service_tier \"priority\" remains a supported alias.",
+      "note": "OpenAI Fast mode pricing, exposed as Phaseo Priority. Requests may use service_tier \"priority\" or \"fast\".",
       "match": [],
       "priority": 100,
       "effective_from": "2026-07-30T00:00:00Z",
@@ -778,7 +778,7 @@
       "price_per_unit": 5,
       "currency": "USD",
       "pricing_plan": "priority",
-      "note": "OpenAI Fast mode pricing; service_tier \"priority\" remains a supported alias.",
+      "note": "OpenAI Fast mode pricing, exposed as Phaseo Priority. Requests may use service_tier \"priority\" or \"fast\".",
       "match": [],
       "priority": 100,
       "effective_from": "2026-07-30T00:00:00Z",
@@ -795,7 +795,7 @@
       "price_per_unit": 24,
       "currency": "USD",
       "pricing_plan": "priority",
-      "note": "OpenAI Fast mode pricing; service_tier \"priority\" remains a supported alias.",
+      "note": "OpenAI Fast mode pricing, exposed as Phaseo Priority. Requests may use service_tier \"priority\" or \"fast\".",
       "match": [],
       "priority": 100,
       "effective_from": "2026-07-30T00:00:00Z",
@@ -810,7 +810,6 @@
   "service_tiers": [
     "standard",
     "flex",
-    "fast",
     "priority"
   ],
   "sources": [
@@ -819,6 +818,6 @@
   "verification": {
     "status": "verified",
     "checked_at": "2026-07-30T00:00:00Z",
-    "notes": "Updated from OpenAI's pricing page for the July 30, 2026 GPT-5.6 price change and Fast mode launch."
+    "notes": "Verified against OpenAI's July 30, 2026 pricing. Phaseo keeps Priority as the canonical tier name and accepts fast as an OpenAI-compatible alias."
   }
 }


### PR DESCRIPTION
## What changed

- keeps **Priority** as Phaseo's canonical service-tier name in the model UI, quickstarts and documentation
- keeps both `service_tier: "priority"` and `service_tier: "fast"` valid in the API, OpenAPI schema and generated SDKs
- maps both request values to the same canonical Priority routing and billing plan
- verifies Fast/Priority pricing for every currently eligible OpenAI catalogue entry:
  - GPT-5.6 Sol, Terra and Luna, including Phaseo `-pro` aliases
  - GPT-5.5
  - GPT-5.4
  - GPT-5.4 Mini
  - GPT-5.3 Codex
- end-dates the older Priority-labelled pricing records on 30 July 2026 and adds source-backed replacement rules representing OpenAI Fast mode under Phaseo's Priority plan
- removes the unsupported GPT-5.4 long-context Fast/Priority rules from the active set
- corrects GPT-5.4 long-context Flex cached input pricing from $0.26 to $0.25

## Compatibility

Existing Phaseo clients can continue sending `priority`. OpenAI-compatible clients may send `fast`. Both select the same model offers and pricing rules, while the UI continues to display **Priority**.

## Validation

- checked every eligible model's active Priority rates against OpenAI's current pricing
- confirmed there are no duplicate active plan/meter/context rules
- confirmed Fast is not exposed as a duplicate UI choice
- confirmed API validation, routing, billing, OpenAPI and TypeScript/Python SDK types retain both aliases