### PR TITLE
fix(web): prevent mobile settings hydration failure

### DIFF
--- a/apps/web/src/app/(dashboard)/settings/layout.tsx
+++ b/apps/web/src/app/(dashboard)/settings/layout.tsx
@@ -59,11 +59,13 @@ export default async function SettingsLayout({
 				<SidebarInset className="flex w-0 min-h-0 min-w-0 flex-1 flex-col overflow-hidden bg-white dark:bg-zinc-950">
 					<div className="container mx-auto flex h-full min-h-0 w-full flex-col px-4 pt-0 sm:px-5 lg:px-6 xl:px-8">
 						<div className="relative z-20 shrink-0 bg-background">
-							<SettingsTopTabsServer
-								isEnterpriseInvoiceMode={isEnterpriseInvoiceMode}
-								showBroadcast={showBroadcast}
-								showWebhooks={showWebhooks}
-							/>
+							<Suspense fallback={<div className="h-[52px]" aria-hidden="true" />}>
+								<SettingsTopTabsServer
+									isEnterpriseInvoiceMode={isEnterpriseInvoiceMode}
+									showBroadcast={showBroadcast}
+									showWebhooks={showWebhooks}
+								/>
+							</Suspense>
 						</div>
 						<div className="min-h-0 w-full flex-1 overflow-y-auto overscroll-contain pb-4 pt-3">
 							<Suspense fallback={<SettingsPageSkeleton />}>

--- a/apps/web/src/components/(gateway)/settings/SettingsUi.contract.test.ts
+++ b/apps/web/src/components/(gateway)/settings/SettingsUi.contract.test.ts
@@ -18,6 +18,9 @@ describe("settings UI contracts", () => {
 		);
 		expect(navigationPosition).toBeGreaterThan(-1);
 		expect(scrollPanePosition).toBeGreaterThan(navigationPosition);
+		expect(layoutSource).toContain(
+			'<Suspense fallback={<div className="h-[52px]" aria-hidden="true" />}>',
+		);
 	});
 
 	it("renders pages without sibling navigation as a single active tab", () => {


### PR DESCRIPTION
## Summary

- wrap the Settings navigation client component in its own Suspense boundary
- keep a fixed 52px fallback so the sticky Settings header does not shift
- add a contract assertion covering the required boundary

## Root cause

Production client telemetry captured React errors #418 and #419 on `/settings/keys` when the mobile Settings menu was clicked. Error #418 is a hydration text mismatch; #419 means the server could not finish a Suspense boundary and switched to client rendering.

`SettingsTopTabsServer` calls Next.js `useSearchParams()`, but was rendered outside the layout's existing Suspense boundary. That boundary only wrapped the page children below it. Next.js requires a client subtree using `useSearchParams` to have a surrounding Suspense boundary during production rendering.

The click caused selective hydration of the previously unhydrated navigation tree, exposing the mismatch at interaction time.

## Validation

- minimal layout-only production fix
- Base UI menus and shared UI primitives remain unchanged
- fixed-height fallback preserves the sticky navigation geometry
- contract test prevents removing the boundary accidentally