### PR TITLE
fix(catalog): record Novita Ling 3.0 Flash free expiry

### DIFF
--- a/packages/data/catalog/src/data/models/inclusionai/ling-3.0-flash/model.json
+++ b/packages/data/catalog/src/data/models/inclusionai/ling-3.0-flash/model.json
@@ -22,7 +22,7 @@
   "details":[
     {"name":"parameters","value":"124B total; approximately 5.1B active"},
     {"name":"input_context_length","value":262144},
-    {"name":"pricing_note","value":"Novita currently lists $0 input and $0 output; the requested August 3 expiry was not present in the official Novita or Vercel sources checked."}
+    {"name":"pricing_note","value":"Free on Novita through 3 August 2026."}
   ],
   "benchmarks":[],
   "page_notice":null,
@@ -34,11 +34,11 @@
   "capabilities":{"attachment":null,"tool_call":true,"structured_output":null,"temperature":null,"streaming":true,"web_search":null},
   "open_weights":null,
   "sources":[
-    {"kind":"documentation","url":"https://novita.ai/de/models/model-detail/inclusionai-ling-3.0-flash","accessed_at":"2026-07-24T00:00:00Z","notes":"Official Novita model page and API examples."},
-    {"kind":"documentation","url":"https://vercel.com/changelog","accessed_at":"2026-07-24T00:00:00Z","notes":"Official Vercel changelog confirms the July 23 AI Gateway release and a three-week free window through mid-August, not August 3."}
+    {"kind":"documentation","url":"https://novita.ai/de/models/model-detail/inclusionai-ling-3.0-flash","accessed_at":"2026-08-01T00:00:00Z","notes":"Official Novita model page and API examples."},
+    {"kind":"announcement","url":"https://x.com/novita_labs/status/2083204529319989745","accessed_at":"2026-08-01T00:00:00Z","notes":"Official Novita announcement confirms the free window through 3 August 2026."}
   ],
-  "verification":{"status":"verified","checked_at":"2026-07-24T00:00:00Z","notes":"Provider availability, model identifier, context, and current free pricing verified from official provider pages."},
-  "last_updated":"2026-07-24T00:00:00Z",
+  "verification":{"status":"verified","checked_at":"2026-08-01T00:00:00Z","notes":"Provider availability, model identifier, context and temporary free pricing verified from official Novita sources."},
+  "last_updated":"2026-08-01T00:00:00Z",
   "removal_date":null,
   "replacement_model_id":null,
   "license_url":null

