### PR TITLE
chore: refresh chat featured models

### DIFF
--- a/apps/web/src/components/(chat)/ChatMessagesEmptyState.tsx
+++ b/apps/web/src/components/(chat)/ChatMessagesEmptyState.tsx
@@ -80,23 +80,19 @@ function buildStarterCollections(models: ModelOption[]) {
 	const collections: StarterCollection[] = [];
 	const frontierModels = findPreferredModels(activeModels, [
 		{
-			id: "openai-gpt-5.5",
+			id: "openai-gpt-5.6-sol",
 			matches: [
-				(model) => model.modelId === "openai/gpt-5.5",
-				(model) => getSearchText(model).includes("gpt-5.5"),
-				(model) => getSearchText(model).includes("gpt 5.5"),
+				(model) => model.modelId === "openai/gpt-5.6-sol",
+				(model) => getSearchText(model).includes("gpt-5.6-sol"),
+				(model) => getSearchText(model).includes("gpt 5.6 sol"),
 			],
 		},
 		{
-			id: "google-gemini-3.1-pro",
+			id: "google-gemini-3.6-flash",
 			matches: [
-				(model) => model.modelId === "google/gemini-3.1-pro-preview",
-				(model) =>
-					getSearchText(model).includes("gemini-3.1-pro") &&
-					!getSearchText(model).includes("customtools"),
-				(model) =>
-					getSearchText(model).includes("gemini 3.1 pro") &&
-					!getSearchText(model).includes("customtools"),
+				(model) => model.modelId === "google/gemini-3.6-flash",
+				(model) => getSearchText(model).includes("gemini-3.6-flash"),
+				(model) => getSearchText(model).includes("gemini 3.6 flash"),
 			],
 		},
 		{
@@ -108,11 +104,11 @@ function buildStarterCollections(models: ModelOption[]) {
 			],
 		},
 		{
-			id: "spacex-ai-grok-4.3",
+			id: "spacex-ai-grok-4.5",
 			matches: [
-				(model) => model.modelId === "spacex-ai/grok-4.3",
-				(model) => getSearchText(model).includes("grok 4.3"),
-				(model) => getSearchText(model).includes("grok-4.3"),
+				(model) => model.modelId === "spacex-ai/grok-4.5",
+				(model) => getSearchText(model).includes("grok 4.5"),
+				(model) => getSearchText(model).includes("grok-4.5"),
 			],
 		},
 	]);
@@ -157,11 +153,11 @@ function buildStarterCollections(models: ModelOption[]) {
 			],
 		},
 		{
-			id: "moonshot-kimi-k2.7-code",
+			id: "moonshot-kimi-k3",
 			matches: [
-				(model) => model.modelId === "moonshotai/kimi-k2.7-code",
-				(model) => getSearchText(model).includes("kimi k2.7 code"),
-				(model) => getSearchText(model).includes("kimi-k2.7-code"),
+				(model) => model.modelId === "moonshotai/kimi-k3",
+				(model) => getSearchText(model).includes("kimi k3"),
+				(model) => getSearchText(model).includes("kimi-k3"),
 			],
 		},
 	]);
@@ -185,11 +181,11 @@ function buildStarterCollections(models: ModelOption[]) {
 			],
 		},
 		{
-			id: "moonshot-kimi-k2.7-code",
+			id: "moonshot-kimi-k3",
 			matches: [
-				(model) => model.modelId === "moonshotai/kimi-k2.7-code",
-				(model) => getSearchText(model).includes("kimi k2.7 code"),
-				(model) => getSearchText(model).includes("kimi-k2.7-code"),
+				(model) => model.modelId === "moonshotai/kimi-k3",
+				(model) => getSearchText(model).includes("kimi k3"),
+				(model) => getSearchText(model).includes("kimi-k3"),
 			],
 		},
 		{

--- a/apps/web/src/components/(chat)/playgroundConfig.test.ts
+++ b/apps/web/src/components/(chat)/playgroundConfig.test.ts
@@ -1,0 +1,22 @@
+import {
+	CHAT_DEFAULT_MODEL_IDS,
+	FEATURED_MODEL_IDS,
+} from "./playgroundConfig";
+
+const CURRENT_FEATURED_MODEL_IDS = [
+	"z-ai/glm-5.2",
+	"moonshotai/kimi-k3",
+	"anthropic/claude-fable-5",
+	"minimax/minimax-m3",
+	"anthropic/claude-opus-5",
+	"spacex-ai/grok-4.5",
+	"openai/gpt-5.6-sol",
+	"google/gemini-3.6-flash",
+];
+
+describe("chat featured models", () => {
+	it("uses the current featured model generations", () => {
+		expect(FEATURED_MODEL_IDS).toEqual(CURRENT_FEATURED_MODEL_IDS);
+		expect(CHAT_DEFAULT_MODEL_IDS).toEqual(CURRENT_FEATURED_MODEL_IDS);
+	});
+});

--- a/apps/web/src/components/(chat)/playgroundConfig.ts
+++ b/apps/web/src/components/(chat)/playgroundConfig.ts
@@ -3,24 +3,24 @@ import { getRoomScopedStorageKey } from "@/lib/chat/rooms";
 // Default favorites use API MODEL ID - NOT internal model ID.
 export const FEATURED_MODEL_IDS = [
 	"z-ai/glm-5.2",
-	"moonshotai/kimi-k2.7-code",
+	"moonshotai/kimi-k3",
 	"anthropic/claude-fable-5",
 	"minimax/minimax-m3",
 	"anthropic/claude-opus-5",
-	"spacex-ai/grok-4.3",
-	"openai/gpt-5.5",
-	"google/gemini-3.1-pro-preview",
+	"spacex-ai/grok-4.5",
+	"openai/gpt-5.6-sol",
+	"google/gemini-3.6-flash",
 ];
 
 export const CHAT_DEFAULT_MODEL_IDS = [
 	"z-ai/glm-5.2",
-	"moonshotai/kimi-k2.7-code",
+	"moonshotai/kimi-k3",
 	"anthropic/claude-fable-5",
 	"minimax/minimax-m3",
 	"anthropic/claude-opus-5",
-	"spacex-ai/grok-4.3",
-	"openai/gpt-5.5",
-	"google/gemini-3.1-pro-preview",
+	"spacex-ai/grok-4.5",
+	"openai/gpt-5.6-sol",
+	"google/gemini-3.6-flash",
 ];
 
 export const MODEL_SELECTOR_FAVORITES_STORAGE_KEY = getRoomScopedStorageKey(


### PR DESCRIPTION
## Summary

Refresh the chat's default featured models and starter collections to use current released generations.

## Changes

- replace Kimi K2.7 Code with Kimi K3
- replace GPT-5.5 with GPT-5.6 Sol
- replace Grok 4.3 with Grok 4.5
- replace Gemini 3.1 Pro Preview with Gemini 3.6 Flash
- keep the default and featured model lists aligned
- add regression coverage for the curated model list

## Impact

New chat defaults, favourites, and empty-state starter collections now surface the current model generations. Existing user-selected favourites remain untouched.

## Validation

- verified all eight featured catalogue IDs are available and have an active text provider
- verified the published branch contains all three intended files and no stale model IDs
- `git diff --check` passed before workspace maintenance
- the focused Jest suite was not run locally because npm registry downloads repeatedly returned HTTP 502; normal PR CI should run the repository checks
