### PR TITLE
fix(web): eliminate settings menu hydration mismatch

### DIFF
--- a/apps/web/src/app/(dashboard)/settings/layout.tsx
+++ b/apps/web/src/app/(dashboard)/settings/layout.tsx
@@ -1,6 +1,6 @@
 import SettingsPageSkeleton from "@/components/(gateway)/settings/SettingsPageSkeleton";
 import SettingsSidebar from "@/components/(gateway)/settings/Sidebar";
-import SettingsTopTabsServer from "@/components/(gateway)/settings/SettingsTopTabsServer";
+import SettingsTopTabsClientOnly from "@/components/(gateway)/settings/SettingsTopTabsClientOnly";
 import { redirect } from "next/navigation";
 import { headers } from "next/headers";
 import { fetchSettingsLayoutInitialData } from "@/lib/fetchers/internal/fetchSettingsLayoutInitialData";
@@ -59,13 +59,11 @@ export default async function SettingsLayout({
 				<SidebarInset className="flex w-0 min-h-0 min-w-0 flex-1 flex-col overflow-hidden bg-white dark:bg-zinc-950">
 					<div className="container mx-auto flex h-full min-h-0 w-full flex-col px-4 pt-0 sm:px-5 lg:px-6 xl:px-8">
 						<div className="relative z-20 shrink-0 bg-background">
-							<Suspense fallback={<div className="h-[52px]" aria-hidden="true" />}>
-								<SettingsTopTabsServer
-									isEnterpriseInvoiceMode={isEnterpriseInvoiceMode}
-									showBroadcast={showBroadcast}
-									showWebhooks={showWebhooks}
-								/>
-							</Suspense>
+							<SettingsTopTabsClientOnly
+								isEnterpriseInvoiceMode={isEnterpriseInvoiceMode}
+								showBroadcast={showBroadcast}
+								showWebhooks={showWebhooks}
+							/>
 						</div>
 						<div className="min-h-0 w-full flex-1 overflow-y-auto overscroll-contain pb-4 pt-3">
 							<Suspense fallback={<SettingsPageSkeleton />}>

--- a/apps/web/src/components/(gateway)/settings/SettingsTopTabsClientOnly.tsx
+++ b/apps/web/src/components/(gateway)/settings/SettingsTopTabsClientOnly.tsx
@@ -1,0 +1,26 @@
+"use client";
+
+import dynamic from "next/dynamic";
+
+const SettingsTopTabs = dynamic(() => import("./SettingsTopTabsServer"), {
+	ssr: false,
+	loading: () => <div className="h-[52px]" aria-hidden="true" />,
+});
+
+export default function SettingsTopTabsClientOnly({
+	isEnterpriseInvoiceMode,
+	showBroadcast = true,
+	showWebhooks = true,
+}: {
+	isEnterpriseInvoiceMode?: boolean;
+	showBroadcast?: boolean;
+	showWebhooks?: boolean;
+}) {
+	return (
+		<SettingsTopTabs
+			isEnterpriseInvoiceMode={isEnterpriseInvoiceMode}
+			showBroadcast={showBroadcast}
+			showWebhooks={showWebhooks}
+		/>
+	);
+}

--- a/apps/web/src/components/(gateway)/settings/SettingsUi.contract.test.ts
+++ b/apps/web/src/components/(gateway)/settings/SettingsUi.contract.test.ts
@@ -10,7 +10,7 @@ function readSource(relativePath: string): string {
 describe("settings UI contracts", () => {
 	it("keeps the section navigation outside the scrollable settings pane", () => {
 		const layoutSource = readSource("src/app/(dashboard)/settings/layout.tsx");
-		const navigationPosition = layoutSource.indexOf("<SettingsTopTabsServer");
+		const navigationPosition = layoutSource.indexOf("<SettingsTopTabsClientOnly");
 		const scrollPanePosition = layoutSource.indexOf("overflow-y-auto");
 
 		expect(layoutSource).toContain(
@@ -18,9 +18,11 @@ describe("settings UI contracts", () => {
 		);
 		expect(navigationPosition).toBeGreaterThan(-1);
 		expect(scrollPanePosition).toBeGreaterThan(navigationPosition);
-		expect(layoutSource).toContain(
-			'<Suspense fallback={<div className="h-[52px]" aria-hidden="true" />}>',
+		const clientOnlySource = readSource(
+			"src/components/(gateway)/settings/SettingsTopTabsClientOnly.tsx",
 		);
+		expect(clientOnlySource).toContain("ssr: false");
+		expect(clientOnlySource).toContain('<div className="h-[52px]" aria-hidden="true" />');
 	});
 
 	it("renders pages without sibling navigation as a single active tab", () => {


### PR DESCRIPTION
## Summary

- render the authenticated Settings navigation client-only
- preserve the 52px sticky-header space while the navigation JavaScript loads
- retain the existing Base UI menus, Account/Workspace switch and grouped sections unchanged
- add a contract preventing SSR from being reintroduced for this path-derived navigation

## Production evidence

PostHog captured repeated React #418 and #419 errors on Android Chrome at `/settings/keys`. The event sequence is:

1. click element text `API Keys`
2. React hydration error
3. temporary error screen
4. click `Try again`

The menu trigger text and contents are derived from `usePathname()`. The mobile menu subtree is selectively hydrated on its first interaction, at which point its server-rendered text can differ from the client path-derived text.

The earlier Suspense boundary did not remove SSR or the hydration comparison. This change does: the internal authenticated navigation has no SEO requirement and now renders only after the client pathname is authoritative.

## Scope

- no shared UI primitive changes
- no Base UI composition changes
- no page content or desktop tab behaviour changes
- fixed-height loading fallback avoids layout shift