### PR TITLE
Add AdSense site verification

### DIFF
--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -35,6 +35,9 @@ export const metadata: Metadata = {
 		"Discover and compare the world's most comprehensive AI model database and gateway. Browse benchmarks, features, pricing, and access state-of-the-art AI models.",
 	applicationName: PREFERRED_SITE_NAME,
 	authors: [{ name: SITE_NAME }],
+	other: {
+		"google-adsense-account": "ca-pub-5904826500425921",
+	},
 	metadataBase: METADATA_BASE,
 	openGraph: {
 		type: "website",
@@ -115,4 +118,3 @@ export default function RootLayout({
 		</html>
 	);
 }
-


### PR DESCRIPTION
## What changed

- Added the Phaseo AdSense publisher account to the root Next.js metadata.
- This renders the `google-adsense-account` verification meta tag across the site.

## Why

This allows Google AdSense to verify ownership of Phaseo without loading the AdSense advertising script or enabling adverts.

## Validation

- Confirmed the branch is one commit ahead of `main` and changes only `apps/web/src/app/layout.tsx`.
- Confirmed the publisher ID is `ca-pub-5904826500425921`.
- Confirmed the implementation uses Next.js's typed `Metadata.other` field for custom meta tags.