### PR TITLE
Fix Base UI dropdown interactions and styling

### DIFF
--- a/apps/web/src/components/(data)/model/ModelIdentifierControl.tsx
+++ b/apps/web/src/components/(data)/model/ModelIdentifierControl.tsx
@@ -142,7 +142,7 @@ export default function ModelIdentifierControl({
 					</span>
 
 			</DropdownMenuTrigger>
-			<DropdownMenuContent align="start" className="w-auto min-w-0 max-w-[calc(100vw-2rem)]">
+			<DropdownMenuContent align="start" className="w-auto min-w-0 max-w-[calc(100vw-2rem)] rounded-lg">
 				{hasVariants ? (
 					<>
 						<div className="px-2 py-1.5 text-[11px] font-medium text-muted-foreground">
@@ -153,10 +153,10 @@ export default function ModelIdentifierControl({
 							return (
 								<DropdownMenuItem
 									key={variant.model_id}
-									onSelect={() => {
+									onClick={() => {
 										if (!isCurrent) router.push(`/models/${variant.model_id}`);
 									}}
-									className="flex items-center justify-between gap-4"
+									className="flex items-center justify-between gap-4 rounded-lg"
 								>
 									<span className="flex min-w-0 items-center gap-2">
 										<Check className={`h-3.5 w-3.5 shrink-0 ${isCurrent ? "opacity-100" : "opacity-0"}`} />
@@ -177,11 +177,11 @@ export default function ModelIdentifierControl({
 				{options.map((option, index) => (
 					<DropdownMenuItem
 						key={option}
-						onSelect={(event) => {
-							event.preventDefault();
+						closeOnClick={false}
+						onClick={() => {
 							void copyIdentifier(option);
 						}}
-						className="flex items-center justify-between gap-3"
+						className="flex items-center justify-between gap-3 rounded-lg"
 					>
 						<span className="min-w-0 truncate">{option}</span>
 						<span className="shrink-0 text-[11px] text-zinc-500 dark:text-zinc-400">

--- a/apps/web/src/components/(data)/model/pricing/PricingPlanSelect.tsx
+++ b/apps/web/src/components/(data)/model/pricing/PricingPlanSelect.tsx
@@ -120,15 +120,15 @@ export default function PricingPlanSelect({
 						<ChevronDown className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
 
 				</DropdownMenuTrigger>
-				<DropdownMenuContent align="end" className="w-72 p-1.5">
+				<DropdownMenuContent align="end" className="w-72 rounded-lg p-1.5">
 					{plans.map((plan) => {
 						const selected = plan === value;
 						const metaLabel = planMetaLabels[plan] ?? null;
 						return (
 							<DropdownMenuItem
 								key={plan}
-								onSelect={() => onChange(plan)}
-								className="items-start gap-3 rounded-md px-2.5 py-2"
+								onClick={() => onChange(plan)}
+								className="items-start gap-3 rounded-lg px-2.5 py-2"
 							>
 								{renderPlanIcon(plan, "mt-0.5 h-4 w-4 shrink-0 text-muted-foreground")}
 								<span className="min-w-0 flex-1">

--- a/apps/web/src/components/(data)/models/ModelCalendar/ModelCalendar.tsx
+++ b/apps/web/src/components/(data)/models/ModelCalendar/ModelCalendar.tsx
@@ -449,11 +449,11 @@ export default function ModelCalendar({
 							<span>{MONTH_NAMES[currentMonth.getMonth()]}</span>
 							<ChevronDown className="h-3.5 w-3.5 text-zinc-500 dark:text-zinc-400" />
 						</DropdownMenuTrigger>
-						<DropdownMenuContent align="start" className="w-40">
+						<DropdownMenuContent align="start" className="w-40 rounded-lg">
 							{MONTH_NAMES.map((month, index) => (
 								<DropdownMenuItem
 									key={month}
-									onSelect={() =>
+									onClick={() =>
 										setCurrentMonth(
 											new Date(
 												currentMonth.getFullYear(),
@@ -462,7 +462,7 @@ export default function ModelCalendar({
 											)
 										)
 									}
-									className="flex items-center justify-between"
+									className="flex items-center justify-between rounded-lg"
 								>
 									<span>{month}</span>
 									{currentMonth.getMonth() === index ? (
@@ -478,7 +478,7 @@ export default function ModelCalendar({
 							<span>{currentMonth.getFullYear()}</span>
 							<ChevronDown className="h-3.5 w-3.5 text-zinc-500 dark:text-zinc-400" />
 						</DropdownMenuTrigger>
-						<DropdownMenuContent align="start" className="w-32">
+						<DropdownMenuContent align="start" className="w-32 rounded-lg">
 							<ScrollArea className="h-48">
 								{Array.from(
 									{ length: endYear - startYear + 1 },
@@ -489,7 +489,7 @@ export default function ModelCalendar({
 									return (
 										<DropdownMenuItem
 											key={year}
-											onSelect={() =>
+											onClick={() =>
 												setCurrentMonth(
 													new Date(
 														year,
@@ -499,7 +499,7 @@ export default function ModelCalendar({
 												)
 											}
 											className={cn(
-												"flex items-center justify-between",
+												"flex items-center justify-between rounded-lg",
 												isCurrent && "font-semibold"
 											)}
 										>

--- a/apps/web/src/components/(gateway)/sections/QuickstartSection.tsx
+++ b/apps/web/src/components/(gateway)/sections/QuickstartSection.tsx
@@ -689,13 +689,14 @@ export function QuickstartSection({ metrics }: QuickstartSectionProps) {
 										<ChevronDown className="h-4 w-4" />
 
 								</DropdownMenuTrigger>
-								<DropdownMenuContent align="end">
+								<DropdownMenuContent align="end" className="rounded-lg">
 									{ENDPOINT_CONFIGS.map((config) => (
 										<DropdownMenuItem
 											key={config.id}
-											onSelect={() =>
+											onClick={() =>
 												setSelectedEndpoint(config.id)
 											}
+											className="rounded-lg"
 										>
 											<div className="flex flex-col">
 												<span>{config.label}</span>
@@ -730,15 +731,16 @@ export function QuickstartSection({ metrics }: QuickstartSectionProps) {
 										<ChevronDown className="h-4 w-4" />
 
 								</DropdownMenuTrigger>
-								<DropdownMenuContent>
+								<DropdownMenuContent className="rounded-lg">
 									{LANGUAGE_OPTIONS.map((option) => (
 										<DropdownMenuItem
 											key={option}
-											onSelect={() =>
+											onClick={() =>
 												setSelectedLanguage(
 													option as Language
 												)
 											}
+											className="rounded-lg"
 										>
 											<div className="flex items-center justify-between gap-2">
 												<span>
@@ -811,12 +813,12 @@ export function QuickstartSection({ metrics }: QuickstartSectionProps) {
 													<ChevronDown className="h-4 w-4" />
 
 											</DropdownMenuTrigger>
-											<DropdownMenuContent>
+											<DropdownMenuContent className="rounded-lg">
 												{availableModels.map(
 													(model) => (
 														<DropdownMenuItem
 															key={model}
-															onSelect={() =>
+															onClick={() =>
 																setSelectedModels(
 																	(prev) => ({
 																		...prev,
@@ -825,6 +827,7 @@ export function QuickstartSection({ metrics }: QuickstartSectionProps) {
 																	})
 																)
 															}
+															className="rounded-lg"
 														>
 															{model}
 														</DropdownMenuItem>

--- a/apps/web/src/components/(gateway)/settings/apps/EditAppDialog.tsx
+++ b/apps/web/src/components/(gateway)/settings/apps/EditAppDialog.tsx
@@ -230,7 +230,7 @@ export default function EditAppDialog({
 										id="app-category"
 										type="button"
 										variant="outline"
-										className="h-auto min-h-9 w-full justify-between gap-3 rounded-2xl bg-input/50 px-3 py-2 text-left font-normal" />}>
+										className="h-auto min-h-9 w-full justify-between gap-3 rounded-lg bg-input/50 px-3 py-2 text-left font-normal" />}>
 
 										<span className="flex min-w-0 items-center gap-2">
 											<Folder className="size-4 shrink-0 text-muted-foreground" />
@@ -241,7 +241,7 @@ export default function EditAppDialog({
 										<ChevronDown className="size-4 shrink-0 text-muted-foreground" />
 
 								</DropdownMenuTrigger>
-								<DropdownMenuContent align="start" className="w-72">
+								<DropdownMenuContent align="start" className="w-72 rounded-lg">
 									{APP_CATEGORY_OPTIONS.map((option) => {
 										const checked = categories.includes(option.value);
 										const disabled =
@@ -254,8 +254,8 @@ export default function EditAppDialog({
 												key={option.value}
 												checked={checked}
 												disabled={disabled}
-												className="group/category"
-												onSelect={(event) => event.preventDefault()}
+												closeOnClick={false}
+												className="group/category rounded-lg"
 												onCheckedChange={(nextChecked) => {
 													setCategoryChecked(option.value, Boolean(nextChecked));
 												}}

--- a/apps/web/src/components/(gateway)/settings/keys/CreateKeyDialog.tsx
+++ b/apps/web/src/components/(gateway)/settings/keys/CreateKeyDialog.tsx
@@ -158,14 +158,15 @@ export default function CreateKeyDialog({
 								<DropdownMenuContent
 									side="bottom"
 									align="start"
-									className="w-full"
+									className="w-full rounded-lg"
 								>
 									{resolvedTeams.map((t) => (
 										<DropdownMenuItem
 											key={String(t.id ?? "__null")}
-											onSelect={() =>
+											onClick={() =>
 												setSelectedTeamId(t.id ?? null)
 											}
+											className="rounded-lg"
 										>
 											{t.name}
 										</DropdownMenuItem>

--- a/apps/web/src/components/(gateway)/settings/keys/SecretRevealActions.tsx
+++ b/apps/web/src/components/(gateway)/settings/keys/SecretRevealActions.tsx
@@ -162,16 +162,17 @@ export function SecretRevealActions({
 								<ChevronDown className="h-4 w-4" />
 
 						</DropdownMenuTrigger>
-						<DropdownMenuContent align="start">
+						<DropdownMenuContent align="start" className="rounded-lg">
 							{appConfigSnippets.map((snippet) => (
 								<DropdownMenuItem
 									key={snippet.id}
-									onSelect={() => {
+									onClick={() => {
 										void navigator.clipboard
 											.writeText(snippet.value)
 											.then(() => toast.success(`Copied ${snippet.label}`))
 											.catch(() => toast.error("Could not copy config"));
 									}}
+									className="rounded-lg"
 								>
 									{snippet.label}
 								</DropdownMenuItem>
@@ -189,11 +190,11 @@ export function SecretRevealActions({
 								<ChevronDown className="h-4 w-4" />
 
 						</DropdownMenuTrigger>
-						<DropdownMenuContent align="start">
+						<DropdownMenuContent align="start" className="rounded-lg">
 							{collectionExports.map((item) => (
 								<DropdownMenuItem
 									key={item.id}
-									onSelect={() => {
+									onClick={() => {
 										downloadTextFile(
 											item.filename,
 											item.content,
@@ -201,6 +202,7 @@ export function SecretRevealActions({
 										);
 										toast.success(`Downloaded ${item.label} collection`);
 									}}
+									className="rounded-lg"
 								>
 									{item.label}
 								</DropdownMenuItem>

--- a/apps/web/src/components/(gateway)/settings/management-api-keys/CreateManagementKeyDialog.tsx
+++ b/apps/web/src/components/(gateway)/settings/management-api-keys/CreateManagementKeyDialog.tsx
@@ -197,14 +197,15 @@ export default function CreateManagementKeyDialog({
 								<DropdownMenuContent
 									side="bottom"
 									align="start"
-									className="w-full"
+									className="w-full rounded-lg"
 								>
 									{workspaces.map((workspace) => (
 										<DropdownMenuItem
 											key={String(workspace.id ?? "__null")}
-											onSelect={() =>
+											onClick={() =>
 												setSelectedWorkspaceId(workspace.id ?? null)
 											}
+											className="rounded-lg"
 										>
 											{workspace.name}
 										</DropdownMenuItem>
@@ -298,4 +299,3 @@ export default function CreateManagementKeyDialog({
 		</Dialog>
 	);
 }
-

--- a/apps/web/src/components/(gateway)/settings/observability/BroadcastDestinationCreateClient.tsx
+++ b/apps/web/src/components/(gateway)/settings/observability/BroadcastDestinationCreateClient.tsx
@@ -514,7 +514,7 @@ export default function BroadcastDestinationCreateClient(props: {
 						<Label className="text-xs font-medium">API Key Filter (Optional)</Label>
 						{keys.length ? (
 							<DropdownMenu>
-								<DropdownMenuTrigger render={<Button variant="outline" className="h-10 w-full justify-between px-3 font-normal" />}>
+								<DropdownMenuTrigger render={<Button variant="outline" className="h-10 w-full justify-between rounded-lg px-3 font-normal" />}>
 
 										{selectedKeyIds.length === 0
 											? "Select API keys"
@@ -522,7 +522,7 @@ export default function BroadcastDestinationCreateClient(props: {
 										<ChevronsUpDown className="ml-2 h-4 w-4 text-muted-foreground" />
 
 								</DropdownMenuTrigger>
-								<DropdownMenuContent align="start" className="w-[var(--radix-dropdown-menu-trigger-width)] min-w-[360px]">
+								<DropdownMenuContent align="start" className="w-(--anchor-width) min-w-[360px] rounded-lg">
 									<DropdownMenuLabel>Filter by API Key</DropdownMenuLabel>
 									<DropdownMenuSeparator />
 									{keys.map((key) => {
@@ -531,7 +531,8 @@ export default function BroadcastDestinationCreateClient(props: {
 											<DropdownMenuCheckboxItem
 												key={key.id}
 												checked={checked}
-												onSelect={(event) => event.preventDefault()}
+												closeOnClick={false}
+												className="rounded-lg"
 												onCheckedChange={(nextChecked) => {
 													const enabled = Boolean(nextChecked);
 													setSelectedKeyIds((prev) =>

--- a/apps/web/src/components/(rankings)/AppsUsageList.tsx
+++ b/apps/web/src/components/(rankings)/AppsUsageList.tsx
@@ -126,16 +126,16 @@ export function AppsUsageList({
 								<ChevronDown className="ml-2 h-4 w-4 opacity-60" />
 
 						</DropdownMenuTrigger>
-						<DropdownMenuContent align="end" className="min-w-32">
+						<DropdownMenuContent align="end" className="min-w-32 rounded-lg">
 							{RANGE_OPTIONS.map((option) => (
 								<DropdownMenuItem
 									key={option.key}
 									disabled={!resolvedDataByRange[option.key]?.length}
-									onSelect={() => {
+									onClick={() => {
 										setRange(option.key);
 										setShowAll(false);
 									}}
-									className="justify-between gap-6"
+									className="justify-between gap-6 rounded-lg"
 								>
 									<span>{option.label}</span>
 									<span className="flex h-4 w-4 items-center justify-center">

--- a/apps/web/src/components/(rankings)/PerformanceLandscapePanel.tsx
+++ b/apps/web/src/components/(rankings)/PerformanceLandscapePanel.tsx
@@ -96,13 +96,13 @@ export function PerformanceLandscapePanel({
 							<ChevronDown className="ml-2 h-4 w-4 opacity-60" />
 
 					</DropdownMenuTrigger>
-					<DropdownMenuContent align="end" className="min-w-32">
+					<DropdownMenuContent align="end" className="min-w-32 rounded-lg">
 						{RANGE_OPTIONS.map((option) => (
 							<DropdownMenuItem
 								key={option.key}
 								disabled={!resolvedDataByRange[option.key]?.length}
-								onSelect={() => setRange(option.key)}
-								className="justify-between gap-6"
+								onClick={() => setRange(option.key)}
+								className="justify-between gap-6 rounded-lg"
 							>
 								<span>{option.label}</span>
 								<span className="flex h-4 w-4 items-center justify-center">
@@ -126,12 +126,12 @@ export function PerformanceLandscapePanel({
 						<ChevronDown className="ml-2 h-4 w-4 opacity-60" />
 
 				</DropdownMenuTrigger>
-				<DropdownMenuContent align="end" className="min-w-36">
+				<DropdownMenuContent align="end" className="min-w-36 rounded-lg">
 					{MODE_OPTIONS.map((option) => (
 						<DropdownMenuItem
 							key={option.key}
-							onSelect={() => setMode(option.key)}
-							className="justify-between gap-6"
+							onClick={() => setMode(option.key)}
+							className="justify-between gap-6 rounded-lg"
 						>
 							<span>{option.label}</span>
 							<span className="flex h-4 w-4 items-center justify-center">

--- a/apps/web/src/components/(rankings)/UsageStackedBar.tsx
+++ b/apps/web/src/components/(rankings)/UsageStackedBar.tsx
@@ -651,15 +651,15 @@ export function UsageStackedBar({
 									<ChevronDown className="ml-2 h-4 w-4 opacity-60" />
 
 							</DropdownMenuTrigger>
-							<DropdownMenuContent align="end" className="min-w-36">
+							<DropdownMenuContent align="end" className="min-w-36 rounded-lg">
 								{MODEL_FILTER_OPTIONS.map((option) => (
 									<DropdownMenuItem
 										key={option.value}
-										onSelect={() => {
+										onClick={() => {
 											setModelFilter(option.value);
 											setListExpanded(false);
 										}}
-										className="justify-between gap-6"
+										className="justify-between gap-6 rounded-lg"
 									>
 										<span>{option.label}</span>
 										<span className="flex h-4 w-4 items-center justify-center">
@@ -682,14 +682,14 @@ export function UsageStackedBar({
 									<ChevronDown className="ml-2 h-4 w-4 opacity-60" />
 
 							</DropdownMenuTrigger>
-							<DropdownMenuContent align="end" className="min-w-32">
+							<DropdownMenuContent align="end" className="min-w-32 rounded-lg">
 								{PERIOD_OPTIONS.map((option) => (
 									<DropdownMenuItem
 										key={option.value}
-										onSelect={() =>
+										onClick={() =>
 											setLeaderboardPeriod(option.value)
 										}
-										className="justify-between gap-6"
+										className="justify-between gap-6 rounded-lg"
 									>
 										<span>{option.label}</span>
 										<span className="flex h-4 w-4 items-center justify-center">

--- a/apps/web/src/components/dropdownMenuMigration.test.ts
+++ b/apps/web/src/components/dropdownMenuMigration.test.ts
@@ -1,0 +1,52 @@
+import fs from "node:fs";
+import path from "node:path";
+
+const componentsRoot = path.join(process.cwd(), "src", "components");
+const uiRoot = path.join(componentsRoot, "ui") + path.sep;
+
+function listComponentFiles(directory: string): string[] {
+	return fs.readdirSync(directory, { withFileTypes: true }).flatMap((entry) => {
+		const entryPath = path.join(directory, entry.name);
+
+		if (entry.isDirectory()) return listComponentFiles(entryPath);
+		return entry.isFile() && entry.name.endsWith(".tsx") ? [entryPath] : [];
+	});
+}
+
+const applicationComponentFiles = listComponentFiles(componentsRoot).filter(
+	(filePath) => !filePath.startsWith(uiRoot),
+);
+
+describe("Base UI dropdown migration", () => {
+	it("does not use the Radix onSelect event on Base UI menu items", () => {
+		const offenders = applicationComponentFiles.filter((filePath) => {
+			const source = fs.readFileSync(filePath, "utf8");
+			return /<DropdownMenu(?:Checkbox|Radio)?Item\b[^>]*\bonSelect=/.test(
+				source,
+			);
+		});
+
+		expect(offenders).toEqual([]);
+	});
+
+	it("does not use Radix dropdown CSS variables at application call sites", () => {
+		const offenders = applicationComponentFiles.filter((filePath) =>
+			/--radix-[a-z-]*dropdown/.test(fs.readFileSync(filePath, "utf8")),
+		);
+
+		expect(offenders).toEqual([]);
+	});
+
+	it("keeps header navigation free of manual view-transition routing", () => {
+		const headerSource = fs.readFileSync(
+			path.join(componentsRoot, "header", "TeamSwitcher.tsx"),
+			"utf8",
+		);
+
+		expect(headerSource).not.toMatch(
+			/startViewTransition|navigateWithViewTransition/,
+		);
+		expect(headerSource).toMatch(/href="\/internal"/);
+		expect(headerSource).toMatch(/href="\/contact"/);
+	});
+});

--- a/apps/web/src/components/header/HeaderClient.tsx
+++ b/apps/web/src/components/header/HeaderClient.tsx
@@ -143,7 +143,7 @@ export default function HeaderClient({
 					open={isMobileNavOpen}
 					onOpenChange={(open) => setIsMobileNavOpen(Boolean(open))}
 				>
-					<ButtonGroup className="h-8 items-stretch overflow-hidden rounded-2xl shadow-xs">
+					<ButtonGroup className="h-8 items-stretch overflow-hidden rounded-lg shadow-xs">
 						<Button asChild className="h-8 rounded-r-none px-4">
 							<Link href="/sign-up" prefetch={false}>
 								Sign Up
@@ -164,7 +164,7 @@ export default function HeaderClient({
 							</Button>
 						</DropdownMenuTrigger>
 					</ButtonGroup>
-					<DropdownMenuContent align="end" className="w-48 rounded-xl p-1">
+					<DropdownMenuContent align="end" className="w-48 rounded-lg p-1">
 						{navLinks.map(({ href, label, icon: Icon }) => {
 							const isActive =
 								pathname === href || pathname.startsWith(href + "/");
@@ -173,7 +173,7 @@ export default function HeaderClient({
 									key={href}
 									asChild
 									className={cn(
-										"rounded-md py-2 text-sm",
+										"rounded-lg py-2 text-sm",
 										isActive && "font-semibold text-primary"
 									)}
 								>
@@ -184,7 +184,7 @@ export default function HeaderClient({
 								</DropdownMenuItem>
 							);
 						})}
-						<DropdownMenuItem asChild className="rounded-md py-2 text-sm">
+						<DropdownMenuItem asChild className="rounded-lg py-2 text-sm">
 							<Link
 								href={docsHref}
 								target="_blank"
@@ -258,10 +258,10 @@ export default function HeaderClient({
 						<CurrentUserAvatar user={user} />
 					</Button>
 				</DropdownMenuTrigger>
-					<DropdownMenuContent align="end" className="w-56">
+					<DropdownMenuContent align="end" className="w-56 rounded-lg">
 						{(userRole === "editor" || userRole === "admin") && (
 							<>
-								<DropdownMenuItem asChild className="cursor-pointer text-sm">
+								<DropdownMenuItem asChild className="cursor-pointer rounded-lg text-sm">
 									<Link href="/internal" prefetch={false}>
 										<Lock className="h-4 w-4" />
 										<span>Internal</span>
@@ -283,7 +283,7 @@ export default function HeaderClient({
 										<button
 											type="button"
 											className={cn(
-												"relative flex min-h-7 w-full cursor-pointer select-none items-center gap-2 rounded-xl px-2 py-1.5 text-left text-sm outline-hidden transition-colors",
+												"relative flex min-h-7 w-full cursor-pointer select-none items-center gap-2 rounded-lg px-2 py-1.5 text-left text-sm outline-hidden transition-colors",
 												"hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground",
 												isMobileTeamDialogOpen && "bg-accent text-accent-foreground",
 											)}
@@ -304,7 +304,7 @@ export default function HeaderClient({
 										side="bottom"
 										align="start"
 										sideOffset={6}
-										className="w-56 gap-0 rounded-2xl p-1"
+										className="w-56 gap-0 rounded-lg p-1"
 									>
 										{teams.slice(0, 5).map((team) => {
 											const isActive = team.id === activeWorkspaceId;
@@ -313,7 +313,7 @@ export default function HeaderClient({
 													key={team.id}
 													type="button"
 													className={cn(
-														"flex min-h-7 w-full cursor-pointer select-none items-center gap-2 rounded-xl px-2 py-1.5 text-sm outline-hidden transition-colors",
+														"flex min-h-7 w-full cursor-pointer select-none items-center gap-2 rounded-lg px-2 py-1.5 text-sm outline-hidden transition-colors",
 														"hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground",
 														isActive && "bg-accent text-accent-foreground",
 													)}
@@ -340,7 +340,7 @@ export default function HeaderClient({
 											href="/settings/workspaces/settings"
 											prefetch={false}
 											className={cn(
-												"flex min-h-7 w-full cursor-pointer select-none items-center gap-2 rounded-xl px-2 py-1.5 text-sm outline-hidden transition-colors",
+												"flex min-h-7 w-full cursor-pointer select-none items-center gap-2 rounded-lg px-2 py-1.5 text-sm outline-hidden transition-colors",
 												"hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground",
 											)}
 											onClick={() => setIsMobileTeamDialogOpen(false)}
@@ -362,7 +362,7 @@ export default function HeaderClient({
 								key={href}
 								asChild
 								className={cn(
-									"cursor-pointer text-sm",
+									"cursor-pointer rounded-lg text-sm",
 									isActive && "bg-accent font-medium text-accent-foreground",
 								)}
 							>
@@ -378,21 +378,21 @@ export default function HeaderClient({
 
 					{isLoggedIn ? (
 						<>
-							<DropdownMenuItem asChild className="cursor-pointer text-sm">
+							<DropdownMenuItem asChild className="cursor-pointer rounded-lg text-sm">
 								<Link href="/experiments" prefetch={false}>
 									<FlaskConical className="h-4 w-4" />
 									<span>Experiments</span>
 								</Link>
 							</DropdownMenuItem>
 
-							<DropdownMenuItem asChild className="cursor-pointer text-sm">
+							<DropdownMenuItem asChild className="cursor-pointer rounded-lg text-sm">
 								<Link href="/settings/workspaces/settings" prefetch={false}>
 									<Users className="h-4 w-4" />
 									<span>Workspaces</span>
 								</Link>
 							</DropdownMenuItem>
 
-								<DropdownMenuItem asChild className="cursor-pointer text-sm">
+								<DropdownMenuItem asChild className="cursor-pointer rounded-lg text-sm">
 									<Link href="/settings/account" prefetch={false}>
 										<Settings className="h-4 w-4" />
 									<span>Settings</span>
@@ -401,7 +401,7 @@ export default function HeaderClient({
 
 							<DropdownMenuSeparator />
 
-							<DropdownMenuItem asChild className="cursor-pointer text-sm">
+							<DropdownMenuItem asChild className="cursor-pointer rounded-lg text-sm">
 								<Link
 									href={`/settings/usage?workspace_id=${encodeURIComponent(
 										activeWorkspaceId ?? "",
@@ -412,19 +412,19 @@ export default function HeaderClient({
 									<span>Usage</span>
 								</Link>
 							</DropdownMenuItem>
-							<DropdownMenuItem asChild className="cursor-pointer text-sm">
+							<DropdownMenuItem asChild className="cursor-pointer rounded-lg text-sm">
 								<Link href="/settings/credits" prefetch={false}>
 									<CreditCard className="h-4 w-4" />
 									<span>Credits</span>
 								</Link>
 							</DropdownMenuItem>
-							<DropdownMenuItem asChild className="cursor-pointer text-sm">
+							<DropdownMenuItem asChild className="cursor-pointer rounded-lg text-sm">
 								<Link href="/settings/keys" prefetch={false}>
 									<KeyIcon className="h-4 w-4" />
 									<span>Keys</span>
 								</Link>
 							</DropdownMenuItem>
-								<DropdownMenuItem asChild className="cursor-pointer text-sm">
+								<DropdownMenuItem asChild className="cursor-pointer rounded-lg text-sm">
 									<Link href="/contact" prefetch={false}>
 										<LifeBuoy className="h-4 w-4" />
 										<span className="flex min-w-0 flex-1 items-center justify-between gap-3">
@@ -449,7 +449,7 @@ export default function HeaderClient({
 										</span>
 									</Link>
 								</DropdownMenuItem>
-								<DropdownMenuItem asChild className="cursor-pointer text-sm">
+								<DropdownMenuItem asChild className="cursor-pointer rounded-lg text-sm">
 									<Link href={docsHref} target="_blank" rel="noreferrer">
 										<BookOpenText className="h-4 w-4" />
 										<span>Docs</span>
@@ -462,7 +462,7 @@ export default function HeaderClient({
 									<div
 										role="radiogroup"
 										aria-label="Theme mode"
-										className="inline-flex w-full items-center justify-center gap-1 rounded-xl bg-muted/60 p-0.5"
+										className="inline-flex w-full items-center justify-center gap-1 rounded-lg bg-muted/60 p-0.5"
 									>
 										{(["light", "dark", "system"] as const).map((mode) => {
 											const Icon = themeMeta[mode].icon;
@@ -476,7 +476,7 @@ export default function HeaderClient({
 													aria-label={`Set theme: ${themeMeta[mode].label}`}
 													onClick={() => setTheme(mode)}
 													className={cn(
-														"relative flex h-7 flex-1 items-center justify-center rounded-lg text-muted-foreground transition-colors",
+														"relative flex h-7 flex-1 items-center justify-center rounded-md text-muted-foreground transition-colors",
 														"hover:bg-background hover:text-foreground",
 														selected
 															? "bg-background text-foreground shadow-xs"
@@ -495,9 +495,8 @@ export default function HeaderClient({
 
 								<DropdownMenuItem
 									variant="destructive"
-									className="cursor-pointer text-sm"
-								onClick={(event) => {
-									event.preventDefault();
+									className="cursor-pointer rounded-lg text-sm"
+								onClick={() => {
 									void handleSignOut();
 								}}
 							>
@@ -507,7 +506,7 @@ export default function HeaderClient({
 						</>
 					) : (
 						<>
-							<DropdownMenuItem asChild className="cursor-pointer text-sm">
+							<DropdownMenuItem asChild className="cursor-pointer rounded-lg text-sm">
 								<Link href="/sign-up" prefetch={false}>
 									Sign Up
 								</Link>
@@ -517,7 +516,7 @@ export default function HeaderClient({
 								<div
 									role="radiogroup"
 									aria-label="Theme mode"
-									className="inline-flex w-full items-center justify-center gap-1 rounded-xl bg-muted/60 p-0.5"
+									className="inline-flex w-full items-center justify-center gap-1 rounded-lg bg-muted/60 p-0.5"
 								>
 									{(["light", "dark", "system"] as const).map((mode) => {
 										const Icon = themeMeta[mode].icon;
@@ -531,7 +530,7 @@ export default function HeaderClient({
 												aria-label={`Set theme: ${themeMeta[mode].label}`}
 												onClick={() => setTheme(mode)}
 												className={cn(
-													"relative flex h-7 flex-1 items-center justify-center rounded-lg text-muted-foreground transition-colors",
+													"relative flex h-7 flex-1 items-center justify-center rounded-md text-muted-foreground transition-colors",
 													"hover:bg-background hover:text-foreground",
 													selected
 														? "bg-background text-foreground shadow-xs"

--- a/apps/web/src/components/header/TeamSwitcher.tsx
+++ b/apps/web/src/components/header/TeamSwitcher.tsx
@@ -1,7 +1,7 @@
 // components/header/TeamSwitcher.tsx (CLIENT)
 "use client";
 
-import React, { useEffect, useState } from "react";
+import { useEffect, useState } from "react";
 import { usePathname, useRouter } from "next/navigation";
 import Link from "next/link";
 import {
@@ -53,24 +53,6 @@ export default function TeamSwitcher({
 	const router = useRouter();
 	const pathname = usePathname();
 	const { theme, setTheme } = useTheme();
-
-	const navigateWithViewTransition = React.useCallback(
-		(href: string) => {
-			const doc = document as Document & {
-				startViewTransition?: (
-					updateCallback: () => void | Promise<void>,
-				) => unknown;
-			};
-			if (typeof doc.startViewTransition === "function") {
-				doc.startViewTransition(() => {
-					router.push(href);
-				});
-				return;
-			}
-			router.push(href);
-		},
-		[router],
-	);
 
 	const getInitialTeamId = (initial?: string) => {
 		if (initial) return initial;
@@ -148,7 +130,7 @@ export default function TeamSwitcher({
 
 				<DropdownMenuContent
 					align="end"
-					className="w-56"
+					className="w-56 rounded-lg"
 				>
 					<div>
 						{teams.slice(0, 5).map((t) => {
@@ -157,11 +139,11 @@ export default function TeamSwitcher({
 								<DropdownMenuItem
 									key={t.id}
 									className={cn(
-										"cursor-pointer",
+										"cursor-pointer rounded-lg",
 										isActive && "bg-accent text-accent-foreground"
 									)}
-									onSelect={(e) => {
-										e.preventDefault();
+									closeOnClick={!isActive}
+									onClick={() => {
 										if (isActive) {
 											if (
 												typeof navigator === "undefined" ||
@@ -229,16 +211,11 @@ export default function TeamSwitcher({
 						) : null}
 						<DropdownMenuItem
 							asChild
-							className="cursor-pointer"
+							className="cursor-pointer rounded-lg"
 						>
 							<Link
 								href="/settings/workspaces/settings"
 								className="flex w-full items-center"
-								onClick={(e) => {
-									e.preventDefault();
-									setIsTeamMenuOpen(false);
-									navigateWithViewTransition("/settings/workspaces/settings");
-								}}
 							>
 								<Users className="mr-2 h-4 w-4" />
 								<span>Manage Workspaces</span>
@@ -272,22 +249,17 @@ export default function TeamSwitcher({
 
 				<DropdownMenuContent
 					align="end"
-					className="w-56"
+					className="w-56 rounded-lg"
 				>
 					{/* Editor access for editors and admins */}
 					{(userRole === "editor" || userRole === "admin") && (
 						<>
 							<DropdownMenuItem
 								asChild
-								className="cursor-pointer"
+								className="cursor-pointer rounded-lg"
 							>
 								<Link
 									href="/internal"
-									onClick={(e) => {
-										e.preventDefault();
-										setIsProfileMenuOpen(false);
-										navigateWithViewTransition("/internal");
-									}}
 								>
 									<Lock className="h-4 w-4" />
 									<span>Internal</span>
@@ -305,7 +277,7 @@ export default function TeamSwitcher({
 							<div
 								role="radiogroup"
 								aria-label="Theme mode"
-								className="inline-flex flex-1 items-center justify-center gap-1 rounded-xl bg-muted/60 p-0.5"
+								className="inline-flex flex-1 items-center justify-center gap-1 rounded-lg bg-muted/60 p-0.5"
 							>
 								{(["light", "dark", "system"] as const).map((mode) => {
 									const Icon = themeMeta[mode].icon;
@@ -319,7 +291,7 @@ export default function TeamSwitcher({
 											aria-label={`Set theme: ${themeMeta[mode].label}`}
 											onClick={() => setTheme(mode)}
 											className={cn(
-												"relative flex h-7 flex-1 items-center justify-center rounded-lg text-muted-foreground transition-colors",
+												"relative flex h-7 flex-1 items-center justify-center rounded-md text-muted-foreground transition-colors",
 												"hover:bg-background hover:text-foreground",
 												selected
 													? "bg-background text-foreground shadow-xs"
@@ -339,15 +311,10 @@ export default function TeamSwitcher({
 
 					<DropdownMenuItem
 						asChild
-						className="cursor-pointer"
+						className="cursor-pointer rounded-lg"
 					>
 						<Link
 							href="/experiments"
-							onClick={(e) => {
-								e.preventDefault();
-								setIsProfileMenuOpen(false);
-								navigateWithViewTransition("/experiments");
-							}}
 						>
 							<FlaskConical className="h-4 w-4" />
 							<span>Experiments</span>
@@ -356,15 +323,10 @@ export default function TeamSwitcher({
 
 					<DropdownMenuItem
 						asChild
-						className="cursor-pointer"
+						className="cursor-pointer rounded-lg"
 					>
 						<Link
 							href="/settings/workspaces/settings"
-							onClick={(e) => {
-								e.preventDefault();
-								setIsProfileMenuOpen(false);
-								navigateWithViewTransition("/settings/workspaces/settings");
-							}}
 						>
 							<Users className="h-4 w-4" />
 							<span>Workspaces</span>
@@ -373,15 +335,10 @@ export default function TeamSwitcher({
 
 					<DropdownMenuItem
 						asChild
-						className="cursor-pointer"
+						className="cursor-pointer rounded-lg"
 					>
 						<Link
 							href="/settings/account"
-							onClick={(e) => {
-								e.preventDefault();
-								setIsProfileMenuOpen(false);
-								navigateWithViewTransition("/settings/account");
-							}}
 						>
 							<Settings className="h-4 w-4" />
 							<span>Settings</span>
@@ -392,21 +349,12 @@ export default function TeamSwitcher({
 
 					<DropdownMenuItem
 						asChild
-						className="cursor-pointer"
+						className="cursor-pointer rounded-lg"
 					>
 						<Link
 							href={`/settings/usage?workspace_id=${encodeURIComponent(
 								activeWorkspaceId ?? "",
 							)}`}
-							onClick={(e) => {
-								e.preventDefault();
-								setIsProfileMenuOpen(false);
-								navigateWithViewTransition(
-									`/settings/usage?workspace_id=${encodeURIComponent(
-										activeWorkspaceId ?? "",
-									)}`,
-								);
-							}}
 						>
 							<BarChart2 className="h-4 w-4" />
 							<span>Usage</span>
@@ -415,15 +363,10 @@ export default function TeamSwitcher({
 
 					<DropdownMenuItem
 						asChild
-						className="cursor-pointer"
+						className="cursor-pointer rounded-lg"
 					>
 						<Link
 							href="/settings/credits"
-							onClick={(e) => {
-								e.preventDefault();
-								setIsProfileMenuOpen(false);
-								navigateWithViewTransition("/settings/credits");
-							}}
 						>
 							<CreditCard className="h-4 w-4" />
 							<span>Credits</span>
@@ -432,30 +375,18 @@ export default function TeamSwitcher({
 
 					<DropdownMenuItem
 						asChild
-						className="cursor-pointer"
+						className="cursor-pointer rounded-lg"
 					>
 						<Link
 							href="/settings/keys"
-							onClick={(e) => {
-								e.preventDefault();
-								setIsProfileMenuOpen(false);
-								navigateWithViewTransition("/settings/keys");
-							}}
 						>
 							<KeyIcon className="h-4 w-4" />
 							<span>Keys</span>
 						</Link>
 					</DropdownMenuItem>
 
-					<DropdownMenuItem
-						className="cursor-pointer"
-						onSelect={(e) => {
-							e.preventDefault();
-							setIsProfileMenuOpen(false);
-							navigateWithViewTransition("/contact");
-						}}
-					>
-						<div className="flex w-full items-center justify-between">
+					<DropdownMenuItem asChild className="cursor-pointer rounded-lg">
+						<Link href="/contact" className="flex w-full items-center justify-between">
 							<div className="flex items-center gap-2">
 								<LifeBuoy className="h-4 w-4" />
 								<span>Support</span>
@@ -486,16 +417,15 @@ export default function TeamSwitcher({
 									}`}
 								></span>
 							</span>
-						</div>
+						</Link>
 					</DropdownMenuItem>
 
 					<DropdownMenuSeparator />
 
 					<DropdownMenuItem
 						variant="destructive"
-						className="cursor-pointer"
-						onClick={(e) => {
-							e.preventDefault();
+						className="cursor-pointer rounded-lg"
+						onClick={() => {
 							setIsProfileMenuOpen(false);
 							onSignOut?.();
 						}}
@@ -508,4 +438,3 @@ export default function TeamSwitcher({
 		</div>
 	);
 }
-

--- a/apps/web/src/components/landingPage/Home/HomeOpenSourceSection.tsx
+++ b/apps/web/src/components/landingPage/Home/HomeOpenSourceSection.tsx
@@ -467,12 +467,12 @@ function FirstPromptCodeBlock({
 									<ChevronDown className="h-3.5 w-3.5" />
 								</button>
 							</DropdownMenuTrigger>
-							<DropdownMenuContent align="start" className="min-w-40">
+							<DropdownMenuContent align="start" className="min-w-40 rounded-lg">
 								{MORE_SNIPPETS.map((snippet) => (
 									<DropdownMenuItem
 										key={snippet.id}
-										onSelect={() => onSelectSnippet(snippet.id)}
-										className="gap-2"
+										onClick={() => onSelectSnippet(snippet.id)}
+										className="gap-2 rounded-lg"
 									>
 										<SnippetIcon id={snippet.id} />
 										<span>{snippet.label}</span>
@@ -879,4 +879,3 @@ export default function HomeOpenSourceSection({
 		</section>
 	);
 }
-


### PR DESCRIPTION
## Summary

- replace remaining Radix-style `onSelect` handlers on application dropdown items with Base UI `onClick` semantics
- keep multi-select and copy menus open with Base UI's `closeOnClick={false}`
- remove the remaining manual view-transition routing from the desktop header and use normal Next links
- repair Support, Internal, workspace, model, pricing, calendar, quick-start, ranking and key-management dropdown actions
- replace the remaining Radix dropdown width variable with Base UI's `--anchor-width`
- align affected dropdown panels and rows to the existing 8px rectangular style while keeping avatar and icon-only controls rounded
- add a migration guard covering stale dropdown events, Radix variables and header view-transition routing

## Root cause

The Base UI migration left Radix's `onSelect` prop on a number of menu items. That prop still type-checked as a native DOM selection event but did not run when a Base UI menu item was activated. The desktop header also manually closed its controlled modal menu while starting a view-transition route change, which could leave the persistent header in a non-interactive state.

## Scope

No file under `apps/web/src/components/ui` is changed. Existing per-menu widths and intentional call-site overrides remain intact.

## Validation

- `pnpm --filter @phaseo/web exec next typegen`
- `pnpm --filter @phaseo/web typecheck`
- `pnpm --filter @phaseo/web test -- dropdownMenuMigration.test.ts` — 3 tests passed
- ESLint across all changed source files — 0 errors; 22 pre-existing warnings
- full web Jest suite — 111 suites and 547 tests passed; the unrelated `pricingCatalogIntegrity.test.ts` GPT-5.6 Sol assertion remains failing on current `main`
- `git diff --check`

Created with Codex