### PR TITLE
fix(settings): use scroll area for content pane

### DIFF
--- a/apps/web/src/app/(dashboard)/settings/layout.tsx
+++ b/apps/web/src/app/(dashboard)/settings/layout.tsx
@@ -9,6 +9,7 @@ import {
 	SidebarInset,
 	SidebarProvider,
 } from "@/components/ui/sidebar";
+import { ScrollArea } from "@/components/ui/scroll-area";
 import { Suspense } from "react";
 import NoFooterStyle from "@/components/layout/NoFooterStyle";
 import { batchApiFlag } from "@/lib/flags";
@@ -65,11 +66,14 @@ export default async function SettingsLayout({
 								showWebhooks={showWebhooks}
 							/>
 						</div>
-						<div className="min-h-0 w-full flex-1 overflow-y-auto overscroll-contain pb-4 pt-3">
+						<ScrollArea
+							className="min-h-0 w-full flex-1 overscroll-y-contain"
+							viewportClassName="pb-4 pt-3"
+						>
 							<Suspense fallback={<SettingsPageSkeleton />}>
 								{children}
 							</Suspense>
-						</div>
+						</ScrollArea>
 					</div>
 				</SidebarInset>
 			</SidebarProvider>

--- a/apps/web/src/components/(gateway)/settings/SettingsUi.contract.test.ts
+++ b/apps/web/src/components/(gateway)/settings/SettingsUi.contract.test.ts
@@ -11,13 +11,17 @@ describe("settings UI contracts", () => {
 	it("keeps the section navigation outside the scrollable settings pane", () => {
 		const layoutSource = readSource("src/app/(dashboard)/settings/layout.tsx");
 		const navigationPosition = layoutSource.indexOf("<SettingsTopTabsClientOnly");
-		const scrollPanePosition = layoutSource.indexOf("overflow-y-auto");
+		const scrollPanePosition = layoutSource.indexOf("<ScrollArea");
 
 		expect(layoutSource).toContain(
 			"fixed inset-x-0 bottom-0 top-[calc(var(--site-header-height,3.75rem)+var(--site-notice-height,0px))]",
 		);
 		expect(navigationPosition).toBeGreaterThan(-1);
 		expect(scrollPanePosition).toBeGreaterThan(navigationPosition);
+		expect(layoutSource).toContain(
+			'import { ScrollArea } from "@/components/ui/scroll-area";',
+		);
+		expect(layoutSource).toContain('viewportClassName="pb-4 pt-3"');
 		const clientOnlySource = readSource(
 			"src/components/(gateway)/settings/SettingsTopTabsClientOnly.tsx",
 		);


### PR DESCRIPTION
## Summary

Replaces the Settings page content pane's native overflow container with the existing shadcn `ScrollArea` component.

The fixed Settings tab strip and sidebar boundary remain unchanged, so only the content beneath the header scrolls.

## Why

This gives the Settings pane the shared shadcn scroll treatment while retaining the explicit viewport boundary added to prevent the prior no-scroll regression.

## Validation

- `pnpm --filter @phaseo/web exec jest --runInBand --runTestsByPath …/SettingsUi.contract.test.ts`
- `pnpm --filter @phaseo/web exec eslint …layout.tsx …SettingsUi.contract.test.ts`
- `pnpm --filter @phaseo/web typecheck` after `next typegen`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved scrolling behavior in the settings area.
  * Preserved consistent spacing while navigating settings content.

* **Tests**
  * Updated coverage to verify the new settings scrolling behavior and layout spacing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->