### PR TITLE
feat(search): add deferred workspace results

### DIFF
--- a/apps/web/src/app/api/search/workspaces/route.ts
+++ b/apps/web/src/app/api/search/workspaces/route.ts
@@ -1,0 +1,24 @@
+import { NextResponse } from "next/server";
+
+import { fetchInternalAuthHeaderData } from "@/lib/fetchers/internal/fetchInternalAuthHeaderData";
+
+export const dynamic = "force-dynamic";
+
+export async function GET() {
+	try {
+		const data = await fetchInternalAuthHeaderData();
+		const workspaces = data.isLoggedIn
+			? data.teams.map(({ id, name }) => ({ id, name }))
+			: [];
+
+		return NextResponse.json(
+			{ workspaces },
+			{ headers: { "Cache-Control": "private, no-store" } },
+		);
+	} catch {
+		return NextResponse.json(
+			{ workspaces: [] },
+			{ headers: { "Cache-Control": "private, no-store" } },
+		);
+	}
+}

--- a/apps/web/src/app/api/search/workspaces/route.ts
+++ b/apps/web/src/app/api/search/workspaces/route.ts
@@ -2,8 +2,6 @@ import { NextResponse } from "next/server";
 
 import { fetchInternalAuthHeaderData } from "@/lib/fetchers/internal/fetchInternalAuthHeaderData";
 
