### PR TITLE
Add provider-qualified model identifiers

### DIFF
--- a/.changeset/provider-qualified-model-ids.md
+++ b/.changeset/provider-qualified-model-ids.md
@@ -1,0 +1,5 @@
+---
+"@phaseo/gateway-api": minor
+---
+
+Add provider-qualified model identifiers for exact provider-model routing while preserving canonical model suffixes and existing workspace routing safeguards.

--- a/apps/api/src/pipeline/before/guards.ts
+++ b/apps/api/src/pipeline/before/guards.ts
@@ -20,7 +20,7 @@ import type { DebugOptions } from "@core/types";
 import { authenticate, authenticateManagement, type AuthFailure } from "./auth";
 import { readAttributionHeaders } from "../after/attribution";
 import type { ProviderCandidateBuildDiagnostics } from "./types";
-import type { PriceCard } from "../pricing";
+import { isFreePriceCard, type PriceCard } from "../pricing";
 
 const MIN_CREDIT_AMOUNT = 1.0;
 const TRUTHY_VALUES = new Set(["1", "true", "yes"]);
@@ -30,18 +30,6 @@ const DEFAULT_REQUEST_BODY_LIMIT_BYTES = 16 * 1024 * 1024;
 const MULTIPART_REQUEST_BODY_LIMIT_BYTES = 32 * 1024 * 1024;
 
 class RequestBodyTooLargeError extends Error {}