--- a/packages/data/catalog/src/data/models/inclusionai/ling-3.0-flash/model.json
+++ b/packages/data/catalog/src/data/models/inclusionai/ling-3.0-flash/model.json
@@ -1,45 +1,103 @@
 {
-  "model_id":"inclusionai/ling-3.0-flash",
-  "organisation_id":"inclusionai",
-  "name":"Ling 3.0 Flash",
-  "status":"Available",
-  "previous_model_id":"inclusionai/ling-2.6-1t",
-  "description":"Ling 3.0 Flash is Inclusion AI's 124B-parameter mixture-of-experts model with approximately 5.1B active parameters per token, designed for token-efficient, production-scale agentic inference.",
-  "announced_date":"2026-07-23T00:00:00",
-  "release_date":"2026-07-23T00:00:00",
-  "deprecation_date":null,
-  "retirement_date":null,
-  "license":null,
-  "input_types":"text",
-  "output_types":"text",
-  "api_model_id":"inclusionai/ling-3.0-flash",
-  "variants": [{ "model_id": "inclusionai/ling-3.0-flash:free", "name": "Ling 3.0 Flash (Free)", "variant_kind": "free" }],
-  "family_id":null,
-  "links":[
-    {"title":"Novita model page","kind":"documentation","url":"https://novita.ai/de/models/model-detail/inclusionai-ling-3.0-flash"},
-    {"title":"Vercel AI Gateway model page","kind":"documentation","url":"https://vercel.com/ai-gateway/models/ling-3.0-flash-free"}
+  "model_id": "inclusionai/ling-3.0-flash",
+  "organisation_id": "inclusionai",
+  "name": "Ling 3.0 Flash",
+  "status": "Available",
+  "previous_model_id": "inclusionai/ling-2.6-1t",
+  "description": "Ling 3.0 Flash is Inclusion AI's 124B-parameter mixture-of-experts model with approximately 5.1B active parameters per token, designed for token-efficient, production-scale agentic inference.",
+  "announced_date": "2026-07-23T00:00:00",
+  "release_date": "2026-07-23T00:00:00",
+  "deprecation_date": null,
+  "retirement_date": null,
+  "license": null,
+  "input_types": "text",
+  "output_types": "text",
+  "api_model_id": "inclusionai/ling-3.0-flash",
+  "variants": [
+    {
+      "model_id": "inclusionai/ling-3.0-flash:free",
+      "name": "Ling 3.0 Flash (Free)",
+      "variant_kind": "free"
+    }
   ],
-  "details":[
-    {"name":"parameters","value":"124B total; approximately 5.1B active"},
-    {"name":"input_context_length","value":262144},
-    {"name":"pricing_note","value":"Free on Novita through 3 August 2026."}
+  "family_id": null,
+  "links": [
+    {
+      "title": "Novita model page",
+      "kind": "documentation",
+      "url": "https://novita.ai/de/models/model-detail/inclusionai-ling-3.0-flash"
+    },
+    {
+      "title": "Vercel AI Gateway model page",
+      "kind": "documentation",
+      "url": "https://vercel.com/ai-gateway/models/ling-3.0-flash-free"
+    }
   ],
-  "benchmarks":[],
-  "page_notice":null,
-  "model_type":null,
-  "knowledge_cutoff":null,
-  "limits":{"context":262144,"input":null,"output":null},
-  "modalities":{"input":["text"],"output":["text"]},
-  "reasoning":{"supported":true,"options":[]},
-  "capabilities":{"attachment":null,"tool_call":true,"structured_output":null,"temperature":null,"streaming":true,"web_search":null},
-  "open_weights":null,
-  "sources":[
-    {"kind":"documentation","url":"https://novita.ai/de/models/model-detail/inclusionai-ling-3.0-flash","accessed_at":"2026-08-01T00:00:00Z","notes":"Official Novita model page and API examples."},
-    {"kind":"announcement","url":"https://x.com/novita_labs/status/2083204529319989745","accessed_at":"2026-08-01T00:00:00Z","notes":"Official Novita announcement confirms the free window through 3 August 2026."}
+  "details": [
+    {
+      "name": "parameters",
+      "value": "124B total; approximately 5.1B active"
+    },
+    {
+      "name": "input_context_length",
+      "value": 262144
+    },
+    {
+      "name": "pricing_note",
+      "value": "Free on Novita through 6 August 2026 at 8:00 AM PT."
+    }
   ],
-  "verification":{"status":"verified","checked_at":"2026-08-01T00:00:00Z","notes":"Provider availability, model identifier, context and temporary free pricing verified from official Novita sources."},
-  "last_updated":"2026-08-01T00:00:00Z",
-  "removal_date":null,
-  "replacement_model_id":null,
-  "license_url":null
+  "benchmarks": [],
+  "page_notice": null,
+  "model_type": null,
+  "knowledge_cutoff": null,
+  "limits": {
+    "context": 262144,
+    "input": null,
+    "output": null
+  },
+  "modalities": {
+    "input": [
+      "text"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "reasoning": {
+    "supported": true,
+    "options": []
+  },
+  "capabilities": {
+    "attachment": null,
+    "tool_call": true,
+    "structured_output": null,
+    "temperature": null,
+    "streaming": true,
+    "web_search": null
+  },
+  "open_weights": null,
+  "sources": [
+    {
+      "kind": "documentation",
+      "url": "https://novita.ai/de/models/model-detail/inclusionai-ling-3.0-flash",
+      "accessed_at": "2026-08-01T00:00:00Z",
+      "notes": "Official Novita model page and API examples."
+    },
+    {
+      "kind": "announcement",
+      "url": "https://x.com/novita_labs/status/2083204529319989745",
+      "accessed_at": "2026-08-01T00:00:00Z",
+      "notes": "Official Novita update extends the free window through 6 August 2026 at 8:00 AM PT."
+    }
+  ],
+  "verification": {
+    "status": "verified",
+    "checked_at": "2026-08-01T00:00:00Z",
+    "notes": "Provider availability, model identifier, context and temporary free pricing verified from official Novita sources."
+  },
+  "last_updated": "2026-08-01T00:00:00Z",
+  "removal_date": null,
+  "replacement_model_id": null,
+  "license_url": null
 }

--- a/packages/data/catalog/src/data/pricing/novita/inclusionai-ling-3.0-flash-free/text.generate/pricing.json
+++ b/packages/data/catalog/src/data/pricing/novita/inclusionai-ling-3.0-flash-free/text.generate/pricing.json
@@ -5,14 +5,58 @@
   "api_model_id": "inclusionai/ling-3.0-flash:free",
   "capability_id": "text.generate",
   "rules": [
-    {"meter":"input_text_tokens","unit":"token","unit_size":1000000,"price_per_unit":0,"currency":"USD","pricing_plan":"free","note":"Free on Novita through 3 August 2026.","match":[],"priority":100,"effective_from":"2026-07-23T00:00:00Z","effective_to":"2026-08-04T00:00:00Z","region":null,"cache_duration_seconds":null,"conditions":[],"source":"https://x.com/novita_labs/status/2083204529319989745"},
-    {"meter":"output_text_tokens","unit":"token","unit_size":1000000,"price_per_unit":0,"currency":"USD","pricing_plan":"free","note":"Free on Novita through 3 August 2026.","match":[],"priority":100,"effective_from":"2026-07-23T00:00:00Z","effective_to":"2026-08-04T00:00:00Z","region":null,"cache_duration_seconds":null,"conditions":[],"source":"https://x.com/novita_labs/status/2083204529319989745"}
+    {
+      "meter": "input_text_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 0,
+      "currency": "USD",
+      "pricing_plan": "free",
+      "note": "Free on Novita through 6 August 2026 at 8:00 AM PT.",
+      "match": [],
+      "priority": 100,
+      "effective_from": "2026-07-23T00:00:00Z",
+      "effective_to": "2026-08-06T15:00:00Z",
+      "region": null,
+      "cache_duration_seconds": null,
+      "conditions": [],
+      "source": "https://x.com/novita_labs/status/2083204529319989745"
+    },
+    {
+      "meter": "output_text_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 0,
+      "currency": "USD",
+      "pricing_plan": "free",
+      "note": "Free on Novita through 6 August 2026 at 8:00 AM PT.",
+      "match": [],
+      "priority": 100,
+      "effective_from": "2026-07-23T00:00:00Z",
+      "effective_to": "2026-08-06T15:00:00Z",
+      "region": null,
+      "cache_duration_seconds": null,
+      "conditions": [],
+      "source": "https://x.com/novita_labs/status/2083204529319989745"
+    }
   ],
   "regions": [],
-  "service_tiers": ["free"],
-  "sources": [
-    {"url":"https://novita.ai/de/models/model-detail/inclusionai-ling-3.0-flash","kind":"documentation"},
-    {"url":"https://x.com/novita_labs/status/2083204529319989745","kind":"announcement"}
+  "service_tiers": [
+    "free"
   ],
-  "verification": {"status":"verified","checked_at":"2026-08-01T00:00:00Z","notes":"Official Novita announcement confirms the model is free through 3 August 2026."}
+  "sources": [
+    {
+      "url": "https://novita.ai/de/models/model-detail/inclusionai-ling-3.0-flash",
+      "kind": "documentation"
+    },
+    {
+      "url": "https://x.com/novita_labs/status/2083204529319989745",
+      "kind": "announcement"
+    }
+  ],
+  "verification": {
+    "status": "verified",
+    "checked_at": "2026-08-01T00:00:00Z",
+    "notes": "Official Novita update extends the free window through 6 August 2026 at 8:00 AM PT."
+  }
 }

--- a/packages/data/catalog/src/data/pricing/novita/inclusionai-ling-3.0-flash-free/text.generate/pricing.json
+++ b/packages/data/catalog/src/data/pricing/novita/inclusionai-ling-3.0-flash-free/text.generate/pricing.json
@@ -5,11 +5,14 @@
   "api_model_id": "inclusionai/ling-3.0-flash:free",
   "capability_id": "text.generate",
   "rules": [
-    {"meter":"input_text_tokens","unit":"token","unit_size":1000000,"price_per_unit":0,"currency":"USD","pricing_plan":"free","note":"Currently free on Novita; no August 3 expiry was verified.","match":[],"priority":100,"effective_from":"2026-07-23T00:00:00Z","region":null,"cache_duration_seconds":null,"conditions":[],"source":"https://novita.ai/pricing"},
-    {"meter":"output_text_tokens","unit":"token","unit_size":1000000,"price_per_unit":0,"currency":"USD","pricing_plan":"free","note":"Currently free on Novita; no August 3 expiry was verified.","match":[],"priority":100,"effective_from":"2026-07-23T00:00:00Z","region":null,"cache_duration_seconds":null,"conditions":[],"source":"https://novita.ai/pricing"}
+    {"meter":"input_text_tokens","unit":"token","unit_size":1000000,"price_per_unit":0,"currency":"USD","pricing_plan":"free","note":"Free on Novita through 3 August 2026.","match":[],"priority":100,"effective_from":"2026-07-23T00:00:00Z","effective_to":"2026-08-04T00:00:00Z","region":null,"cache_duration_seconds":null,"conditions":[],"source":"https://x.com/novita_labs/status/2083204529319989745"},
+    {"meter":"output_text_tokens","unit":"token","unit_size":1000000,"price_per_unit":0,"currency":"USD","pricing_plan":"free","note":"Free on Novita through 3 August 2026.","match":[],"priority":100,"effective_from":"2026-07-23T00:00:00Z","effective_to":"2026-08-04T00:00:00Z","region":null,"cache_duration_seconds":null,"conditions":[],"source":"https://x.com/novita_labs/status/2083204529319989745"}
   ],
   "regions": [],
   "service_tiers": ["free"],
-  "sources": [{"url":"https://novita.ai/de/models/model-detail/inclusionai-ling-3.0-flash","kind":"documentation"}],
-  "verification": {"status":"verified","checked_at":"2026-07-24T00:00:00Z","notes":"Official Novita model page and pricing list current input/output pricing as free."}
+  "sources": [
+    {"url":"https://novita.ai/de/models/model-detail/inclusionai-ling-3.0-flash","kind":"documentation"},
+    {"url":"https://x.com/novita_labs/status/2083204529319989745","kind":"announcement"}
+  ],
+  "verification": {"status":"verified","checked_at":"2026-08-01T00:00:00Z","notes":"Official Novita announcement confirms the model is free through 3 August 2026."}
 }


### PR DESCRIPTION
## Summary

Corrects the existing Novita Ling 3.0 Flash free-tier metadata using Novita’s official update.

- records the extended $0 input/output pricing through **6 August 2026, 8:00 AM PT**
- sets the zero-price rules to end at `2026-08-06T15:00:00Z`
- replaces the previously unsupported no-expiry / three-week wording with the official update as the source

## Validation

- Parsed both updated catalogue JSON files successfully.
- Confirmed the model and both price rules retain the expected identifiers and a zero price during the stated window.