### PR TITLE
fix(web): polish settings navigation and select labels

### DIFF
--- a/apps/web/src/app/(dashboard)/settings/layout.tsx
+++ b/apps/web/src/app/(dashboard)/settings/layout.tsx
@@ -47,7 +47,7 @@ export default async function SettingsLayout({
 		<>
 			<NoFooterStyle />
 
-			<SidebarProvider defaultOpen className="flex flex-1 min-h-0 [&_button:not([data-settings-segment])]:!rounded-lg [&_[data-slot=button]]:!rounded-lg">
+			<SidebarProvider defaultOpen className="flex h-[calc(100dvh-var(--site-header-height,3.75rem)-var(--site-notice-height,0px))] min-h-0 flex-1 overflow-hidden [&_button:not([data-settings-segment])]:!rounded-lg [&_[data-slot=button]]:!rounded-lg">
 				<Sidebar
 					collapsible="icon"
 					desktopClassName="hidden lg:block"
@@ -56,18 +56,16 @@ export default async function SettingsLayout({
 				>
 					<SettingsSidebar showBroadcast={showBroadcast} showWebhooks={showWebhooks} workspaceName={initialData.workspaceName} />
 				</Sidebar>
-				<SidebarInset className="w-0 min-w-0 bg-white dark:bg-zinc-950 flex flex-1 min-h-0 flex-col">
-					<div className="container mx-auto flex w-full flex-col gap-3 px-4 pb-4 pt-0 sm:px-5 lg:px-6 xl:px-8">
-						<div className="shrink-0">
-							<div>
-								<SettingsTopTabsServer
-									isEnterpriseInvoiceMode={isEnterpriseInvoiceMode}
-									showBroadcast={showBroadcast}
-									showWebhooks={showWebhooks}
-								/>
-							</div>
+				<SidebarInset className="flex w-0 min-h-0 min-w-0 flex-1 flex-col overflow-hidden bg-white dark:bg-zinc-950">
+					<div className="container mx-auto flex h-full min-h-0 w-full flex-col px-4 pt-0 sm:px-5 lg:px-6 xl:px-8">
+						<div className="relative z-20 shrink-0 bg-background">
+							<SettingsTopTabsServer
+								isEnterpriseInvoiceMode={isEnterpriseInvoiceMode}
+								showBroadcast={showBroadcast}
+								showWebhooks={showWebhooks}
+							/>
 						</div>
-						<div className="w-full pt-3">
+						<div className="min-h-0 w-full flex-1 overflow-y-auto overscroll-contain pb-4 pt-3">
 							<Suspense fallback={<SettingsPageSkeleton />}>
 								{children}
 							</Suspense>

--- a/apps/web/src/components/(gateway)/settings/SettingsSidebarTrigger.tsx
+++ b/apps/web/src/components/(gateway)/settings/SettingsSidebarTrigger.tsx
@@ -41,8 +41,8 @@ export default function SettingsSidebarTrigger({
 						className="w-full justify-between"
 						aria-haspopup="menu"
 					>
-						<span className="flex items-center gap-2 min-w-0">
-							<span className="truncate"><span className="text-muted-foreground">{activeScope === "personal" ? "My account" : "Workspace"}</span><span className="mx-1.5 text-muted-foreground/60">/</span>{activeItem?.label ?? "Settings"}</span>
+							<span className="flex min-w-0 items-center gap-2">
+								<span className="truncate">{activeItem?.label ?? "Settings"}</span>
 							{activeItem?.badge && (
 								<Badge
 									variant="outline"

--- a/apps/web/src/components/(gateway)/settings/SettingsTopTabsServer.tsx
+++ b/apps/web/src/components/(gateway)/settings/SettingsTopTabsServer.tsx
@@ -3,7 +3,7 @@
 import * as React from "react";
 import Link from "next/link";
 import { usePathname, useSearchParams } from "next/navigation";
-import { ChevronDown, ChevronRight, PanelLeftIcon } from "lucide-react";
+import { ChevronDown, PanelLeftIcon } from "lucide-react";
 
 import { cn } from "@/lib/utils";
 import { Badge } from "@/components/ui/badge";
@@ -208,7 +208,7 @@ export default function SettingsTopTabsServer({
 						return b.score!.len - a.score!.len;
 					})[0]?.t ?? tabs[0]
 			: null;
-	const mobileSectionLabel = `${activeNav?.group.scope === "personal" ? "My account" : "Workspace"} / ${activeNav?.item.label ?? "Settings"}`;
+	const mobileSectionLabel = activeNav?.group.scope === "personal" ? "My account" : "Workspace";
 
 	const setIndicatorToHref = React.useCallback((href: string | null) => {
 		const container = containerRef.current;
@@ -239,26 +239,27 @@ export default function SettingsTopTabsServer({
 		return (
 			<>
 				<SettingsSidebarTrigger showBroadcast={showBroadcast} showWebhooks={showWebhooks} />
-				<div className="hidden h-[52px] items-center gap-2 border-b border-border px-2 text-sm lg:flex">
-					<span className="font-medium text-muted-foreground">
-						{activeNav?.group.heading ?? "Settings"}
-					</span>
-					<ChevronRight
-						aria-hidden="true"
-						className="h-3.5 w-3.5 shrink-0 text-muted-foreground/70"
-					/>
-					<span className="font-semibold text-foreground">
-						{activeNav?.item.label ?? "Settings"}
-					</span>
-					{activeNav?.item.badge ? (
-						<Badge
-							variant="outline"
-							className="ml-2 h-5 px-1.5 text-[10px] capitalize"
-						>
-							{activeNav.item.badge}
-						</Badge>
-					) : null}
-				</div>
+				<nav
+					className="relative hidden h-[52px] items-end border-b border-border lg:flex"
+					aria-label="Settings section navigation"
+				>
+					<div
+						aria-current="page"
+						className="flex border-b-2 border-muted-foreground px-2 pb-2 text-sm font-medium text-primary"
+					>
+						<span className="flex items-center gap-2">
+							<span>{activeNav?.item.label ?? "Settings"}</span>
+							{activeNav?.item.badge ? (
+								<Badge
+									variant="outline"
+									className="h-5 px-1.5 text-[10px] capitalize"
+								>
+									{activeNav.item.badge}
+								</Badge>
+							) : null}
+						</span>
+					</div>
+				</nav>
 			</>
 		);
 	}
@@ -372,4 +373,3 @@ export default function SettingsTopTabsServer({
 		</>
 	);
 }
-

--- a/apps/web/src/components/(gateway)/settings/SettingsUi.contract.test.ts
+++ b/apps/web/src/components/(gateway)/settings/SettingsUi.contract.test.ts
@@ -1,0 +1,66 @@
+import fs from "node:fs";
+import path from "node:path";
+
+const webRoot = process.cwd();
+
+function readSource(relativePath: string): string {
+	return fs.readFileSync(path.join(webRoot, relativePath), "utf8");
+}
+
+describe("settings UI contracts", () => {
+	it("keeps the section navigation outside the scrollable settings pane", () => {
+		const layoutSource = readSource("src/app/(dashboard)/settings/layout.tsx");
+		const navigationPosition = layoutSource.indexOf("<SettingsTopTabsServer");
+		const scrollPanePosition = layoutSource.indexOf("overflow-y-auto");
+
+		expect(layoutSource).toContain(
+			"h-[calc(100dvh-var(--site-header-height,3.75rem)-var(--site-notice-height,0px))]",
+		);
+		expect(navigationPosition).toBeGreaterThan(-1);
+		expect(scrollPanePosition).toBeGreaterThan(navigationPosition);
+	});
+
+	it("renders pages without sibling navigation as a single active tab", () => {
+		const tabsSource = readSource(
+			"src/components/(gateway)/settings/SettingsTopTabsServer.tsx",
+		);
+
+		expect(tabsSource).not.toContain("ChevronRight");
+		expect(tabsSource).toContain('aria-current="page"');
+		expect(tabsSource).toContain("border-b-2 border-muted-foreground");
+	});
+
+	it("provides display-label collections for ID-backed settings selects", () => {
+		const expectedItemCollections: Record<string, string[]> = {
+			"src/components/(gateway)/settings/account/AccountSettingsClient.tsx": [
+				"items={teams.map",
+			],
+			"src/components/(gateway)/settings/routing/DynamicRoutesStudio.tsx": [
+				"items={options}",
+				"items={items}",
+			],
+			"src/components/(gateway)/settings/routing/RoutingSettingsClient.tsx": [
+				"items={ROUTING_OPTIONS}",
+				"items={RESPONSE_HEALING_OPTIONS}",
+			],
+			"src/components/(gateway)/usage/UsageHeader/UsageHeader.tsx": [
+				"items={RANGE_ITEMS}",
+			],
+			"src/components/(gateway)/usage/UsageTableFilters.tsx": [
+				"items={modelFilterItems}",
+				"items={providerFilterItems}",
+				"items={keyFilterItems}",
+				"items={STATUS_FILTER_ITEMS}",
+			],
+		};
+
+		for (const [relativePath, collections] of Object.entries(
+			expectedItemCollections,
+		)) {
+			const source = readSource(relativePath);
+			for (const collection of collections) {
+				expect(source).toContain(collection);
+			}
+		}
+	});
+});

--- a/apps/web/src/components/(gateway)/settings/account/AccountSettingsClient.tsx
+++ b/apps/web/src/components/(gateway)/settings/account/AccountSettingsClient.tsx
@@ -416,6 +416,7 @@ export default function AccountSettingsClient({
 								{teams && teams.length > 0 ? (
 									<Select
 										value={defaultWorkspaceId ?? ""}
+										items={teams.map((team) => ({ value: team.id, label: team.name }))}
 										onValueChange={(v) => setDefaultTeamId(v || null)}
 									>
 										<SelectTrigger id="defaultTeam" className="w-full">
@@ -423,7 +424,7 @@ export default function AccountSettingsClient({
 										</SelectTrigger>
 										<SelectContent>
 											{teams.map((t) => (
-												<SelectItem key={t.id} value={t.id}>
+												<SelectItem key={t.id} value={t.id} label={t.name}>
 													{t.name}
 												</SelectItem>
 											))}

--- a/apps/web/src/components/(gateway)/settings/routing/DynamicRoutesStudio.tsx
+++ b/apps/web/src/components/(gateway)/settings/routing/DynamicRoutesStudio.tsx
@@ -246,14 +246,53 @@ function getProviderLogoId(providerId: string): string {
 	return normalized.includes("bedrock") ? "amazon-bedrock" : normalized || "phaseo";
 }
 
+
 function StudioSelect({ value, onChange, options, ariaLabel }: { value: string; onChange: (value: string) => void; options: Array<{ value: string; label: string }>; ariaLabel: string }) {
 	const selectedLabel = options.find((option) => option.value === value)?.label ?? value;
-	return <Select value={value} onValueChange={onChange}><SelectTrigger aria-label={ariaLabel} className="h-9 w-full rounded-md border border-input bg-background"><SelectValue>{selectedLabel}</SelectValue></SelectTrigger><SelectContent align="start">{options.map((option) => <SelectItem key={option.value} value={option.value}>{option.label}</SelectItem>)}</SelectContent></Select>;
+	return (
+		<Select value={value} items={options} onValueChange={onChange}>
+			<SelectTrigger aria-label={ariaLabel} className="h-9 w-full rounded-md border border-input bg-background">
+				<SelectValue>{selectedLabel}</SelectValue>
+			</SelectTrigger>
+			<SelectContent align="start">
+				{options.map((option) => (
+					<SelectItem key={option.value} value={option.value} label={option.label}>
+						{option.label}
+					</SelectItem>
+				))}
+			</SelectContent>
+		</Select>
+	);
 }
 
 function ProviderSelect({ value, onChange, providers }: { value: string; onChange: (value: string) => void; providers: Provider[] }) {
 	const selected = providers.find((provider) => provider.id === value);
-	return <Select value={value} onValueChange={onChange}><SelectTrigger aria-label="Preferred provider" className="h-9 w-full rounded-md border border-input bg-background"><SelectValue><span className="flex min-w-0 items-center gap-2">{selected ? <Logo id={getProviderLogoId(selected.id)} alt={selected.name} width={16} height={16} className="size-4 shrink-0 object-contain" /> : <Route className="size-4 shrink-0 text-muted-foreground" />}<span className="truncate">{selected?.name ?? "Any eligible provider"}</span></span></SelectValue></SelectTrigger><SelectContent align="start"><SelectItem value="__any__"><span className="flex items-center gap-2"><Route className="size-4 text-muted-foreground" />Any eligible provider</span></SelectItem>{providers.map((provider) => <SelectItem key={provider.id} value={provider.id}><span className="flex items-center gap-2"><Logo id={getProviderLogoId(provider.id)} alt={provider.name} width={16} height={16} className="size-4 shrink-0 object-contain" />{provider.name}</span></SelectItem>)}</SelectContent></Select>;
+	const items = [
+		{ value: "__any__", label: "Any eligible provider" },
+		...providers.map((provider) => ({ value: provider.id, label: provider.name })),
+	];
+	return (
+		<Select value={value} items={items} onValueChange={onChange}>
+			<SelectTrigger aria-label="Preferred provider" className="h-9 w-full rounded-md border border-input bg-background">
+				<SelectValue>
+					<span className="flex min-w-0 items-center gap-2">
+						{selected ? <Logo id={getProviderLogoId(selected.id)} alt={selected.name} width={16} height={16} className="size-4 shrink-0 object-contain" /> : <Route className="size-4 shrink-0 text-muted-foreground" />}
+						<span className="truncate">{selected?.name ?? "Any eligible provider"}</span>
+					</span>
+				</SelectValue>
+			</SelectTrigger>
+			<SelectContent align="start">
+				<SelectItem value="__any__" label="Any eligible provider">
+					<span className="flex items-center gap-2"><Route className="size-4 text-muted-foreground" />Any eligible provider</span>
+				</SelectItem>
+				{providers.map((provider) => (
+					<SelectItem key={provider.id} value={provider.id} label={provider.name}>
+						<span className="flex items-center gap-2"><Logo id={getProviderLogoId(provider.id)} alt={provider.name} width={16} height={16} className="size-4 shrink-0 object-contain" />{provider.name}</span>
+					</SelectItem>
+				))}
+			</SelectContent>
+		</Select>
+	);
 }
 
 function GatewayModelCombobox({ value, onChange, options, excludedIds = [], requiredCapabilities = [], ariaLabel, loading, error }: { value: string; onChange: (value: string) => void; options: RoutingModelOption[]; excludedIds?: string[]; requiredCapabilities?: string[]; ariaLabel: string; loading: boolean; error: boolean }) {

--- a/apps/web/src/components/(gateway)/settings/routing/RoutingSettingsClient.tsx
+++ b/apps/web/src/components/(gateway)/settings/routing/RoutingSettingsClient.tsx
@@ -52,6 +52,11 @@ const ROUTING_OPTIONS: RoutingOption[] = [
 	},
 ];
 
+const RESPONSE_HEALING_OPTIONS = [
+	{ value: "safe", label: "Safe" },
+	{ value: "strict", label: "Strict" },
+] as const;
+
 type Props = {
 	initialMode?: RoutingMode | null;
 	initialBetaChannelEnabled?: boolean;
@@ -296,6 +301,7 @@ export default function RoutingSettingsClient({
 					</label>
 					<Select
 						value={mode}
+						items={ROUTING_OPTIONS}
 						onValueChange={(value) => setMode(value as RoutingMode)}
 					>
 						<SelectTrigger id="routing-mode" className="max-w-sm">
@@ -303,7 +309,11 @@ export default function RoutingSettingsClient({
 						</SelectTrigger>
 						<SelectContent>
 							{ROUTING_OPTIONS.map((option) => (
-								<SelectItem key={option.value} value={option.value}>
+								<SelectItem
+									key={option.value}
+									value={option.value}
+									label={option.label}
+								>
 									{option.label}
 								</SelectItem>
 							))}
@@ -377,6 +387,7 @@ export default function RoutingSettingsClient({
 					<div className="space-y-2 rounded-lg border bg-muted/20 px-3 py-2">
 						<Select
 							value={responseHealingMode}
+							items={RESPONSE_HEALING_OPTIONS}
 							onValueChange={(value) =>
 								setResponseHealingMode(value as "safe" | "strict")
 							}
@@ -385,8 +396,15 @@ export default function RoutingSettingsClient({
 								<SelectValue placeholder="Select a healing mode" />
 							</SelectTrigger>
 							<SelectContent>
-								<SelectItem value="safe">Safe</SelectItem>
-								<SelectItem value="strict">Strict</SelectItem>
+								{RESPONSE_HEALING_OPTIONS.map((option) => (
+									<SelectItem
+										key={option.value}
+										value={option.value}
+										label={option.label}
+									>
+										{option.label}
+									</SelectItem>
+								))}
 							</SelectContent>
 						</Select>
 						<p className="text-xs text-muted-foreground">

--- a/apps/web/src/components/(gateway)/usage/UsageHeader/UsageHeader.tsx
+++ b/apps/web/src/components/(gateway)/usage/UsageHeader/UsageHeader.tsx
@@ -36,6 +36,14 @@ import { revalidateUsage } from "@/app/(dashboard)/gateway/usage/actions";
 type RangeKey = "1h" | "1d" | "1w" | "1m" | "1y";
 type GroupBy = "model" | "key";
 
+const RANGE_ITEMS: Array<{ value: RangeKey; label: string }> = [
+	{ value: "1h", label: "Last 1 Hour" },
+	{ value: "1d", label: "Last 1 Day" },
+	{ value: "1w", label: "Last 1 Week" },
+	{ value: "1m", label: "Last 1 Month" },
+	{ value: "1y", label: "Last 1 Year" },
+];
+
 type ApiKeyOption = {
 	id: string;
 	name?: string | null;
@@ -210,17 +218,18 @@ export default function UsageHeader({
 				</DropdownMenu>
 				<Select
 					value={range}
+					items={RANGE_ITEMS}
 					onValueChange={(v) => setRange(v as RangeKey)}
 				>
 					<SelectTrigger className="w-[180px]">
 						<SelectValue placeholder="Range" />
 					</SelectTrigger>
 					<SelectContent>
-						<SelectItem value="1h">Last 1 Hour</SelectItem>
-						<SelectItem value="1d">Last 1 Day</SelectItem>
-						<SelectItem value="1w">Last 1 Week</SelectItem>
-						<SelectItem value="1m">Last 1 Month</SelectItem>
-						<SelectItem value="1y">Last 1 Year</SelectItem>
+						{RANGE_ITEMS.map((item) => (
+							<SelectItem key={item.value} value={item.value} label={item.label}>
+								{item.label}
+							</SelectItem>
+						))}
 					</SelectContent>
 				</Select>
 				<Tooltip>

--- a/apps/web/src/components/(gateway)/usage/UsageTableFilters.tsx
+++ b/apps/web/src/components/(gateway)/usage/UsageTableFilters.tsx
@@ -28,6 +28,12 @@ interface UsageTableFiltersProps {
 	children?: React.ReactNode;
 }
 
+const STATUS_FILTER_ITEMS = [
+	{ value: "all", label: "All requests" },
+	{ value: "success", label: "Successful only" },
+	{ value: "error", label: "Errors only" },
+];
+
 export default function UsageTableFilters({
 	models,
 	providers,
@@ -140,6 +146,36 @@ export default function UsageTableFilters({
 			return a.label.localeCompare(b.label, undefined, { sensitivity: "base" });
 		});
 	}, [models, modelProviders, getProviderLabel]);
+	const modelFilterItems = React.useMemo(
+		() => [
+			{ value: "all", label: "All models" },
+			...models.map((model) => ({
+				value: model,
+				label: getModelDisplayName(model, modelMetadata),
+			})),
+		],
+		[modelMetadata, models],
+	);
+	const providerFilterItems = React.useMemo(
+		() => [
+			{ value: "all", label: "All providers" },
+			...sortedProviders.map((provider) => ({
+				value: provider,
+				label: getProviderLabel(provider),
+			})),
+		],
+		[getProviderLabel, sortedProviders],
+	);
+	const keyFilterItems = React.useMemo(
+		() => [
+			{ value: "all", label: "All keys" },
+			...apiKeys.map((key) => ({
+				value: key.id,
+				label: key.name || key.prefix || key.id.slice(0, 8),
+			})),
+		],
+		[apiKeys],
+	);
 
 	const clearFilters = () => {
 		setModelFilter("");
@@ -158,6 +194,7 @@ export default function UsageTableFilters({
 				<div className="flex flex-wrap items-center gap-2 sm:flex-nowrap sm:overflow-x-auto sm:pb-0.5">
 				<Select
 					value={modelFilter || "all"}
+					items={modelFilterItems}
 					onValueChange={(v) => setModelFilter(v === "all" ? "" : v)}
 				>
 					<SelectTrigger
@@ -168,7 +205,7 @@ export default function UsageTableFilters({
 						<SelectValue placeholder="Model (all)" />
 					</SelectTrigger>
 					<SelectContent className="max-h-[320px]">
-						<SelectItem value="all">All models</SelectItem>
+						<SelectItem value="all" label="All models">All models</SelectItem>
 						{groupedModels.map((group) => (
 							<SelectGroup key={group.providerId}>
 								<SelectLabel>
@@ -187,7 +224,11 @@ export default function UsageTableFilters({
 								{group.models.map((model) => {
 									const metadata = modelMetadata.get(model);
 									return (
-										<SelectItem key={model} value={model}>
+										<SelectItem
+											key={model}
+											value={model}
+											label={getModelDisplayName(model, modelMetadata)}
+										>
 											<div className="flex items-center gap-2">
 												{metadata ? (
 													<Logo
@@ -209,6 +250,7 @@ export default function UsageTableFilters({
 
 				<Select
 					value={providerFilter || "all"}
+					items={providerFilterItems}
 					onValueChange={(v) => setProviderFilter(v === "all" ? "" : v)}
 				>
 					<SelectTrigger
@@ -219,9 +261,13 @@ export default function UsageTableFilters({
 						<SelectValue placeholder="Provider (all)" />
 					</SelectTrigger>
 					<SelectContent className="max-h-[320px]">
-						<SelectItem value="all">All providers</SelectItem>
+						<SelectItem value="all" label="All providers">All providers</SelectItem>
 						{sortedProviders.map((provider) => (
-							<SelectItem key={provider} value={provider}>
+							<SelectItem
+								key={provider}
+								value={provider}
+								label={getProviderLabel(provider)}
+							>
 								<div className="flex items-center gap-2">
 									<Logo
 										id={provider}
@@ -240,6 +286,7 @@ export default function UsageTableFilters({
 
 				<Select
 					value={keyFilter || "all"}
+					items={keyFilterItems}
 					onValueChange={(v) => setKeyFilter(v === "all" ? "" : v)}
 				>
 					<SelectTrigger
@@ -250,16 +297,24 @@ export default function UsageTableFilters({
 						<SelectValue placeholder="Key (all)" />
 					</SelectTrigger>
 					<SelectContent>
-						<SelectItem value="all">All keys</SelectItem>
+						<SelectItem value="all" label="All keys">All keys</SelectItem>
 						{apiKeys.map((key) => (
-							<SelectItem key={key.id} value={key.id}>
+							<SelectItem
+								key={key.id}
+								value={key.id}
+								label={key.name || key.prefix || key.id.slice(0, 8)}
+							>
 								{key.name || key.prefix || key.id.slice(0, 8)}
 							</SelectItem>
 						))}
 					</SelectContent>
 				</Select>
 
-				<Select value={statusFilter} onValueChange={setStatusFilter}>
+				<Select
+					value={statusFilter}
+					items={STATUS_FILTER_ITEMS}
+					onValueChange={setStatusFilter}
+				>
 					<SelectTrigger
 						id="status-filter"
 						className={cn(triggerClassName, "min-w-[150px]")}
@@ -268,9 +323,11 @@ export default function UsageTableFilters({
 						<SelectValue placeholder="Status" />
 					</SelectTrigger>
 					<SelectContent>
-						<SelectItem value="all">All requests</SelectItem>
-						<SelectItem value="success">Successful only</SelectItem>
-						<SelectItem value="error">Errors only</SelectItem>
+						{STATUS_FILTER_ITEMS.map((item) => (
+							<SelectItem key={item.value} value={item.value} label={item.label}>
+								{item.label}
+							</SelectItem>
+						))}
 					</SelectContent>
 				</Select>
 


### PR DESCRIPTION
## Summary

Follow-up to #1314.

- keep the Settings section navigation fixed while the pane beneath it scrolls
- replace breadcrumb-style section headings with one active tab
- show friendly labels in ID-backed workspace, routing, provider, model, API key, status and date-range selects
- register item labels for keyboard navigation as well as trigger display
- add focused Settings UI regression contracts

## Validation

- `pnpm --filter @phaseo/web exec jest --runInBand --runTestsByPath 'src/components/(gateway)/settings/SettingsUi.contract.test.ts' 'src/components/(gateway)/settings/Sidebar.config.test.ts'`
- `pnpm --filter @phaseo/web typecheck`
- targeted ESLint across all changed files, with no errors; three pre-existing warnings remain in AccountSettingsClient and RoutingSettingsClient
- `git diff --check`

## Visual review

Screenshots are not included because these Settings routes require authenticated workspace data. Please verify the draft preview at desktop and mobile widths, especially Settings > Routing, Usage logs and Account.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Improvements**
  * Improved settings page layout so navigation remains fixed while content scrolls independently.
  * Simplified settings labels and tabs for clearer navigation on desktop and mobile.
  * Enhanced truncation and visual styling for active settings sections.

* **Select Improvements**
  * Standardized option labels across settings and usage filters.
  * Preserved existing filtering choices and display text while improving selector consistency.

* **Tests**
  * Added coverage to verify settings navigation, tabs, and select behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->