### PR TITLE
fix(chat): open model selector when send has no model

### DIFF
--- a/apps/web/src/components/(chat)/ChatConversationComposer.tsx
+++ b/apps/web/src/components/(chat)/ChatConversationComposer.tsx
@@ -14,6 +14,7 @@ import {
 } from "react";
 import Link from "next/link";
 import { AIGeneratedNotice } from "@/components/(chat)/AIGeneratedNotice";
+import { getChatComposerSendAction } from "@/components/(chat)/chatComposerSendAction";
 import Image from "next/image";
 import {
 	ArrowLeft,
@@ -1011,8 +1012,14 @@ export function ChatConversationComposer(props: ChatConversationComposerProps) {
 		selectedModelIds.length > 0 ||
 		selectedModelCount > 0 ||
 		Boolean(selectedModelId);
-	const canSubmit =
-		!isRecording && hasSelectedModel && !slashMenuOpen && hasComposerContent;
+	const sendAction = getChatComposerSendAction({
+		hasComposerContent,
+		hasSelectedModel,
+		isRecording,
+		slashMenuOpen,
+	});
+	const canSubmit = sendAction === "submit";
+	const canActivateSendButton = sendAction !== "none";
 	const showChooseModelTooltip = !hasSelectedModel && hasComposerContent;
 	const resetPromptHistoryNavigation = useCallback(() => {
 		setHistoryIndex(null);
@@ -2749,25 +2756,29 @@ export function ChatConversationComposer(props: ChatConversationComposerProps) {
 						: "Send message"
 					: "Choose a model to send"
 			}
-			aria-disabled={!canSubmit}
+			aria-disabled={!canActivateSendButton}
 			data-chat-send-button="true"
 			title={showChooseModelTooltip ? "Choose a model" : undefined}
 			className={cn(
-				canSubmit
+				canActivateSendButton
 					? "cursor-pointer border-transparent hover:brightness-95"
 					: "cursor-default border-transparent opacity-50",
 			)}
 			style={{
 				backgroundColor: accentColor,
 				color: getReadableTextColor(accentColor),
-				cursor: canSubmit ? "pointer" : "default",
+				cursor: canActivateSendButton ? "pointer" : "default",
 			}}
 			onClick={() => {
-				if (canSubmit) {
+				if (sendAction === "open-model-selector") {
+					openSlashSubmenu("model");
+					return;
+				}
+				if (sendAction === "submit") {
 					handleComposerSubmit();
 				}
 			}}
-			tabIndex={canSubmit ? undefined : -1}
+			tabIndex={canActivateSendButton ? undefined : -1}
 		>
 			{isSending ? (
 				<ListPlus className="h-4 w-4" />

--- a/apps/web/src/components/(chat)/ChatConversationComposer.tsx
+++ b/apps/web/src/components/(chat)/ChatConversationComposer.tsx
@@ -1005,15 +1005,15 @@ export function ChatConversationComposer(props: ChatConversationComposerProps) {
 			setCommandSearch("");
 		}
 	}, [isRecording]);
-	const hasComposerContent =
-		(composer.trim().length > 0 && slashQuery === null) ||
-		attachments.length > 0;
+	const hasComposerText = composer.trim().length > 0 && slashQuery === null;
+	const hasComposerContent = hasComposerText || attachments.length > 0;
 	const hasSelectedModel =
 		selectedModelIds.length > 0 ||
 		selectedModelCount > 0 ||
 		Boolean(selectedModelId);
 	const sendAction = getChatComposerSendAction({
 		hasComposerContent,
+		hasComposerText,
 		hasSelectedModel,
 		isRecording,
 		slashMenuOpen,

--- a/apps/web/src/components/(chat)/chatComposerSendAction.test.ts
+++ b/apps/web/src/components/(chat)/chatComposerSendAction.test.ts
@@ -5,6 +5,7 @@ describe("getChatComposerSendAction", () => {
 		expect(
 			getChatComposerSendAction({
 				hasComposerContent: true,
+				hasComposerText: true,
 				hasSelectedModel: false,
 				isRecording: false,
 				slashMenuOpen: false,
@@ -16,6 +17,7 @@ describe("getChatComposerSendAction", () => {
 		expect(
 			getChatComposerSendAction({
 				hasComposerContent: true,
+				hasComposerText: true,
 				hasSelectedModel: true,
 				isRecording: false,
 				slashMenuOpen: false,
@@ -24,9 +26,10 @@ describe("getChatComposerSendAction", () => {
 	});
 
 	it.each([
-		{ hasComposerContent: false, isRecording: false, slashMenuOpen: false },
-		{ hasComposerContent: true, isRecording: true, slashMenuOpen: false },
-		{ hasComposerContent: true, isRecording: false, slashMenuOpen: true },
+		{ hasComposerContent: false, hasComposerText: false, isRecording: false, slashMenuOpen: false },
+		{ hasComposerContent: true, hasComposerText: true, isRecording: true, slashMenuOpen: false },
+		{ hasComposerContent: true, hasComposerText: true, isRecording: false, slashMenuOpen: true },
+		{ hasComposerContent: true, hasComposerText: false, isRecording: false, slashMenuOpen: false },
 	])("does nothing when the composer cannot act: %o", (state) => {
 		expect(
 			getChatComposerSendAction({

--- a/apps/web/src/components/(chat)/chatComposerSendAction.test.ts
+++ b/apps/web/src/components/(chat)/chatComposerSendAction.test.ts
@@ -1,0 +1,38 @@
+import { getChatComposerSendAction } from "./chatComposerSendAction";
+
+describe("getChatComposerSendAction", () => {
+	it("opens model selection when content is ready but no model is selected", () => {
+		expect(
+			getChatComposerSendAction({
+				hasComposerContent: true,
+				hasSelectedModel: false,
+				isRecording: false,
+				slashMenuOpen: false,
+			}),
+		).toBe("open-model-selector");
+	});
+
+	it("submits when content and a selected model are present", () => {
+		expect(
+			getChatComposerSendAction({
+				hasComposerContent: true,
+				hasSelectedModel: true,
+				isRecording: false,
+				slashMenuOpen: false,
+			}),
+		).toBe("submit");
+	});
+
+	it.each([
+		{ hasComposerContent: false, isRecording: false, slashMenuOpen: false },
+		{ hasComposerContent: true, isRecording: true, slashMenuOpen: false },
+		{ hasComposerContent: true, isRecording: false, slashMenuOpen: true },
+	])("does nothing when the composer cannot act: %o", (state) => {
+		expect(
+			getChatComposerSendAction({
+				...state,
+				hasSelectedModel: false,
+			}),
+		).toBe("none");
+	});
+});

--- a/apps/web/src/components/(chat)/chatComposerSendAction.ts
+++ b/apps/web/src/components/(chat)/chatComposerSendAction.ts
@@ -1,0 +1,24 @@
+export type ChatComposerSendAction =
+	| "none"
+	| "open-model-selector"
+	| "submit";
+
+type ChatComposerSendState = {
+	hasComposerContent: boolean;
+	hasSelectedModel: boolean;
+	isRecording: boolean;
+	slashMenuOpen: boolean;
+};
+
+export function getChatComposerSendAction({
+	hasComposerContent,
+	hasSelectedModel,
+	isRecording,
+	slashMenuOpen,
+}: ChatComposerSendState): ChatComposerSendAction {
+	if (isRecording || slashMenuOpen || !hasComposerContent) {
+		return "none";
+	}
+
+	return hasSelectedModel ? "submit" : "open-model-selector";
+}

--- a/apps/web/src/components/(chat)/chatComposerSendAction.ts
+++ b/apps/web/src/components/(chat)/chatComposerSendAction.ts
@@ -5,6 +5,7 @@ export type ChatComposerSendAction =
 
 type ChatComposerSendState = {
 	hasComposerContent: boolean;
+	hasComposerText: boolean;
 	hasSelectedModel: boolean;
 	isRecording: boolean;
 	slashMenuOpen: boolean;
@@ -12,6 +13,7 @@ type ChatComposerSendState = {
 
 export function getChatComposerSendAction({
 	hasComposerContent,
+	hasComposerText,
 	hasSelectedModel,
 	isRecording,
 	slashMenuOpen,
@@ -20,5 +22,9 @@ export function getChatComposerSendAction({
 		return "none";
 	}
 
-	return hasSelectedModel ? "submit" : "open-model-selector";
+	if (hasSelectedModel) {
+		return "submit";
+	}
+
+	return hasComposerText ? "open-model-selector" : "none";
 }

--- a/apps/web/src/components/announcements/BlogTableOfContents.tsx
+++ b/apps/web/src/components/announcements/BlogTableOfContents.tsx
@@ -1,3 +1,6 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
 import Link from "next/link";
 import { ChevronDown } from "lucide-react";
 import { cn } from "@/lib/utils";
@@ -7,88 +10,102 @@ type BlogTableOfContentsProps = {
 	items: BlogTocItem[];
 };
 
-function getTocScript(items: BlogTocItem[]) {
-	const itemIds = JSON.stringify(items.map((item) => item.id)).replace(
-		/</g,
-		"\\u003c",
-	);
-
-	return `(() => {
-  const itemIds = new Set(${itemIds});
-  let frame = 0;
-
-  const updateActiveSection = () => {
-    frame = 0;
-    const headings = [...itemIds]
-      .map((id) => document.getElementById(id))
-      .filter(Boolean);
-    if (!headings.length) return;
-
-    let activeId = headings[0].id;
-    for (const heading of headings) {
-      if (heading.getBoundingClientRect().top <= 160) activeId = heading.id;
-      else break;
-    }
-
-    document.querySelectorAll("[data-blog-toc-id]").forEach((link) => {
-      const isActive = link.dataset.blogTocId === activeId;
-      link.dataset.active = String(isActive);
-      if (isActive) link.setAttribute("aria-current", "location");
-      else link.removeAttribute("aria-current");
-    });
-
-    document.querySelectorAll("[data-blog-toc-list]").forEach((list) => {
-      const activeLink = list.querySelector("[data-blog-toc-id][data-active=true]");
-      const indicator = list.querySelector("[data-blog-toc-indicator]");
-      if (!activeLink || !indicator) return;
-      indicator.style.height = activeLink.offsetHeight + "px";
-      indicator.style.transform = "translateY(" + activeLink.offsetTop + "px)";
-    });
-  };
-
-  const requestUpdate = () => {
-    if (frame) return;
-    frame = requestAnimationFrame(updateActiveSection);
-  };
-
-  window.addEventListener("scroll", requestUpdate, { passive: true });
-  document.addEventListener("scroll", requestUpdate, { capture: true, passive: true });
-  window.addEventListener("resize", requestUpdate);
-  window.addEventListener("hashchange", requestUpdate);
-  new MutationObserver(requestUpdate).observe(document.body, { childList: true, subtree: true });
-  requestUpdate();
-})();`;
-}
-
-function TableOfContentsLinks({ items }: { items: BlogTocItem[] }) {
+function TableOfContentsLinks({
+	activeId,
+	items,
+}: {
+	activeId: string;
+	items: BlogTocItem[];
+}) {
 	return (
 		<nav aria-label="Table of contents">
 			<ul className="space-y-1">
-				{items.map((item) => {
-					return (
-						<li key={item.id}>
-							<Link
-								href={`#${item.id}`}
-								aria-current={item.id === items[0]?.id ? "location" : undefined}
-								data-active={item.id === items[0]?.id ? "true" : "false"}
-								data-blog-toc-id={item.id}
-								className={cn(
-                  "block border-l-2 border-transparent py-1.5 text-sm leading-5 text-zinc-500 transition-colors data-[active=true]:font-medium data-[active=true]:text-zinc-950 dark:text-zinc-400 dark:data-[active=true]:text-zinc-50",
-									item.level === 3 ? "pl-5 text-xs" : "pl-3",
-									"hover:border-zinc-300 hover:text-zinc-950 dark:hover:border-zinc-700 dark:hover:text-zinc-50",
-								)}
-							>
-								{item.label}
-							</Link>
-						</li>
-					);
-				})}
+				{items.map((item) => (
+					<li key={item.id}>
+						<Link
+							href={`#${item.id}`}
+							aria-current={item.id === activeId ? "location" : undefined}
+							data-active={item.id === activeId ? "true" : "false"}
+							data-blog-toc-id={item.id}
+							className={cn(
+								"block border-l-2 border-transparent py-1.5 text-sm leading-5 text-zinc-500 transition-colors data-[active=true]:font-medium data-[active=true]:text-zinc-950 dark:text-zinc-400 dark:data-[active=true]:text-zinc-50",
+								item.level === 3 ? "pl-5 text-xs" : "pl-3",
+								"hover:border-zinc-300 hover:text-zinc-950 dark:hover:border-zinc-700 dark:hover:text-zinc-50",
+							)}
+						>
+							{item.label}
+						</Link>
+					</li>
+				))}
 			</ul>
 		</nav>
 	);
 }
 
 export function BlogTableOfContents({ items }: BlogTableOfContentsProps) {
+	const [activeId, setActiveId] = useState(items[0]?.id ?? "");
+	const desktopListRef = useRef<HTMLDivElement>(null);
+
+	useEffect(() => {
+		let frame = 0;
+		const headings = items
+			.map((item) => document.getElementById(item.id))
+			.filter((heading): heading is HTMLElement => Boolean(heading));
+
+		const updateActiveSection = () => {
+			frame = 0;
+			if (!headings.length) return;
+
+			let nextActiveId = headings[0].id;
+			for (const heading of headings) {
+				if (heading.getBoundingClientRect().top <= 160) {
+					nextActiveId = heading.id;
+				} else {
+					break;
+				}
+			}
+			setActiveId((current) =>
+				current === nextActiveId ? current : nextActiveId,
+			);
+		};
+
+		const requestUpdate = () => {
+			if (frame) return;
+			frame = requestAnimationFrame(updateActiveSection);
+		};
+
+		window.addEventListener("scroll", requestUpdate, { passive: true });
+		document.addEventListener("scroll", requestUpdate, {
+			capture: true,
+			passive: true,
+		});
+		window.addEventListener("resize", requestUpdate);
+		window.addEventListener("hashchange", requestUpdate);
+		requestUpdate();
+
+		return () => {
+			window.removeEventListener("scroll", requestUpdate);
+			document.removeEventListener("scroll", requestUpdate, true);
+			window.removeEventListener("resize", requestUpdate);
+			window.removeEventListener("hashchange", requestUpdate);
+			if (frame) cancelAnimationFrame(frame);
+		};
+	}, [items]);
+
+	useEffect(() => {
+		const list = desktopListRef.current;
+		const activeLink = list?.querySelector<HTMLElement>(
+			`[data-blog-toc-id="${CSS.escape(activeId)}"]`,
+		);
+		const indicator = list?.querySelector<HTMLElement>(
+			"[data-blog-toc-indicator]",
+		);
+		if (!activeLink || !indicator) return;
+
+		indicator.style.height = `${activeLink.offsetHeight}px`;
+		indicator.style.transform = `translateY(${activeLink.offsetTop}px)`;
+	}, [activeId]);
+
 	return (
 		<>
 			<div className="lg:hidden">
@@ -101,7 +118,7 @@ export function BlogTableOfContents({ items }: BlogTableOfContentsProps) {
 						/>
 					</summary>
 					<div className="mt-4">
-						<TableOfContentsLinks items={items} />
+						<TableOfContentsLinks activeId={activeId} items={items} />
 					</div>
 				</details>
 			</div>
@@ -110,16 +127,15 @@ export function BlogTableOfContents({ items }: BlogTableOfContentsProps) {
 				<p className="mb-3 text-xs font-semibold text-zinc-500 dark:text-zinc-400">
 					On this page
 				</p>
-				<div data-blog-toc-list className="relative">
+				<div ref={desktopListRef} data-blog-toc-list className="relative">
 					<span
 						data-blog-toc-indicator
 						aria-hidden="true"
 						className="pointer-events-none absolute left-0 top-0 z-10 h-6 w-0.5 rounded-full bg-sky-500 transition-[height,transform] duration-300 ease-[cubic-bezier(0.22,1,0.36,1)] motion-reduce:transition-none"
 					/>
-					<TableOfContentsLinks items={items} />
+					<TableOfContentsLinks activeId={activeId} items={items} />
 				</div>
 			</aside>
-			<script dangerouslySetInnerHTML={{ __html: getTocScript(items) }} />
 		</>
 	);
 }

--- a/apps/web/src/components/announcements/BlogTableOfContents.tsx
+++ b/apps/web/src/components/announcements/BlogTableOfContents.tsx
@@ -1,6 +1,3 @@
-"use client";
-
-import { useEffect, useRef, useState } from "react";
 import Link from "next/link";
 import { ChevronDown } from "lucide-react";
 import { cn } from "@/lib/utils";
@@ -10,102 +7,88 @@ type BlogTableOfContentsProps = {
 	items: BlogTocItem[];
 };
 
-function TableOfContentsLinks({
-	activeId,
-	items,
-}: {
-	activeId: string;
-	items: BlogTocItem[];
-}) {
+function getTocScript(items: BlogTocItem[]) {
+	const itemIds = JSON.stringify(items.map((item) => item.id)).replace(
+		/</g,
+		"\\u003c",
+	);
+
+	return `(() => {
+  const itemIds = new Set(${itemIds});
+  let frame = 0;
+
+  const updateActiveSection = () => {
+    frame = 0;
+    const headings = [...itemIds]
+      .map((id) => document.getElementById(id))
+      .filter(Boolean);
+    if (!headings.length) return;
+
+    let activeId = headings[0].id;
+    for (const heading of headings) {
+      if (heading.getBoundingClientRect().top <= 160) activeId = heading.id;
+      else break;
+    }
+
+    document.querySelectorAll("[data-blog-toc-id]").forEach((link) => {
+      const isActive = link.dataset.blogTocId === activeId;
+      link.dataset.active = String(isActive);
+      if (isActive) link.setAttribute("aria-current", "location");
+      else link.removeAttribute("aria-current");
+    });
+
+    document.querySelectorAll("[data-blog-toc-list]").forEach((list) => {
+      const activeLink = list.querySelector("[data-blog-toc-id][data-active=true]");
+      const indicator = list.querySelector("[data-blog-toc-indicator]");
+      if (!activeLink || !indicator) return;
+      indicator.style.height = activeLink.offsetHeight + "px";
+      indicator.style.transform = "translateY(" + activeLink.offsetTop + "px)";
+    });
+  };
+
+  const requestUpdate = () => {
+    if (frame) return;
+    frame = requestAnimationFrame(updateActiveSection);
+  };
+
+  window.addEventListener("scroll", requestUpdate, { passive: true });
+  document.addEventListener("scroll", requestUpdate, { capture: true, passive: true });
+  window.addEventListener("resize", requestUpdate);
+  window.addEventListener("hashchange", requestUpdate);
+  new MutationObserver(requestUpdate).observe(document.body, { childList: true, subtree: true });
+  requestUpdate();
+})();`;
+}
+
+function TableOfContentsLinks({ items }: { items: BlogTocItem[] }) {
 	return (
 		<nav aria-label="Table of contents">
 			<ul className="space-y-1">
-				{items.map((item) => (
-					<li key={item.id}>
-						<Link
-							href={`#${item.id}`}
-							aria-current={item.id === activeId ? "location" : undefined}
-							data-active={item.id === activeId ? "true" : "false"}
-							data-blog-toc-id={item.id}
-							className={cn(
-								"block border-l-2 border-transparent py-1.5 text-sm leading-5 text-zinc-500 transition-colors data-[active=true]:font-medium data-[active=true]:text-zinc-950 dark:text-zinc-400 dark:data-[active=true]:text-zinc-50",
-								item.level === 3 ? "pl-5 text-xs" : "pl-3",
-								"hover:border-zinc-300 hover:text-zinc-950 dark:hover:border-zinc-700 dark:hover:text-zinc-50",
-							)}
-						>
-							{item.label}
-						</Link>
-					</li>
-				))}
+				{items.map((item) => {
+					return (
+						<li key={item.id}>
+							<Link
+								href={`#${item.id}`}
+								aria-current={item.id === items[0]?.id ? "location" : undefined}
+								data-active={item.id === items[0]?.id ? "true" : "false"}
+								data-blog-toc-id={item.id}
+								className={cn(
+                  "block border-l-2 border-transparent py-1.5 text-sm leading-5 text-zinc-500 transition-colors data-[active=true]:font-medium data-[active=true]:text-zinc-950 dark:text-zinc-400 dark:data-[active=true]:text-zinc-50",
+									item.level === 3 ? "pl-5 text-xs" : "pl-3",
+									"hover:border-zinc-300 hover:text-zinc-950 dark:hover:border-zinc-700 dark:hover:text-zinc-50",
+								)}
+							>
+								{item.label}
+							</Link>
+						</li>
+					);
+				})}
 			</ul>
 		</nav>
 	);
 }
 
 export function BlogTableOfContents({ items }: BlogTableOfContentsProps) {
-	const [activeId, setActiveId] = useState(items[0]?.id ?? "");
-	const desktopListRef = useRef<HTMLDivElement>(null);
-
-	useEffect(() => {
-		let frame = 0;
-		const headings = items
-			.map((item) => document.getElementById(item.id))
-			.filter((heading): heading is HTMLElement => Boolean(heading));
-
-		const updateActiveSection = () => {
-			frame = 0;
-			if (!headings.length) return;
-
-			let nextActiveId = headings[0].id;
-			for (const heading of headings) {
-				if (heading.getBoundingClientRect().top <= 160) {
-					nextActiveId = heading.id;
-				} else {
-					break;
-				}
-			}
-			setActiveId((current) =>
-				current === nextActiveId ? current : nextActiveId,
-			);
-		};
-
-		const requestUpdate = () => {
-			if (frame) return;
-			frame = requestAnimationFrame(updateActiveSection);
-		};
-
-		window.addEventListener("scroll", requestUpdate, { passive: true });
-		document.addEventListener("scroll", requestUpdate, {
-			capture: true,
-			passive: true,
-		});
-		window.addEventListener("resize", requestUpdate);
-		window.addEventListener("hashchange", requestUpdate);
-		requestUpdate();
-
-		return () => {
-			window.removeEventListener("scroll", requestUpdate);
-			document.removeEventListener("scroll", requestUpdate, true);
-			window.removeEventListener("resize", requestUpdate);
-			window.removeEventListener("hashchange", requestUpdate);
-			if (frame) cancelAnimationFrame(frame);
-		};
-	}, [items]);
-
-	useEffect(() => {
-		const list = desktopListRef.current;
-		const activeLink = list?.querySelector<HTMLElement>(
-			`[data-blog-toc-id="${CSS.escape(activeId)}"]`,
-		);
-		const indicator = list?.querySelector<HTMLElement>(
-			"[data-blog-toc-indicator]",
-		);
-		if (!activeLink || !indicator) return;
-
-		indicator.style.height = `${activeLink.offsetHeight}px`;
-		indicator.style.transform = `translateY(${activeLink.offsetTop}px)`;
-	}, [activeId]);
-
 	return (
 		<>
 			<div className="lg:hidden">
@@ -118,7 +101,7 @@ export function BlogTableOfContents({ items }: BlogTableOfContentsProps) {
 						/>
 					</summary>
 					<div className="mt-4">
-						<TableOfContentsLinks activeId={activeId} items={items} />
+						<TableOfContentsLinks items={items} />
 					</div>
 				</details>
 			</div>
@@ -127,15 +110,16 @@ export function BlogTableOfContents({ items }: BlogTableOfContentsProps) {
 				<p className="mb-3 text-xs font-semibold text-zinc-500 dark:text-zinc-400">
 					On this page
 				</p>
-				<div ref={desktopListRef} data-blog-toc-list className="relative">
+				<div data-blog-toc-list className="relative">
 					<span
 						data-blog-toc-indicator
 						aria-hidden="true"
 						className="pointer-events-none absolute left-0 top-0 z-10 h-6 w-0.5 rounded-full bg-sky-500 transition-[height,transform] duration-300 ease-[cubic-bezier(0.22,1,0.36,1)] motion-reduce:transition-none"
 					/>
-					<TableOfContentsLinks activeId={activeId} items={items} />
+					<TableOfContentsLinks items={items} />
 				</div>
 			</aside>
+			<script dangerouslySetInnerHTML={{ __html: getTocScript(items) }} />
 		</>
 	);
 }


### PR DESCRIPTION
## What changed

- make the chat send button actionable when the textarea contains non-whitespace text but no model is selected
- open the existing model selection submenu instead of allowing a dead click
- preserve normal submission once a model is selected
- keep the model-selection fallback inactive for an empty textarea, including attachment-only composer state
- keep the button inert while recording or while another command menu is open
- add focused regression coverage for each send-button action state

## Root cause

The composer derived `canSubmit` from the presence of a selected model and only called its click handler when that value was true. The button still appeared for a composed message, but clicking it with no model selected did nothing.

## Checks

- Added Jest regression tests for the pure send-action decision, including the empty-text case
- Local Jest execution was blocked before test startup by the repository's existing pnpm minimum-release-age policy rejecting five lockfile entries; the policy was not bypassed or changed
- CI should run the test in the repository's normal environment