### PR TITLE
fix(blog): restore Table of Contents scroll spy

### DIFF
--- a/apps/web/src/components/announcements/BlogTableOfContents.tsx
+++ b/apps/web/src/components/announcements/BlogTableOfContents.tsx
@@ -1,3 +1,6 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
 import Link from "next/link";
 import { ChevronDown } from "lucide-react";
 import { cn } from "@/lib/utils";
@@ -7,88 +10,102 @@ type BlogTableOfContentsProps = {
 	items: BlogTocItem[];
 };
 
-function getTocScript(items: BlogTocItem[]) {
-	const itemIds = JSON.stringify(items.map((item) => item.id)).replace(
-		/</g,
-		"\\u003c",
-	);
-
-	return `(() => {
-  const itemIds = new Set(${itemIds});
-  let frame = 0;
-
-  const updateActiveSection = () => {
-    frame = 0;
-    const headings = [...itemIds]
-      .map((id) => document.getElementById(id))
-      .filter(Boolean);
-    if (!headings.length) return;
-
-    let activeId = headings[0].id;
-    for (const heading of headings) {
-      if (heading.getBoundingClientRect().top <= 160) activeId = heading.id;
-      else break;
-    }
-
-    document.querySelectorAll("[data-blog-toc-id]").forEach((link) => {
-      const isActive = link.dataset.blogTocId === activeId;
-      link.dataset.active = String(isActive);
-      if (isActive) link.setAttribute("aria-current", "location");
-      else link.removeAttribute("aria-current");
-    });
-
-    document.querySelectorAll("[data-blog-toc-list]").forEach((list) => {
-      const activeLink = list.querySelector("[data-blog-toc-id][data-active=true]");
-      const indicator = list.querySelector("[data-blog-toc-indicator]");
-      if (!activeLink || !indicator) return;
-      indicator.style.height = activeLink.offsetHeight + "px";
-      indicator.style.transform = "translateY(" + activeLink.offsetTop + "px)";
-    });
-  };
-
-  const requestUpdate = () => {
-    if (frame) return;
-    frame = requestAnimationFrame(updateActiveSection);
-  };
-
-  window.addEventListener("scroll", requestUpdate, { passive: true });
-  document.addEventListener("scroll", requestUpdate, { capture: true, passive: true });
-  window.addEventListener("resize", requestUpdate);
-  window.addEventListener("hashchange", requestUpdate);
-  new MutationObserver(requestUpdate).observe(document.body, { childList: true, subtree: true });
-  requestUpdate();
-})();`;
-}
-
-function TableOfContentsLinks({ items }: { items: BlogTocItem[] }) {
+function TableOfContentsLinks({
+	activeId,
+	items,
+}: {
+	activeId: string;
+	items: BlogTocItem[];
+}) {
 	return (
 		<nav aria-label="Table of contents">
 			<ul className="space-y-1">
-				{items.map((item) => {
-					return (
-						<li key={item.id}>
-							<Link
-								href={`#${item.id}`}
-								aria-current={item.id === items[0]?.id ? "location" : undefined}
-								data-active={item.id === items[0]?.id ? "true" : "false"}
-								data-blog-toc-id={item.id}
-								className={cn(
-                  "block border-l-2 border-transparent py-1.5 text-sm leading-5 text-zinc-500 transition-colors data-[active=true]:font-medium data-[active=true]:text-zinc-950 dark:text-zinc-400 dark:data-[active=true]:text-zinc-50",
-									item.level === 3 ? "pl-5 text-xs" : "pl-3",
-									"hover:border-zinc-300 hover:text-zinc-950 dark:hover:border-zinc-700 dark:hover:text-zinc-50",
-								)}
-							>
-								{item.label}
-							</Link>
-						</li>
-					);
-				})}
+				{items.map((item) => (
+					<li key={item.id}>
+						<Link
+							href={`#${item.id}`}
+							aria-current={item.id === activeId ? "location" : undefined}
+							data-active={item.id === activeId ? "true" : "false"}
+							data-blog-toc-id={item.id}
+							className={cn(
+								"block border-l-2 border-transparent py-1.5 text-sm leading-5 text-zinc-500 transition-colors data-[active=true]:font-medium data-[active=true]:text-zinc-950 dark:text-zinc-400 dark:data-[active=true]:text-zinc-50",
+								item.level === 3 ? "pl-5 text-xs" : "pl-3",
+								"hover:border-zinc-300 hover:text-zinc-950 dark:hover:border-zinc-700 dark:hover:text-zinc-50",
+							)}
+						>
+							{item.label}
+						</Link>
+					</li>
+				))}
 			</ul>
 		</nav>
 	);
 }
 
 export function BlogTableOfContents({ items }: BlogTableOfContentsProps) {
+	const [activeId, setActiveId] = useState(items[0]?.id ?? "");
+	const desktopListRef = useRef<HTMLDivElement>(null);
+
+	useEffect(() => {
+		let frame = 0;
+		const headings = items
+			.map((item) => document.getElementById(item.id))
+			.filter((heading): heading is HTMLElement => Boolean(heading));
+
+		const updateActiveSection = () => {
+			frame = 0;
+			if (!headings.length) return;
+
+			let nextActiveId = headings[0].id;
+			for (const heading of headings) {
+				if (heading.getBoundingClientRect().top <= 160) {
+					nextActiveId = heading.id;
+				} else {
+					break;
+				}
+			}
+			setActiveId((current) =>
+				current === nextActiveId ? current : nextActiveId,
+			);
+		};
+
+		const requestUpdate = () => {
+			if (frame) return;
+			frame = requestAnimationFrame(updateActiveSection);
+		};
+
+		window.addEventListener("scroll", requestUpdate, { passive: true });
+		document.addEventListener("scroll", requestUpdate, {
+			capture: true,
+			passive: true,
+		});
+		window.addEventListener("resize", requestUpdate);
+		window.addEventListener("hashchange", requestUpdate);
+		requestUpdate();
+
+		return () => {
+			window.removeEventListener("scroll", requestUpdate);
+			document.removeEventListener("scroll", requestUpdate, true);
+			window.removeEventListener("resize", requestUpdate);
+			window.removeEventListener("hashchange", requestUpdate);
+			if (frame) cancelAnimationFrame(frame);
+		};
+	}, [items]);
+
+	useEffect(() => {
+		const list = desktopListRef.current;
+		const activeLink = list?.querySelector<HTMLElement>(
+			`[data-blog-toc-id="${CSS.escape(activeId)}"]`,
+		);
+		const indicator = list?.querySelector<HTMLElement>(
+			"[data-blog-toc-indicator]",
+		);
+		if (!activeLink || !indicator) return;
+
+		indicator.style.height = `${activeLink.offsetHeight}px`;
+		indicator.style.transform = `translateY(${activeLink.offsetTop}px)`;
+	}, [activeId]);
+
 	return (
 		<>
 			<div className="lg:hidden">
@@ -101,7 +118,7 @@ export function BlogTableOfContents({ items }: BlogTableOfContentsProps) {
 						/>
 					</summary>
 					<div className="mt-4">
-						<TableOfContentsLinks items={items} />
+						<TableOfContentsLinks activeId={activeId} items={items} />
 					</div>
 				</details>
 			</div>
@@ -110,16 +127,15 @@ export function BlogTableOfContents({ items }: BlogTableOfContentsProps) {
 				<p className="mb-3 text-xs font-semibold text-zinc-500 dark:text-zinc-400">
 					On this page
 				</p>
-				<div data-blog-toc-list className="relative">
+				<div ref={desktopListRef} data-blog-toc-list className="relative">
 					<span
 						data-blog-toc-indicator
 						aria-hidden="true"
 						className="pointer-events-none absolute left-0 top-0 z-10 h-6 w-0.5 rounded-full bg-sky-500 transition-[height,transform] duration-300 ease-[cubic-bezier(0.22,1,0.36,1)] motion-reduce:transition-none"
 					/>
-					<TableOfContentsLinks items={items} />
+					<TableOfContentsLinks activeId={activeId} items={items} />
 				</div>
 			</aside>
-			<script dangerouslySetInnerHTML={{ __html: getTocScript(items) }} />
 		</>
 	);
 }


### PR DESCRIPTION
## What changed

- move the blog Table of Contents scroll spy into a client component lifecycle
- update the active heading and animated indicator during window or nested-container scrolling
- support client-side navigation, resizing, and hash changes
- clean up listeners and pending animation frames when navigating away

## Root cause

The previous implementation emitted a raw inline `<script>` from a Server Component. It could run on a full document load, but scripts inserted during Next.js client navigation are not reliably executed, leaving the initial Table of Contents item permanently active.

## Scope

This preserves the existing heading IDs, scroll threshold, mobile disclosure, desktop sticky layout, and animated indicator.