### PR TITLE
fix(api): tolerate pending dynamic-route schema rollout

### DIFF
--- a/apps/api/src/pipeline/before/workspacePolicy.test.ts
+++ b/apps/api/src/pipeline/before/workspacePolicy.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { applyWorkspacePolicy, buildWorkspacePolicy } from "./workspacePolicy";
+import { applyWorkspacePolicy, buildWorkspacePolicy, isOptionalDynamicRouteSchemaUnavailable } from "./workspacePolicy";
 
 function candidate(args: {
     providerId: string;
@@ -438,4 +438,32 @@ describe("applyWorkspacePolicy", () => {
             },
         ]);
     });
+});
+
+
+describe("isOptionalDynamicRouteSchemaUnavailable", () => {
+	it("allows a rollout fallback when the dynamic-route link table is absent", () => {
+		expect(isOptionalDynamicRouteSchemaUnavailable({
+			code: "PGRST205",
+			message: "Could not find the table 'public.gateway_dynamic_route_keys' in the schema cache",
+		})).toBe(true);
+	});
+
+	it("allows a rollout fallback when the dynamic-route table relation is absent", () => {
+		expect(isOptionalDynamicRouteSchemaUnavailable({
+			code: "42P01",
+			message: 'relation "gateway_dynamic_routes" does not exist',
+		})).toBe(true);
+	});
+
+	it("keeps permission and unrelated schema errors fail-closed", () => {
+		expect(isOptionalDynamicRouteSchemaUnavailable({
+			code: "42501",
+			message: 'permission denied for table gateway_dynamic_route_keys',
+		})).toBe(false);
+		expect(isOptionalDynamicRouteSchemaUnavailable({
+			code: "PGRST205",
+			message: "Could not find the table 'public.workspace_guardrails' in the schema cache",
+		})).toBe(false);
+	});
 });

--- a/apps/api/src/pipeline/before/workspacePolicy.ts
+++ b/apps/api/src/pipeline/before/workspacePolicy.ts
@@ -13,6 +13,27 @@ import { normalizeDynamicRouteConfig, type DynamicRoutePolicy } from "./dynamic-
 
 type ProviderRestrictionMode = "none" | "allowlist" | "blocklist";
 
+export function isOptionalDynamicRouteSchemaUnavailable(error: unknown): boolean {
+	if (!error || typeof error !== "object") return false;
+	const record = error as Record<string, unknown>;
+	const code = String(record.code ?? "").trim().toUpperCase();
+	const message = [record.message, record.details, record.hint]
+		.filter((value): value is string => typeof value === "string")
+		.join(" ")
+		.toLowerCase();
+	const referencesDynamicRouteSchema =
+		message.includes("gateway_dynamic_route_keys") ||
+		message.includes("gateway_dynamic_routes");
+	if (!referencesDynamicRouteSchema) return false;
+	return (
+		code === "42P01" ||
+		code === "PGRST204" ||
+		code === "PGRST205" ||
+		message.includes("does not exist") ||
+		message.includes("schema cache")
+	);
+}
+
 type WorkspaceSettingsRow = {
 	provider_restriction_mode?: string | null;
 	provider_restriction_provider_ids?: string[] | null;
@@ -473,7 +494,14 @@ export async function fetchWorkspacePolicy(args: {
 		throw new Error(`key_guardrails_lookup_failed:${keyGuardrailsResult.error.message}`);
 	}
 	if (routeLinkResult.error) {
-		throw new Error(`dynamic_route_link_lookup_failed:${routeLinkResult.error.message}`);
+		if (isOptionalDynamicRouteSchemaUnavailable(routeLinkResult.error)) {
+			console.warn("[fetchWorkspacePolicy] dynamic_route_schema_unavailable", {
+				workspaceId: args.workspaceId,
+				code: routeLinkResult.error.code ?? null,
+			});
+		} else {
+			throw new Error(`dynamic_route_link_lookup_failed:${routeLinkResult.error.message}`);
+		}
 	}
 
 	const guardrailIds = (keyGuardrailsResult.data ?? [])
@@ -508,9 +536,16 @@ export async function fetchWorkspacePolicy(args: {
 			.eq("workspace_id", args.workspaceId)
 			.maybeSingle();
 		if (routeResult.error) {
-			throw new Error(`dynamic_route_lookup_failed:${routeResult.error.message}`);
+			if (isOptionalDynamicRouteSchemaUnavailable(routeResult.error)) {
+				console.warn("[fetchWorkspacePolicy] dynamic_route_schema_unavailable", {
+					workspaceId: args.workspaceId,
+					code: routeResult.error.code ?? null,
+				});
+			} else {
+				throw new Error(`dynamic_route_lookup_failed:${routeResult.error.message}`);
+			}
 		}
-		if (routeResult.data && routeResult.data.status === "active" && routeResult.data.deployed_version) {
+		if (!routeResult.error && routeResult.data && routeResult.data.status === "active" && routeResult.data.deployed_version) {
 			dynamicRoute = {
 				id: routeResult.data.id,
 				name: routeResult.data.name,


### PR DESCRIPTION
## Summary

- keep workspace policy, guardrail, and permission failures fail-closed
- treat only recognised missing-schema errors for the optional dynamic-route tables as no dynamic route
- preserve the complete dynamic-routing implementation for when the migration is deployed
- add regression coverage for missing-table, permission, and unrelated-schema cases

## Root cause

The gateway now loads `gateway_dynamic_route_keys` for every request. When migration `20260726120000_dynamic_routes_and_affinity.sql` has not reached the connected Supabase schema or PostgREST schema cache, that optional lookup returns an error and the entire request is converted to `workspace_policy_fetch_failed`, including keys with no dynamic route.

## Safety

This is deliberately narrow. Only `42P01`, `PGRST204`, or `PGRST205` errors that explicitly reference `gateway_dynamic_route_keys` or `gateway_dynamic_routes` use the compatibility fallback. Permission failures, connectivity errors, workspace settings failures, guardrail failures, and unrelated missing tables continue to fail closed.

## Validation

- focused unit coverage added for the compatibility classifier
- exact branch diff reviewed: two gateway policy files only
- CI will run the dependency-backed gateway test and build suites
