### PR TITLE
Make issue triage refresh opt-in

### DIFF
--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -17,7 +17,8 @@ jobs:
             (
               github.event_name == 'issue_comment' &&
               github.event.issue.pull_request == null &&
-              !endsWith(github.actor, '[bot]')
+              github.event.comment.body == '/triage update' &&
+              contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)
             )
         runs-on: ubuntu-latest
         permissions:
@@ -35,18 +36,29 @@ jobs:
               with:
                   model: opencode/big-pickle
                   prompt: |
-                      You are responding to a new GitHub issue on Phaseo.
+                      You are creating a triage snapshot for a GitHub issue on Phaseo.
                       Phaseo is an open-source monorepo with a Next.js web app, Cloudflare
                       Worker API gateway, docs, and SDKs.
+
+                      This workflow runs automatically when an issue is opened. A trusted
+                      maintainer can request a refreshed snapshot later by commenting the
+                      exact command `/triage update`.
+
+                      When the workflow is invoked by an issue comment:
+                      - Treat `/triage update` only as a control command, not as issue content.
+                      - Inspect the original issue body and every comment available up to and
+                        including the command.
+                      - Produce a consolidated, current understanding of the whole thread.
+                      - Do not merely reply to or summarize the latest comment in isolation.
 
                       Your job is to produce:
                       1) a concise issue understanding, and
                       2) a short copy/paste prompt the maintainer can give to an AI coding agent.
 
                       Determine the issue type from the title prefix, issue template, labels,
-                      body content, and whether this is an issue comment asking for follow-up.
-                      In this repo the main title prefixes are [Bug], [Chore], [Data Request],
-                      [Docs], [Feature], and [Incorrect Info].
+                      body content, and full discussion. In this repo the main title prefixes
+                      are [Bug], [Chore], [Data Request], [Docs], [Feature], and
+                      [Incorrect Info].
 
                       Opening-tone rules:
                       - Default to neutral, direct task language.


### PR DESCRIPTION
## What changed

- keep automatic OpenCode issue triage for newly opened issues
- stop ordinary issue comments from launching the triage workflow
- add the exact maintainer command `/triage update` for an on-demand refresh
- restrict refresh commands to owners, organisation members, and collaborators
- instruct refresh runs to read the original issue and complete discussion before producing a consolidated snapshot

## Why

The previous workflow ran on every human issue comment. External contributors without repository write access caused OpenCode to fail and publish a confusing permission-error comment. Ordinary conversation also did not need a fresh AI triage response each time.

## Behaviour

| Event | Result |
| --- | --- |
| New issue opened | OpenCode triage runs automatically |
| Ordinary issue comment | No triage run |
| Trusted maintainer comments `/triage update` | OpenCode posts a refreshed consolidated triage snapshot |
| External contributor comments `/triage update` | No triage run |
| Pull request comment | No issue-triage run |

## Validation

- reviewed the committed workflow expression and event guards
- verified the branch contains only the intended workflow-file update
- command intentionally does not overlap the existing `/oc` and `/opencode` command workflow


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved issue triage command validation by requiring the exact `/triage update` command.
  * Restricted triage updates to authorized commenters.
  * Improved triage accuracy by considering the complete issue discussion and generating a consolidated snapshot.
  * Prevented the triage command itself from being included in issue content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->