### PR TITLE
fix(settings): keep mobile scope switching in menu state

### DIFF
--- a/apps/web/src/components/(gateway)/settings/SettingsSidebarTrigger.tsx
+++ b/apps/web/src/components/(gateway)/settings/SettingsSidebarTrigger.tsx
@@ -13,6 +13,8 @@ import {
 	DropdownMenuGroup,
 	DropdownMenuItem,
 	DropdownMenuLabel,
+	DropdownMenuRadioGroup,
+	DropdownMenuRadioItem,
 	DropdownMenuSeparator,
 	DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
@@ -82,13 +84,20 @@ export default function SettingsSidebarTrigger({
 					align="start"
 					className="w-[min(24rem,calc(100vw-2rem))]"
 				>
-					<div className="grid grid-cols-2 gap-1 p-1">
-						<button
-							type="button"
-							onClick={() => setVisibleScope("personal")}
-							aria-pressed={visibleScope === "personal"}
+					<DropdownMenuRadioGroup
+						value={visibleScope}
+						onValueChange={(value) => {
+							if (value === "personal" || value === "workspace") {
+								setVisibleScope(value);
+							}
+						}}
+						className="grid grid-cols-2 gap-1 p-1"
+					>
+						<DropdownMenuRadioItem
+							value="personal"
+							closeOnClick={false}
 							className={cn(
-								"flex h-9 items-center justify-center gap-2 rounded-md px-2 text-xs font-medium",
+								"h-9 justify-center px-2 text-xs font-medium",
 								visibleScope === "personal"
 									? "bg-accent text-accent-foreground"
 									: "text-muted-foreground hover:bg-accent/60 hover:text-foreground",
@@ -96,13 +105,12 @@ export default function SettingsSidebarTrigger({
 						>
 							<UserRound className="size-3.5" aria-hidden="true" />
 							My account
-						</button>
-						<button
-							type="button"
-							onClick={() => setVisibleScope("workspace")}
-							aria-pressed={visibleScope === "workspace"}
+						</DropdownMenuRadioItem>
+						<DropdownMenuRadioItem
+							value="workspace"
+							closeOnClick={false}
 							className={cn(
-								"flex h-9 items-center justify-center gap-2 rounded-md px-2 text-xs font-medium",
+								"h-9 justify-center px-2 text-xs font-medium",
 								visibleScope === "workspace"
 									? "bg-accent text-accent-foreground"
 									: "text-muted-foreground hover:bg-accent/60 hover:text-foreground",
@@ -110,8 +118,8 @@ export default function SettingsSidebarTrigger({
 						>
 							<Building2 className="size-3.5" aria-hidden="true" />
 							Workspace
-						</button>
-					</div>
+						</DropdownMenuRadioItem>
+					</DropdownMenuRadioGroup>
 					<DropdownMenuSeparator />
 					{visibleGroups.map((group, index) => (
 						<DropdownMenuGroup key={`${group.heading ?? "group"}-${index}`}>

--- a/apps/web/src/components/(gateway)/settings/SettingsSidebarTrigger.tsx
+++ b/apps/web/src/components/(gateway)/settings/SettingsSidebarTrigger.tsx
@@ -42,13 +42,19 @@ export default function SettingsSidebarTrigger({
 	const activeNav = getActiveSettingsNav(pathname ?? "", { showBroadcast, showWebhooks });
 	const activeItem = activeNav?.item ?? null;
 	const activeScope = activeNav?.group.scope ?? "personal";
-	const visibleGroups = navGroups.filter((group) => group.scope === activeScope);
+	const [visibleScope, setVisibleScope] = useState(activeScope);
+	const visibleGroups = navGroups.filter((group) => group.scope === visibleScope);
+
+	const handleOpenChange = (nextOpen: boolean) => {
+		if (nextOpen) setVisibleScope(activeScope);
+		setOpen(nextOpen);
+	};
 
 	if (!isHydrated || !pathname?.startsWith("/settings")) return null;
 
 	return (
 		<div className="flex items-center lg:hidden">
-			<DropdownMenu open={open} onOpenChange={setOpen}>
+			<DropdownMenu open={open} onOpenChange={handleOpenChange}>
 				<DropdownMenuTrigger
 					className={cn(
 						buttonVariants({ variant: "ghost", size: "icon" }),
@@ -77,8 +83,34 @@ export default function SettingsSidebarTrigger({
 					className="w-[min(24rem,calc(100vw-2rem))]"
 				>
 					<div className="grid grid-cols-2 gap-1 p-1">
-						<Link href="/settings/profile" className={cn("flex h-9 items-center justify-center gap-2 rounded-md px-2 text-xs font-medium", activeScope === "personal" ? "bg-accent text-accent-foreground" : "text-muted-foreground hover:bg-accent/60 hover:text-foreground")}><UserRound className="size-3.5" aria-hidden="true" />My account</Link>
-						<Link href="/settings/workspaces/settings" className={cn("flex h-9 items-center justify-center gap-2 rounded-md px-2 text-xs font-medium", activeScope === "workspace" ? "bg-accent text-accent-foreground" : "text-muted-foreground hover:bg-accent/60 hover:text-foreground")}><Building2 className="size-3.5" aria-hidden="true" />Workspace</Link>
+						<button
+							type="button"
+							onClick={() => setVisibleScope("personal")}
+							aria-pressed={visibleScope === "personal"}
+							className={cn(
+								"flex h-9 items-center justify-center gap-2 rounded-md px-2 text-xs font-medium",
+								visibleScope === "personal"
+									? "bg-accent text-accent-foreground"
+									: "text-muted-foreground hover:bg-accent/60 hover:text-foreground",
+							)}
+						>
+							<UserRound className="size-3.5" aria-hidden="true" />
+							My account
+						</button>
+						<button
+							type="button"
+							onClick={() => setVisibleScope("workspace")}
+							aria-pressed={visibleScope === "workspace"}
+							className={cn(
+								"flex h-9 items-center justify-center gap-2 rounded-md px-2 text-xs font-medium",
+								visibleScope === "workspace"
+									? "bg-accent text-accent-foreground"
+									: "text-muted-foreground hover:bg-accent/60 hover:text-foreground",
+							)}
+						>
+							<Building2 className="size-3.5" aria-hidden="true" />
+							Workspace
+						</button>
 					</div>
 					<DropdownMenuSeparator />
 					{visibleGroups.map((group, index) => (

--- a/apps/web/src/components/(gateway)/settings/SettingsUi.contract.test.ts
+++ b/apps/web/src/components/(gateway)/settings/SettingsUi.contract.test.ts
@@ -79,10 +79,11 @@ describe("settings UI contracts", () => {
 		expect(menuSource).toContain('onOpenChange={handleOpenChange}');
 		expect(menuSource).toContain("const [visibleScope, setVisibleScope]");
 		expect(menuSource).toContain("group.scope === visibleScope");
-		expect(menuSource).toContain('onClick={() => setVisibleScope("personal")}');
-		expect(menuSource).toContain('onClick={() => setVisibleScope("workspace")}');
-		expect(menuSource).toContain('aria-pressed={visibleScope === "personal"}');
-		expect(menuSource).toContain('aria-pressed={visibleScope === "workspace"}');
+		expect(menuSource).toContain("<DropdownMenuRadioGroup");
+		expect(menuSource).toContain("<DropdownMenuRadioItem");
+		expect(menuSource).toContain('value="personal"');
+		expect(menuSource).toContain('value="workspace"');
+		expect(menuSource.match(/closeOnClick=\{false\}/g)).toHaveLength(2);
 		expect(menuSource).not.toContain('<Link href="/settings/profile"');
 		expect(menuSource).not.toContain('<Link href="/settings/workspaces/settings"');
 		expect(menuSource).toContain('"Close settings menu"');

--- a/apps/web/src/components/(gateway)/settings/SettingsUi.contract.test.ts
+++ b/apps/web/src/components/(gateway)/settings/SettingsUi.contract.test.ts
@@ -76,7 +76,15 @@ describe("settings UI contracts", () => {
 		expect(tabsSource).toContain("shrink-0 whitespace-nowrap");
 		expect(menuSource).not.toContain("asChild");
 		expect(menuSource).toContain('open={open}');
-		expect(menuSource).toContain('onOpenChange={setOpen}');
+		expect(menuSource).toContain('onOpenChange={handleOpenChange}');
+		expect(menuSource).toContain("const [visibleScope, setVisibleScope]");
+		expect(menuSource).toContain("group.scope === visibleScope");
+		expect(menuSource).toContain('onClick={() => setVisibleScope("personal")}');
+		expect(menuSource).toContain('onClick={() => setVisibleScope("workspace")}');
+		expect(menuSource).toContain('aria-pressed={visibleScope === "personal"}');
+		expect(menuSource).toContain('aria-pressed={visibleScope === "workspace"}');
+		expect(menuSource).not.toContain('<Link href="/settings/profile"');
+		expect(menuSource).not.toContain('<Link href="/settings/workspaces/settings"');
 		expect(menuSource).toContain('"Close settings menu"');
 		expect(menuSource).toContain('"Open settings menu"');
 		expect(menuSource).toContain("<MenuIcon");


### PR DESCRIPTION
## Summary

Makes the mobile Account/Workspace control browse settings sections without navigating immediately.

## Changes

- replaces the two scope links with stateful Base UI radio menu items
- keeps the Base UI dropdown open while switching scope
- derives the initial scope from the current route whenever the menu opens
- navigates only when a settings destination is selected
- preserves keyboard, typeahead and screen-reader menu semantics
- adds contract coverage preventing the scope controls becoming links or raw buttons again

## Impact

Mobile users can inspect both Account and Workspace settings without unexpectedly being sent to either section's first page.

## Validation

- settings UI contract assertions updated
- Base UI radio-item composition reviewed
- complete PR CI required before merge