### PR TITLE
Align mobile header controls

### DIFF
--- a/apps/web/src/components/(gateway)/settings/SettingsSidebarTrigger.tsx
+++ b/apps/web/src/components/(gateway)/settings/SettingsSidebarTrigger.tsx
@@ -47,7 +47,7 @@ export default function SettingsSidebarTrigger({
 	if (!isHydrated || !pathname?.startsWith("/settings")) return null;
 
 	return (
-		<div className="lg:hidden">
+		<div className="flex items-center lg:hidden">
 			<DropdownMenu open={open} onOpenChange={setOpen}>
 				<DropdownMenuTrigger
 					className={cn(

--- a/apps/web/src/components/(gateway)/settings/SettingsUi.contract.test.ts
+++ b/apps/web/src/components/(gateway)/settings/SettingsUi.contract.test.ts
@@ -40,6 +40,7 @@ describe("settings UI contracts", () => {
 
 	it("keeps the complete mobile settings navigation on Base UI", () => {
 		const headerSource = readSource("src/components/header/header.tsx");
+		const searchSource = readSource("src/components/header/Search/Search.tsx");
 		const tabsSource = readSource(
 			"src/components/(gateway)/settings/SettingsTopTabsServer.tsx",
 		);
@@ -56,11 +57,14 @@ describe("settings UI contracts", () => {
 			headerSource.indexOf('aria-label="Phaseo home"'),
 		);
 		expect(headerSource.match(/<SearchWrapper/g)).toHaveLength(1);
-		expect(headerSource.indexOf('<AuthControls variant="mobile"')).toBeLessThan(
-			headerSource.indexOf("<SearchWrapper"),
+		expect(headerSource.indexOf("<SearchWrapper")).toBeLessThan(
+			headerSource.indexOf('<AuthControls variant="mobile"'),
 		);
-		expect(headerSource).toContain('className="order-2 size-');
-		expect(headerSource).toContain("lg:order-1");
+		expect(headerSource).toContain("mobileGhost");
+		expect(headerSource).toContain('className="size-9');
+		expect(searchSource).toContain("mobileGhost &&");
+		expect(searchSource).toContain("border-transparent bg-transparent");
+		expect(searchSource).toContain("lg:border-zinc-200/80");
 		expect(tabsSource).not.toContain("<SettingsSidebarTrigger");
 		expect(tabsSource).not.toContain("<DropdownMenu");
 		expect(tabsSource).toContain("overflow-x-auto");
@@ -76,6 +80,7 @@ describe("settings UI contracts", () => {
 		expect(menuSource).toContain("transition-[opacity,transform]");
 		expect(menuSource).not.toContain("uppercase");
 		expect(menuSource).not.toContain("tracking-wide");
+		expect(menuSource).toContain('className="flex items-center lg:hidden"');
 		expect(menuSource).toContain("const Icon = item.icon");
 		expect(menuSource).toContain("<Icon className=");
 		expect(menuSource).toContain("My account");

--- a/apps/web/src/components/header/Search/Search.tsx
+++ b/apps/web/src/components/header/Search/Search.tsx
@@ -58,6 +58,7 @@ import {
 
 interface Props {
 	className?: string;
+	mobileGhost?: boolean;
 }
 
 type SearchableItem = PaletteItem;
@@ -603,7 +604,7 @@ function SearchEmptyState({
 	);
 }
 
-export default function Search({ className }: Props) {
+export default function Search({ className, mobileGhost = false }: Props) {
 	const router = useRouter();
 	const pathname = usePathname() ?? "/";
 	const { resolvedTheme, setTheme } = useTheme();
@@ -1148,7 +1149,11 @@ export default function Search({ className }: Props) {
 			<button
 				type="button"
 				onClick={() => setOpen(true)}
-				className="relative flex h-[var(--site-header-control-h,2.25rem)] w-[var(--site-header-control-h,2.25rem)] items-center justify-center rounded-lg border border-zinc-200/80 bg-white px-0 text-left text-sm text-zinc-500 shadow-none transition-[border-color,color,background-color] hover:border-zinc-300 hover:text-zinc-700 xl:w-full xl:justify-start xl:pl-9 xl:pr-12 dark:border-zinc-800 dark:bg-zinc-950 dark:text-zinc-400 dark:hover:border-zinc-700 dark:hover:text-zinc-200"
+				className={cn(
+					"relative flex size-9 items-center justify-center rounded-lg border border-zinc-200/80 bg-white px-0 text-left text-sm text-zinc-500 shadow-none transition-[border-color,color,background-color] hover:border-zinc-300 hover:text-zinc-700 xl:w-full xl:justify-start xl:pl-9 xl:pr-12 dark:border-zinc-800 dark:bg-zinc-950 dark:text-zinc-400 dark:hover:border-zinc-700 dark:hover:text-zinc-200",
+					mobileGhost &&
+						"border-transparent bg-transparent hover:border-transparent hover:bg-zinc-100/70 lg:border-zinc-200/80 lg:bg-white lg:hover:border-zinc-300 dark:border-transparent dark:bg-transparent dark:hover:border-transparent dark:hover:bg-zinc-900/60 lg:dark:border-zinc-800 lg:dark:bg-zinc-950 lg:dark:hover:border-zinc-700",
+				)}
 				aria-label="Open command palette"
 			>
 				<SearchIcon className="pointer-events-none absolute left-1/2 top-1/2 size-4 -translate-x-1/2 -translate-y-1/2 text-zinc-400 xl:left-3 xl:translate-x-0 dark:text-zinc-500" />

--- a/apps/web/src/components/header/Search/SearchWrapper.tsx
+++ b/apps/web/src/components/header/Search/SearchWrapper.tsx
@@ -2,8 +2,9 @@ import Search from "./Search";
 
 interface SearchWrapperProps {
 	className?: string;
+	mobileGhost?: boolean;
 }
 
-export function SearchWrapper({ className }: SearchWrapperProps) {
-	return <Search className={className} />;
+export function SearchWrapper({ className, mobileGhost }: SearchWrapperProps) {
+	return <Search className={className} mobileGhost={mobileGhost} />;
 }

--- a/apps/web/src/components/header/header.tsx
+++ b/apps/web/src/components/header/header.tsx
@@ -85,12 +85,15 @@ export default function Header() {
 				</div>
 				<Suspense
 					fallback={
-						<Skeleton className="order-2 size-[var(--site-header-control-h,2.5rem)] rounded-lg lg:order-1 xl:w-[15rem]" />
+						<Skeleton className="size-9 rounded-lg xl:w-[15rem]" />
 					}
 				>
-					<SearchWrapper className="order-2 size-[var(--site-header-control-h,2.25rem)] lg:order-1 xl:w-[var(--site-header-search-width-xl,15rem)]" />
+					<SearchWrapper
+					className="size-9 xl:w-[var(--site-header-search-width-xl,15rem)]"
+					mobileGhost
+				/>
 				</Suspense>
-				<div className="order-1 hidden lg:order-2 lg:block">
+				<div className="hidden lg:block">
 					<Suspense
 						fallback={
 							<div className="flex items-center gap-2">
@@ -102,7 +105,7 @@ export default function Header() {
 						<AuthControls variant="desktop" />
 					</Suspense>
 				</div>
-				<div className="order-1 lg:hidden">
+				<div className="flex items-center lg:hidden">
 					<Suspense
 						fallback={
 							<Skeleton className="size-[var(--site-header-control-h,2.5rem)] rounded-lg" />

--- a/apps/web/src/components/header/header.tsx
+++ b/apps/web/src/components/header/header.tsx
@@ -89,9 +89,9 @@ export default function Header() {
 					}
 				>
 					<SearchWrapper
-					className="size-9 xl:w-[var(--site-header-search-width-xl,15rem)]"
-					mobileGhost
-				/>
+						className="size-9 xl:w-[var(--site-header-search-width-xl,15rem)]"
+						mobileGhost
+					/>
 				</Suspense>
 				<div className="hidden lg:block">
 					<Suspense


### PR DESCRIPTION
## Summary
- place mobile Search immediately to the left of Profile
- use explicit 36px flex-centred wrappers for Search, Profile, and the settings trigger
- remove the Search control’s outline and fill on mobile while retaining the desktop search field treatment
- extend UI contracts for responsive order and styling

## Validation
- Apps web CI
- authenticated production browser verification at 400px after deployment