### PR TITLE
fix(chat): open full model picker from Send

### DIFF
--- a/apps/web/src/components/(chat)/ChatConversation.tsx
+++ b/apps/web/src/components/(chat)/ChatConversation.tsx
@@ -89,6 +89,7 @@ type ChatConversationProps = {
 	selectedModelIds: string[];
 	modelOptions: ModelOption[];
 	onToggleModel: (modelId: string) => void;
+	onOpenModelPicker: () => void;
 	onAddModelSet: (modelIds: string[]) => void;
 	onAudioAttachmentRequirementChange?: (requiresAudioInput: boolean) => void;
 	requestError?: ChatRequestErrorDetails | null;
@@ -138,6 +139,7 @@ export function ChatConversation({
 	selectedModelIds,
 	modelOptions,
 	onToggleModel,
+	onOpenModelPicker,
 	onAddModelSet,
 	onAudioAttachmentRequirementChange,
 	requestError = null,
@@ -838,6 +840,7 @@ export function ChatConversation({
 				recordingSupported={recordingSupported}
 				onToggleRecording={toggleRecording}
 				onToggleModel={onToggleModel}
+				onOpenModelPicker={onOpenModelPicker}
 				onSubmit={handleSubmit}
 				queuedPrompts={queuedPrompts.map((prompt) => ({
 					id: prompt.id,

--- a/apps/web/src/components/(chat)/ChatConversationComposer.tsx
+++ b/apps/web/src/components/(chat)/ChatConversationComposer.tsx
@@ -908,6 +908,7 @@ interface ChatConversationComposerProps {
 	recordingSupported: boolean;
 	onToggleRecording: () => void;
 	onToggleModel: (modelId: string) => void;
+	onOpenModelPicker: () => void;
 	onSubmit: () => void;
 	queuedPrompts?: Array<{
 		id: string;
@@ -958,6 +959,7 @@ export function ChatConversationComposer(props: ChatConversationComposerProps) {
 		recordingSupported,
 		onToggleRecording,
 		onToggleModel,
+		onOpenModelPicker,
 		onSubmit,
 		queuedPrompts = [],
 		onRemoveQueuedPrompt,
@@ -2771,7 +2773,7 @@ export function ChatConversationComposer(props: ChatConversationComposerProps) {
 			}}
 			onClick={() => {
 				if (sendAction === "open-model-selector") {
-					openSlashSubmenu("model");
+					onOpenModelPicker();
 					return;
 				}
 				if (sendAction === "submit") {

--- a/apps/web/src/components/(chat)/ChatPlayground.tsx
+++ b/apps/web/src/components/(chat)/ChatPlayground.tsx
@@ -4493,6 +4493,7 @@ function ChatPlaygroundContent({
 					selectedModelIds={selectedModelIds}
 					modelOptions={modelOptions.active}
 					onToggleModel={toggleComposerModel}
+					onOpenModelPicker={() => setModelPickerOpen(true)}
 					onAddModelSet={addComposerModelSet}
 					onAudioAttachmentRequirementChange={
 						handleAudioAttachmentRequirementChange


### PR DESCRIPTION
## What changed

- route the no-model Send action to the existing full model-selection dialog
- pass the existing model-picker open callback from `ChatPlayground` through `ChatConversation` to the composer
- remove the incorrect use of the slash-command model submenu
- retain the existing guard that requires non-whitespace textarea content

## Behaviour

When a user types a message with no selected models and presses Send, the same full model picker used by the header's **Add Model** button now opens. Empty and attachment-only composer states remain inactive.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The chat composer’s model-selection button now opens the model picker directly.
  * Model selection is consistently available from the chat conversation interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->