### PR TITLE
fix(web): group Base UI settings menu sections

### DIFF
--- a/apps/web/src/components/(gateway)/settings/SettingsSidebarTrigger.tsx
+++ b/apps/web/src/components/(gateway)/settings/SettingsSidebarTrigger.tsx
@@ -9,6 +9,7 @@ import { buttonVariants } from "@/components/ui/button";
 import {
 	DropdownMenu,
 	DropdownMenuContent,
+	DropdownMenuGroup,
 	DropdownMenuItem,
 	DropdownMenuLabel,
 	DropdownMenuSeparator,
@@ -62,7 +63,7 @@ export default function SettingsSidebarTrigger({
 					</div>
 					<DropdownMenuSeparator />
 					{visibleGroups.map((group, index) => (
-						<div key={`${group.heading ?? "group"}-${index}`}>
+						<DropdownMenuGroup key={`${group.heading ?? "group"}-${index}`}>
 							{group.heading ? (
 								<DropdownMenuLabel className="text-xs uppercase tracking-wide text-muted-foreground">
 									{group.heading}
@@ -93,7 +94,7 @@ export default function SettingsSidebarTrigger({
 								);
 							})}
 							{index < visibleGroups.length - 1 ? <DropdownMenuSeparator /> : null}
-						</div>
+						</DropdownMenuGroup>
 					))}
 				</DropdownMenuContent>
 			</DropdownMenu>

--- a/apps/web/src/components/(gateway)/settings/SettingsUi.contract.test.ts
+++ b/apps/web/src/components/(gateway)/settings/SettingsUi.contract.test.ts
@@ -56,6 +56,11 @@ describe("settings UI contracts", () => {
 		expect(menuSource).toContain("My account");
 		expect(menuSource).toContain("Workspace");
 		expect(menuSource).toContain("visibleGroups.map");
+		expect(menuSource).toContain("<DropdownMenuGroup key=");
+		expect(menuSource).toContain("<DropdownMenuLabel");
+		expect(menuSource.indexOf("<DropdownMenuGroup key=")).toBeLessThan(
+			menuSource.indexOf("<DropdownMenuLabel"),
+		);
 	});
 	it("provides display-label collections for ID-backed settings selects", () => {
 		const expectedItemCollections: Record<string, string[]> = {


### PR DESCRIPTION
## What changed

- Wrapped every grouped mobile Settings section in `DropdownMenuGroup`.
- Kept the existing Base UI dropdown primitives, Account/Workspace scope links, section labels, items, and visual styling.
- Added a contract assertion that group labels remain nested beneath a Base UI menu group.

## Root cause

Authenticated browser reproduction at a 400px viewport produced Base UI production error #31 immediately when the mobile navigation mounted. In Base UI 1.6.0, error #31 means menu group parts are being used without `<Menu.Group>`. `DropdownMenuLabel` mapped to `Menu.GroupLabel`, but each Settings section was wrapped in a plain `div`.

The React #418/#419 events in PostHog were downstream error-boundary and hydration recovery symptoms, which is why the previous hydration-only fixes did not resolve the underlying crash.

## Validation plan

- Run the web validation job, including the Settings UI contract suite.
- Merge after checks pass.
- Wait for production deployment, then reload `/settings/keys` in the same authenticated 400px browser and test the Account/Workspace and section dropdown interactions while inspecting console errors.