### PR TITLE
chore(data): refresh retired Mistral model statuses

### DIFF
--- a/packages/data/catalog/src/data/models/mistral/devstral-2.0/model.json
+++ b/packages/data/catalog/src/data/models/mistral/devstral-2.0/model.json
@@ -2,7 +2,7 @@
   "model_id": "mistral/devstral-2.0",
   "organisation_id": "mistral",
   "name": "Devstral 2.0",
-  "status": "Deprecated",
+  "status": "Retired",
   "previous_model_id": null,
   "description": "Devstral 2.0 is a coding model from Mistral for code generation, edits, and software tasks. It accepts text inputs and produces text outputs.",
   "announced_date": "2025-12-09T00:00:00",

--- a/packages/data/catalog/src/data/models/mistral/magistral-medium-1.2/model.json
+++ b/packages/data/catalog/src/data/models/mistral/magistral-medium-1.2/model.json
@@ -2,7 +2,7 @@
   "model_id": "mistral/magistral-medium-1.2",
   "organisation_id": "mistral",
   "name": "Magistral Medium 1.2",
-  "status": "Deprecated",
+  "status": "Retired",
   "previous_model_id": null,
   "description": "Magistral Medium 1.2 is a multimodal model from Mistral that can work across text and visual inputs. It accepts text and image inputs and produces text outputs.",
   "announced_date": "2025-09-17T00:00:00",

--- a/packages/data/catalog/src/data/models/mistral/magistral-small-1.2/model.json
+++ b/packages/data/catalog/src/data/models/mistral/magistral-small-1.2/model.json
@@ -2,7 +2,7 @@
   "model_id": "mistral/magistral-small-1.2",
   "organisation_id": "mistral",
   "name": "Magistral Small 1.2",
-  "status": "Deprecated",
+  "status": "Retired",
   "previous_model_id": null,
   "description": "Magistral Small 1.2 is a multimodal model from Mistral that can work across text and visual inputs. It is a smaller-footprint option suited to tighter latency or deployment budgets.",
   "announced_date": "2025-09-17T00:00:00",

--- a/packages/data/catalog/src/data/models/mistral/mistral-nemo-12b/model.json
+++ b/packages/data/catalog/src/data/models/mistral/mistral-nemo-12b/model.json
@@ -2,7 +2,7 @@
   "model_id": "mistral/mistral-nemo-12b",
   "organisation_id": "mistral",
   "name": "Mistral Nemo 12B",
-  "status": "Deprecated",
+  "status": "Retired",
   "previous_model_id": null,
   "description": "Mistral Nemo 12B is a language model from Mistral for chat, writing, analysis, and general-purpose automation. It accepts text inputs and produces text outputs.",
   "announced_date": "2024-07-18T00:00:00",

--- a/packages/data/catalog/src/data/models/mistral/mistral-small-3.2/model.json
+++ b/packages/data/catalog/src/data/models/mistral/mistral-small-3.2/model.json
@@ -2,7 +2,7 @@
   "model_id": "mistral/mistral-small-3.2",
   "organisation_id": "mistral",
   "name": "Mistral Small 3.2",
-  "status": "Deprecated",
+  "status": "Retired",
   "previous_model_id": null,
   "description": "Mistral Small 3.2 is a multimodal model from Mistral that can work across text and visual inputs. It is a smaller-footprint option suited to tighter latency or deployment budgets.",
   "announced_date": "2025-06-20T00:00:00",


### PR DESCRIPTION
Replaces #1372 with the same five date-driven model status transitions on current `main`. The automation branch is protected and could not be force-rebased, so this branch preserves the generated changes without carrying the conflict.

- Devstral 2.0: Deprecated → Retired
- Magistral Medium 1.2: Deprecated → Retired
- Magistral Small 1.2: Deprecated → Retired
- Mistral Nemo 12B: Deprecated → Retired
- Mistral Small 3.2: Deprecated → Retired

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Updated the status of five Mistral models from **Deprecated** to **Retired** in the model catalog.
  * Affected models include Devstral 2.0, Magistral Medium 1.2, Magistral Small 1.2, Mistral Nemo 12B, and Mistral Small 3.2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->