### PR TITLE
fix(data): close late MiniMax H3 pricing review gaps

### DIFF
--- a/apps/web/scripts/importer/v2.test.ts
+++ b/apps/web/scripts/importer/v2.test.ts
@@ -196,6 +196,13 @@ describe("validateJsonPricingRules", () => {
             { ...baseRule, source_key: "correct", price_per_unit: 37.5 },
         ])).toThrow("Conflicting JSON pricing rates");
     });
+
+    it("rejects conflicting included quantities for the same offer and meter", () => {
+        expect(() => validateJsonPricingRules([
+            { ...baseRule, source_key: "five-free", price_per_unit: 0.04, included_quantity: 5 },
+            { ...baseRule, source_key: "no-allowance", price_per_unit: 0.04, included_quantity: 0 },
+        ])).toThrow("Conflicting JSON pricing rates");
+    });
 });
 
 describe("v2PricingMeterMetadata", () => {

--- a/apps/web/scripts/importer/v2.test.ts
+++ b/apps/web/scripts/importer/v2.test.ts
@@ -11,6 +11,7 @@ import {
     pricingModelPart,
     v2RouteModelSlug,
     v2RouteExecutionRegions,
+    v2PricingMeterMetadata,
     validateJsonPricingRules,
     routeStatus,
     staleJsonProviderRouteIds,
@@ -194,6 +195,23 @@ describe("validateJsonPricingRules", () => {
             { ...baseRule, source_key: "wrong", price_per_unit: 2 },
             { ...baseRule, source_key: "correct", price_per_unit: 37.5 },
         ])).toThrow("Conflicting JSON pricing rates");
+    });
+});
+
+describe("v2PricingMeterMetadata", () => {
+    it("preserves an authored included quantity for pricing imports", () => {
+        expect(v2PricingMeterMetadata({
+            rule_id: "minimax-h3-input-images",
+            included_quantity: 5,
+        })).toEqual(expect.objectContaining({
+            source: "json",
+            included_quantity: 5,
+        }));
+    });
+
+    it("does not invent an allowance when none is authored", () => {
+        expect(v2PricingMeterMetadata({ rule_id: "meter-without-allowance" }))
+            .not.toHaveProperty("included_quantity");
     });
 });
 