-
-function isFreePriceCard(card: PriceCard | null | undefined): boolean {
-    if (!card || !Array.isArray(card.rules) || card.rules.length === 0) return false;
-    return card.rules.every((rule) => {
-        const pricingPlan = String(rule.pricing_plan ?? "")
-            .trim()
-            .toLowerCase();
-        const pricePerUnit = Number(rule.price_per_unit);
-
-        return pricingPlan === "free" && Number.isFinite(pricePerUnit) && pricePerUnit <= 0;
-    });
-}
 
 function allowsNoCreditForFreeRequest(args: { model: string; context: any; providers: any[] }): boolean {
     const routableProviders = Array.isArray(args.providers)

--- a/apps/api/src/pipeline/before/guards.ts
+++ b/apps/api/src/pipeline/before/guards.ts
@@ -20,7 +20,8 @@ import type { DebugOptions } from "@core/types";
 import { authenticate, authenticateManagement, type AuthFailure } from "./auth";
 import { readAttributionHeaders } from "../after/attribution";
 import type { ProviderCandidateBuildDiagnostics } from "./types";
-import { isFreePriceCard, type PriceCard } from "../pricing";
+import { isFreePriceCard } from "../pricing/free";
+import type { PriceCard } from "../pricing";
 
 const MIN_CREDIT_AMOUNT = 1.0;
 const TRUTHY_VALUES = new Set(["1", "true", "yes"]);

--- a/apps/api/src/pipeline/before/index.ts
+++ b/apps/api/src/pipeline/before/index.ts
@@ -14,8 +14,8 @@ import { Timer } from "../telemetry/timer";
 import { resolveCapabilityFromEndpoint } from "@/lib/config/capabilityToEndpoints";
 import { validateCapabilities } from "./capabilityValidation";
 import { isDebugAllowed } from "../debug";
-import { isProviderCapabilityEnabled, normalizeCapability } from "@/executors";
-import { adapterFor, allProviderNames } from "@/providers/index";
+import { EXECUTORS_BY_PROVIDER, isProviderCapabilityEnabled, normalizeCapability } from "@/executors";
+import { adapterFor } from "@/providers/index";
 import type { ProviderEnablementDiagnostics } from "./types";
 import {
 	isPerfGatewayEndpointAllowed,
@@ -249,7 +249,7 @@ export async function beforeRequest(
     }
     const providerSlugValidation = validateProviderQualifiedModelProvider(
         providerQualifiedModelRequest.selection,
-        allProviderNames(),
+        Object.keys(EXECUTORS_BY_PROVIDER),
     );
     if (providerSlugValidation.ok === false) {
         return {

--- a/apps/api/src/pipeline/before/index.ts
+++ b/apps/api/src/pipeline/before/index.ts
@@ -27,6 +27,8 @@ import { normalizeGatewayPlugins, resolveGatewayPlugins } from "@/plugins/normal
 import { findUnknownGatewayPluginIds } from "@/plugins/registry";
 import { validateSynchronousTextServiceTierRequest } from "./serviceTierValidation";
 import {
+	applyProviderQualifiedModelConstraint,
+	canonicalizeProviderQualifiedModelRequest,
 	collectUnsupportedRoutingFields,
 	getEffectiveRoutingHints,
 	normalizeRequestRoutingBody,
@@ -216,7 +218,10 @@ export async function beforeRequest(
     // 3) Zod (route schema: shape depends on request path)
     const v = await timer.span("guardZod", () => guardZod(zodSchema, rawBody, workspaceId, requestId));
     if (!v.ok) return v as { ok: false; response: Response };
-    const body = v.value;
+    let body = v.value;
+    const providerQualifiedModelRequest =
+        canonicalizeProviderQualifiedModelRequest(body);
+    body = providerQualifiedModelRequest.body;
 
     const serviceTierValidation = validateSynchronousTextServiceTierRequest({
         endpoint,
@@ -408,6 +413,37 @@ export async function beforeRequest(
         };
     }
     mergedBody = normalizeRequestRoutingBody(mergedBody);
+
+    // Keep this as the final request-level provider constraint before workspace
+    // policy enforcement. A provider-qualified model is an exact pair, not a
+    // provider preference that presets or other routing hints may widen.
+    const providerQualifiedConstraint =
+        applyProviderQualifiedModelConstraint(
+            mergedBody,
+            providerQualifiedModelRequest.selection,
+        );
+    if (providerQualifiedConstraint.ok === false) {
+        return {
+            ok: false,
+            response: err("validation_error", {
+                details: [{
+                    message:
+                        `Provider-qualified model "${providerQualifiedConstraint.providerId}:${providerQualifiedConstraint.model}" conflicts with ${providerQualifiedConstraint.field}`,
+                    path: providerQualifiedConstraint.field.split("."),
+                    keyword: "provider_qualified_model_conflict",
+                    params: {
+                        provider: providerQualifiedConstraint.providerId,
+                        model: providerQualifiedConstraint.model,
+                        field: providerQualifiedConstraint.field,
+                        values: providerQualifiedConstraint.values,
+                    },
+                }],
+                request_id: requestId,
+                workspace_id: workspaceId,
+            }),
+        };
+    }
+    mergedBody = providerQualifiedConstraint.body;
 
     const workspacePolicyLoad = await workspacePolicyPromise;
     if ("error" in workspacePolicyLoad) {

--- a/apps/api/src/pipeline/before/index.ts
+++ b/apps/api/src/pipeline/before/index.ts
@@ -15,7 +15,7 @@ import { resolveCapabilityFromEndpoint } from "@/lib/config/capabilityToEndpoint
 import { validateCapabilities } from "./capabilityValidation";
 import { isDebugAllowed } from "../debug";
 import { isProviderCapabilityEnabled, normalizeCapability } from "@/executors";
-import { adapterFor } from "@/providers/index";
+import { adapterFor, allProviderNames } from "@/providers/index";
 import type { ProviderEnablementDiagnostics } from "./types";
 import {
 	isPerfGatewayEndpointAllowed,
@@ -33,6 +33,7 @@ import {
 	collectUnsupportedRoutingFields,
 	getEffectiveRoutingHints,
 	normalizeRequestRoutingBody,
+	validateProviderQualifiedModelProvider,
 } from "../requestRouting";
 import { fetchWorkspacePolicy, applyWorkspacePolicy } from "./workspacePolicy";
 
@@ -222,6 +223,59 @@ export async function beforeRequest(
     let body = v.value;
     const providerQualifiedModelRequest =
         canonicalizeProviderQualifiedModelRequest(body);
+    if (providerQualifiedModelRequest.syntaxError) {
+        const syntaxError = providerQualifiedModelRequest.syntaxError;
+        return {
+            ok: false,
+            response: err("validation_error", {
+                reason: syntaxError.reason,
+                description: syntaxError.message,
+                error_type: "user",
+                error_origin: "user",
+                error_operational_kind: syntaxError.reason,
+                details: [{
+                    message: syntaxError.message,
+                    path: ["model"],
+                    keyword: syntaxError.reason,
+                    params: {
+                        input: syntaxError.input,
+                        provider: syntaxError.providerSlug || null,
+                    },
+                }],
+                request_id: requestId,
+                workspace_id: workspaceId,
+            }),
+        };
+    }
+    const providerSlugValidation = validateProviderQualifiedModelProvider(
+        providerQualifiedModelRequest.selection,
+        allProviderNames(),
+    );
+    if (providerSlugValidation.ok === false) {
+        return {
+            ok: false,
+            response: err("validation_error", {
+                model: providerSlugValidation.model,
+                provider: providerSlugValidation.providerId,
+                reason: providerSlugValidation.reason,
+                description: providerSlugValidation.message,
+                error_type: "user",
+                error_origin: "user",
+                error_operational_kind: providerSlugValidation.reason,
+                details: [{
+                    message: providerSlugValidation.message,
+                    path: ["model"],
+                    keyword: providerSlugValidation.reason,
+                    params: {
+                        provider: providerSlugValidation.providerId,
+                        model: providerSlugValidation.model,
+                    },
+                }],
+                request_id: requestId,
+                workspace_id: workspaceId,
+            }),
+        };
+    }
     body = providerQualifiedModelRequest.body;
 
     const serviceTierValidation = validateSynchronousTextServiceTierRequest({

--- a/apps/api/src/pipeline/before/index.ts
+++ b/apps/api/src/pipeline/before/index.ts
@@ -29,6 +29,7 @@ import { validateSynchronousTextServiceTierRequest } from "./serviceTierValidati
 import {
 	applyProviderQualifiedModelConstraint,
 	canonicalizeProviderQualifiedModelRequest,
+	filterProviderQualifiedModelCandidates,
 	collectUnsupportedRoutingFields,
 	getEffectiveRoutingHints,
 	normalizeRequestRoutingBody,
@@ -444,6 +445,46 @@ export async function beforeRequest(
         };
     }
     mergedBody = providerQualifiedConstraint.body;
+
+    const providerQualifiedCandidates =
+        filterProviderQualifiedModelCandidates(
+            presetFilteredProviders,
+            providerQualifiedModelRequest.selection,
+        );
+    if (providerQualifiedCandidates.ok === false) {
+        const qualifiedModel =
+            `${providerQualifiedCandidates.providerId}:${providerQualifiedCandidates.model}`;
+        const freeRouteUnavailable =
+            providerQualifiedCandidates.reason ===
+            "qualified_free_provider_unavailable";
+        const description = freeRouteUnavailable
+            ? `Provider-qualified free model "${qualifiedModel}" does not have an eligible all-zero free pricing route`
+            : `Provider-qualified model "${qualifiedModel}" is not available for this endpoint`;
+        return {
+            ok: false,
+            response: err("validation_error", {
+                model: providerQualifiedCandidates.model,
+                provider: providerQualifiedCandidates.providerId,
+                reason: providerQualifiedCandidates.reason,
+                description,
+                error_type: "user",
+                error_origin: "user",
+                error_operational_kind: providerQualifiedCandidates.reason,
+                details: [{
+                    message: description,
+                    path: ["model"],
+                    keyword: providerQualifiedCandidates.reason,
+                    params: {
+                        provider: providerQualifiedCandidates.providerId,
+                        model: providerQualifiedCandidates.model,
+                    },
+                }],
+                request_id: requestId,
+                workspace_id: workspaceId,
+            }),
+        };
+    }
+    presetFilteredProviders = providerQualifiedCandidates.providers;
 
     const workspacePolicyLoad = await workspacePolicyPromise;
     if ("error" in workspacePolicyLoad) {

--- a/apps/api/src/pipeline/pricing/free.test.ts
+++ b/apps/api/src/pipeline/pricing/free.test.ts
@@ -50,6 +50,14 @@ describe("isFreePriceCard", () => {
 		).toBe(false);
 	});
 
+	it("rejects negative prices instead of treating them as free", () => {
+		expect(
+			isFreePriceCard(card([
+				{ pricingPlan: "free", pricePerUnit: "-0.000001" },
+			])),
+		).toBe(false);
+	});
+
 	it("rejects zero-priced rules that are not explicitly on the free plan", () => {
 		expect(
 			isFreePriceCard(card([

--- a/apps/api/src/pipeline/pricing/free.test.ts
+++ b/apps/api/src/pipeline/pricing/free.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+import { isFreePriceCard } from "./free";
+
+function card(rules: Array<{
+	pricingPlan: string;
+	pricePerUnit: string;
+}>) {
+	return {
+		provider: "test-provider",
+		model: "publisher/model:free",
+		endpoint: "responses",
+		effective_from: null,
+		effective_to: null,
+		currency: "USD",
+		version: null,
+		rules: rules.map((rule) => ({
+			pricing_plan: rule.pricingPlan,
+			meter: "input_tokens",
+			unit: "token",
+			unit_size: 1,
+			price_per_unit: rule.pricePerUnit,
+			currency: "USD",
+			match: [],
+			priority: 100,
+		})),
+	} as any;
+}
+
+describe("isFreePriceCard", () => {
+	it("accepts a non-empty card whose rules are explicitly free and zero", () => {
+		expect(
+			isFreePriceCard(card([
+				{ pricingPlan: "free", pricePerUnit: "0" },
+				{ pricingPlan: "FREE", pricePerUnit: "0.000000" },
+			])),
+		).toBe(true);
+	});
+
+	it("rejects missing and empty pricing cards", () => {
+		expect(isFreePriceCard(null)).toBe(false);
+		expect(isFreePriceCard(card([]))).toBe(false);
+	});
+
+	it("rejects a free-labelled card containing a positive price", () => {
+		expect(
+			isFreePriceCard(card([
+				{ pricingPlan: "free", pricePerUnit: "0" },
+				{ pricingPlan: "free", pricePerUnit: "0.000001" },
+			])),
+		).toBe(false);
+	});
+
+	it("rejects zero-priced rules that are not explicitly on the free plan", () => {
+		expect(
+			isFreePriceCard(card([
+				{ pricingPlan: "standard", pricePerUnit: "0" },
+			])),
+		).toBe(false);
+	});
+});

--- a/apps/api/src/pipeline/pricing/free.ts
+++ b/apps/api/src/pipeline/pricing/free.ts
@@ -1,0 +1,20 @@
+import type { PriceCard } from "./types";
+
+export function isFreePriceCard(
+	card: PriceCard | null | undefined,
+): boolean {
+	if (!card || !Array.isArray(card.rules) || card.rules.length === 0) {
+		return false;
+	}
+	return card.rules.every((rule) => {
+		const pricingPlan = String(rule.pricing_plan ?? "")
+			.trim()
+			.toLowerCase();
+		const pricePerUnit = Number(rule.price_per_unit);
+		return (
+			pricingPlan === "free" &&
+			Number.isFinite(pricePerUnit) &&
+			pricePerUnit <= 0
+		);
+	});
+}

--- a/apps/api/src/pipeline/pricing/free.ts
+++ b/apps/api/src/pipeline/pricing/free.ts
@@ -14,7 +14,7 @@ export function isFreePriceCard(
 		return (
 			pricingPlan === "free" &&
 			Number.isFinite(pricePerUnit) &&
-			pricePerUnit <= 0
+			pricePerUnit === 0
 		);
 	});
 }

--- a/apps/api/src/pipeline/pricing/index.ts
+++ b/apps/api/src/pipeline/pricing/index.ts
@@ -4,6 +4,7 @@
 
 export * from "./types";
 export * from "./money";
+export * from "./free";
 export * from "./conditions";
 export * from "./loader";
 export * from "./engine";

--- a/apps/api/src/pipeline/requestRouting.provider-qualified.test.ts
+++ b/apps/api/src/pipeline/requestRouting.provider-qualified.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from "vitest";
+import {
+	applyProviderQualifiedModelConstraint,
+	canonicalizeProviderQualifiedModelRequest,
+	parseProviderQualifiedModel,
+} from "./requestRouting";
+
+describe("provider-qualified model ids", () => {
+	it("parses an exact provider-model pair", () => {
+		expect(
+			parseProviderQualifiedModel(
+				"Baseten:thinking-machines/inkling-small",
+			),
+		).toEqual({
+			providerId: "baseten",
+			model: "thinking-machines/inkling-small",
+		});
+	});
+
+	it("preserves canonical model suffixes", () => {
+		expect(
+			parseProviderQualifiedModel(
+				"baseten:google/gemma-4-26b-a4b:free",
+			),
+		).toEqual({
+			providerId: "baseten",
+			model: "google/gemma-4-26b-a4b:free",
+		});
+	});
+
+	it("does not interpret canonical suffixes as provider qualifiers", () => {
+		expect(
+			parseProviderQualifiedModel("google/gemma-4-26b-a4b:free"),
+		).toBeNull();
+		expect(parseProviderQualifiedModel("phaseo/free")).toBeNull();
+	});
+
+	it("canonicalizes the model without mutating the input body", () => {
+		const body = {
+			model: "deepinfra:deepseek/deepseek-v3",
+			input: "Hello",
+		};
+		const result = canonicalizeProviderQualifiedModelRequest(body);
+		expect(result.body).not.toBe(body);
+		expect(result.body.model).toBe("deepseek/deepseek-v3");
+		expect(body.model).toBe("deepinfra:deepseek/deepseek-v3");
+	});
+
+	it("applies the provider as an exact constraint", () => {
+		const canonical = canonicalizeProviderQualifiedModelRequest({
+			model: "baseten:thinking-machines/inkling-small",
+			routing: { mode: "latency" },
+		});
+		const result = applyProviderQualifiedModelConstraint(
+			canonical.body,
+			canonical.selection,
+		);
+		expect(result.ok).toBe(true);
+		if (!result.ok) return;
+		expect(result.body.provider.only).toEqual(["baseten"]);
+		expect(result.body.routing.only).toEqual(["baseten"]);
+		expect(result.body.routing.mode).toBe("latency");
+	});
+
+	it("accepts a matching explicit provider allowlist", () => {
+		const canonical = canonicalizeProviderQualifiedModelRequest({
+			model: "baseten:thinking-machines/inkling-small",
+			provider: { only: ["BASETEN"] },
+		});
+		const result = applyProviderQualifiedModelConstraint(
+			canonical.body,
+			canonical.selection,
+		);
+		expect(result.ok).toBe(true);
+	});
+
+	it("rejects a contradictory provider allowlist", () => {
+		const canonical = canonicalizeProviderQualifiedModelRequest({
+			model: "baseten:thinking-machines/inkling-small",
+			provider: { only: ["deepinfra"] },
+		});
+		expect(
+			applyProviderQualifiedModelConstraint(
+				canonical.body,
+				canonical.selection,
+			),
+		).toMatchObject({
+			ok: false,
+			field: "provider.only",
+			providerId: "baseten",
+		});
+	});
+
+	it("rejects a routing ignore list containing the qualifier", () => {
+		const canonical = canonicalizeProviderQualifiedModelRequest({
+			model: "baseten:thinking-machines/inkling-small",
+			routing: { ignore: ["baseten"] },
+		});
+		expect(
+			applyProviderQualifiedModelConstraint(
+				canonical.body,
+				canonical.selection,
+			),
+		).toMatchObject({
+			ok: false,
+			field: "routing.ignore",
+			providerId: "baseten",
+		});
+	});
+});

--- a/apps/api/src/pipeline/requestRouting.provider-qualified.test.ts
+++ b/apps/api/src/pipeline/requestRouting.provider-qualified.test.ts
@@ -74,6 +74,19 @@ describe("provider-qualified model ids", () => {
 		expect(result.ok).toBe(true);
 	});
 
+	it("normalizes provider aliases consistently with provider.only", () => {
+		const canonical = canonicalizeProviderQualifiedModelRequest({
+			model: "NovitaAI:deepseek/deepseek-v3",
+			provider: { only: ["novita-ai"] },
+		});
+		expect(canonical.selection?.providerId).toBe("novita");
+		const result = applyProviderQualifiedModelConstraint(
+			canonical.body,
+			canonical.selection,
+		);
+		expect(result.ok).toBe(true);
+	});
+
 	it("rejects a contradictory provider allowlist", () => {
 		const canonical = canonicalizeProviderQualifiedModelRequest({
 			model: "baseten:thinking-machines/inkling-small",

--- a/apps/api/src/pipeline/requestRouting.provider-qualified.test.ts
+++ b/apps/api/src/pipeline/requestRouting.provider-qualified.test.ts
@@ -4,6 +4,7 @@ import {
 	canonicalizeProviderQualifiedModelRequest,
 	filterProviderQualifiedModelCandidates,
 	parseProviderQualifiedModel,
+	validateProviderQualifiedModelProvider,
 } from "./requestRouting";
 
 function candidate(args: {
@@ -71,6 +72,62 @@ describe("provider-qualified model ids", () => {
 			parseProviderQualifiedModel("google/gemma-4-26b-a4b:free"),
 		).toBeNull();
 		expect(parseProviderQualifiedModel("phaseo/free")).toBeNull();
+	});
+
+	it("reports a malformed provider slug instead of treating it as a model id", () => {
+		const result = canonicalizeProviderQualifiedModelRequest({
+			model: "bad provider:publisher/model",
+		});
+		expect(result.selection).toBeNull();
+		expect(result.syntaxError).toMatchObject({
+			reason: "invalid_provider_slug",
+			providerSlug: "bad provider",
+		});
+	});
+
+	it("reports an empty provider slug", () => {
+		const result = canonicalizeProviderQualifiedModelRequest({
+			model: ":publisher/model",
+		});
+		expect(result.syntaxError).toMatchObject({
+			reason: "invalid_provider_slug",
+			providerSlug: "",
+		});
+	});
+
+	it("reports a malformed provider-qualified model shape", () => {
+		const result = canonicalizeProviderQualifiedModelRequest({
+			model: "baseten:/model",
+		});
+		expect(result.syntaxError).toMatchObject({
+			reason: "invalid_provider_qualified_model",
+			providerSlug: "baseten",
+		});
+	});
+
+	it("rejects an unknown but syntactically valid provider slug", () => {
+		const selection = parseProviderQualifiedModel(
+			"not-a-real-provider:publisher/model",
+		);
+		expect(
+			validateProviderQualifiedModelProvider(selection, [
+				"baseten",
+				"deepinfra",
+			]),
+		).toMatchObject({
+			ok: false,
+			reason: "unknown_provider_slug",
+			providerId: "not-a-real-provider",
+		});
+	});
+
+	it("accepts a known provider slug after alias normalization", () => {
+		const selection = parseProviderQualifiedModel(
+			"NovitaAI:publisher/model",
+		);
+		expect(
+			validateProviderQualifiedModelProvider(selection, ["novita"]),
+		).toEqual({ ok: true });
 	});
 
 	it("canonicalizes the model without mutating the input body", () => {

--- a/apps/api/src/pipeline/requestRouting.provider-qualified.test.ts
+++ b/apps/api/src/pipeline/requestRouting.provider-qualified.test.ts
@@ -2,8 +2,46 @@ import { describe, expect, it } from "vitest";
 import {
 	applyProviderQualifiedModelConstraint,
 	canonicalizeProviderQualifiedModelRequest,
+	filterProviderQualifiedModelCandidates,
 	parseProviderQualifiedModel,
 } from "./requestRouting";
+
+function candidate(args: {
+	providerId: string;
+	pricing?: "free" | "paid" | "missing";
+}) {
+	return {
+		providerId: args.providerId,
+		adapter: { name: args.providerId },
+		baseWeight: 1,
+		byokMeta: [],
+		providerModelSlug: "upstream/model",
+		pricingCard:
+			args.pricing === "missing"
+				? null
+				: {
+					provider: args.providerId,
+					model: "publisher/model:free",
+					endpoint: "responses",
+					effective_from: null,
+					effective_to: null,
+					currency: "USD",
+					version: null,
+					rules: [{
+						pricing_plan:
+							args.pricing === "free" ? "free" : "standard",
+						meter: "input_tokens",
+						unit: "token",
+						unit_size: 1,
+						price_per_unit:
+							args.pricing === "free" ? "0" : "0.000001",
+						currency: "USD",
+						match: [],
+						priority: 100,
+					}],
+				},
+	} as any;
+}
 
 describe("provider-qualified model ids", () => {
 	it("parses an exact provider-model pair", () => {
@@ -119,5 +157,81 @@ describe("provider-qualified model ids", () => {
 			field: "routing.ignore",
 			providerId: "baseten",
 		});
+	});
+
+	it("rejects a provider that is absent for the exact model", () => {
+		const selection = parseProviderQualifiedModel(
+			"baseten:publisher/model:free",
+		);
+		expect(
+			filterProviderQualifiedModelCandidates(
+				[candidate({ providerId: "deepinfra", pricing: "free" })],
+				selection,
+			),
+		).toMatchObject({
+			ok: false,
+			reason: "qualified_provider_unavailable",
+			providerId: "baseten",
+			model: "publisher/model:free",
+		});
+	});
+
+	it("rejects paid pricing for a provider-qualified free model", () => {
+		const selection = parseProviderQualifiedModel(
+			"baseten:publisher/model:free",
+		);
+		expect(
+			filterProviderQualifiedModelCandidates(
+				[candidate({ providerId: "baseten", pricing: "paid" })],
+				selection,
+			),
+		).toMatchObject({
+			ok: false,
+			reason: "qualified_free_provider_unavailable",
+		});
+	});
+
+	it("rejects missing pricing for a provider-qualified free model", () => {
+		const selection = parseProviderQualifiedModel(
+			"baseten:publisher/model:free",
+		);
+		expect(
+			filterProviderQualifiedModelCandidates(
+				[candidate({ providerId: "baseten", pricing: "missing" })],
+				selection,
+			),
+		).toMatchObject({
+			ok: false,
+			reason: "qualified_free_provider_unavailable",
+		});
+	});
+
+	it("accepts only the requested provider when its free route is valid", () => {
+		const selection = parseProviderQualifiedModel(
+			"baseten:publisher/model:free",
+		);
+		const result = filterProviderQualifiedModelCandidates(
+			[
+				candidate({ providerId: "baseten", pricing: "free" }),
+				candidate({ providerId: "deepinfra", pricing: "free" }),
+			],
+			selection,
+		);
+		expect(result.ok).toBe(true);
+		if (!result.ok) return;
+		expect(result.providers.map((provider) => provider.providerId)).toEqual([
+			"baseten",
+		]);
+	});
+
+	it("does not require free pricing for a qualified paid model", () => {
+		const selection = parseProviderQualifiedModel(
+			"baseten:publisher/model",
+		);
+		const result = filterProviderQualifiedModelCandidates(
+			[candidate({ providerId: "baseten", pricing: "paid" })],
+			selection,
+		);
+		expect(result.ok).toBe(true);
 	});
 });

--- a/apps/api/src/pipeline/requestRouting.ts
+++ b/apps/api/src/pipeline/requestRouting.ts
@@ -62,6 +62,133 @@ function normalizeNullableObject(value: unknown): PlainObject | null {
 	return objectValue ? { ...objectValue } : null;
 }
 
+export type ProviderQualifiedModelSelection = {
+	providerId: string;
+	model: string;
+};
+
+export type ProviderQualifiedModelConstraintResult =
+	| { ok: true; body: any }
+	| {
+		ok: false;
+		providerId: string;
+		model: string;
+		field: "provider.only" | "provider.ignore" | "routing.only" | "routing.ignore";
+		values: string[];
+	};
+
+const PROVIDER_QUALIFIER_PATTERN = /^[a-z0-9][a-z0-9._-]{0,127}$/i;
+
+export function parseProviderQualifiedModel(
+	value: unknown,
+): ProviderQualifiedModelSelection | null {
+	if (typeof value !== "string") return null;
+	const input = value.trim();
+	const qualifierSeparator = input.indexOf(":");
+	const modelNamespaceSeparator = input.indexOf("/");
+	if (
+		qualifierSeparator <= 0 ||
+		modelNamespaceSeparator <= qualifierSeparator + 1
+	) {
+		return null;
+	}
+
+	const providerId = input.slice(0, qualifierSeparator).trim();
+	const model = input.slice(qualifierSeparator + 1).trim();
+	if (!PROVIDER_QUALIFIER_PATTERN.test(providerId) || !model.includes("/")) {
+		return null;
+	}
+
+	return {
+		providerId: providerId.toLowerCase(),
+		model,
+	};
+}
+
+export function canonicalizeProviderQualifiedModelRequest(body: any): {
+	body: any;
+	selection: ProviderQualifiedModelSelection | null;
+} {
+	if (!body || typeof body !== "object" || Array.isArray(body)) {
+		return { body, selection: null };
+	}
+	const selection = parseProviderQualifiedModel(body.model);
+	if (!selection) return { body, selection: null };
+	return {
+		body: {
+			...body,
+			model: selection.model,
+		},
+		selection,
+	};
+}
+
+function normalizedProviderConstraintValues(value: unknown): string[] {
+	return (normalizeStringArray(value) ?? []).map((item) => item.toLowerCase());
+}
+
+export function applyProviderQualifiedModelConstraint(
+	body: any,
+	selection: ProviderQualifiedModelSelection | null,
+): ProviderQualifiedModelConstraintResult {
+	if (!selection || !body || typeof body !== "object" || Array.isArray(body)) {
+		return { ok: true, body };
+	}
+
+	const sources: Array<{
+		name: "provider" | "routing";
+		value: PlainObject | null;
+	}> = [
+		{ name: "provider", value: asPlainObject(body.provider) },
+		{ name: "routing", value: asPlainObject(body.routing) },
+	];
+
+	for (const source of sources) {
+		if (!source.value) continue;
+		const only = normalizedProviderConstraintValues(source.value.only);
+		if (only.length > 0 && !only.includes(selection.providerId)) {
+			return {
+				ok: false,
+				providerId: selection.providerId,
+				model: selection.model,
+				field: `${source.name}.only`,
+				values: only,
+			};
+		}
+		const ignore = normalizedProviderConstraintValues(source.value.ignore);
+		if (ignore.includes(selection.providerId)) {
+			return {
+				ok: false,
+				providerId: selection.providerId,
+				model: selection.model,
+				field: `${source.name}.ignore`,
+				values: ignore,
+			};
+		}
+	}
+
+	const provider = {
+		...clonePlainObject(asPlainObject(body.provider)),
+		only: [selection.providerId],
+	};
+	const routing = asPlainObject(body.routing);
+	return {
+		ok: true,
+		body: {
+			...body,
+			provider,
+			...(routing
+				? {
+					routing: {
+						...routing,
+						only: [selection.providerId],
+					},
+				}
+				: {}),
+		},
+	};
+}
+
 export type EffectiveRoutingHints = {
 	provider: PlainObject;
 	routing: PlainObject;

--- a/apps/api/src/pipeline/requestRouting.ts
+++ b/apps/api/src/pipeline/requestRouting.ts
@@ -4,7 +4,7 @@
 
 import { normalizeProviderId, normalizeProviderList } from "@/lib/config/providerAliases";
 import type { ProviderCandidate } from "./before/types";
-import { isFreePriceCard } from "./pricing";
+import { isFreePriceCard } from "./pricing/free";
 
 type PlainObject = Record<string, any>;
 

--- a/apps/api/src/pipeline/requestRouting.ts
+++ b/apps/api/src/pipeline/requestRouting.ts
@@ -3,6 +3,8 @@
 // How: Merges provider/routing hints, resolves aliases, and surfaces explicit routing flags.
 
 import { normalizeProviderId, normalizeProviderList } from "@/lib/config/providerAliases";
+import type { ProviderCandidate } from "./before/types";
+import { isFreePriceCard } from "./pricing";
 
 type PlainObject = Record<string, any>;
 
@@ -77,6 +79,17 @@ export type ProviderQualifiedModelConstraintResult =
 		model: string;
 		field: "provider.only" | "provider.ignore" | "routing.only" | "routing.ignore";
 		values: string[];
+	};
+
+export type ProviderQualifiedModelCandidateResult =
+	| { ok: true; providers: ProviderCandidate[] }
+	| {
+		ok: false;
+		reason:
+			| "qualified_provider_unavailable"
+			| "qualified_free_provider_unavailable";
+		providerId: string;
+		model: string;
 	};
 
 const PROVIDER_QUALIFIER_PATTERN = /^[a-z0-9][a-z0-9._-]{0,127}$/i;
@@ -189,6 +202,46 @@ export function applyProviderQualifiedModelConstraint(
 				: {}),
 		},
 	};
+}
+
+export function filterProviderQualifiedModelCandidates(
+	providers: ProviderCandidate[],
+	selection: ProviderQualifiedModelSelection | null,
+): ProviderQualifiedModelCandidateResult {
+	if (!selection) {
+		return { ok: true, providers };
+	}
+
+	const matchingProviders = providers.filter(
+		(provider) =>
+			normalizeProviderId(provider.providerId) === selection.providerId,
+	);
+	if (matchingProviders.length === 0) {
+		return {
+			ok: false,
+			reason: "qualified_provider_unavailable",
+			providerId: selection.providerId,
+			model: selection.model,
+		};
+	}
+
+	if (!selection.model.toLowerCase().endsWith(":free")) {
+		return { ok: true, providers: matchingProviders };
+	}
+
+	const freeProviders = matchingProviders.filter((provider) =>
+		isFreePriceCard(provider.pricingCard),
+	);
+	if (freeProviders.length === 0) {
+		return {
+			ok: false,
+			reason: "qualified_free_provider_unavailable",
+			providerId: selection.providerId,
+			model: selection.model,
+		};
+	}
+
+	return { ok: true, providers: freeProviders };
 }
 
 export type EffectiveRoutingHints = {

--- a/apps/api/src/pipeline/requestRouting.ts
+++ b/apps/api/src/pipeline/requestRouting.ts
@@ -2,6 +2,8 @@
 // Why: Keeps `provider` compatibility while letting `routing` become the canonical interface.
 // How: Merges provider/routing hints, resolves aliases, and surfaces explicit routing flags.
 
+import { normalizeProviderId, normalizeProviderList } from "@/lib/config/providerAliases";
+
 type PlainObject = Record<string, any>;
 
 export type RoutingModePreference =
@@ -100,7 +102,7 @@ export function parseProviderQualifiedModel(
 	}
 
 	return {
-		providerId: providerId.toLowerCase(),
+		providerId: normalizeProviderId(providerId),
 		model,
 	};
 }
@@ -124,7 +126,7 @@ export function canonicalizeProviderQualifiedModelRequest(body: any): {
 }
 
 function normalizedProviderConstraintValues(value: unknown): string[] {
-	return (normalizeStringArray(value) ?? []).map((item) => item.toLowerCase());
+	return normalizeProviderList(normalizeStringArray(value) ?? []);
 }
 
 export function applyProviderQualifiedModelConstraint(

--- a/apps/api/src/pipeline/requestRouting.ts
+++ b/apps/api/src/pipeline/requestRouting.ts
@@ -94,10 +94,76 @@ export type ProviderQualifiedModelCandidateResult =
 
 const PROVIDER_QUALIFIER_PATTERN = /^[a-z0-9][a-z0-9._-]{0,127}$/i;
 
+export type ProviderQualifiedModelSyntaxError = {
+	reason: "invalid_provider_slug" | "invalid_provider_qualified_model";
+	input: string;
+	providerSlug: string;
+	message: string;
+};
+
+export type ProviderQualifiedModelProviderValidationResult =
+	| { ok: true }
+	| {
+		ok: false;
+		reason: "unknown_provider_slug";
+		providerId: string;
+		model: string;
+		message: string;
+	};
+
+export function validateProviderQualifiedModelSyntax(
+	value: unknown,
+): ProviderQualifiedModelSyntaxError | null {
+	if (typeof value !== "string") return null;
+	const input = value.trim();
+	const qualifierSeparator = input.indexOf(":");
+	const modelNamespaceSeparator = input.indexOf("/");
+
+	// A colon after the namespace slash is a canonical model suffix such as
+	// ":free", not a provider qualifier.
+	if (
+		qualifierSeparator < 0 ||
+		modelNamespaceSeparator < 0 ||
+		qualifierSeparator > modelNamespaceSeparator
+	) {
+		return null;
+	}
+
+	const providerSlug = input.slice(0, qualifierSeparator).trim();
+	if (!PROVIDER_QUALIFIER_PATTERN.test(providerSlug)) {
+		return {
+			reason: "invalid_provider_slug",
+			input,
+			providerSlug,
+			message:
+				`Invalid provider slug "${providerSlug}" in model identifier "${input}". Provider slugs must start with a letter or number and contain only letters, numbers, ".", "_" or "-".`,
+		};
+	}
+
+	const model = input.slice(qualifierSeparator + 1).trim();
+	if (
+		modelNamespaceSeparator <= qualifierSeparator + 1 ||
+		model.startsWith(":") ||
+		model.startsWith("/") ||
+		model.endsWith("/")
+	) {
+		return {
+			reason: "invalid_provider_qualified_model",
+			input,
+			providerSlug,
+			message:
+				`Invalid provider-qualified model identifier "${input}". Expected "<provider>:<publisher>/<model>".`,
+		};
+	}
+
+	return null;
+}
+
 export function parseProviderQualifiedModel(
 	value: unknown,
 ): ProviderQualifiedModelSelection | null {
 	if (typeof value !== "string") return null;
+	if (validateProviderQualifiedModelSyntax(value)) return null;
 	const input = value.trim();
 	const qualifierSeparator = input.indexOf(":");
 	const modelNamespaceSeparator = input.indexOf("/");
@@ -123,18 +189,40 @@ export function parseProviderQualifiedModel(
 export function canonicalizeProviderQualifiedModelRequest(body: any): {
 	body: any;
 	selection: ProviderQualifiedModelSelection | null;
+	syntaxError: ProviderQualifiedModelSyntaxError | null;
 } {
 	if (!body || typeof body !== "object" || Array.isArray(body)) {
-		return { body, selection: null };
+		return { body, selection: null, syntaxError: null };
 	}
+	const syntaxError = validateProviderQualifiedModelSyntax(body.model);
+	if (syntaxError) return { body, selection: null, syntaxError };
 	const selection = parseProviderQualifiedModel(body.model);
-	if (!selection) return { body, selection: null };
+	if (!selection) return { body, selection: null, syntaxError: null };
 	return {
 		body: {
 			...body,
 			model: selection.model,
 		},
 		selection,
+		syntaxError: null,
+	};
+}
+
+export function validateProviderQualifiedModelProvider(
+	selection: ProviderQualifiedModelSelection | null,
+	knownProviderIds: string[],
+): ProviderQualifiedModelProviderValidationResult {
+	if (!selection) return { ok: true };
+	const knownProviders = new Set(normalizeProviderList(knownProviderIds));
+	if (knownProviders.has(selection.providerId)) return { ok: true };
+	const qualifiedModel = `${selection.providerId}:${selection.model}`;
+	return {
+		ok: false,
+		reason: "unknown_provider_slug",
+		providerId: selection.providerId,
+		model: selection.model,
+		message:
+			`Unknown provider slug "${selection.providerId}" in provider-qualified model "${qualifiedModel}". Use a provider slug returned by Phaseo's provider catalogue.`,
 	};
 }
 

--- a/apps/docs/docs.json
+++ b/apps/docs/docs.json
@@ -58,6 +58,7 @@
 									"v1/exploring/models",
 									"v1/exploring/api-providers",
 									"v1/guides/routing-and-fallbacks",
+									"v1/guides/provider-qualified-models",
 									"v1/guides/provider-statuses"
 								]
 							},

--- a/apps/docs/v1/guides/provider-qualified-models.mdx
+++ b/apps/docs/v1/guides/provider-qualified-models.mdx
@@ -1,0 +1,204 @@
+---
+title: "Provider-qualified model IDs"
+description: "Route a request to one exact provider and model using a single model identifier."
+icon: "route"
+---
+
+Provider-qualified model IDs let you select an exact provider and canonical model in the `model` field. Use them when provider choice is part of the request contract rather than a routing preference.
+
+## Syntax
+
+```text
+<provider-id>:<canonical-model-id>
+```
+
+For example:
+
+```text
+baseten:thinking-machines/inkling-small
+deepinfra:deepseek/deepseek-v3
+crofai:moonshotai/kimi-k3
+```
+
+The first colon separates the provider from the canonical model ID. Colons after the model namespace remain model suffixes, so this is unambiguous:
+
+```text
+baseten:google/gemma-4-26b-a4b:free
+```
+
+In that example:
+
+- `baseten` is the requested provider
+- `google/gemma-4-26b-a4b:free` is the canonical Phaseo model ID
+
+## Send a request
+
+Use the qualified identifier anywhere the endpoint accepts a model ID.
+
+<CodeGroup>
+```bash cURL
+curl https://api.phaseo.app/v1/responses \
+  -H "Authorization: Bearer YOUR_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "baseten:thinking-machines/inkling-small",
+    "input": "Explain mixture-of-experts routing in two sentences."
+  }'
+```
+
+```javascript JavaScript
+const response = await fetch("https://api.phaseo.app/v1/responses", {
+  method: "POST",
+  headers: {
+    Authorization: "Bearer YOUR_API_KEY",
+    "Content-Type": "application/json",
+  },
+  body: JSON.stringify({
+    model: "baseten:thinking-machines/inkling-small",
+    input: "Explain mixture-of-experts routing in two sentences.",
+  }),
+});
+
+const result = await response.json();
+```
+
+```python Python
+import os
+import requests
+
+response = requests.post(
+    "https://api.phaseo.app/v1/responses",
+    headers={
+        "Authorization": f"Bearer {os.environ['PHASEO_API_KEY']}",
+        "Content-Type": "application/json",
+    },
+    json={
+        "model": "baseten:thinking-machines/inkling-small",
+        "input": "Explain mixture-of-experts routing in two sentences.",
+    },
+)
+
+result = response.json()
+```
+</CodeGroup>
+
+## Exact routing behaviour
+
+A provider qualifier is an exact constraint. Phaseo narrows the eligible provider set to the requested provider and will not fall back to another provider for that request.
+
+The qualifier does not bypass other controls. The provider must still:
+
+- expose the canonical model on the requested endpoint
+- be enabled for the endpoint capability
+- satisfy workspace and API key policies
+- satisfy preset and privacy restrictions
+- support the requested service tier and parameters
+- have valid pricing configured
+
+If any of these checks fail, Phaseo rejects the request rather than silently selecting another provider.
+
+## Interaction with routing fields
+
+The qualified provider and explicit routing fields must agree.
+
+```json
+{
+  "model": "baseten:thinking-machines/inkling-small",
+  "provider": {
+    "only": ["baseten"]
+  }
+}
+```
+
+A matching `provider.only` or `routing.only` value is accepted. A conflicting allowlist, or an ignore list containing the qualified provider, returns a validation error.
+
+For example, this request is contradictory and is rejected:
+
+```json
+{
+  "model": "baseten:thinking-machines/inkling-small",
+  "provider": {
+    "only": ["deepinfra"]
+  }
+}
+```
+
+If provider choice is only a preference and cross-provider fallback is desirable, continue using an unqualified canonical model ID with the normal [routing and fallback controls](./routing-and-fallbacks).
+
+## Provider-qualified free models
+
+A qualified `:free` request is accepted only when that exact provider has an eligible free route for the canonical model and endpoint.
+
+```json
+{
+  "model": "baseten:google/gemma-4-26b-a4b:free",
+  "input": "Hello"
+}
+```
+
+Phaseo fails closed unless the selected route has a non-empty pricing card where every current pricing rule:
+
+- is explicitly labelled `free`
+- has a price of exactly zero
+
+Missing pricing, paid pricing, mixed pricing, negative pricing, or a zero-priced rule that is not explicitly labelled `free` causes the request to be rejected before provider execution.
+
+<Note>
+The existence of a canonical `:free` model does not imply that every provider serving the underlying model offers a free route.
+</Note>
+
+## Provider slugs and aliases
+
+Use a provider slug exposed by Phaseo's provider catalogue. Slugs are normalised to lowercase, and supported legacy or brand aliases are mapped to their canonical provider ID.
+
+For example, `NovitaAI` and `novita-ai` currently normalise to `novita`.
+
+Malformed and unknown slugs are rejected before provider selection. Phaseo does not send them upstream as part of the model name.
+
+## Validation errors
+
+Provider-qualified identifier failures use HTTP `400` with the top-level error code `validation_error`. Inspect `reason` or `details[].keyword` for the precise cause.
+
+| Reason | Meaning |
+| --- | --- |
+| `invalid_provider_slug` | The provider portion is empty or contains unsupported characters. |
+| `unknown_provider_slug` | The slug is well formed but is not a recognised Phaseo provider. |
+| `invalid_provider_qualified_model` | The combined identifier does not match `<provider>:<publisher>/<model>`. |
+| `provider_qualified_model_conflict` | `provider.only`, `provider.ignore`, `routing.only`, or `routing.ignore` contradicts the qualifier. |
+| `qualified_provider_unavailable` | The provider is recognised but does not expose that model on the requested endpoint. |
+| `qualified_free_provider_unavailable` | The exact provider route is not verified as explicitly free with all-zero pricing. |
+
+Example error:
+
+```json
+{
+  "error": "validation_error",
+  "status_code": 400,
+  "reason": "unknown_provider_slug",
+  "description": "Unknown provider slug \"not-a-provider\" in provider-qualified model \"not-a-provider:publisher/model\". Use a provider slug returned by Phaseo's provider catalogue.",
+  "provider": "not-a-provider",
+  "model": "publisher/model",
+  "details": [
+    {
+      "path": ["model"],
+      "keyword": "unknown_provider_slug"
+    }
+  ]
+}
+```
+
+## Choosing between the two forms
+
+| Requirement | Recommended model value |
+| --- | --- |
+| Let Phaseo choose and fall back between providers | `thinking-machines/inkling-small` |
+| Require Baseten with no cross-provider fallback | `baseten:thinking-machines/inkling-small` |
+| Require one verified free provider route | `baseten:google/gemma-4-26b-a4b:free` |
+
+## Related guides
+
+- [Routing and Fallbacks](./routing-and-fallbacks)
+- [API Providers](../exploring/api-providers)
+- [Models](../exploring/models)
+- [Error Handling](../developers/error-handling)
+- [Presets](./presets)

--- a/apps/docs/v1/guides/routing-and-fallbacks.mdx
+++ b/apps/docs/v1/guides/routing-and-fallbacks.mdx
@@ -27,6 +27,25 @@ Configure the workspace default in **Dashboard -> Settings -> Routing**. Use pre
 
 Inspect request outcomes through your activity logs and response metadata when debugging routing behavior.
 
+## Choose an exact provider in the model id
+
+Use `<provider-id>:<canonical-model-id>` when a request must use one specific provider-model pair:
+
+```json
+{
+  "model": "baseten:thinking-machines/inkling-small",
+  "input": "Hello"
+}
+```
+
+The provider qualifier is an exact routing constraint, equivalent to narrowing `provider.only` to that provider. Phaseo will not fall back to a different provider for the request. Canonical model suffixes remain unambiguous because they follow the model id:
+
+```text
+baseten:google/gemma-4-26b-a4b:free
+```
+
+Workspace policies, presets, endpoint support, provider availability, and privacy controls still apply. If `provider.only` or `provider.ignore` contradicts the qualifier, Phaseo returns a validation error instead of silently choosing one setting.
+
 ## Control routing and fallbacks
 
 The current public fallback and routing controls are intentionally explicit:

--- a/apps/docs/v1/guides/routing-and-fallbacks.mdx
+++ b/apps/docs/v1/guides/routing-and-fallbacks.mdx
@@ -38,13 +38,9 @@ Use `<provider-id>:<canonical-model-id>` when a request must use one specific pr
 }
 ```
 
-The provider qualifier is an exact routing constraint, equivalent to narrowing `provider.only` to that provider. Phaseo will not fall back to a different provider for the request. Canonical model suffixes remain unambiguous because they follow the model id:
+The qualifier disables cross-provider fallback for that request. Model suffixes remain part of the canonical model ID, including in identifiers such as `baseten:google/gemma-4-26b-a4b:free`.
 
-```text
-baseten:google/gemma-4-26b-a4b:free
-```
-
-Workspace policies, presets, endpoint support, provider availability, and privacy controls still apply. If `provider.only` or `provider.ignore` contradicts the qualifier, Phaseo returns a validation error instead of silently choosing one setting.
+Read [Provider-qualified model IDs](./provider-qualified-models) for complete syntax, free-route validation, routing precedence, aliases, error codes, and request examples.
 
 ## Control routing and fallbacks
 


### PR DESCRIPTION
## Summary

Adds provider-qualified model identifiers for exact provider-model routing.

- accepts `<provider-id>:<canonical-model-id>` across the existing model-based request pipeline
- resolves the canonical model before context and capability lookup
- constrains routing to the qualified provider without allowing cross-provider fallback
- preserves Phaseo model suffixes such as `:free`
- normalises existing provider aliases such as `NovitaAI` consistently with `provider.only`
- validates provider slugs against the active executor registry
- returns precise HTTP 400 validation errors for malformed and unknown provider slugs
- rejects providers that do not expose the exact canonical model and endpoint
- fails closed for `:free` when pricing is missing, not explicitly free, or contains any non-zero rule
- returns a validation error when `provider.only` or `provider.ignore` contradicts the qualifier
- preserves workspace policies, presets, privacy controls and provider availability checks
- adds a dedicated provider-qualified model guide to the Models & Routing documentation
- documents the syntax and adds a gateway API changeset

Examples:

```text
baseten:thinking-machines/inkling-small
deepinfra:deepseek/deepseek-v3
baseten:google/gemma-4-26b-a4b:free
```

## Routing precedence

The qualifier is an exact request-level provider constraint. Workspace security and availability policies still apply and may reject the route. Explicit contradictory request routing fields fail rather than silently overriding either setting.

The constraint is deliberately applied at the final request-routing boundary before workspace policy enforcement. This keeps it compatible with the dynamic routing work in #1314: when that PR is rebased, dynamic provider actions must not silently widen an exact provider-model pair.

No catalogue or status schema changes are required, so this remains independent of #1366.

## Slug validation

Provider-qualified identifiers return `validation_error` with HTTP 400 and a specific machine-readable reason:

- `invalid_provider_slug` for malformed provider slugs
- `unknown_provider_slug` for well-formed slugs not present in the active executor registry
- `invalid_provider_qualified_model` for malformed `<provider>:<publisher>/<model>` shapes
- `qualified_provider_unavailable` when a valid provider does not expose that exact model and endpoint

## Free-route safety

A provider-qualified `:free` request is accepted only when the selected provider has an eligible candidate for that exact canonical model and endpoint, with a non-empty pricing card whose current rules are all explicitly on the `free` plan and priced at exactly zero. Missing, ambiguous, negative or paid pricing fails closed before execution.

## Validation

Added 24 focused Vitest cases covering:

- provider-qualified parsing and canonical `:free` suffix preservation
- malformed, empty and unknown provider slugs
- malformed provider-qualified model shapes
- canonicalisation without request mutation
- exact provider constraints and provider aliases
- conflicting `provider.only` and `provider.ignore` settings
- unavailable provider/model combinations
- valid provider-qualified free routes
- paid or missing pricing on `:free` routes
- non-empty free pricing cards, positive or negative prices, and zero-priced non-free plans
- paid qualified models remaining valid
- Mintlify navigation and cross-links for the dedicated guide

Previously passed on this PR: API lint, full API test suite, Worker build, CodeQL, OpenAPI lint, catalogue validation and dependency review. The complete workflow matrix is rerunning on the latest head.

Created with Codex