### PR TITLE
fix(web): repair Base UI mobile settings navigation

### DIFF
--- a/apps/web/src/components/(gateway)/settings/SettingsSidebarTrigger.tsx
+++ b/apps/web/src/components/(gateway)/settings/SettingsSidebarTrigger.tsx
@@ -5,7 +5,7 @@ import { usePathname } from "next/navigation";
 import { Building2, Check, ChevronDown, UserRound } from "lucide-react";
 
 import { Badge } from "@/components/ui/badge";
-import { Button } from "@/components/ui/button";
+import { buttonVariants } from "@/components/ui/button";
 import {
 	DropdownMenu,
 	DropdownMenuContent,
@@ -35,12 +35,10 @@ export default function SettingsSidebarTrigger({
 	return (
 		<div className="lg:hidden">
 			<DropdownMenu>
-				<DropdownMenuTrigger asChild>
-					<Button
-						variant="outline"
-						className="w-full justify-between"
-						aria-haspopup="menu"
-					>
+				<DropdownMenuTrigger
+					className={cn(buttonVariants({ variant: "outline" }), "w-full justify-between")}
+					aria-haspopup="menu"
+				>
 							<span className="flex min-w-0 items-center gap-2">
 								<span className="truncate">{activeItem?.label ?? "Settings"}</span>
 							{activeItem?.badge && (
@@ -53,7 +51,6 @@ export default function SettingsSidebarTrigger({
 							)}
 						</span>
 						<ChevronDown className="h-4 w-4 shrink-0" aria-hidden="true" />
-					</Button>
 				</DropdownMenuTrigger>
 				<DropdownMenuContent
 					align="start"
@@ -74,8 +71,12 @@ export default function SettingsSidebarTrigger({
 							{group.items.map((item) => {
 								const active = activeItem?.href === item.href;
 								return (
-									<DropdownMenuItem key={item.href} asChild>
-										<Link href={item.href} className="flex w-full items-center gap-2">
+									<DropdownMenuItem
+										key={item.href}
+										render={
+											<Link href={item.href} className="flex w-full items-center gap-2" />
+										}
+									>
 											<span className="min-w-0 flex-1 truncate">
 												{item.label}
 											</span>
@@ -88,7 +89,6 @@ export default function SettingsSidebarTrigger({
 												</Badge>
 											) : null}
 											{active ? <Check className="h-4 w-4 shrink-0" /> : null}
-										</Link>
 									</DropdownMenuItem>
 								);
 							})}

--- a/apps/web/src/components/(gateway)/settings/SettingsTopTabsServer.tsx
+++ b/apps/web/src/components/(gateway)/settings/SettingsTopTabsServer.tsx
@@ -7,7 +7,7 @@ import { ChevronDown } from "lucide-react";
 
 import { cn } from "@/lib/utils";
 import { Badge } from "@/components/ui/badge";
-import { Button } from "@/components/ui/button";
+import { buttonVariants } from "@/components/ui/button";
 import {
 	DropdownMenu,
 	DropdownMenuContent,
@@ -273,16 +273,13 @@ export default function SettingsTopTabsServer({
 					</div>
 					<div className="min-w-0 flex-1">
 						<DropdownMenu>
-							<DropdownMenuTrigger asChild>
-								<Button
-									variant="outline"
-									className="h-9 w-full min-w-0 justify-between"
-								>
+							<DropdownMenuTrigger
+								className={cn(buttonVariants({ variant: "outline" }), "h-9 w-full min-w-0 justify-between")}
+							>
 									<span className="truncate">
 										{activeTab?.label ?? "Settings"}
 									</span>
 									<ChevronDown className="h-4 w-4 shrink-0" />
-								</Button>
 							</DropdownMenuTrigger>
 							<DropdownMenuContent
 								align="end"
@@ -291,13 +288,17 @@ export default function SettingsTopTabsServer({
 								{tabs.map((tab) => {
 									const active = tab.href === activeTab?.href;
 									return (
-										<DropdownMenuItem key={tab.href} asChild>
-											<Link
+										<DropdownMenuItem
+											key={tab.href}
+											render={
+												<Link
 												href={navigationHref(tab)}
 												prefetch={false}
 												aria-current={active ? "page" : undefined}
 												className="flex items-center gap-2"
-											>
+												/>
+											}
+										>
 												<span className={cn("flex-1 truncate", active && "font-semibold")}>
 													{tab.label}
 												</span>
@@ -309,7 +310,6 @@ export default function SettingsTopTabsServer({
 														{tab.badge}
 													</Badge>
 												) : null}
-											</Link>
 										</DropdownMenuItem>
 									);
 								})}

--- a/apps/web/src/components/(gateway)/settings/SettingsTopTabsServer.tsx
+++ b/apps/web/src/components/(gateway)/settings/SettingsTopTabsServer.tsx
@@ -2,14 +2,20 @@
 
 import * as React from "react";
 import Link from "next/link";
-import { usePathname, useRouter, useSearchParams } from "next/navigation";
-import { ChevronDown, PanelLeftIcon } from "lucide-react";
+import { usePathname, useSearchParams } from "next/navigation";
+import { ChevronDown } from "lucide-react";
 
 import { cn } from "@/lib/utils";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import { useSidebar } from "@/components/ui/sidebar";
+import {
+	DropdownMenu,
+	DropdownMenuContent,
+	DropdownMenuItem,
+	DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
 import { getActiveSettingsNav } from "./Sidebar.config";
+import SettingsSidebarTrigger from "./SettingsSidebarTrigger";
 
 type Tab = {
 	href: string;
@@ -145,11 +151,8 @@ export default function SettingsTopTabsServer({
 } = {}) {
 	void isEnterpriseInvoiceMode;
 	const pathname = usePathname() ?? "";
-	const router = useRouter();
 	const searchParams = useSearchParams();
-	const mobileSelectId = React.useId();
 	const logsView = searchParams.get("view") ?? "logs";
-	const { toggleSidebar } = useSidebar();
 	const tabs = resolveTabs(pathname, { showBroadcast, showWebhooks });
 	const activeNav = React.useMemo(
 		() => getActiveSettingsNav(pathname, { showBroadcast, showWebhooks }),
@@ -203,7 +206,6 @@ export default function SettingsTopTabsServer({
 						return b.score!.len - a.score!.len;
 					})[0]?.t ?? tabs[0]
 			: null;
-	const mobileSectionLabel = activeNav?.group.scope === "personal" ? "My account" : "Workspace";
 
 	const setIndicatorToHref = React.useCallback((href: string | null) => {
 		const container = containerRef.current;
@@ -233,17 +235,7 @@ export default function SettingsTopTabsServer({
 	if (!tabs?.length) {
 		return (
 			<>
-				<nav className="flex h-[52px] items-center lg:hidden" aria-label="Settings navigation">
-					<Button
-						variant="outline"
-						className="h-9 w-full justify-start px-3"
-						onClick={toggleSidebar}
-						aria-haspopup="dialog"
-					>
-						<PanelLeftIcon className="mr-1.5 h-4 w-4" />
-						<span className="truncate">{activeNav?.item.label ?? "Settings"}</span>
-					</Button>
-				</nav>
+				<SettingsSidebarTrigger showBroadcast={showBroadcast} showWebhooks={showWebhooks} />
 				<nav
 					className="relative hidden h-[52px] items-end border-b border-border lg:flex"
 					aria-label="Settings section navigation"
@@ -273,35 +265,56 @@ export default function SettingsTopTabsServer({
 		<>
 			<nav className="flex h-[52px] items-center md:hidden" aria-label="Settings section navigation">
 				<div className="flex w-full items-center gap-2">
-					<Button
-						variant="outline"
-						className="h-9 max-w-[11rem] shrink-0 px-3"
-						onClick={toggleSidebar}
-						aria-haspopup="dialog"
-					>
-						<PanelLeftIcon className="mr-1.5 h-4 w-4" />
-						<span className="truncate">{mobileSectionLabel}</span>
-					</Button>
-					<div className="relative min-w-0 flex-1">
-						<label htmlFor={mobileSelectId} className="sr-only">
-							Settings subsection
-						</label>
-						<select
-							id={mobileSelectId}
-							value={activeTab ? navigationHref(activeTab) : ""}
-							onChange={(event) => router.push(event.currentTarget.value)}
-							className="h-9 w-full appearance-none rounded-lg border border-border bg-background px-3 pr-9 text-sm font-medium text-foreground outline-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/30"
-						>
-							{tabs.map((tab) => (
-								<option key={tab.href} value={navigationHref(tab)}>
-									{tab.label}
-								</option>
-							))}
-						</select>
-						<ChevronDown
-							aria-hidden="true"
-							className="pointer-events-none absolute right-3 top-1/2 h-4 w-4 -translate-y-1/2"
+					<div className="min-w-0 flex-1">
+						<SettingsSidebarTrigger
+							showBroadcast={showBroadcast}
+							showWebhooks={showWebhooks}
 						/>
+					</div>
+					<div className="min-w-0 flex-1">
+						<DropdownMenu>
+							<DropdownMenuTrigger asChild>
+								<Button
+									variant="outline"
+									className="h-9 w-full min-w-0 justify-between"
+								>
+									<span className="truncate">
+										{activeTab?.label ?? "Settings"}
+									</span>
+									<ChevronDown className="h-4 w-4 shrink-0" />
+								</Button>
+							</DropdownMenuTrigger>
+							<DropdownMenuContent
+								align="end"
+								className="w-[min(20rem,calc(100vw-1rem))]"
+							>
+								{tabs.map((tab) => {
+									const active = tab.href === activeTab?.href;
+									return (
+										<DropdownMenuItem key={tab.href} asChild>
+											<Link
+												href={navigationHref(tab)}
+												prefetch={false}
+												aria-current={active ? "page" : undefined}
+												className="flex items-center gap-2"
+											>
+												<span className={cn("flex-1 truncate", active && "font-semibold")}>
+													{tab.label}
+												</span>
+												{tab.badge ? (
+													<Badge
+														variant="outline"
+														className="h-4 px-1 text-[9px] capitalize"
+													>
+														{tab.badge}
+													</Badge>
+												) : null}
+											</Link>
+										</DropdownMenuItem>
+									);
+								})}
+							</DropdownMenuContent>
+						</DropdownMenu>
 					</div>
 				</div>
 			</nav>

--- a/apps/web/src/components/(gateway)/settings/SettingsTopTabsServer.tsx
+++ b/apps/web/src/components/(gateway)/settings/SettingsTopTabsServer.tsx
@@ -2,21 +2,14 @@
 
 import * as React from "react";
 import Link from "next/link";
-import { usePathname, useSearchParams } from "next/navigation";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { ChevronDown, PanelLeftIcon } from "lucide-react";
 
 import { cn } from "@/lib/utils";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import {
-	DropdownMenu,
-	DropdownMenuContent,
-	DropdownMenuItem,
-	DropdownMenuTrigger,
-} from "@/components/ui/dropdown-menu";
 import { useSidebar } from "@/components/ui/sidebar";
 import { getActiveSettingsNav } from "./Sidebar.config";
-import SettingsSidebarTrigger from "./SettingsSidebarTrigger";
 
 type Tab = {
 	href: string;
@@ -152,7 +145,9 @@ export default function SettingsTopTabsServer({
 } = {}) {
 	void isEnterpriseInvoiceMode;
 	const pathname = usePathname() ?? "";
+	const router = useRouter();
 	const searchParams = useSearchParams();
+	const mobileSelectId = React.useId();
 	const logsView = searchParams.get("view") ?? "logs";
 	const { toggleSidebar } = useSidebar();
 	const tabs = resolveTabs(pathname, { showBroadcast, showWebhooks });
@@ -238,7 +233,17 @@ export default function SettingsTopTabsServer({
 	if (!tabs?.length) {
 		return (
 			<>
-				<SettingsSidebarTrigger showBroadcast={showBroadcast} showWebhooks={showWebhooks} />
+				<nav className="flex h-[52px] items-center md:hidden" aria-label="Settings navigation">
+					<Button
+						variant="outline"
+						className="h-9 w-full justify-start px-3"
+						onClick={toggleSidebar}
+						aria-haspopup="dialog"
+					>
+						<PanelLeftIcon className="mr-1.5 h-4 w-4" />
+						<span className="truncate">{activeNav?.item.label ?? "Settings"}</span>
+					</Button>
+				</nav>
 				<nav
 					className="relative hidden h-[52px] items-end border-b border-border lg:flex"
 					aria-label="Settings section navigation"
@@ -267,7 +272,7 @@ export default function SettingsTopTabsServer({
 	return (
 		<>
 			<nav className="flex h-[52px] items-center md:hidden" aria-label="Settings section navigation">
-				<div className="flex items-center gap-2">
+				<div className="flex w-full items-center gap-2">
 					<Button
 						variant="outline"
 						className="h-9 max-w-[11rem] shrink-0 px-3"
@@ -277,47 +282,27 @@ export default function SettingsTopTabsServer({
 						<PanelLeftIcon className="mr-1.5 h-4 w-4" />
 						<span className="truncate">{mobileSectionLabel}</span>
 					</Button>
-					<DropdownMenu>
-						<DropdownMenuTrigger render={<Button
-								variant="outline"
-								className="h-9 flex-1 justify-between min-w-0" />}>
-
-								<span className="truncate">
-									{activeTab?.label ?? "Settings"}
-								</span>
-								<ChevronDown className="h-4 w-4 shrink-0" />
-
-						</DropdownMenuTrigger>
-						<DropdownMenuContent
-							align="end"
-							className="w-[min(20rem,calc(100vw-1rem))]"
+					<div className="relative min-w-0 flex-1">
+						<label htmlFor={mobileSelectId} className="sr-only">
+							Settings subsection
+						</label>
+						<select
+							id={mobileSelectId}
+							value={activeTab ? navigationHref(activeTab) : ""}
+							onChange={(event) => router.push(event.currentTarget.value)}
+							className="h-9 w-full appearance-none rounded-lg border border-border bg-background px-3 pr-9 text-sm font-medium text-foreground outline-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/30"
 						>
-							{tabs.map((tab) => {
-								const active = tab.href === activeTab?.href;
-								return (
-									<DropdownMenuItem key={tab.href}  render={<Link
-										href={navigationHref(tab)}
-											prefetch={false}
-											aria-current={active ? "page" : undefined}
-											className="flex items-center gap-2" />}>
-
-											<span className={cn("flex-1 truncate", active && "font-semibold")}>
-												{tab.label}
-											</span>
-											{tab.badge ? (
-												<Badge
-													variant="outline"
-											className="h-4 px-1 text-[9px] capitalize"
-												>
-													{tab.badge}
-												</Badge>
-											) : null}
-
-									</DropdownMenuItem>
-								);
-							})}
-						</DropdownMenuContent>
-					</DropdownMenu>
+							{tabs.map((tab) => (
+								<option key={tab.href} value={navigationHref(tab)}>
+									{tab.label}
+								</option>
+							))}
+						</select>
+						<ChevronDown
+							aria-hidden="true"
+							className="pointer-events-none absolute right-3 top-1/2 h-4 w-4 -translate-y-1/2"
+						/>
+					</div>
 				</div>
 			</nav>
 

--- a/apps/web/src/components/(gateway)/settings/SettingsTopTabsServer.tsx
+++ b/apps/web/src/components/(gateway)/settings/SettingsTopTabsServer.tsx
@@ -233,7 +233,7 @@ export default function SettingsTopTabsServer({
 	if (!tabs?.length) {
 		return (
 			<>
-				<nav className="flex h-[52px] items-center md:hidden" aria-label="Settings navigation">
+				<nav className="flex h-[52px] items-center lg:hidden" aria-label="Settings navigation">
 					<Button
 						variant="outline"
 						className="h-9 w-full justify-start px-3"

--- a/apps/web/src/components/(gateway)/settings/SettingsUi.contract.test.ts
+++ b/apps/web/src/components/(gateway)/settings/SettingsUi.contract.test.ts
@@ -40,10 +40,12 @@ describe("settings UI contracts", () => {
 
 		expect(tabsSource).toContain("<SettingsSidebarTrigger");
 		expect(tabsSource).toContain("<DropdownMenu>");
-		expect(tabsSource).toContain("<DropdownMenuTrigger asChild>");
-		expect(tabsSource).toContain("<DropdownMenuItem key={tab.href} asChild>");
-		expect(tabsSource).not.toContain("render={<Button");
-		expect(tabsSource).not.toContain("render={<Link");
+		expect(tabsSource).toContain("<DropdownMenuTrigger");
+		expect(tabsSource).toContain("buttonVariants({ variant: \"outline\" })");
+		expect(tabsSource).toContain("render={");
+		expect(tabsSource).toContain("<Link");
+		expect(tabsSource).not.toContain("asChild");
+		expect(menuSource).not.toContain("asChild");
 		expect(menuSource).toContain("My account");
 		expect(menuSource).toContain("Workspace");
 		expect(menuSource).toContain("visibleGroups.map");

--- a/apps/web/src/components/(gateway)/settings/SettingsUi.contract.test.ts
+++ b/apps/web/src/components/(gateway)/settings/SettingsUi.contract.test.ts
@@ -38,7 +38,7 @@ describe("settings UI contracts", () => {
 		expect(tabsSource).toContain("<select");
 		expect(tabsSource).toContain("router.push(event.currentTarget.value)");
 		expect(tabsSource).toContain("onClick={toggleSidebar}");
-		expect(tabsSource).not.toContain("<DropdownMenu");
+		expect(tabsSource).toContain(\n			\'className="flex h-[52px] items-center lg:hidden" aria-label="Settings navigation"\',\n		);\n		expect(tabsSource).not.toContain("<DropdownMenu");
 	});
 
 	it("provides display-label collections for ID-backed settings selects", () => {

--- a/apps/web/src/components/(gateway)/settings/SettingsUi.contract.test.ts
+++ b/apps/web/src/components/(gateway)/settings/SettingsUi.contract.test.ts
@@ -30,6 +30,17 @@ describe("settings UI contracts", () => {
 		expect(tabsSource).toContain("border-b-2 border-muted-foreground");
 	});
 
+	it("uses stable mobile settings navigation without a floating menu", () => {
+		const tabsSource = readSource(
+			"src/components/(gateway)/settings/SettingsTopTabsServer.tsx",
+		);
+
+		expect(tabsSource).toContain("<select");
+		expect(tabsSource).toContain("router.push(event.currentTarget.value)");
+		expect(tabsSource).toContain("onClick={toggleSidebar}");
+		expect(tabsSource).not.toContain("<DropdownMenu");
+	});
+
 	it("provides display-label collections for ID-backed settings selects", () => {
 		const expectedItemCollections: Record<string, string[]> = {
 			"src/components/(gateway)/settings/account/AccountSettingsClient.tsx": [

--- a/apps/web/src/components/(gateway)/settings/SettingsUi.contract.test.ts
+++ b/apps/web/src/components/(gateway)/settings/SettingsUi.contract.test.ts
@@ -30,17 +30,24 @@ describe("settings UI contracts", () => {
 		expect(tabsSource).toContain("border-b-2 border-muted-foreground");
 	});
 
-	it("uses stable mobile settings navigation without a floating menu", () => {
+	it("keeps the complete mobile settings navigation on Base UI", () => {
 		const tabsSource = readSource(
 			"src/components/(gateway)/settings/SettingsTopTabsServer.tsx",
 		);
+		const menuSource = readSource(
+			"src/components/(gateway)/settings/SettingsSidebarTrigger.tsx",
+		);
 
-		expect(tabsSource).toContain("<select");
-		expect(tabsSource).toContain("router.push(event.currentTarget.value)");
-		expect(tabsSource).toContain("onClick={toggleSidebar}");
-		expect(tabsSource).toContain(\n			\'className="flex h-[52px] items-center lg:hidden" aria-label="Settings navigation"\',\n		);\n		expect(tabsSource).not.toContain("<DropdownMenu");
+		expect(tabsSource).toContain("<SettingsSidebarTrigger");
+		expect(tabsSource).toContain("<DropdownMenu>");
+		expect(tabsSource).toContain("<DropdownMenuTrigger asChild>");
+		expect(tabsSource).toContain("<DropdownMenuItem key={tab.href} asChild>");
+		expect(tabsSource).not.toContain("render={<Button");
+		expect(tabsSource).not.toContain("render={<Link");
+		expect(menuSource).toContain("My account");
+		expect(menuSource).toContain("Workspace");
+		expect(menuSource).toContain("visibleGroups.map");
 	});
-
 	it("provides display-label collections for ID-backed settings selects", () => {
 		const expectedItemCollections: Record<string, string[]> = {
 			"src/components/(gateway)/settings/account/AccountSettingsClient.tsx": [


### PR DESCRIPTION
## Summary

- keep both mobile Settings controls on Base UI
- restore the complete Settings menu beside subsection navigation on pages with tabs
- preserve the Account / Workspace toggle and grouped Settings sections in the top-level menu
- use Base UI's native trigger element and documented `render` composition for linked menu items
- add a focused contract covering the two-menu structure and preventing Radix-style `asChild` composition in these Settings components

## User impact

Mobile Settings keeps the intended two-level navigation:

1. The first Base UI menu contains the Account / Workspace toggle followed by the relevant grouped Settings sections.
2. The second Base UI menu switches between subsections such as Details, MFA and Danger Zone.

Desktop tab navigation remains unchanged.

## Client-side issue

The newly introduced subsection trigger composed a Base UI Menu trigger with the project's Base UI Button primitive. This adds two button behaviours to one rendered element and is unnecessary. The revised implementation lets `Menu.Trigger` render its own native button and applies the existing button styles directly. Links use Base UI's documented `render={<Link />}` API.

The repository does expose an `asChild` compatibility shim, but that is a Radix-style adapter over Base UI's `render` prop and is deliberately not used by these Settings menus.

## Validation

- focused Settings UI composition contract updated to require Base UI `render` and reject `asChild`
- mobile layout retains Account / Workspace, grouped sections, and subsection navigation
- no shared UI primitive changed
- PR remains draft pending CI and authenticated mobile verification

Created with Codex

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved mobile settings navigation with a full-width tab dropdown and accessible sidebar controls.
  * Preserved active tab states, badges, and account/workspace navigation links.

* **Bug Fixes**
  * Updated dropdown links and controls for more consistent interaction and rendering behavior.

* **Tests**
  * Added coverage for mobile settings navigation and its dropdown content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->