### PR TITLE
Widen side-by-side Chat comparisons on large screens

### DIFF
--- a/apps/web/src/components/(chat)/ChatConversation.tsx
+++ b/apps/web/src/components/(chat)/ChatConversation.tsx
@@ -735,6 +735,8 @@ export function ChatConversation({
 	const effectiveSendGateType =
 		isAuthenticated && sendGateType === "auth" ? null : sendGateType;
 	const hasNoMessages = (activeThread?.messages.length ?? 0) === 0;
+	const useWideComparisonLayout =
+		responseLayout === "side-by-side" && selectedModelCount > 1;
 	const promptHistory = useMemo(
 		() =>
 			(activeThread?.messages ?? [])
@@ -757,7 +759,7 @@ export function ChatConversation({
 						className="h-full w-full overflow-y-auto overscroll-contain"
 					>
 						<MessageScroller.Content
-							className={`mx-auto flex w-full max-w-5xl flex-col gap-4 px-4 py-6 md:px-8 ${hasNoMessages ? "min-h-full" : ""}`}
+							className={`mx-auto flex w-full max-w-5xl flex-col gap-4 px-4 py-6 md:px-8 ${useWideComparisonLayout ? "2xl:max-w-[96rem]" : ""} ${hasNoMessages ? "min-h-full" : ""}`}
 						>
 							<ChatConversationMessages
 								activeThread={activeThread}

--- a/apps/web/src/components/(chat)/ChatConversationMessages.tsx
+++ b/apps/web/src/components/(chat)/ChatConversationMessages.tsx
@@ -1368,9 +1368,9 @@ export function ChatConversationMessages({
 						viewportClassName="overscroll-x-contain"
 					>
 						<div
-							className="grid min-w-max items-stretch gap-x-4 gap-y-5 pr-4"
+							className="grid w-full min-w-max items-stretch gap-x-4 gap-y-5 pr-4"
 							style={{
-								gridTemplateColumns: `repeat(${modelKeys.length}, minmax(0, min(88vw, 32rem)))`,
+								gridTemplateColumns: `repeat(${modelKeys.length}, minmax(min(88vw, 32rem), 1fr))`,
 							}}
 						>
 							{turns.flatMap((turn) =>


### PR DESCRIPTION
## Summary

- widen the Chat transcript to 96rem at the `2xl` breakpoint when side-by-side mode has multiple selected models
- allow comparison columns to share and fill the available wide-screen space
- retain the existing 32rem minimum column width and horizontal scrolling when all models cannot fit
- leave sequential and single-model conversations at the existing `max-w-5xl` width

## Why

Side-by-side responses were constrained by both the transcript's `max-w-5xl` wrapper and a fixed 32rem column size. On wide displays this left useful horizontal space unused and made model comparison feel unnecessarily cramped.

## Responsive behaviour

- below `2xl`: existing transcript width and horizontal scrolling
- `2xl` with multiple models in side-by-side mode: transcript can expand up to 96rem and columns distribute the available width
- sequential or single-model mode: unchanged

## Validation

- reviewed the responsive class conditions against the existing Chat layout
- confirmed the comparison grid retains a bounded minimum column width and horizontal overflow fallback
- full local lint, type-check, and browser verification were not available in this connector-only workspace; CI should provide repository-level validation

## UI note

A screenshot or recording should be added after preview deployment so the two-model layout can be checked at both the `2xl` boundary and a wider desktop viewport.
