### PR TITLE
style(settings): simplify mobile scope controls

### DIFF
--- a/apps/web/src/components/(gateway)/settings/SettingsSidebarTrigger.tsx
+++ b/apps/web/src/components/(gateway)/settings/SettingsSidebarTrigger.tsx
@@ -97,20 +97,20 @@ export default function SettingsSidebarTrigger({
 							value="personal"
 							closeOnClick={false}
 							className={cn(
-								"h-9 justify-center px-2 text-xs font-medium",
+								"h-9 justify-center px-2 text-xs font-medium [&_[data-slot=dropdown-menu-radio-item-indicator]]:hidden",
 								visibleScope === "personal"
 									? "bg-accent text-accent-foreground"
 									: "text-muted-foreground hover:bg-accent/60 hover:text-foreground",
 							)}
 						>
 							<UserRound className="size-3.5" aria-hidden="true" />
-							My account
+							Account
 						</DropdownMenuRadioItem>
 						<DropdownMenuRadioItem
 							value="workspace"
 							closeOnClick={false}
 							className={cn(
-								"h-9 justify-center px-2 text-xs font-medium",
+								"h-9 justify-center px-2 text-xs font-medium [&_[data-slot=dropdown-menu-radio-item-indicator]]:hidden",
 								visibleScope === "workspace"
 									? "bg-accent text-accent-foreground"
 									: "text-muted-foreground hover:bg-accent/60 hover:text-foreground",

--- a/apps/web/src/components/(gateway)/settings/SettingsUi.contract.test.ts
+++ b/apps/web/src/components/(gateway)/settings/SettingsUi.contract.test.ts
@@ -84,6 +84,10 @@ describe("settings UI contracts", () => {
 		expect(menuSource).toContain('value="personal"');
 		expect(menuSource).toContain('value="workspace"');
 		expect(menuSource.match(/closeOnClick=\{false\}/g)).toHaveLength(2);
+		expect(
+			menuSource.match(/dropdown-menu-radio-item-indicator/g),
+		).toHaveLength(2);
+		expect(menuSource).not.toContain("My account");
 		expect(menuSource).not.toContain('<Link href="/settings/profile"');
 		expect(menuSource).not.toContain('<Link href="/settings/workspaces/settings"');
 		expect(menuSource).toContain('"Close settings menu"');
@@ -96,7 +100,7 @@ describe("settings UI contracts", () => {
 		expect(menuSource).toContain('className="flex items-center lg:hidden"');
 		expect(menuSource).toContain("const Icon = item.icon");
 		expect(menuSource).toContain("<Icon className=");
-		expect(menuSource).toContain("My account");
+		expect(menuSource).toContain("Account");
 		expect(menuSource).toContain("Workspace");
 		expect(menuSource).toContain("visibleGroups.map");
 		expect(menuSource).toContain("<DropdownMenuGroup key=");


### PR DESCRIPTION
## Summary

Polishes the mobile Settings scope selector following the stateful Account/Workspace change.

## Changes

- renames `My account` to `Account`
- removes the visible selected ticks from both scope controls
- retains Base UI radio-item semantics for keyboard and screen-reader support
- preserves the selected background treatment and stateful, non-navigating behaviour
- adds contract coverage for the label and hidden indicators

## Workspace switching

This PR intentionally does not change the active-workspace selector. Active workspace is global application context, whereas Account/Workspace in this menu only filters Settings navigation. The existing mobile profile menu already supports changing the active workspace; a follow-up can make that control more discoverable without mixing the two concepts.

## Validation

- settings UI contract assertions updated
- Base UI radio semantics retained