### PR TITLE
fix(web): hydrate settings navigation deterministically

### DIFF
--- a/apps/web/src/components/(gateway)/settings/SettingsTopTabsClientOnly.tsx
+++ b/apps/web/src/components/(gateway)/settings/SettingsTopTabsClientOnly.tsx
@@ -1,11 +1,12 @@
 "use client";
 
-import dynamic from "next/dynamic";
+import { useSyncExternalStore } from "react";
 
-const SettingsTopTabs = dynamic(() => import("./SettingsTopTabsServer"), {
-	ssr: false,
-	loading: () => <div className="h-[52px]" aria-hidden="true" />,
-});
+import SettingsTopTabs from "./SettingsTopTabsServer";
+
+const subscribe = () => () => {};
+const getClientSnapshot = () => true;
+const getServerSnapshot = () => false;
 
 export default function SettingsTopTabsClientOnly({
 	isEnterpriseInvoiceMode,
@@ -16,6 +17,16 @@ export default function SettingsTopTabsClientOnly({
 	showBroadcast?: boolean;
 	showWebhooks?: boolean;
 }) {
+	const isHydrated = useSyncExternalStore(
+		subscribe,
+		getClientSnapshot,
+		getServerSnapshot,
+	);
+
+	if (!isHydrated) {
+		return <div className="h-[52px]" aria-hidden="true" />;
+	}
+
 	return (
 		<SettingsTopTabs
 			isEnterpriseInvoiceMode={isEnterpriseInvoiceMode}

--- a/apps/web/src/components/(gateway)/settings/SettingsUi.contract.test.ts
+++ b/apps/web/src/components/(gateway)/settings/SettingsUi.contract.test.ts
@@ -21,7 +21,9 @@ describe("settings UI contracts", () => {
 		const clientOnlySource = readSource(
 			"src/components/(gateway)/settings/SettingsTopTabsClientOnly.tsx",
 		);
-		expect(clientOnlySource).toContain("useSyncExternalStore");\n\t\texpect(clientOnlySource).toContain("getServerSnapshot");\n\t\texpect(clientOnlySource).not.toContain("ssr: false");
+		expect(clientOnlySource).toContain("useSyncExternalStore");
+		expect(clientOnlySource).toContain("getServerSnapshot");
+		expect(clientOnlySource).not.toContain("ssr: false");
 		expect(clientOnlySource).toContain('<div className="h-[52px]" aria-hidden="true" />');
 	});
 

--- a/apps/web/src/components/(gateway)/settings/SettingsUi.contract.test.ts
+++ b/apps/web/src/components/(gateway)/settings/SettingsUi.contract.test.ts
@@ -21,7 +21,7 @@ describe("settings UI contracts", () => {
 		const clientOnlySource = readSource(
 			"src/components/(gateway)/settings/SettingsTopTabsClientOnly.tsx",
 		);
-		expect(clientOnlySource).toContain("ssr: false");
+		expect(clientOnlySource).toContain("useSyncExternalStore");\n\t\texpect(clientOnlySource).toContain("getServerSnapshot");\n\t\texpect(clientOnlySource).not.toContain("ssr: false");
 		expect(clientOnlySource).toContain('<div className="h-[52px]" aria-hidden="true" />');
 	});
 


### PR DESCRIPTION
## What changed

- Replaced the `next/dynamic` `ssr: false` Settings navigation bailout with a deterministic hydration gate using `useSyncExternalStore`.
- Kept the same 52px placeholder for the server render and the first client hydration pass.
- Mounted the existing Base UI Account/Workspace and section navigation only after hydration completes.
- Updated the Settings UI contract test to prevent restoring the SSR bailout.

## Root cause

Fresh PostHog telemetry showed React #419 during the initial `/settings/keys` page load, before the menu was tapped, followed by text hydration error #418. The previous `ssr: false` workaround deliberately aborted server rendering for this subtree, so it moved the failure instead of removing the hydration hazard.

## Impact

The Settings route now hydrates identical markup on server and client before mounting the path-dependent Base UI navigation. No Base UI primitives, menu structure, Account/Workspace toggle, or settings sections were changed.

## Validation

- Contract coverage updated for the deterministic hydration strategy.
- Production telemetry sequence used to verify the error occurs before interaction.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the settings page loading experience by preserving layout space while settings tabs initialize.
  * Reduced visual shifts during hydration, helping the tabs appear more smoothly and consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->