### PR TITLE
data: add Fish Audio models and pricing

### DIFF
--- a/apps/api/src/pipeline/pricing/engine.ts
+++ b/apps/api/src/pipeline/pricing/engine.ts
@@ -9,7 +9,7 @@ import { pickFirstFiniteNumber, resolveCanonicalTokenUsage, resolveRequestCountU
 
 const KNOWN_METERS = new Set<string>([
     "input_tokens",
-    "input_characters", "input_pages",
+    "input_characters", "input_text_bytes", "input_pages",
     "input_text_tokens", "input_text_messages", "input_image", "input_image_tokens", "input_audio_minutes", "input_audio_seconds", "input_audio_tokens", "input_video_seconds", "input_video_tokens",
     "output_tokens",
     "output_text_tokens", "output_reasoning_tokens", "output_image_tokens", "output_audio_minutes", "output_audio_seconds", "output_audio_tokens", "output_video_tokens",

--- a/apps/api/src/pipeline/pricing/types.ts
+++ b/apps/api/src/pipeline/pricing/types.ts
@@ -33,6 +33,7 @@ export type PricingTimeWindow = {
 export type PricingDimensionKey =
     | "input_tokens"
     | "input_characters"
+    | "input_text_bytes"
     | "input_pages"
     | "input_text_tokens"
     | "input_image_tokens"

--- a/apps/api/src/routes/v1/control/models.catalogue.ts
+++ b/apps/api/src/routes/v1/control/models.catalogue.ts
@@ -244,6 +244,7 @@ export type CatalogueFilters = {
 const PRICING_METERS = [
     "input_tokens",
     "input_characters",
+    "input_text_bytes",
     "input_text_tokens",
     "input_image_tokens",
     "input_image",

--- a/apps/web/src/lib/pricing/meters.ts
+++ b/apps/web/src/lib/pricing/meters.ts
@@ -2,6 +2,7 @@
 const CORE_PRICING_METER_VALUES = [
   "input_tokens",
   "input_characters",
+  "input_text_bytes",
   "input_pages",
   "input_text_tokens",
   "input_text_messages",

--- a/packages/data/catalog/src/data/__tests__/validate.test.ts
+++ b/packages/data/catalog/src/data/__tests__/validate.test.ts
@@ -104,6 +104,7 @@ describe('pricing safety checks', () => {
     test('new canonical pricing meters are accepted', () => {
         const allowed = [
             'input_characters',
+            'input_text_bytes',
             'input_pages',
             'input_audio_minutes',
             'output_reasoning_tokens',

--- a/packages/data/catalog/src/data/api_providers/fish-audio/api_provider.json
+++ b/packages/data/catalog/src/data/api_providers/fish-audio/api_provider.json
@@ -1,0 +1,30 @@
+{
+  "api_provider_id": "fish-audio",
+  "provider_family_id": "fish-audio",
+  "offer_scope": "global",
+  "api_provider_name": "Fish Audio",
+  "description": "Fish Audio's hosted speech generation, transcription, and voice design API.",
+  "link": "https://fish.audio/developers/",
+  "pricing_source_url": "https://docs.fish.audio/developer-guide/models-pricing/pricing-and-rate-limits",
+  "country_code": null,
+  "status": "NotReady",
+  "colour": "#FF6B4A",
+  "privacy_policy_url": "https://fish.audio/privacy/",
+  "terms_of_service_url": "https://fish.audio/terms/",
+  "prompt_training_policy": "may_train",
+  "prompt_training_notes": "Fish Audio states that free-tier requests may be retained and used to improve model quality; production plans offer stronger data protection commitments.",
+  "prompt_training_source_url": "https://docs.fish.audio/developer-guide/models-pricing/pricing-and-rate-limits",
+  "gateway_kind": null,
+  "routable": false,
+  "routing_enabled": false,
+  "sdk_package": null,
+  "api_base_url": "https://api.fish.audio",
+  "docs_url": "https://docs.fish.audio/",
+  "auth_env": null,
+  "api_formats": [],
+  "service_tiers": ["standard", "free"],
+  "sources": [
+    { "kind": "documentation", "url": "https://docs.fish.audio/developer-guide/models-pricing/models-overview", "accessed_at": "2026-08-01T00:00:00Z", "notes": null }
+  ],
+  "verification": { "status": "verified", "checked_at": "2026-08-01T00:00:00Z", "notes": "Current models and prices verified from official Fish Audio documentation." }
+}

--- a/packages/data/catalog/src/data/api_providers/fish-audio/models.json
+++ b/packages/data/catalog/src/data/api_providers/fish-audio/models.json
@@ -1,0 +1,38 @@
+[
+  {
+    "api_model_id": "fish-audio/s2.1-pro", "provider_api_model_id": "fish-audio:fish-audio/s2.1-pro", "provider_model_slug": "s2.1-pro", "internal_model_id": "fish-audio/s2.1-pro",
+    "is_active_gateway": false, "quantization_scheme": null, "input_modalities": "text", "output_modalities": "audio_tts", "context_length": null, "max_output_tokens": null, "effective_from": "2026-06-23T00:00:00", "effective_to": null,
+    "capabilities": [{ "capability_id": "audio.speech", "status": "active", "params": [], "reasoning": null, "tool_call": null, "structured_output": null, "temperature": null, "attachment": null, "input_modalities": null, "output_modalities": null, "modes": [] }],
+    "routing_status": null, "routable": false, "regions": { "execution": null, "data": null }, "service_tiers": ["standard"], "api": { "formats": [], "endpoint": "/v1/tts", "deployment": null }, "sources": [], "verification": { "status": "verified", "checked_at": "2026-08-01T00:00:00Z", "notes": null }, "rate_limits": []
+  },
+  {
+    "api_model_id": "fish-audio/s2.1-pro:free", "provider_api_model_id": "fish-audio:fish-audio/s2.1-pro:free", "provider_model_slug": "s2.1-pro-free", "internal_model_id": "fish-audio/s2.1-pro", "canonical_model_id": "fish-audio/s2.1-pro:free",
+    "is_active_gateway": false, "quantization_scheme": null, "input_modalities": "text", "output_modalities": "audio_tts", "context_length": null, "max_output_tokens": null, "effective_from": "2026-06-23T00:00:00", "effective_to": "2026-09-01T00:00:00",
+    "capabilities": [{ "capability_id": "audio.speech", "status": "active", "params": [], "reasoning": null, "tool_call": null, "structured_output": null, "temperature": null, "attachment": null, "input_modalities": null, "output_modalities": null, "modes": [] }],
+    "routing_status": null, "routable": false, "regions": { "execution": null, "data": null }, "service_tiers": ["free"], "api": { "formats": [], "endpoint": "/v1/tts", "deployment": null }, "sources": [], "verification": { "status": "verified", "checked_at": "2026-08-01T00:00:00Z", "notes": "Free access is documented through 31 August 2026." }, "rate_limits": []
+  },
+  {
+    "api_model_id": "fish-audio/s2-pro", "provider_api_model_id": "fish-audio:fish-audio/s2-pro", "provider_model_slug": "s2-pro", "internal_model_id": "fish-audio/s2-pro",
+    "is_active_gateway": false, "quantization_scheme": null, "input_modalities": "text", "output_modalities": "audio_tts", "context_length": null, "max_output_tokens": null, "effective_from": "2026-03-09T00:00:00", "effective_to": null,
+    "capabilities": [{ "capability_id": "audio.speech", "status": "active", "params": [], "reasoning": null, "tool_call": null, "structured_output": null, "temperature": null, "attachment": null, "input_modalities": null, "output_modalities": null, "modes": [] }],
+    "routing_status": null, "routable": false, "regions": { "execution": null, "data": null }, "service_tiers": ["standard"], "api": { "formats": [], "endpoint": "/v1/tts", "deployment": null }, "sources": [], "verification": { "status": "verified", "checked_at": "2026-08-01T00:00:00Z", "notes": null }, "rate_limits": []
+  },
+  {
+    "api_model_id": "fish-audio/s1", "provider_api_model_id": "fish-audio:fish-audio/s1", "provider_model_slug": "s1", "internal_model_id": "fish-audio/s1",
+    "is_active_gateway": false, "quantization_scheme": null, "input_modalities": "text", "output_modalities": "audio_tts", "context_length": null, "max_output_tokens": null, "effective_from": "2025-11-20T00:00:00", "effective_to": null,
+    "capabilities": [{ "capability_id": "audio.speech", "status": "active", "params": [], "reasoning": null, "tool_call": null, "structured_output": null, "temperature": null, "attachment": null, "input_modalities": null, "output_modalities": null, "modes": [] }],
+    "routing_status": null, "routable": false, "regions": { "execution": null, "data": null }, "service_tiers": ["standard"], "api": { "formats": [], "endpoint": "/v1/tts", "deployment": null }, "sources": [], "verification": { "status": "verified", "checked_at": "2026-08-01T00:00:00Z", "notes": null }, "rate_limits": []
+  },
+  {
+    "api_model_id": "fish-audio/transcribe-1", "provider_api_model_id": "fish-audio:fish-audio/transcribe-1", "provider_model_slug": "transcribe-1", "internal_model_id": "fish-audio/transcribe-1",
+    "is_active_gateway": false, "quantization_scheme": null, "input_modalities": "audio", "output_modalities": "text", "context_length": null, "max_output_tokens": null, "effective_from": null, "effective_to": null,
+    "capabilities": [{ "capability_id": "audio.transcription", "status": "active", "params": [], "reasoning": null, "tool_call": null, "structured_output": null, "temperature": null, "attachment": true, "input_modalities": null, "output_modalities": null, "modes": [] }],
+    "routing_status": null, "routable": false, "regions": { "execution": null, "data": null }, "service_tiers": ["standard"], "api": { "formats": [], "endpoint": "/v1/asr", "deployment": null }, "sources": [], "verification": { "status": "verified", "checked_at": "2026-08-01T00:00:00Z", "notes": null }, "rate_limits": []
+  },
+  {
+    "api_model_id": "fish-audio/voice-design-1", "provider_api_model_id": "fish-audio:fish-audio/voice-design-1", "provider_model_slug": "voice-design-1", "internal_model_id": "fish-audio/voice-design-1",
+    "is_active_gateway": false, "quantization_scheme": null, "input_modalities": "text", "output_modalities": "audio_tts", "context_length": null, "max_output_tokens": null, "effective_from": null, "effective_to": null,
+    "capabilities": [{ "capability_id": "voice.design", "status": "active", "params": [], "reasoning": null, "tool_call": null, "structured_output": null, "temperature": null, "attachment": null, "input_modalities": null, "output_modalities": null, "modes": [] }],
+    "routing_status": null, "routable": false, "regions": { "execution": null, "data": null }, "service_tiers": ["standard"], "api": { "formats": [], "endpoint": "/v1/voice-design", "deployment": null }, "sources": [], "verification": { "status": "verified", "checked_at": "2026-08-01T00:00:00Z", "notes": null }, "rate_limits": []
+  }
+]

--- a/packages/data/catalog/src/data/models/fish-audio/s1-mini/model.json
+++ b/packages/data/catalog/src/data/models/fish-audio/s1-mini/model.json
@@ -1,0 +1,12 @@
+{
+  "model_id": "fish-audio/s1-mini", "organisation_id": "fish-audio", "name": "OpenAudio S1 Mini", "status": "Available", "previous_model_id": null,
+  "description": "The compact 0.5B-parameter open-weight edition of Fish Audio's S1 expressive text-to-speech model.",
+  "announced_date": "2025-11-20T00:00:00", "release_date": "2025-11-20T00:00:00", "deprecation_date": null, "retirement_date": null,
+  "license": "Fish Audio Research License", "input_types": "text", "output_types": "audio", "api_model_id": "fish-audio/s1-mini",
+  "links": [{ "title": "Weights", "kind": "weights", "url": "https://huggingface.co/fishaudio/openaudio-s1-mini" }], "details": [{ "name": "parameter_count", "value": 500000000 }],
+  "benchmarks": [], "family_id": null, "page_notice": { "tone": "info", "markdown": "Open-weight model; not listed as a selectable model on Fish Audio's hosted API." }, "model_type": "text-to-speech", "knowledge_cutoff": null,
+  "limits": { "context": null, "input": null, "output": null }, "modalities": { "input": ["text"], "output": ["audio"] }, "reasoning": { "supported": false, "options": [] },
+  "capabilities": { "attachment": false, "tool_call": false, "structured_output": false, "temperature": null, "streaming": null, "web_search": false }, "open_weights": true,
+  "sources": [{ "kind": "weights", "url": "https://huggingface.co/fishaudio/openaudio-s1-mini", "accessed_at": "2026-08-01T00:00:00Z", "notes": null }],
+  "verification": { "status": "verified", "checked_at": "2026-08-01T00:00:00Z", "notes": null }, "last_updated": null, "removal_date": null, "replacement_model_id": null, "license_url": "https://huggingface.co/fishaudio/openaudio-s1-mini"
+}

--- a/packages/data/catalog/src/data/models/fish-audio/s1/model.json
+++ b/packages/data/catalog/src/data/models/fish-audio/s1/model.json
@@ -1,0 +1,12 @@
+{
+  "model_id": "fish-audio/s1", "organisation_id": "fish-audio", "name": "S1", "status": "Available", "previous_model_id": null,
+  "description": "Fish Audio's 4B-parameter expressive text-to-speech model with 13-language support and more than 64 expression controls.",
+  "announced_date": "2025-11-20T00:00:00", "release_date": "2025-11-20T00:00:00", "deprecation_date": null, "retirement_date": null,
+  "license": "Proprietary", "input_types": "text", "output_types": "audio", "api_model_id": "fish-audio/s1",
+  "links": [{ "title": "Announcement", "kind": "announcement", "url": "https://fish.audio/blog/introducing-s1/" }],
+  "details": [{ "name": "parameter_count", "value": 4000000000 }, { "name": "languages", "value": 13 }], "benchmarks": [], "family_id": null, "page_notice": null, "model_type": "text-to-speech", "knowledge_cutoff": null,
+  "limits": { "context": null, "input": null, "output": null }, "modalities": { "input": ["text"], "output": ["audio"] }, "reasoning": { "supported": false, "options": [] },
+  "capabilities": { "attachment": false, "tool_call": false, "structured_output": false, "temperature": null, "streaming": true, "web_search": false }, "open_weights": false,
+  "sources": [{ "kind": "documentation", "url": "https://docs.fish.audio/developer-guide/models-pricing/models-overview", "accessed_at": "2026-08-01T00:00:00Z", "notes": null }],
+  "verification": { "status": "verified", "checked_at": "2026-08-01T00:00:00Z", "notes": null }, "last_updated": null, "removal_date": null, "replacement_model_id": "fish-audio/s2-pro", "license_url": null
+}

--- a/packages/data/catalog/src/data/models/fish-audio/s2-pro/model.json
+++ b/packages/data/catalog/src/data/models/fish-audio/s2-pro/model.json
@@ -1,0 +1,12 @@
+{
+  "model_id": "fish-audio/s2-pro", "organisation_id": "fish-audio", "name": "S2 Pro", "status": "Available", "previous_model_id": "fish-audio/s1",
+  "description": "Fish Audio's open-weight multilingual text-to-speech model, supporting more than 80 languages and low-latency streaming generation.",
+  "announced_date": "2026-03-09T00:00:00", "release_date": "2026-03-09T00:00:00", "deprecation_date": null, "retirement_date": null,
+  "license": "Fish Audio Research License", "input_types": "text", "output_types": "audio", "api_model_id": "fish-audio/s2-pro",
+  "links": [{ "title": "Announcement", "kind": "announcement", "url": "https://fish.audio/blog/fish-audio-open-sources-s2/" }, { "title": "Weights", "kind": "weights", "url": "https://huggingface.co/fishaudio" }],
+  "details": [{ "name": "parameter_count", "value": 4400000000 }], "benchmarks": [], "family_id": null, "page_notice": null, "model_type": "text-to-speech", "knowledge_cutoff": null,
+  "limits": { "context": null, "input": null, "output": null }, "modalities": { "input": ["text"], "output": ["audio"] }, "reasoning": { "supported": false, "options": [] },
+  "capabilities": { "attachment": false, "tool_call": false, "structured_output": false, "temperature": null, "streaming": true, "web_search": false },
+  "open_weights": true, "sources": [{ "kind": "documentation", "url": "https://docs.fish.audio/developer-guide/models-pricing/models-overview", "accessed_at": "2026-08-01T00:00:00Z", "notes": null }],
+  "verification": { "status": "verified", "checked_at": "2026-08-01T00:00:00Z", "notes": null }, "last_updated": null, "removal_date": null, "replacement_model_id": "fish-audio/s2.1-pro", "license_url": "https://huggingface.co/fishaudio"
+}

--- a/packages/data/catalog/src/data/models/fish-audio/s2.1-pro/model.json
+++ b/packages/data/catalog/src/data/models/fish-audio/s2.1-pro/model.json
@@ -1,0 +1,13 @@
+{
+  "model_id": "fish-audio/s2.1-pro", "organisation_id": "fish-audio", "name": "S2.1 Pro", "status": "Available",
+  "previous_model_id": "fish-audio/s2-pro", "description": "Fish Audio's production text-to-speech model with multi-speaker generation, inline expression controls, and support for 83 languages.",
+  "announced_date": "2026-06-23T00:00:00", "release_date": "2026-06-23T00:00:00", "deprecation_date": null, "retirement_date": null,
+  "license": "Proprietary", "input_types": "text", "output_types": "audio", "api_model_id": "fish-audio/s2.1-pro",
+  "variants": [{ "model_id": "fish-audio/s2.1-pro:free", "name": "S2.1 Pro (Free)", "variant_kind": "free" }],
+  "links": [{ "title": "Announcement", "kind": "announcement", "url": "https://fish.audio/blog/s2-1-pro-free-api/" }],
+  "details": [{ "name": "languages", "value": 83 }], "benchmarks": [], "family_id": null, "page_notice": null, "model_type": "text-to-speech", "knowledge_cutoff": null,
+  "limits": { "context": null, "input": null, "output": null }, "modalities": { "input": ["text"], "output": ["audio"] },
+  "reasoning": { "supported": false, "options": [] }, "capabilities": { "attachment": false, "tool_call": false, "structured_output": false, "temperature": null, "streaming": true, "web_search": false },
+  "open_weights": false, "sources": [{ "kind": "documentation", "url": "https://docs.fish.audio/developer-guide/models-pricing/models-overview", "accessed_at": "2026-08-01T00:00:00Z", "notes": null }],
+  "verification": { "status": "verified", "checked_at": "2026-08-01T00:00:00Z", "notes": null }, "last_updated": null, "removal_date": null, "replacement_model_id": null, "license_url": null
+}

--- a/packages/data/catalog/src/data/models/fish-audio/transcribe-1/model.json
+++ b/packages/data/catalog/src/data/models/fish-audio/transcribe-1/model.json
@@ -1,0 +1,10 @@
+{
+  "model_id": "fish-audio/transcribe-1", "organisation_id": "fish-audio", "name": "Transcribe-1", "status": "Available", "previous_model_id": null,
+  "description": "Fish Audio's speech-to-text model for transcription with timestamped output.", "announced_date": null, "release_date": null, "deprecation_date": null, "retirement_date": null,
+  "license": "Proprietary", "input_types": "audio", "output_types": "text", "api_model_id": "fish-audio/transcribe-1",
+  "links": [{ "title": "Documentation", "kind": "documentation", "url": "https://docs.fish.audio/features/speech-to-text" }], "details": [], "benchmarks": [], "family_id": null, "page_notice": null, "model_type": "speech-to-text", "knowledge_cutoff": null,
+  "limits": { "context": null, "input": null, "output": null }, "modalities": { "input": ["audio"], "output": ["text"] }, "reasoning": { "supported": false, "options": [] },
+  "capabilities": { "attachment": true, "tool_call": false, "structured_output": false, "temperature": null, "streaming": null, "web_search": false }, "open_weights": false,
+  "sources": [{ "kind": "documentation", "url": "https://docs.fish.audio/features/speech-to-text", "accessed_at": "2026-08-01T00:00:00Z", "notes": "Official documentation does not publish a model release date." }],
+  "verification": { "status": "verified", "checked_at": "2026-08-01T00:00:00Z", "notes": null }, "last_updated": null, "removal_date": null, "replacement_model_id": null, "license_url": null
+}

--- a/packages/data/catalog/src/data/models/fish-audio/voice-design-1/model.json
+++ b/packages/data/catalog/src/data/models/fish-audio/voice-design-1/model.json
@@ -1,0 +1,10 @@
+{
+  "model_id": "fish-audio/voice-design-1", "organisation_id": "fish-audio", "name": "Voice Design 1", "status": "Available", "previous_model_id": null,
+  "description": "Fish Audio's model for creating a reusable synthetic voice from a natural-language description.", "announced_date": null, "release_date": null, "deprecation_date": null, "retirement_date": null,
+  "license": "Proprietary", "input_types": "text", "output_types": "audio", "api_model_id": "fish-audio/voice-design-1",
+  "links": [{ "title": "Documentation", "kind": "documentation", "url": "https://docs.fish.audio/features/voice-design" }], "details": [], "benchmarks": [], "family_id": null, "page_notice": null, "model_type": "voice-design", "knowledge_cutoff": null,
+  "limits": { "context": null, "input": null, "output": null }, "modalities": { "input": ["text"], "output": ["audio"] }, "reasoning": { "supported": false, "options": [] },
+  "capabilities": { "attachment": false, "tool_call": false, "structured_output": false, "temperature": null, "streaming": null, "web_search": false }, "open_weights": false,
+  "sources": [{ "kind": "documentation", "url": "https://docs.fish.audio/developer-guide/models-pricing/pricing-and-rate-limits", "accessed_at": "2026-08-01T00:00:00Z", "notes": "Official documentation does not publish a model release date." }],
+  "verification": { "status": "verified", "checked_at": "2026-08-01T00:00:00Z", "notes": null }, "last_updated": null, "removal_date": null, "replacement_model_id": null, "license_url": null
+}

--- a/packages/data/catalog/src/data/organisations/fish-audio/organisation.json
+++ b/packages/data/catalog/src/data/organisations/fish-audio/organisation.json
@@ -1,0 +1,18 @@
+{
+  "organisation_id": "fish-audio",
+  "name": "Fish Audio",
+  "country_code": "US",
+  "description": "Fish Audio develops expressive speech generation, voice design, and speech recognition models and APIs.",
+  "colour": "#FF6B4A",
+  "organisation_links": [
+    { "platform": "website", "url": "https://fish.audio/" },
+    { "platform": "github", "url": "https://github.com/fishaudio" },
+    { "platform": "hugging_face", "url": "https://huggingface.co/fishaudio" }
+  ],
+  "status": "active",
+  "routable": false,
+  "sources": [
+    { "kind": "website", "url": "https://fish.audio/developers/", "accessed_at": "2026-08-01T00:00:00Z", "notes": null }
+  ],
+  "verification": { "status": "verified", "checked_at": "2026-08-01T00:00:00Z", "notes": "Verified against Fish Audio's developer site and documentation." }
+}

--- a/packages/data/catalog/src/data/pricing/fish-audio/s1/audio.speech/pricing.json
+++ b/packages/data/catalog/src/data/pricing/fish-audio/s1/audio.speech/pricing.json
@@ -1,0 +1,5 @@
+{
+  "key": "fish-audio:fish-audio/s1:audio.speech", "api_provider_id": "fish-audio", "provider_slug": "fish-audio", "api_model_id": "fish-audio/s1", "capability_id": "audio.speech",
+  "rules": [{ "meter": "input_text_bytes", "unit": "byte", "unit_size": 1000000, "price_per_unit": 15, "currency": "USD", "pricing_plan": "standard", "note": "Fish Audio bills UTF-8 encoded input bytes.", "match": [], "priority": 100, "effective_from": "2025-11-20T00:00:00Z", "region": null, "cache_duration_seconds": null, "conditions": [], "source": "https://docs.fish.audio/developer-guide/models-pricing/pricing-and-rate-limits" }],
+  "regions": [], "service_tiers": ["standard"], "sources": [], "verification": { "status": "verified", "checked_at": "2026-08-01T00:00:00Z", "notes": null }
+}

--- a/packages/data/catalog/src/data/pricing/fish-audio/s2-pro/audio.speech/pricing.json
+++ b/packages/data/catalog/src/data/pricing/fish-audio/s2-pro/audio.speech/pricing.json
@@ -1,0 +1,5 @@
+{
+  "key": "fish-audio:fish-audio/s2-pro:audio.speech", "api_provider_id": "fish-audio", "provider_slug": "fish-audio", "api_model_id": "fish-audio/s2-pro", "capability_id": "audio.speech",
+  "rules": [{ "meter": "input_text_bytes", "unit": "byte", "unit_size": 1000000, "price_per_unit": 15, "currency": "USD", "pricing_plan": "standard", "note": "Fish Audio bills UTF-8 encoded input bytes.", "match": [], "priority": 100, "effective_from": "2026-03-09T00:00:00Z", "region": null, "cache_duration_seconds": null, "conditions": [], "source": "https://docs.fish.audio/developer-guide/models-pricing/pricing-and-rate-limits" }],
+  "regions": [], "service_tiers": ["standard"], "sources": [], "verification": { "status": "verified", "checked_at": "2026-08-01T00:00:00Z", "notes": null }
+}

--- a/packages/data/catalog/src/data/pricing/fish-audio/s2.1-pro-free/audio.speech/pricing.json
+++ b/packages/data/catalog/src/data/pricing/fish-audio/s2.1-pro-free/audio.speech/pricing.json
@@ -1,0 +1,5 @@
+{
+  "key": "fish-audio:fish-audio/s2.1-pro:free:audio.speech", "api_provider_id": "fish-audio", "provider_slug": "fish-audio", "api_model_id": "fish-audio/s2.1-pro:free", "capability_id": "audio.speech",
+  "rules": [{ "meter": "input_text_bytes", "unit": "byte", "unit_size": 1000000, "price_per_unit": 0, "currency": "USD", "pricing_plan": "free", "note": "Free access is documented through 31 August 2026 and has no production SLA or DPA guarantee.", "match": [], "priority": 100, "effective_from": "2026-06-23T00:00:00Z", "effective_to": "2026-09-01T00:00:00Z", "region": null, "cache_duration_seconds": null, "conditions": [], "source": "https://docs.fish.audio/developer-guide/models-pricing/pricing-and-rate-limits" }],
+  "regions": [], "service_tiers": ["free"], "sources": [], "verification": { "status": "verified", "checked_at": "2026-08-01T00:00:00Z", "notes": null }
+}

--- a/packages/data/catalog/src/data/pricing/fish-audio/s2.1-pro/audio.speech/pricing.json
+++ b/packages/data/catalog/src/data/pricing/fish-audio/s2.1-pro/audio.speech/pricing.json
@@ -1,0 +1,5 @@
+{
+  "key": "fish-audio:fish-audio/s2.1-pro:audio.speech", "api_provider_id": "fish-audio", "provider_slug": "fish-audio", "api_model_id": "fish-audio/s2.1-pro", "capability_id": "audio.speech",
+  "rules": [{ "meter": "input_text_bytes", "unit": "byte", "unit_size": 1000000, "price_per_unit": 15, "currency": "USD", "pricing_plan": "standard", "note": "Fish Audio bills UTF-8 encoded input bytes, not Unicode characters.", "match": [], "priority": 100, "effective_from": "2026-06-23T00:00:00Z", "region": null, "cache_duration_seconds": null, "conditions": [], "source": "https://docs.fish.audio/developer-guide/models-pricing/pricing-and-rate-limits" }],
+  "regions": [], "service_tiers": ["standard"], "sources": [], "verification": { "status": "verified", "checked_at": "2026-08-01T00:00:00Z", "notes": null }
+}

--- a/packages/data/catalog/src/data/pricing/fish-audio/transcribe-1/audio.transcription/pricing.json
+++ b/packages/data/catalog/src/data/pricing/fish-audio/transcribe-1/audio.transcription/pricing.json
@@ -1,0 +1,5 @@
+{
+  "key": "fish-audio:fish-audio/transcribe-1:audio.transcription", "api_provider_id": "fish-audio", "provider_slug": "fish-audio", "api_model_id": "fish-audio/transcribe-1", "capability_id": "audio.transcription",
+  "rules": [{ "meter": "input_audio_seconds", "unit": "second", "unit_size": 3600, "price_per_unit": 0.36, "currency": "USD", "pricing_plan": "standard", "note": "Usage is rounded up to the nearest second.", "match": [], "priority": 100, "effective_from": "2026-08-01T00:00:00Z", "region": null, "cache_duration_seconds": null, "conditions": [], "source": "https://docs.fish.audio/developer-guide/models-pricing/pricing-and-rate-limits" }],
+  "regions": [], "service_tiers": ["standard"], "sources": [], "verification": { "status": "verified", "checked_at": "2026-08-01T00:00:00Z", "notes": null }
+}

--- a/packages/data/catalog/src/data/pricing/fish-audio/voice-design-1/voice.design/pricing.json
+++ b/packages/data/catalog/src/data/pricing/fish-audio/voice-design-1/voice.design/pricing.json
@@ -1,0 +1,5 @@
+{
+  "key": "fish-audio:fish-audio/voice-design-1:voice.design", "api_provider_id": "fish-audio", "provider_slug": "fish-audio", "api_model_id": "fish-audio/voice-design-1", "capability_id": "voice.design",
+  "rules": [{ "meter": "requests", "unit": "successful request", "unit_size": 1, "price_per_unit": 0.01, "currency": "USD", "pricing_plan": "standard", "note": "Charged only for successful voice-design requests.", "match": [], "priority": 100, "effective_from": "2026-08-01T00:00:00Z", "region": null, "cache_duration_seconds": null, "conditions": [], "source": "https://docs.fish.audio/developer-guide/models-pricing/pricing-and-rate-limits" }],
+  "regions": [], "service_tiers": ["standard"], "sources": [], "verification": { "status": "verified", "checked_at": "2026-08-01T00:00:00Z", "notes": null }
+}


### PR DESCRIPTION
## Summary

- add Fish Audio as an organisation and catalogue-only API provider
- add S2.1 Pro (including the temporary free variant), S2 Pro, S1, OpenAudio S1 Mini, Transcribe-1, and Voice Design 1
- add official hosted pricing for TTS, transcription, and voice design
- introduce `input_text_bytes` so Fish Audio's UTF-8 byte billing is represented exactly rather than approximated as characters
- retain official release dates where published and leave undocumented dates unset

## Routing

Fish Audio provider entries are deliberately not routable yet because Phaseo does not currently have a Fish Audio gateway adapter.

## Validation

- catalogue structure validation passed
- pricing validation passed
- gateway validation passed
- JSON parsing and cross-reference checks passed

## Research notes

Official Fish Audio documentation and announcements were used as the source of truth. Deprecated `speech-1.5` and `speech-1.6` were not added because sufficiently reliable historical launch and pricing data was not available.