### PR TITLE
Polish mobile settings header controls

### DIFF
--- a/apps/web/src/components/(gateway)/settings/SettingsSidebarTrigger.tsx
+++ b/apps/web/src/components/(gateway)/settings/SettingsSidebarTrigger.tsx
@@ -2,8 +2,8 @@
 
 import Link from "next/link";
 import { usePathname } from "next/navigation";
-import { useSyncExternalStore } from "react";
-import { Building2, Check, Menu as MenuIcon, UserRound } from "lucide-react";
+import { useState, useSyncExternalStore } from "react";
+import { Building2, Check, Menu as MenuIcon, UserRound, X } from "lucide-react";
 
 import { Badge } from "@/components/ui/badge";
 import { buttonVariants } from "@/components/ui/button";
@@ -32,6 +32,7 @@ export default function SettingsSidebarTrigger({
 	showWebhooks?: boolean;
 }) {
 	const pathname = usePathname();
+	const [open, setOpen] = useState(false);
 	const isHydrated = useSyncExternalStore(
 		subscribe,
 		getClientSnapshot,
@@ -47,16 +48,29 @@ export default function SettingsSidebarTrigger({
 
 	return (
 		<div className="lg:hidden">
-			<DropdownMenu>
+			<DropdownMenu open={open} onOpenChange={setOpen}>
 				<DropdownMenuTrigger
 					className={cn(
 						buttonVariants({ variant: "ghost", size: "icon" }),
-						"size-[var(--site-header-control-h,2.25rem)] shrink-0 rounded-lg",
+						"relative size-[var(--site-header-control-h,2.25rem)] shrink-0 rounded-lg",
 					)}
-					aria-label="Open settings menu"
+					aria-label={open ? "Close settings menu" : "Open settings menu"}
 					aria-haspopup="menu"
 				>
-					<MenuIcon className="size-5" aria-hidden="true" />
+					<MenuIcon
+						className={cn(
+							"absolute size-5 transition-[opacity,transform] duration-200",
+							open ? "rotate-90 scale-75 opacity-0" : "rotate-0 scale-100 opacity-100",
+						)}
+						aria-hidden="true"
+					/>
+					<X
+						className={cn(
+							"absolute size-5 transition-[opacity,transform] duration-200",
+							open ? "rotate-0 scale-100 opacity-100" : "-rotate-90 scale-75 opacity-0",
+						)}
+						aria-hidden="true"
+					/>
 				</DropdownMenuTrigger>
 				<DropdownMenuContent
 					align="start"
@@ -70,7 +84,7 @@ export default function SettingsSidebarTrigger({
 					{visibleGroups.map((group, index) => (
 						<DropdownMenuGroup key={`${group.heading ?? "group"}-${index}`}>
 							{group.heading ? (
-								<DropdownMenuLabel className="text-xs uppercase tracking-wide text-muted-foreground">
+								<DropdownMenuLabel className="text-xs font-medium text-muted-foreground">
 									{group.heading}
 								</DropdownMenuLabel>
 							) : null}

--- a/apps/web/src/components/(gateway)/settings/SettingsUi.contract.test.ts
+++ b/apps/web/src/components/(gateway)/settings/SettingsUi.contract.test.ts
@@ -55,14 +55,24 @@ describe("settings UI contracts", () => {
 		expect(headerSource.indexOf("<SettingsSidebarTrigger")).toBeLessThan(
 			headerSource.indexOf('aria-label="Phaseo home"'),
 		);
+		expect(headerSource.indexOf('<AuthControls variant="mobile"')).toBeLessThan(
+			headerSource.lastIndexOf("<SearchWrapper"),
+		);
 		expect(tabsSource).not.toContain("<SettingsSidebarTrigger");
 		expect(tabsSource).not.toContain("<DropdownMenu");
 		expect(tabsSource).toContain("overflow-x-auto");
 		expect(tabsSource).toContain("overscroll-x-contain");
 		expect(tabsSource).toContain("shrink-0 whitespace-nowrap");
 		expect(menuSource).not.toContain("asChild");
-		expect(menuSource).toContain('aria-label="Open settings menu"');
+		expect(menuSource).toContain('open={open}');
+		expect(menuSource).toContain('onOpenChange={setOpen}');
+		expect(menuSource).toContain('"Close settings menu"');
+		expect(menuSource).toContain('"Open settings menu"');
 		expect(menuSource).toContain("<MenuIcon");
+		expect(menuSource).toContain("<X");
+		expect(menuSource).toContain("transition-[opacity,transform]");
+		expect(menuSource).not.toContain("uppercase");
+		expect(menuSource).not.toContain("tracking-wide");
 		expect(menuSource).toContain("const Icon = item.icon");
 		expect(menuSource).toContain("<Icon className=");
 		expect(menuSource).toContain("My account");

--- a/apps/web/src/components/(gateway)/settings/SettingsUi.contract.test.ts
+++ b/apps/web/src/components/(gateway)/settings/SettingsUi.contract.test.ts
@@ -55,9 +55,12 @@ describe("settings UI contracts", () => {
 		expect(headerSource.indexOf("<SettingsSidebarTrigger")).toBeLessThan(
 			headerSource.indexOf('aria-label="Phaseo home"'),
 		);
+		expect(headerSource.match(/<SearchWrapper/g)).toHaveLength(1);
 		expect(headerSource.indexOf('<AuthControls variant="mobile"')).toBeLessThan(
-			headerSource.lastIndexOf("<SearchWrapper"),
+			headerSource.indexOf("<SearchWrapper"),
 		);
+		expect(headerSource).toContain('className="order-2 size-');
+		expect(headerSource).toContain("lg:order-1");
 		expect(tabsSource).not.toContain("<SettingsSidebarTrigger");
 		expect(tabsSource).not.toContain("<DropdownMenu");
 		expect(tabsSource).toContain("overflow-x-auto");

--- a/apps/web/src/components/header/header.tsx
+++ b/apps/web/src/components/header/header.tsx
@@ -65,56 +65,52 @@ export default function Header() {
 				</div>
 			</div>
 
-			<div className="hidden shrink-0 items-center gap-3 lg:flex">
+			<div className="flex shrink-0 items-center gap-1 lg:gap-3">
+				<div className="hidden lg:order-0 lg:block">
+					<Suspense
+						fallback={
+							<Skeleton className="h-[var(--site-header-control-h,2.5rem)] w-16 rounded-lg" />
+						}
+					>
+						<Link href={docsLink} target="_blank" rel="noreferrer" prefetch={false}>
+							<Button
+								variant="ghost"
+								className="h-[var(--site-header-control-h,2.25rem)] rounded-lg px-2 text-[13px] font-medium text-zinc-600 shadow-none hover:bg-zinc-100/70 xl:px-2.5 dark:text-zinc-300 dark:hover:bg-zinc-900/60"
+							>
+								<BookOpenText className="h-3.5 w-3.5" />
+								Docs
+							</Button>
+						</Link>
+					</Suspense>
+				</div>
 				<Suspense
 					fallback={
-						<Skeleton className="h-[var(--site-header-control-h,2.5rem)] w-16 rounded-lg" />
+						<Skeleton className="order-2 size-[var(--site-header-control-h,2.5rem)] rounded-lg lg:order-1 xl:w-[15rem]" />
 					}
 				>
-					<Link href={docsLink} target="_blank" rel="noreferrer" prefetch={false}>
-						<Button
-							variant="ghost"
-							className="h-[var(--site-header-control-h,2.25rem)] rounded-lg px-2 text-[13px] font-medium text-zinc-600 shadow-none hover:bg-zinc-100/70 xl:px-2.5 dark:text-zinc-300 dark:hover:bg-zinc-900/60"
-						>
-							<BookOpenText className="h-3.5 w-3.5" />
-							Docs
-						</Button>
-					</Link>
+					<SearchWrapper className="order-2 size-[var(--site-header-control-h,2.25rem)] lg:order-1 xl:w-[var(--site-header-search-width-xl,15rem)]" />
 				</Suspense>
-				<Suspense
-					fallback={
-						<Skeleton className="h-[var(--site-header-control-h,2.5rem)] w-[var(--site-header-control-h,2.25rem)] rounded-lg xl:w-[15rem]" />
-					}
-				>
-					<SearchWrapper className="w-[var(--site-header-control-h,2.25rem)] xl:w-[var(--site-header-search-width-xl,15rem)]" />
-				</Suspense>
-				<Suspense
-					fallback={
-						<div className="flex items-center gap-2">
-							<Skeleton className="h-[calc(var(--site-header-control-h,2.5rem)-0.125rem)] w-32 rounded-lg" />
-							<Skeleton className="h-[calc(var(--site-header-control-h,2.5rem)-0.25rem)] w-8 rounded-lg" />
-						</div>
-					}
-				>
-					<AuthControls variant="desktop" />
-				</Suspense>
-			</div>
-
-			<div className="flex shrink-0 items-center gap-1 lg:hidden">
-				<Suspense
-					fallback={
-						<Skeleton className="h-[var(--site-header-control-h,2.5rem)] w-[var(--site-header-control-h,2.5rem)] rounded-lg" />
-					}
-				>
-					<AuthControls variant="mobile" />
-				</Suspense>
-				<Suspense
-					fallback={
-						<Skeleton className="size-[var(--site-header-control-h,2.5rem)] rounded-lg" />
-					}
-				>
-					<SearchWrapper className="size-[var(--site-header-control-h,2.25rem)]" />
-				</Suspense>
+				<div className="order-1 hidden lg:order-2 lg:block">
+					<Suspense
+						fallback={
+							<div className="flex items-center gap-2">
+								<Skeleton className="h-[calc(var(--site-header-control-h,2.5rem)-0.125rem)] w-32 rounded-lg" />
+								<Skeleton className="h-[calc(var(--site-header-control-h,2.5rem)-0.25rem)] w-8 rounded-lg" />
+							</div>
+						}
+					>
+						<AuthControls variant="desktop" />
+					</Suspense>
+				</div>
+				<div className="order-1 lg:hidden">
+					<Suspense
+						fallback={
+							<Skeleton className="size-[var(--site-header-control-h,2.5rem)] rounded-lg" />
+						}
+					>
+						<AuthControls variant="mobile" />
+					</Suspense>
+				</div>
 			</div>
 		</div>
 	);

--- a/apps/web/src/components/header/header.tsx
+++ b/apps/web/src/components/header/header.tsx
@@ -100,13 +100,20 @@ export default function Header() {
 				</Suspense>
 			</div>
 
-			<div className="lg:hidden">
+			<div className="flex shrink-0 items-center gap-1 lg:hidden">
 				<Suspense
 					fallback={
 						<Skeleton className="h-[var(--site-header-control-h,2.5rem)] w-[var(--site-header-control-h,2.5rem)] rounded-lg" />
 					}
 				>
 					<AuthControls variant="mobile" />
+				</Suspense>
+				<Suspense
+					fallback={
+						<Skeleton className="size-[var(--site-header-control-h,2.5rem)] rounded-lg" />
+					}
+				>
+					<SearchWrapper className="size-[var(--site-header-control-h,2.25rem)]" />
 				</Suspense>
 			</div>
 		</div>


### PR DESCRIPTION
## Summary
- match mobile settings menu headings to the desktop sidebar’s sentence-case styling
- animate the Base UI settings trigger between hamburger and close icons
- add the global search control immediately to the right of the mobile profile control
- extend settings UI contracts for control state, ordering, and styling

## Validation
- Apps web CI
- mobile browser verification after deployment