### PR TITLE
Refine mobile settings navigation and page actions

### DIFF
--- a/apps/web/src/app/(dashboard)/settings/keys/page.tsx
+++ b/apps/web/src/app/(dashboard)/settings/keys/page.tsx
@@ -51,7 +51,7 @@ async function KeysContent({
 				title="API Keys"
 				description="Create and manage gateway API keys for this workspace."
 				actions={
-					<div className="flex items-center gap-2">
+					<div className="flex flex-wrap items-center gap-2">
 						<Button asChild variant="outline" size="sm">
 							<Link
 								href={QUICKSTART_DOCS_HREF}

--- a/apps/web/src/components/(gateway)/settings/SettingsPageHeader.tsx
+++ b/apps/web/src/components/(gateway)/settings/SettingsPageHeader.tsx
@@ -12,7 +12,7 @@ export default function SettingsPageHeader(props: {
 	const { title, description, meta, actions, className } = props;
 
 	return (
-		<div className={cn("flex items-start justify-between gap-4", className)}>
+		<div className={cn("space-y-4", className)}>
 			<div className="min-w-0">
 				<div className="flex flex-wrap items-center gap-2">
 					<h1 className="text-2xl font-semibold tracking-tight">{title}</h1>
@@ -22,7 +22,7 @@ export default function SettingsPageHeader(props: {
 					<p className="mt-1 text-sm text-muted-foreground">{description}</p>
 				) : null}
 			</div>
-			{actions ? <div className="shrink-0">{actions}</div> : null}
+			{actions ? <div className="w-full">{actions}</div> : null}
 		</div>
 	);
 }

--- a/apps/web/src/components/(gateway)/settings/SettingsSidebarTrigger.tsx
+++ b/apps/web/src/components/(gateway)/settings/SettingsSidebarTrigger.tsx
@@ -2,7 +2,8 @@
 
 import Link from "next/link";
 import { usePathname } from "next/navigation";
-import { Building2, Check, ChevronDown, UserRound } from "lucide-react";
+import { useSyncExternalStore } from "react";
+import { Building2, Check, Menu as MenuIcon, UserRound } from "lucide-react";
 
 import { Badge } from "@/components/ui/badge";
 import { buttonVariants } from "@/components/ui/button";
@@ -19,6 +20,10 @@ import {
 import { getActiveSettingsNav, getSettingsSidebar } from "./Sidebar.config";
 import { cn } from "@/lib/utils";
 
+const subscribe = () => () => {};
+const getClientSnapshot = () => true;
+const getServerSnapshot = () => false;
+
 export default function SettingsSidebarTrigger({
 	showBroadcast = true,
 	showWebhooks = true,
@@ -27,39 +32,39 @@ export default function SettingsSidebarTrigger({
 	showWebhooks?: boolean;
 }) {
 	const pathname = usePathname();
+	const isHydrated = useSyncExternalStore(
+		subscribe,
+		getClientSnapshot,
+		getServerSnapshot,
+	);
 	const navGroups = getSettingsSidebar({ showBroadcast, showWebhooks });
 	const activeNav = getActiveSettingsNav(pathname ?? "", { showBroadcast, showWebhooks });
 	const activeItem = activeNav?.item ?? null;
 	const activeScope = activeNav?.group.scope ?? "personal";
 	const visibleGroups = navGroups.filter((group) => group.scope === activeScope);
 
+	if (!isHydrated || !pathname?.startsWith("/settings")) return null;
+
 	return (
 		<div className="lg:hidden">
 			<DropdownMenu>
 				<DropdownMenuTrigger
-					className={cn(buttonVariants({ variant: "outline" }), "w-full justify-between")}
+					className={cn(
+						buttonVariants({ variant: "ghost", size: "icon" }),
+						"size-[var(--site-header-control-h,2.25rem)] shrink-0 rounded-lg",
+					)}
+					aria-label="Open settings menu"
 					aria-haspopup="menu"
 				>
-							<span className="flex min-w-0 items-center gap-2">
-								<span className="truncate">{activeItem?.label ?? "Settings"}</span>
-							{activeItem?.badge && (
-								<Badge
-									variant="outline"
-									className="h-5 px-1.5 text-[10px] capitalize"
-								>
-									{activeItem.badge}
-								</Badge>
-							)}
-						</span>
-						<ChevronDown className="h-4 w-4 shrink-0" aria-hidden="true" />
+					<MenuIcon className="size-5" aria-hidden="true" />
 				</DropdownMenuTrigger>
 				<DropdownMenuContent
 					align="start"
 					className="w-[min(24rem,calc(100vw-2rem))]"
 				>
 					<div className="grid grid-cols-2 gap-1 p-1">
-						<Link href="/settings/profile" className={cn("flex h-9 items-center justify-center gap-2 rounded-md px-2 text-xs font-medium", activeScope === "personal" ? "bg-accent text-accent-foreground" : "text-muted-foreground hover:bg-accent/60 hover:text-foreground")}><UserRound className="size-3.5" />My account</Link>
-						<Link href="/settings/workspaces/settings" className={cn("flex h-9 items-center justify-center gap-2 rounded-md px-2 text-xs font-medium", activeScope === "workspace" ? "bg-accent text-accent-foreground" : "text-muted-foreground hover:bg-accent/60 hover:text-foreground")}><Building2 className="size-3.5" />Workspace</Link>
+						<Link href="/settings/profile" className={cn("flex h-9 items-center justify-center gap-2 rounded-md px-2 text-xs font-medium", activeScope === "personal" ? "bg-accent text-accent-foreground" : "text-muted-foreground hover:bg-accent/60 hover:text-foreground")}><UserRound className="size-3.5" aria-hidden="true" />My account</Link>
+						<Link href="/settings/workspaces/settings" className={cn("flex h-9 items-center justify-center gap-2 rounded-md px-2 text-xs font-medium", activeScope === "workspace" ? "bg-accent text-accent-foreground" : "text-muted-foreground hover:bg-accent/60 hover:text-foreground")}><Building2 className="size-3.5" aria-hidden="true" />Workspace</Link>
 					</div>
 					<DropdownMenuSeparator />
 					{visibleGroups.map((group, index) => (
@@ -71,6 +76,7 @@ export default function SettingsSidebarTrigger({
 							) : null}
 							{group.items.map((item) => {
 								const active = activeItem?.href === item.href;
+								const Icon = item.icon;
 								return (
 									<DropdownMenuItem
 										key={item.href}
@@ -78,18 +84,19 @@ export default function SettingsSidebarTrigger({
 											<Link href={item.href} className="flex w-full items-center gap-2" />
 										}
 									>
-											<span className="min-w-0 flex-1 truncate">
-												{item.label}
-											</span>
-											{item.badge ? (
-												<Badge
-													variant="outline"
-											className="h-5 px-1.5 text-[10px] capitalize"
-												>
-													{item.badge}
-												</Badge>
-											) : null}
-											{active ? <Check className="h-4 w-4 shrink-0" /> : null}
+										{Icon ? <Icon className="size-4 shrink-0" aria-hidden="true" /> : null}
+										<span className="min-w-0 flex-1 truncate">
+											{item.label}
+										</span>
+										{item.badge ? (
+											<Badge
+												variant="outline"
+												className="h-5 px-1.5 text-[10px] capitalize"
+											>
+												{item.badge}
+											</Badge>
+										) : null}
+										{active ? <Check className="size-4 shrink-0" aria-hidden="true" /> : null}
 									</DropdownMenuItem>
 								);
 							})}

--- a/apps/web/src/components/(gateway)/settings/SettingsTopTabsServer.tsx
+++ b/apps/web/src/components/(gateway)/settings/SettingsTopTabsServer.tsx
@@ -3,19 +3,9 @@
 import * as React from "react";
 import Link from "next/link";
 import { usePathname, useSearchParams } from "next/navigation";
-import { ChevronDown } from "lucide-react";
-
 import { cn } from "@/lib/utils";
 import { Badge } from "@/components/ui/badge";
-import { buttonVariants } from "@/components/ui/button";
-import {
-	DropdownMenu,
-	DropdownMenuContent,
-	DropdownMenuItem,
-	DropdownMenuTrigger,
-} from "@/components/ui/dropdown-menu";
 import { getActiveSettingsNav } from "./Sidebar.config";
-import SettingsSidebarTrigger from "./SettingsSidebarTrigger";
 
 type Tab = {
 	href: string;
@@ -159,10 +149,6 @@ export default function SettingsTopTabsServer({
 		[pathname, showBroadcast, showWebhooks],
 	);
 
-	const containerRef = React.useRef<HTMLDivElement | null>(null);
-	const linkRefs = React.useRef<Record<string, HTMLAnchorElement | null>>({});
-	const [indicator, setIndicator] = React.useState({ left: 0, width: 0, opacity: 0 });
-
 	const matchScore = React.useCallback((t: Tab) => {
 		if (t.view) {
 			return pathname.startsWith("/settings/usage/logs") && t.view === logsView
@@ -207,167 +193,48 @@ export default function SettingsTopTabsServer({
 					})[0]?.t ?? tabs[0]
 			: null;
 
-	const setIndicatorToHref = React.useCallback((href: string | null) => {
-		const container = containerRef.current;
-		if (!container || !href) return;
-		const el = linkRefs.current[href];
-		if (!el) return;
+	const displayedTabs: Tab[] = tabs?.length
+		? tabs
+		: [{
+			href: (activeNav?.item.href ?? pathname) || "/settings",
+			label: activeNav?.item.label ?? "Settings",
+			badge: activeNav?.item.badge,
+		}];
 
-		const containerRect = container.getBoundingClientRect();
-		const rect = el.getBoundingClientRect();
-		setIndicator({
-			left: rect.left - containerRect.left,
-			width: rect.width,
-			opacity: 1,
-		});
-	}, []);
-
-	React.useEffect(() => {
-		const update = () => setIndicatorToHref(activeTab?.href ?? null);
-		const raf = requestAnimationFrame(update);
-		window.addEventListener("resize", update);
-		return () => {
-			cancelAnimationFrame(raf);
-			window.removeEventListener("resize", update);
-		};
-	}, [activeTab?.href, setIndicatorToHref]);
-
-	if (!tabs?.length) {
-		return (
-			<>
-				<SettingsSidebarTrigger showBroadcast={showBroadcast} showWebhooks={showWebhooks} />
-				<nav
-					className="relative hidden h-[52px] items-end border-b border-border lg:flex"
-					aria-label="Settings section navigation"
-				>
-					<div
-						aria-current="page"
-						className="flex border-b-2 border-muted-foreground px-2 pb-2 text-sm font-medium text-primary"
+	return (
+		<nav
+			className="flex h-[52px] items-end gap-2 overflow-x-auto overscroll-x-contain border-b border-border [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
+			aria-label="Settings section navigation"
+		>
+			{displayedTabs.map((tab) => {
+				const active = !tabs?.length || tab.href === activeTab?.href;
+				return (
+					<Link
+						key={tab.href}
+						href={navigationHref(tab)}
+						prefetch={false}
+						aria-current={active ? "page" : undefined}
+						className={cn(
+							"shrink-0 whitespace-nowrap border-b-2 px-2 pb-2 text-sm font-medium transition-colors duration-150",
+							active
+								? "border-muted-foreground text-primary"
+								: "border-transparent text-muted-foreground hover:text-primary",
+						)}
 					>
 						<span className="flex items-center gap-2">
-							<span>{activeNav?.item.label ?? "Settings"}</span>
-							{activeNav?.item.badge ? (
+							<span>{tab.label}</span>
+							{tab.badge ? (
 								<Badge
 									variant="outline"
 									className="h-5 px-1.5 text-[10px] capitalize"
 								>
-									{activeNav.item.badge}
+									{tab.badge}
 								</Badge>
 							) : null}
 						</span>
-					</div>
-				</nav>
-			</>
-		);
-	}
-
-	return (
-		<>
-			<nav className="flex h-[52px] items-center md:hidden" aria-label="Settings section navigation">
-				<div className="flex w-full items-center gap-2">
-					<div className="min-w-0 flex-1">
-						<SettingsSidebarTrigger
-							showBroadcast={showBroadcast}
-							showWebhooks={showWebhooks}
-						/>
-					</div>
-					<div className="min-w-0 flex-1">
-						<DropdownMenu>
-							<DropdownMenuTrigger
-								className={cn(buttonVariants({ variant: "outline" }), "h-9 w-full min-w-0 justify-between")}
-							>
-									<span className="truncate">
-										{activeTab?.label ?? "Settings"}
-									</span>
-									<ChevronDown className="h-4 w-4 shrink-0" />
-							</DropdownMenuTrigger>
-							<DropdownMenuContent
-								align="end"
-								className="w-[min(20rem,calc(100vw-1rem))]"
-							>
-								{tabs.map((tab) => {
-									const active = tab.href === activeTab?.href;
-									return (
-										<DropdownMenuItem
-											key={tab.href}
-											render={
-												<Link
-												href={navigationHref(tab)}
-												prefetch={false}
-												aria-current={active ? "page" : undefined}
-												className="flex items-center gap-2"
-												/>
-											}
-										>
-												<span className={cn("flex-1 truncate", active && "font-semibold")}>
-													{tab.label}
-												</span>
-												{tab.badge ? (
-													<Badge
-														variant="outline"
-														className="h-4 px-1 text-[9px] capitalize"
-													>
-														{tab.badge}
-													</Badge>
-												) : null}
-										</DropdownMenuItem>
-									);
-								})}
-							</DropdownMenuContent>
-						</DropdownMenu>
-					</div>
-				</div>
-			</nav>
-
-			<nav
-				ref={containerRef}
-				className="relative hidden h-[52px] items-end gap-4 border-b border-border md:flex"
-				onMouseLeave={() => setIndicatorToHref(activeTab?.href ?? null)}
-				aria-label="Settings section navigation"
-			>
-				<div
-					aria-hidden="true"
-					className="pointer-events-none absolute bottom-0 h-0.5 rounded bg-muted-foreground transition-[left,width,opacity] duration-200 ease-out"
-					style={{
-						left: indicator.left,
-						width: indicator.width,
-						opacity: indicator.opacity,
-					}}
-				/>
-
-				{tabs.map((tab) => {
-					const active = tab.href === activeTab?.href;
-					return (
-						<Link
-							key={tab.href}
-							href={navigationHref(tab)}
-							prefetch={false}
-							aria-current={active ? "page" : undefined}
-							ref={(el) => {
-								linkRefs.current[tab.href] = el;
-							}}
-							onMouseEnter={() => setIndicatorToHref(tab.href)}
-							onFocus={() => setIndicatorToHref(tab.href)}
-							className={cn(
-								"pb-2 px-2 text-sm font-medium transition-colors duration-150",
-								active ? "text-primary" : "text-muted-foreground hover:text-primary",
-							)}
-						>
-							<span className="flex items-center gap-2">
-								<span>{tab.label}</span>
-								{tab.badge ? (
-									<Badge
-										variant="outline"
-									className="h-5 px-1.5 text-[10px] capitalize"
-									>
-										{tab.badge}
-									</Badge>
-								) : null}
-							</span>
-						</Link>
-					);
-				})}
-			</nav>
-		</>
+					</Link>
+				);
+			})}
+		</nav>
 	);
 }

--- a/apps/web/src/components/(gateway)/settings/SettingsUi.contract.test.ts
+++ b/apps/web/src/components/(gateway)/settings/SettingsUi.contract.test.ts
@@ -38,21 +38,32 @@ describe("settings UI contracts", () => {
 	});
 
 	it("keeps the complete mobile settings navigation on Base UI", () => {
+		const headerSource = readSource("src/components/header/header.tsx");
 		const tabsSource = readSource(
 			"src/components/(gateway)/settings/SettingsTopTabsServer.tsx",
 		);
 		const menuSource = readSource(
 			"src/components/(gateway)/settings/SettingsSidebarTrigger.tsx",
 		);
+		const pageHeaderSource = readSource(
+			"src/components/(gateway)/settings/SettingsPageHeader.tsx",
+		);
+		const keysPageSource = readSource("src/app/(dashboard)/settings/keys/page.tsx");
 
-		expect(tabsSource).toContain("<SettingsSidebarTrigger");
-		expect(tabsSource).toContain("<DropdownMenu>");
-		expect(tabsSource).toContain("<DropdownMenuTrigger");
-		expect(tabsSource).toContain("buttonVariants({ variant: \"outline\" })");
-		expect(tabsSource).toContain("render={");
-		expect(tabsSource).toContain("<Link");
-		expect(tabsSource).not.toContain("asChild");
+		expect(headerSource).toContain("<SettingsSidebarTrigger");
+		expect(headerSource.indexOf("<SettingsSidebarTrigger")).toBeLessThan(
+			headerSource.indexOf('aria-label="Phaseo home"'),
+		);
+		expect(tabsSource).not.toContain("<SettingsSidebarTrigger");
+		expect(tabsSource).not.toContain("<DropdownMenu");
+		expect(tabsSource).toContain("overflow-x-auto");
+		expect(tabsSource).toContain("overscroll-x-contain");
+		expect(tabsSource).toContain("shrink-0 whitespace-nowrap");
 		expect(menuSource).not.toContain("asChild");
+		expect(menuSource).toContain('aria-label="Open settings menu"');
+		expect(menuSource).toContain("<MenuIcon");
+		expect(menuSource).toContain("const Icon = item.icon");
+		expect(menuSource).toContain("<Icon className=");
 		expect(menuSource).toContain("My account");
 		expect(menuSource).toContain("Workspace");
 		expect(menuSource).toContain("visibleGroups.map");
@@ -61,7 +72,13 @@ describe("settings UI contracts", () => {
 		expect(menuSource.indexOf("<DropdownMenuGroup key=")).toBeLessThan(
 			menuSource.indexOf("<DropdownMenuLabel"),
 		);
+		expect(pageHeaderSource).toContain('className={cn("space-y-4", className)}');
+		expect(pageHeaderSource.indexOf("{actions ?")).toBeGreaterThan(
+			pageHeaderSource.indexOf("{description ?"),
+		);
+		expect(keysPageSource).toContain("flex flex-wrap items-center gap-2");
 	});
+
 	it("provides display-label collections for ID-backed settings selects", () => {
 		const expectedItemCollections: Record<string, string[]> = {
 			"src/components/(gateway)/settings/account/AccountSettingsClient.tsx": [

--- a/apps/web/src/components/(gateway)/settings/SettingsUi.contract.test.ts
+++ b/apps/web/src/components/(gateway)/settings/SettingsUi.contract.test.ts
@@ -34,7 +34,8 @@ describe("settings UI contracts", () => {
 
 		expect(tabsSource).not.toContain("ChevronRight");
 		expect(tabsSource).toContain('aria-current="page"');
-		expect(tabsSource).toContain("border-b-2 border-muted-foreground");
+		expect(tabsSource).toContain("border-b-2");
+		expect(tabsSource).toContain("border-muted-foreground");
 	});
 
 	it("keeps the complete mobile settings navigation on Base UI", () => {

--- a/apps/web/src/components/header/header.tsx
+++ b/apps/web/src/components/header/header.tsx
@@ -10,6 +10,7 @@ import { HeaderAnnouncements } from "./HeaderAnnouncements";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Button } from "@/components/ui/button";
 import HeaderShell from "./HeaderShell";
+import SettingsSidebarTrigger from "@/components/(gateway)/settings/SettingsSidebarTrigger";
 
 const releaseMessage = "Introducing Phaseo Gateway";
 const docsLink = "https://phaseo.app/docs/v1";
@@ -19,6 +20,9 @@ export default function Header() {
 	const headerContent = (
 		<div className="flex h-[var(--site-header-height,4rem)] items-center justify-between gap-[var(--site-header-gap,1.5rem)]">
 			<div className="flex min-w-0 flex-1 items-center gap-[var(--site-header-left-gap,1.25rem)] overflow-hidden">
+				<Suspense fallback={null}>
+					<SettingsSidebarTrigger />
+				</Suspense>
 				<Link
 					href="/"
 					aria-label="Phaseo home"


### PR DESCRIPTION
## Summary
- move the Base UI settings menu trigger into the mobile header, before the Phaseo logo
- retain settings tabs as a horizontally scrollable strip on mobile
- add configured icons to every settings menu entry
- place settings page actions below their title and description, including API Keys

## Validation
- updated settings UI contract coverage
- browser verification at mobile width after deployment

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Redesigned settings navigation with responsive horizontal tabs and compact mobile controls.
  * Added optional icons and improved accessibility for settings navigation items.
  * Added a settings navigation trigger to the main header on applicable pages.

* **Improvements**
  * Settings page actions now wrap cleanly on smaller screens while maintaining alignment and spacing.
  * Improved responsive layout and scrolling behavior for settings tabs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->