### PR TITLE
fix(web): restore settings pane scrolling

### DIFF
--- a/apps/web/src/app/(dashboard)/settings/layout.tsx
+++ b/apps/web/src/app/(dashboard)/settings/layout.tsx
@@ -47,7 +47,7 @@ export default async function SettingsLayout({
 		<>
 			<NoFooterStyle />
 
-			<SidebarProvider defaultOpen className="flex h-[calc(100dvh-var(--site-header-height,3.75rem)-var(--site-notice-height,0px))] min-h-0 flex-1 overflow-hidden [&_button:not([data-settings-segment])]:!rounded-lg [&_[data-slot=button]]:!rounded-lg">
+			<SidebarProvider defaultOpen className="fixed inset-x-0 bottom-0 top-[calc(var(--site-header-height,3.75rem)+var(--site-notice-height,0px))] flex min-h-0 overflow-hidden [&_button:not([data-settings-segment])]:!rounded-lg [&_[data-slot=button]]:!rounded-lg">
 				<Sidebar
 					collapsible="icon"
 					desktopClassName="hidden lg:block"

--- a/apps/web/src/components/(gateway)/settings/SettingsUi.contract.test.ts
+++ b/apps/web/src/components/(gateway)/settings/SettingsUi.contract.test.ts
@@ -14,7 +14,7 @@ describe("settings UI contracts", () => {
 		const scrollPanePosition = layoutSource.indexOf("overflow-y-auto");
 
 		expect(layoutSource).toContain(
-			"h-[calc(100dvh-var(--site-header-height,3.75rem)-var(--site-notice-height,0px))]",
+			"fixed inset-x-0 bottom-0 top-[calc(var(--site-header-height,3.75rem)+var(--site-notice-height,0px))]",
 		);
 		expect(navigationPosition).toBeGreaterThan(-1);
 		expect(scrollPanePosition).toBeGreaterThan(navigationPosition);


### PR DESCRIPTION
## Summary

- anchor the Settings shell between the site header and viewport bottom
- restore a definite height for the content pane so `overflow-y-auto` can scroll
- update the Settings layout regression contract

## Root cause

The previous viewport height calculation was applied inside a flex parent without a guaranteed containing height. That allowed the nested scroll pane to be clipped without receiving a usable scrollable height.

## Validation

- focused Settings UI contract: 3 tests passed
- full web typecheck
- targeted ESLint
- `git diff --check`