### PR TITLE
feat(chat): outline temporary messages

### DIFF
--- a/apps/web/src/components/(chat)/ChatConversationMessages.tsx
+++ b/apps/web/src/components/(chat)/ChatConversationMessages.tsx
@@ -694,6 +694,9 @@ export function ChatConversationMessages({
 							color: getReadableTextColor(accentColor),
 						}
 					: undefined;
+			const temporaryMessageOutline = temporaryMode
+				? "rounded-2xl border border-dashed border-muted-foreground/60"
+				: "";
 			const sentAtLabel = formatMessageSentAt(
 				!isUser && activeVariant?.createdAt
 					? activeVariant.createdAt
@@ -762,9 +765,10 @@ export function ChatConversationMessages({
 									<div
 										data-slot="message-panel"
 										className={cn(
-											isUser
-												? cn(
+										isUser
+											? cn(
 														"max-w-full rounded-2xl px-4 py-3 text-sm leading-relaxed shadow-sm",
+														temporaryMessageOutline,
 														inSideBySideGroup
 															? "flex h-full min-h-[180px] w-full flex-col"
 															: "w-fit",
@@ -772,8 +776,10 @@ export function ChatConversationMessages({
 															? ""
 															: "bg-foreground text-background",
 													)
-												: cn(
+											: cn(
 														"w-full max-w-[min(100%,46rem)] px-0 py-1 text-sm leading-relaxed text-foreground",
+														temporaryMessageOutline,
+														temporaryMode && "px-4 py-3",
 														inSideBySideGroup &&
 															"flex h-full min-h-[180px] flex-col",
 													),
@@ -1540,6 +1546,7 @@ export function ChatConversationMessages({
 		modelOptions,
 		selectedModelIds,
 		onAddModelSet,
+		temporaryMode,
 	]);
 
 	return <>{messagesContent}</>;

--- a/apps/web/src/components/(chat)/ChatConversationMessages.tsx
+++ b/apps/web/src/components/(chat)/ChatConversationMessages.tsx
@@ -765,8 +765,8 @@ export function ChatConversationMessages({
 									<div
 										data-slot="message-panel"
 										className={cn(
-										isUser
-											? cn(
+											isUser
+												? cn(
 														"max-w-full rounded-2xl px-4 py-3 text-sm leading-relaxed shadow-sm",
 														temporaryMessageOutline,
 														inSideBySideGroup
@@ -776,7 +776,7 @@ export function ChatConversationMessages({
 															? ""
 															: "bg-foreground text-background",
 													)
-											: cn(
+												: cn(
 														"w-full max-w-[min(100%,46rem)] px-0 py-1 text-sm leading-relaxed text-foreground",
 														temporaryMessageOutline,
 														temporaryMode && "px-4 py-3",


### PR DESCRIPTION
## Summary

- add a rounded dashed outline to every message in temporary chats
- keep normal chats unchanged
- support sequential, virtualised, and side-by-side response layouts

## Why

The dashed treatment makes a temporary conversation immediately recognisable, following the supplied visual reference.

## Validation

- `git diff --check`
- Web lint could not run because this isolated checkout has no installed dependencies and the environment could not complete the dependency installation.

## Reference

The mobile temporary-chat screenshot was supplied with this task. The available GitHub integration does not support binary PR attachments, so it has not been committed to the product repository.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Added dashed rounded outlines to user and assistant message panels in temporary mode.
  * Increased padding within assistant message panels for improved visual spacing.
  * Updated styling to refresh correctly when temporary mode changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->