--- a/apps/web/scripts/importer/v2.ts
+++ b/apps/web/scripts/importer/v2.ts
@@ -110,6 +110,7 @@ export function validateJsonPricingRules(rules: Record<string, any>[]): void {
             unit: rule.unit ?? "unit",
             unit_size: Number(rule.unit_size ?? 1),
             price_per_unit: Number(rule.price_per_unit ?? 0),
+            included_quantity: Number(rule.included_quantity ?? 0),
         };
         const previous = rates.get(identity);
         if (previous && stableJson(previous.comparable) !== stableJson(comparable)) {
@@ -1177,7 +1178,15 @@ export async function syncV2Catalogue(): Promise<void> {
         };
         const meterIdentity = `${row.sku_id}:${row.meter_key}`;
         const previous = meterRowsByKey.get(meterIdentity);
-        if (previous && stableJson({ ...previous, metadata: undefined }) !== stableJson({ ...row, metadata: undefined })) {
+        const comparableRow = {
+            ...row,
+            metadata: { included_quantity: row.metadata.included_quantity ?? 0 },
+        };
+        const comparablePrevious = previous ? {
+            ...previous,
+            metadata: { included_quantity: previous.metadata?.included_quantity ?? 0 },
+        } : null;
+        if (comparablePrevious && stableJson(comparablePrevious) !== stableJson(comparableRow)) {
             throw new Error(
                 `Conflicting JSON pricing rates for ${meterIdentity}: ${String(previous.metadata?.source_key)} and ${String(row.metadata.source_key)}`,
             );

--- a/apps/web/scripts/importer/v2.ts
+++ b/apps/web/scripts/importer/v2.ts
@@ -121,6 +121,20 @@ export function validateJsonPricingRules(rules: Record<string, any>[]): void {
     }
 }
 
+export function v2PricingMeterMetadata(rule: Record<string, any>): Record<string, any> {
+    return {
+        source: "json",
+        source_key: rule.source_key ?? rule.rule_id,
+        note: rule.note ?? null,
+        priority: rule.priority ?? 100,
+        billing_timestamp_basis: rule.billing_timestamp_basis ?? "request_start",
+        time_windows: rule.time_windows ?? [],
+        ...(rule.included_quantity === undefined
+            ? {}
+            : { included_quantity: Number(rule.included_quantity) }),
+    };
+}
+
 export function isFreeModelVariant(value: unknown): boolean {
     return String(value ?? "").trim().toLowerCase().endsWith(":free");
 }
@@ -1159,14 +1173,7 @@ export async function syncV2Catalogue(): Promise<void> {
             price_nanos: Number(rule.price_per_unit ?? 0) * 1_000_000_000,
             display_label: meter,
             display_unit: `${rule.unit_size ?? 1} ${rule.unit ?? "unit"}`,
-            metadata: {
-                source: "json",
-                source_key: rule.source_key ?? rule.rule_id,
-                note: rule.note ?? null,
-                priority: rule.priority ?? 100,
-                billing_timestamp_basis: rule.billing_timestamp_basis ?? "request_start",
-                time_windows: rule.time_windows ?? [],
-            },
+            metadata: v2PricingMeterMetadata(rule),
         };
         const meterIdentity = `${row.sku_id}:${row.meter_key}`;
         const previous = meterRowsByKey.get(meterIdentity);

--- a/apps/web/scripts/importer/v2.ts
+++ b/apps/web/scripts/importer/v2.ts
@@ -1188,7 +1188,7 @@ export async function syncV2Catalogue(): Promise<void> {
         } : null;
         if (comparablePrevious && stableJson(comparablePrevious) !== stableJson(comparableRow)) {
             throw new Error(
-                `Conflicting JSON pricing rates for ${meterIdentity}: ${String(previous.metadata?.source_key)} and ${String(row.metadata.source_key)}`,
+                `Conflicting JSON pricing rates for ${meterIdentity}: ${String(previous?.metadata?.source_key)} and ${String(row.metadata.source_key)}`,
             );
         }
         meterRowsByKey.set(meterIdentity, row);

--- a/supabase/migrations/20260731120000_fix_gpt_transcribe_route_and_h3_allowance.sql
+++ b/supabase/migrations/20260731120000_fix_gpt_transcribe_route_and_h3_allowance.sql
@@ -1,0 +1,48 @@
+-- Repair catalogue projections introduced with GPT Transcribe and MiniMax H3.
+-- The importer now preserves included_quantity; this migration also repairs
+-- databases before their next catalogue sync.
+
+insert into public.v2_route_variants (
+  provider_model_id, variant_key, service_tier_slug, status,
+  routing_enabled, endpoint_label, metadata
+)
+select
+  route.provider_model_id,
+  'global:standard',
+  'standard',
+  route.status,
+  route.routing_enabled,
+  'Standard',
+  '{"source":"gpt_transcribe_route_fix"}'::jsonb
+from public.v2_model_provider_routes route
+where route.provider_model_id = 'openai:openai/gpt-transcribe'
+on conflict (provider_model_id, variant_key) do update set
+  service_tier_slug = excluded.service_tier_slug,
+  status = excluded.status,
+  routing_enabled = excluded.routing_enabled,
+  endpoint_label = excluded.endpoint_label,
+  metadata = public.v2_route_variants.metadata || excluded.metadata,
+  updated_at = now();
+
+update public.v2_pricing_skus sku
+set route_variant_id = variant.variant_id,
+    updated_at = now()
+from public.v2_route_variants variant
+where sku.provider_model_id = 'openai:openai/gpt-transcribe'
+  and variant.provider_model_id = sku.provider_model_id
+  and variant.variant_key = 'global:standard'
+  and variant.service_tier_slug = coalesce(sku.service_tier_slug, 'standard')
+  and sku.route_variant_id is distinct from variant.variant_id;
+
+update public.v2_pricing_sku_meters meter
+set metadata = jsonb_set(
+      coalesce(meter.metadata, '{}'::jsonb),
+      '{included_quantity}',
+      '5'::jsonb,
+      true
+    ),
+    updated_at = now()
+from public.v2_pricing_skus sku
+where meter.sku_id = sku.sku_id
+  and sku.provider_model_id = 'minimax:minimax/h3'
+  and meter.meter_key = 'input_image';


### PR DESCRIPTION
## Summary

- add the missing `global:standard` route variant for the GPT Transcribe pricing SKU
- relink GPT Transcribe pricing to that route variant for public catalogue projections
- preserve canonical `included_quantity` values when the V2 importer upserts pricing meters
- repair MiniMax H3's five included input images for databases already migrated
- add focused importer regression coverage

## Context

This addresses the two actionable review threads posted on #1333 while its merge-queue run was already in flight.

## Validation

- `git diff --check`
- focused source assertions for the route variant, SKU link, and H3 allowance
- importer regression tests added for present and absent `included_quantity` metadata
