### PR TITLE
fix(web): align mobile observability section spacing

### DIFF
--- a/apps/web/src/components/(gateway)/usage/observability/ObservabilityHub.tsx
+++ b/apps/web/src/components/(gateway)/usage/observability/ObservabilityHub.tsx
@@ -1724,7 +1724,7 @@ function TrendSection({
 
 function Overview({ data }: { data: ObservabilityData }) {
 	return (
-		<div className="space-y-6">
+		<div className="space-y-4 sm:space-y-6">
 			<div className="grid grid-cols-1 gap-3 sm:grid-cols-2 md:grid-cols-3 2xl:grid-cols-6">
 				{data.kpis.map((kpi) => (
 					<KpiMetric


### PR DESCRIPTION
## Summary

Aligns the vertical spacing between the mobile observability sections.

## Changes

- uses the same 16px gap between the KPI cards, Top section, and Usage section on mobile
- retains the existing 24px desktop section spacing from the `sm` breakpoint upwards
- leaves card-internal spacing and desktop layout unchanged

## Validation

- scoped one-class responsive Tailwind change
- compared the section wrapper against the existing 16px mobile grid gaps