-export const dynamic = "force-dynamic";
-
 export async function GET() {
 	try {
 		const data = await fetchInternalAuthHeaderData();

--- a/apps/web/src/components/header/Search/Search.tsx
+++ b/apps/web/src/components/header/Search/Search.tsx
@@ -21,6 +21,7 @@ import {
 	ArrowUp,
 	ArrowUpRight,
 	Bolt,
+	Building2,
 	Compass,
 	CornerDownLeft,
 	ExternalLink,
@@ -45,6 +46,7 @@ import {
 	writePinnedItems,
 } from "./Search.storage";
 import type { PaletteItem } from "./Search.types";
+import { fetchWorkspaceSearchItems } from "./Search.workspaces";
 import type {
 	CompactSearchData,
 	SearchData,
@@ -70,7 +72,8 @@ type SearchRowType =
 	| "context"
 	| "default"
 	| "navigation"
-	| "resource";
+	| "resource"
+	| "workspace";
 
 type DefaultSearchCategory = {
 	key: string;
@@ -107,7 +110,8 @@ type SearchResultCategory = {
 		| "models"
 		| "navigation"
 		| "organisations"
-		| "resources";
+		| "resources"
+		| "workspaces";
 	items: SearchableItem[];
 	score: number;
 };
@@ -525,6 +529,14 @@ function SearchBrowseIcon({
 		);
 	}
 
+	if (effectiveType === "workspace") {
+		return (
+			<div className="flex size-5 shrink-0 items-center justify-center rounded-md border border-zinc-200 bg-white text-zinc-500 dark:border-zinc-800 dark:bg-zinc-950 dark:text-zinc-400">
+				<Building2 className="size-3" />
+			</div>
+		);
+	}
+
 	if (effectiveType === "benchmark") {
 		return (
 			<div className="flex size-5 shrink-0 items-center justify-center rounded-md border border-zinc-200 bg-white text-zinc-500 dark:border-zinc-800 dark:bg-zinc-950 dark:text-zinc-400">
@@ -627,6 +639,17 @@ export default function Search({ className, mobileGhost = false }: Props) {
 		revalidateOnFocus: false,
 		revalidateOnReconnect: false,
 	});
+	const { data: workspaceItems = [] } = useSWR(
+		open ? "/api/search/workspaces" : null,
+		fetchWorkspaceSearchItems,
+		{
+			dedupingInterval: 5 * 60 * 1_000,
+			revalidateIfStale: false,
+			revalidateOnFocus: false,
+			revalidateOnReconnect: false,
+			shouldRetryOnError: false,
+		},
+	);
 	searchGenerationRef.current = searchData?.cacheGeneration ?? 1;
 	const searchDataError = searchDataFetchError
 		? "Unable to load search data."
@@ -860,6 +883,10 @@ export default function Search({ className, mobileGhost = false }: Props) {
 		};
 	}, [searchData]);
 	const contextSearchIndex = useMemo(() => createSearchIndex(contextItems), [contextItems]);
+	const workspaceSearchIndex = useMemo(
+		() => createSearchIndex(workspaceItems),
+		[workspaceItems],
+	);
 
 	const orderedCategories = useMemo<SearchResultCategory[]>(() => {
 		if (!hasQuery) return [];
@@ -896,6 +923,9 @@ export default function Search({ className, mobileGhost = false }: Props) {
 		const benchmarks = searchScope === "all" && searchIndex
 			? filterAndSortIndexed(searchIndex.benchmarks, searchTerm, resultLimit)
 			: [];
+		const workspaces = searchScope === "all"
+			? filterAndSortIndexed(workspaceSearchIndex, searchTerm, 12)
+			: [];
 
 		return [
 			{
@@ -917,6 +947,11 @@ export default function Search({ className, mobileGhost = false }: Props) {
 				name: "resources" as const,
 				items: resources,
 				score: getFirstResultScore(RESOURCE_SEARCH_INDEX, resources, searchTerm),
+			},
+			{
+				name: "workspaces" as const,
+				items: workspaces,
+				score: getFirstResultScore(workspaceSearchIndex, workspaces, searchTerm),
 			},
 			{
 				name: "models" as const,
@@ -949,7 +984,14 @@ export default function Search({ className, mobileGhost = false }: Props) {
 		]
 			.filter((category) => category.items.length > 0)
 			.sort((left, right) => right.score - left.score);
-	}, [contextSearchIndex, hasQuery, searchIndex, searchScope, searchTerm]);
+	}, [
+		contextSearchIndex,
+		hasQuery,
+		searchIndex,
+		searchScope,
+		searchTerm,
+		workspaceSearchIndex,
+	]);
 
 	const defaultCategories = useMemo<DefaultSearchCategory[]>(() => {
 		if (hasQuery) return [];
@@ -959,6 +1001,12 @@ export default function Search({ className, mobileGhost = false }: Props) {
 				key: "pinned",
 				heading: "Pinned",
 				items: pinnedItems,
+			},
+			{
+				key: "workspaces",
+				heading: "Workspaces",
+				items: workspaceItems,
+				type: "workspace" as const,
 			},
 			{
 				key: "models",
@@ -990,7 +1038,7 @@ export default function Search({ className, mobileGhost = false }: Props) {
 				items: searchData?.apiProviders ?? [],
 			},
 		].filter((category) => category.items.length > 0);
-	}, [contextItems, hasQuery, pinnedItems, searchData]);
+	}, [contextItems, hasQuery, pinnedItems, searchData, workspaceItems]);
 
 	const defaultBrowseRows = useMemo<DefaultBrowseRow[]>(() => {
 		if (hasQuery) return [];
@@ -1220,6 +1268,7 @@ export default function Search({ className, mobileGhost = false }: Props) {
 											context: { heading: "On this page", type: "context" as const, showSubtitle: true },
 											navigation: { heading: "Navigation", type: "navigation" as const, showSubtitle: true },
 											resources: { heading: "External resources", type: "resource" as const, showSubtitle: true },
+											workspaces: { heading: "Workspaces", type: "workspace" as const, showSubtitle: true },
 											models: { heading: "Models", type: undefined, showSubtitle: false },
 											apiProviders: { heading: "API Providers", type: undefined, showSubtitle: true },
 											organisations: { heading: "Organisations", type: undefined, showSubtitle: true },

--- a/apps/web/src/components/header/Search/Search.workspaces.test.ts
+++ b/apps/web/src/components/header/Search/Search.workspaces.test.ts
@@ -1,0 +1,33 @@
+import {
+	createWorkspaceSearchItem,
+	fetchWorkspaceSearchItems,
+} from "./Search.workspaces";
+
+describe("workspace search", () => {
+	it("maps a workspace to its settings destination", () => {
+		expect(
+			createWorkspaceSearchItem({
+				id: "workspace/id",
+				name: "Production",
+			}),
+		).toEqual({
+			id: "workspace:workspace/id",
+			title: "Production",
+			subtitle: "Workspace settings",
+			href: "/settings/workspaces/settings?workspaceId=workspace%2Fid",
+			keywords: ["workspace", "team", "Production"],
+		});
+	});
+
+	it("fails open without blocking the rest of search", async () => {
+		const fetchMock = jest
+			.spyOn(global, "fetch")
+			.mockResolvedValue(new Response(null, { status: 503 }));
+
+		await expect(fetchWorkspaceSearchItems("/api/search/workspaces")).resolves.toEqual([]);
+		expect(fetchMock).toHaveBeenCalledWith(
+			"/api/search/workspaces",
+			expect.objectContaining({ credentials: "same-origin" }),
+		);
+	});
+});

--- a/apps/web/src/components/header/Search/Search.workspaces.ts
+++ b/apps/web/src/components/header/Search/Search.workspaces.ts
@@ -1,0 +1,37 @@
+import type { PaletteItem } from "./Search.types";
+
+export type SearchWorkspace = {
+	id: string;
+	name: string;
+};
+
+type WorkspaceSearchResponse = {
+	workspaces?: SearchWorkspace[];
+};
+
+export function createWorkspaceSearchItem(
+	workspace: SearchWorkspace,
+): PaletteItem {
+	return {
+		id: `workspace:${workspace.id}`,
+		title: workspace.name,
+		subtitle: "Workspace settings",
+		href: `/settings/workspaces/settings?workspaceId=${encodeURIComponent(workspace.id)}`,
+		keywords: ["workspace", "team", workspace.name],
+	};
+}
+
+export async function fetchWorkspaceSearchItems(
+	path: string,
+): Promise<PaletteItem[]> {
+	const response = await fetch(path, {
+		method: "GET",
+		credentials: "same-origin",
+		headers: { Accept: "application/json" },
+	});
+
+	if (!response.ok) return [];
+
+	const payload = (await response.json()) as WorkspaceSearchResponse;
+	return (payload.workspaces ?? []).map(createWorkspaceSearchItem);
+}


### PR DESCRIPTION
## Summary

Adds signed-in workspaces to global search without delaying the existing public search index.

## Changes

- starts a separate authenticated workspace request only when the palette opens
- loads workspace data independently through SWR with retries disabled
- renders existing navigation, model and provider results immediately
- merges workspace matches into results whenever the private request completes
- includes workspaces in the default browse view after they arrive
- opens the selected workspace's settings without silently changing global workspace context
- treats unavailable or unauthenticated workspace data as an empty optional source

## Performance and privacy

- the public search payload and cache remain unchanged
- workspace membership is never included in the public index
- the private endpoint uses the signed-in server session and `private, no-store`
- workspace loading cannot put the main search into an error or loading state

## Validation

- workspace result mapping and URL encoding tests
- fail-open response test for unavailable workspace search
- full PR CI required before merge

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added workspace search to the header search experience.
  * Workspace results appear in search listings and browse categories with a dedicated icon.
  * Selecting a workspace opens its settings page.
* **Bug Fixes**
  * Search remains available with no workspace results when workspace data cannot be retrieved.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->