### PR TITLE
catalog: add Qwen 3.8 Max on Venice and Novita

### DIFF
--- a/packages/data/catalog/src/data/api_providers/novita/models.json
+++ b/packages/data/catalog/src/data/api_providers/novita/models.json
@@ -2209,10 +2209,15 @@
     ],
     "routing_status": "active",
     "routable": true,
-    "regions": { "execution": null, "data": null },
+    "regions": {
+      "execution": null,
+      "data": null
+    },
     "service_tiers": [],
     "api": {
-      "formats": ["openai.chat.completions"],
+      "formats": [
+        "openai.chat.completions"
+      ],
       "endpoint": null,
       "deployment": null
     },
@@ -12479,6 +12484,63 @@
     "rate_limits": []
   },
   {
+    "api_model_id": "qwen/qwen3.8-max",
+    "provider_api_model_id": "novita:qwen/qwen3.8-max",
+    "provider_model_slug": "qwen/qwen3.8-max",
+    "internal_model_id": "qwen/qwen3.8-max",
+    "is_active_gateway": true,
+    "quantization_scheme": null,
+    "input_modalities": "text,image,video",
+    "output_modalities": "text",
+    "context_length": 1000000,
+    "max_output_tokens": 131072,
+    "effective_from": "2026-08-03T00:00:00",
+    "effective_to": null,
+    "capabilities": [
+      {
+        "capability_id": "text.generate",
+        "status": "active",
+        "params": [],
+        "reasoning": true,
+        "tool_call": true,
+        "structured_output": null,
+        "temperature": null,
+        "attachment": true,
+        "input_modalities": null,
+        "output_modalities": null,
+        "modes": []
+      }
+    ],
+    "routing_status": "active",
+    "routable": true,
+    "regions": {
+      "execution": null,
+      "data": null
+    },
+    "service_tiers": [],
+    "api": {
+      "formats": [],
+      "endpoint": null,
+      "deployment": null
+    },
+    "sources": [
+      {
+        "url": "https://novita.ai/pricing",
+        "kind": "pricing"
+      },
+      {
+        "url": "https://novita.ai/models/model-detail/qwen-qwen3.8-max",
+        "kind": "documentation"
+      }
+    ],
+    "verification": {
+      "status": "verified",
+      "checked_at": "2026-08-03T00:00:00Z",
+      "notes": "Official Novita pricing and model-detail listing; API model id qwen/qwen3.8-max."
+    },
+    "rate_limits": []
+  },
+  {
     "api_model_id": "minimax/minimax-m3",
     "provider_api_model_id": "novita:minimax/minimax-m3",
     "provider_model_slug": "minimax/minimax-m3",
@@ -12718,9 +12780,16 @@
     ],
     "routing_status": "active",
     "routable": true,
-    "regions": { "execution": null, "data": null },
+    "regions": {
+      "execution": null,
+      "data": null
+    },
     "service_tiers": [],
-    "api": { "formats": [], "endpoint": null, "deployment": null },
+    "api": {
+      "formats": [],
+      "endpoint": null,
+      "deployment": null
+    },
     "sources": [
       {
         "url": "https://novita.ai/de/models/model-detail/inclusionai-ling-3.0-flash",
@@ -12765,9 +12834,16 @@
     ],
     "routing_status": "active",
     "routable": true,
-    "regions": { "execution": null, "data": null },
+    "regions": {
+      "execution": null,
+      "data": null
+    },
     "service_tiers": [],
-    "api": { "formats": [], "endpoint": null, "deployment": null },
+    "api": {
+      "formats": [],
+      "endpoint": null,
+      "deployment": null
+    },
     "sources": [
       {
         "url": "https://novita.ai/models/model-detail/mindai-macaron-v1-venti",

--- a/packages/data/catalog/src/data/api_providers/venice/models.json
+++ b/packages/data/catalog/src/data/api_providers/venice/models.json
@@ -288,6 +288,102 @@
     "rate_limits": []
   },
   {
+    "api_model_id": "anthropic/claude-opus-4.8",
+    "provider_api_model_id": "venice:anthropic/claude-opus-4.8",
+    "provider_model_slug": "claude-opus-4-8",
+    "internal_model_id": "anthropic/claude-opus-4.8",
+    "is_active_gateway": true,
+    "quantization_scheme": null,
+    "input_modalities": "text,image",
+    "output_modalities": "text",
+    "context_length": 1000000,
+    "max_output_tokens": 128000,
+    "effective_from": "2026-05-29T00:00:00",
+    "effective_to": null,
+    "capabilities": [
+      {
+        "capability_id": "text.generate",
+        "status": "deranked_lvl2",
+        "params": [],
+        "reasoning": null,
+        "tool_call": null,
+        "structured_output": null,
+        "temperature": null,
+        "attachment": null,
+        "input_modalities": null,
+        "output_modalities": null,
+        "modes": []
+      }
+    ],
+    "routing_status": "active",
+    "routable": true,
+    "regions": {
+      "execution": null,
+      "data": null
+    },
+    "service_tiers": [],
+    "api": {
+      "formats": [],
+      "endpoint": null,
+      "deployment": null
+    },
+    "sources": [],
+    "verification": {
+      "status": "unverified",
+      "checked_at": null,
+      "notes": null
+    },
+    "rate_limits": []
+  },
+  {
+    "api_model_id": "anthropic/claude-opus-4.8-fast",
+    "provider_api_model_id": "venice:anthropic/claude-opus-4.8-fast",
+    "provider_model_slug": "claude-opus-4-8-fast",
+    "internal_model_id": "anthropic/claude-opus-4.8",
+    "is_active_gateway": false,
+    "quantization_scheme": null,
+    "input_modalities": "text,image",
+    "output_modalities": "text",
+    "context_length": 1000000,
+    "max_output_tokens": 128000,
+    "effective_from": "2026-05-29T00:00:00",
+    "effective_to": null,
+    "capabilities": [
+      {
+        "capability_id": "text.generate",
+        "status": "deranked_lvl2",
+        "params": [],
+        "reasoning": null,
+        "tool_call": null,
+        "structured_output": null,
+        "temperature": null,
+        "attachment": null,
+        "input_modalities": null,
+        "output_modalities": null,
+        "modes": []
+      }
+    ],
+    "routing_status": null,
+    "routable": false,
+    "regions": {
+      "execution": null,
+      "data": null
+    },
+    "service_tiers": [],
+    "api": {
+      "formats": [],
+      "endpoint": null,
+      "deployment": null
+    },
+    "sources": [],
+    "verification": {
+      "status": "unverified",
+      "checked_at": null,
+      "notes": null
+    },
+    "rate_limits": []
+  },
+  {
     "api_model_id": "anthropic/claude-opus-5",
     "provider_api_model_id": "venice:anthropic/claude-opus-5",
     "provider_model_slug": "claude-opus-5",
@@ -572,6 +668,59 @@
       "status": "unverified",
       "checked_at": null,
       "notes": null
+    },
+    "rate_limits": []
+  },
+  {
+    "api_model_id": "bytedance/seed-2.1-turbo",
+    "provider_api_model_id": "venice:bytedance/seed-2.1-turbo",
+    "provider_model_slug": "seed-2-1-turbo",
+    "internal_model_id": "bytedance/seed-2.1-turbo",
+    "is_active_gateway": true,
+    "quantization_scheme": null,
+    "input_modalities": "text,image,video",
+    "output_modalities": "text",
+    "context_length": 256000,
+    "max_output_tokens": 65536,
+    "effective_from": "2026-07-24T00:00:00",
+    "effective_to": null,
+    "capabilities": [
+      {
+        "capability_id": "text.generate",
+        "status": "active",
+        "params": [],
+        "reasoning": true,
+        "tool_call": true,
+        "structured_output": true,
+        "temperature": null,
+        "attachment": true,
+        "input_modalities": null,
+        "output_modalities": null,
+        "modes": []
+      }
+    ],
+    "routing_status": "active",
+    "routable": true,
+    "regions": {
+      "execution": null,
+      "data": null
+    },
+    "service_tiers": [],
+    "api": {
+      "formats": [],
+      "endpoint": null,
+      "deployment": null
+    },
+    "sources": [
+      {
+        "url": "https://api.venice.ai/api/v1/models",
+        "kind": "api"
+      }
+    ],
+    "verification": {
+      "status": "verified",
+      "checked_at": "2026-07-24T00:00:00Z",
+      "notes": "Official Venice models API; model id seed-2-1-turbo."
     },
     "rate_limits": []
   },
@@ -3481,6 +3630,63 @@
     "rate_limits": []
   },
   {
+    "api_model_id": "qwen/qwen3.8-max",
+    "provider_api_model_id": "venice:qwen/qwen3.8-max",
+    "provider_model_slug": "qwen-3-8-max",
+    "internal_model_id": "qwen/qwen3.8-max",
+    "is_active_gateway": true,
+    "quantization_scheme": null,
+    "input_modalities": "text,image,video",
+    "output_modalities": "text",
+    "context_length": 1000000,
+    "max_output_tokens": 131072,
+    "effective_from": "2026-07-22T00:00:00",
+    "effective_to": null,
+    "capabilities": [
+      {
+        "capability_id": "text.generate",
+        "status": "active",
+        "params": [],
+        "reasoning": true,
+        "tool_call": true,
+        "structured_output": false,
+        "temperature": null,
+        "attachment": true,
+        "input_modalities": null,
+        "output_modalities": null,
+        "modes": []
+      }
+    ],
+    "routing_status": "active",
+    "routable": true,
+    "regions": {
+      "execution": null,
+      "data": null
+    },
+    "service_tiers": [],
+    "api": {
+      "formats": [],
+      "endpoint": null,
+      "deployment": null
+    },
+    "sources": [
+      {
+        "url": "https://api.venice.ai/api/v1/models",
+        "kind": "api"
+      },
+      {
+        "url": "https://docs.venice.ai/guides/features/tee-e2ee-models",
+        "kind": "documentation"
+      }
+    ],
+    "verification": {
+      "status": "verified",
+      "checked_at": "2026-08-03T00:00:00Z",
+      "notes": "Official Venice models API; model id qwen-3-8-max. Route is beta and anonymized, with supportsE2EE=false and supportsTeeAttestation=false."
+    },
+    "rate_limits": []
+  },
+  {
     "api_model_id": "spacex-ai/grok-4.1-fast",
     "provider_api_model_id": "venice:spacex-ai/grok-4.1-fast",
     "provider_model_slug": "grok-41-fast",
@@ -4151,104 +4357,5 @@
       "notes": null
     },
     "rate_limits": []
-  },
-  {
-    "api_model_id": "anthropic/claude-opus-4.8",
-    "provider_api_model_id": "venice:anthropic/claude-opus-4.8",
-    "provider_model_slug": "claude-opus-4-8",
-    "internal_model_id": "anthropic/claude-opus-4.8",
-    "is_active_gateway": true,
-    "quantization_scheme": null,
-    "input_modalities": "text,image",
-    "output_modalities": "text",
-    "context_length": 1000000,
-    "max_output_tokens": 128000,
-    "effective_from": "2026-05-29T00:00:00",
-    "effective_to": null,
-    "capabilities": [
-      {
-        "capability_id": "text.generate",
-        "status": "deranked_lvl2",
-        "params": [],
-        "reasoning": null,
-        "tool_call": null,
-        "structured_output": null,
-        "temperature": null,
-        "attachment": null,
-        "input_modalities": null,
-        "output_modalities": null,
-        "modes": []
-      }
-    ],
-    "routing_status": "active",
-    "routable": true,
-    "regions": {
-      "execution": null,
-      "data": null
-    },
-    "service_tiers": [],
-    "api": {
-      "formats": [],
-      "endpoint": null,
-      "deployment": null
-    },
-    "sources": [],
-    "verification": {
-      "status": "unverified",
-      "checked_at": null,
-      "notes": null
-    },
-    "rate_limits": []
-  },
-  {
-    "api_model_id": "anthropic/claude-opus-4.8-fast",
-    "provider_api_model_id": "venice:anthropic/claude-opus-4.8-fast",
-    "provider_model_slug": "claude-opus-4-8-fast",
-    "internal_model_id": "anthropic/claude-opus-4.8",
-    "is_active_gateway": false,
-    "quantization_scheme": null,
-    "input_modalities": "text,image",
-    "output_modalities": "text",
-    "context_length": 1000000,
-    "max_output_tokens": 128000,
-    "effective_from": "2026-05-29T00:00:00",
-    "effective_to": null,
-    "capabilities": [
-      {
-        "capability_id": "text.generate",
-        "status": "deranked_lvl2",
-        "params": [],
-        "reasoning": null,
-        "tool_call": null,
-        "structured_output": null,
-        "temperature": null,
-        "attachment": null,
-        "input_modalities": null,
-        "output_modalities": null,
-        "modes": []
-      }
-    ],
-    "routing_status": null,
-    "routable": false,
-    "regions": {
-      "execution": null,
-      "data": null
-    },
-    "service_tiers": [],
-    "api": {
-      "formats": [],
-      "endpoint": null,
-      "deployment": null
-    },
-    "sources": [],
-    "verification": {
-      "status": "unverified",
-      "checked_at": null,
-      "notes": null
-    },
-    "rate_limits": []
-  },
-  {
-    "api_model_id":"bytedance/seed-2.1-turbo","provider_api_model_id":"venice:bytedance/seed-2.1-turbo","provider_model_slug":"seed-2-1-turbo","internal_model_id":"bytedance/seed-2.1-turbo","is_active_gateway":true,"quantization_scheme":null,"input_modalities":"text,image,video","output_modalities":"text","context_length":256000,"max_output_tokens":65536,"effective_from":"2026-07-24T00:00:00","effective_to":null,"capabilities":[{"capability_id":"text.generate","status":"active","params":[],"reasoning":true,"tool_call":true,"structured_output":true,"temperature":null,"attachment":true,"input_modalities":null,"output_modalities":null,"modes":[]}],"routing_status":"active","routable":true,"regions":{"execution":null,"data":null},"service_tiers":[],"api":{"formats":[],"endpoint":null,"deployment":null},"sources":[{"url":"https://api.venice.ai/api/v1/models","kind":"api"}],"verification":{"status":"verified","checked_at":"2026-07-24T00:00:00Z","notes":"Official Venice models API; model id seed-2-1-turbo."},"rate_limits":[]
   }
 ]

--- a/packages/data/catalog/src/data/api_providers/venice/models.json
+++ b/packages/data/catalog/src/data/api_providers/venice/models.json
@@ -288,102 +288,6 @@
     "rate_limits": []
   },
   {
-    "api_model_id": "anthropic/claude-opus-4.8",
-    "provider_api_model_id": "venice:anthropic/claude-opus-4.8",
-    "provider_model_slug": "claude-opus-4-8",
-    "internal_model_id": "anthropic/claude-opus-4.8",
-    "is_active_gateway": true,
-    "quantization_scheme": null,
-    "input_modalities": "text,image",
-    "output_modalities": "text",
-    "context_length": 1000000,
-    "max_output_tokens": 128000,
-    "effective_from": "2026-05-29T00:00:00",
-    "effective_to": null,
-    "capabilities": [
-      {
-        "capability_id": "text.generate",
-        "status": "deranked_lvl2",
-        "params": [],
-        "reasoning": null,
-        "tool_call": null,
-        "structured_output": null,
-        "temperature": null,
-        "attachment": null,
-        "input_modalities": null,
-        "output_modalities": null,
-        "modes": []
-      }
-    ],
-    "routing_status": "active",
-    "routable": true,
-    "regions": {
-      "execution": null,
-      "data": null
-    },
-    "service_tiers": [],
-    "api": {
-      "formats": [],
-      "endpoint": null,
-      "deployment": null
-    },
-    "sources": [],
-    "verification": {
-      "status": "unverified",
-      "checked_at": null,
-      "notes": null
-    },
-    "rate_limits": []
-  },
-  {
-    "api_model_id": "anthropic/claude-opus-4.8-fast",
-    "provider_api_model_id": "venice:anthropic/claude-opus-4.8-fast",
-    "provider_model_slug": "claude-opus-4-8-fast",
-    "internal_model_id": "anthropic/claude-opus-4.8",
-    "is_active_gateway": false,
-    "quantization_scheme": null,
-    "input_modalities": "text,image",
-    "output_modalities": "text",
-    "context_length": 1000000,
-    "max_output_tokens": 128000,
-    "effective_from": "2026-05-29T00:00:00",
-    "effective_to": null,
-    "capabilities": [
-      {
-        "capability_id": "text.generate",
-        "status": "deranked_lvl2",
-        "params": [],
-        "reasoning": null,
-        "tool_call": null,
-        "structured_output": null,
-        "temperature": null,
-        "attachment": null,
-        "input_modalities": null,
-        "output_modalities": null,
-        "modes": []
-      }
-    ],
-    "routing_status": null,
-    "routable": false,
-    "regions": {
-      "execution": null,
-      "data": null
-    },
-    "service_tiers": [],
-    "api": {
-      "formats": [],
-      "endpoint": null,
-      "deployment": null
-    },
-    "sources": [],
-    "verification": {
-      "status": "unverified",
-      "checked_at": null,
-      "notes": null
-    },
-    "rate_limits": []
-  },
-  {
     "api_model_id": "anthropic/claude-opus-5",
     "provider_api_model_id": "venice:anthropic/claude-opus-5",
     "provider_model_slug": "claude-opus-5",
@@ -668,59 +572,6 @@
       "status": "unverified",
       "checked_at": null,
       "notes": null
-    },
-    "rate_limits": []
-  },
-  {
-    "api_model_id": "bytedance/seed-2.1-turbo",
-    "provider_api_model_id": "venice:bytedance/seed-2.1-turbo",
-    "provider_model_slug": "seed-2-1-turbo",
-    "internal_model_id": "bytedance/seed-2.1-turbo",
-    "is_active_gateway": true,
-    "quantization_scheme": null,
-    "input_modalities": "text,image,video",
-    "output_modalities": "text",
-    "context_length": 256000,
-    "max_output_tokens": 65536,
-    "effective_from": "2026-07-24T00:00:00",
-    "effective_to": null,
-    "capabilities": [
-      {
-        "capability_id": "text.generate",
-        "status": "active",
-        "params": [],
-        "reasoning": true,
-        "tool_call": true,
-        "structured_output": true,
-        "temperature": null,
-        "attachment": true,
-        "input_modalities": null,
-        "output_modalities": null,
-        "modes": []
-      }
-    ],
-    "routing_status": "active",
-    "routable": true,
-    "regions": {
-      "execution": null,
-      "data": null
-    },
-    "service_tiers": [],
-    "api": {
-      "formats": [],
-      "endpoint": null,
-      "deployment": null
-    },
-    "sources": [
-      {
-        "url": "https://api.venice.ai/api/v1/models",
-        "kind": "api"
-      }
-    ],
-    "verification": {
-      "status": "verified",
-      "checked_at": "2026-07-24T00:00:00Z",
-      "notes": "Official Venice models API; model id seed-2-1-turbo."
     },
     "rate_limits": []
   },
@@ -3582,54 +3433,6 @@
     "rate_limits": []
   },
   {
-    "api_model_id": "qwen/qwen3.7-plus",
-    "provider_api_model_id": "venice:qwen/qwen3.7-plus",
-    "provider_model_slug": "qwen-3-7-plus",
-    "internal_model_id": "qwen/qwen3.7-plus",
-    "is_active_gateway": true,
-    "quantization_scheme": null,
-    "input_modalities": "text,image,video",
-    "output_modalities": "text",
-    "context_length": 1000000,
-    "max_output_tokens": 65536,
-    "effective_from": "2026-06-08T00:00:00",
-    "effective_to": null,
-    "capabilities": [
-      {
-        "capability_id": "text.generate",
-        "status": "active",
-        "params": [],
-        "reasoning": null,
-        "tool_call": null,
-        "structured_output": null,
-        "temperature": null,
-        "attachment": null,
-        "input_modalities": null,
-        "output_modalities": null,
-        "modes": []
-      }
-    ],
-    "routing_status": "active",
-    "routable": true,
-    "regions": {
-      "execution": null,
-      "data": null
-    },
-    "service_tiers": [],
-    "api": {
-      "formats": [],
-      "endpoint": null,
-      "deployment": null
-    },
-    "sources": [],
-    "verification": {
-      "status": "unverified",
-      "checked_at": null,
-      "notes": null
-    },
-    "rate_limits": []
-  },
-  {
     "api_model_id": "qwen/qwen3.8-max",
     "provider_api_model_id": "venice:qwen/qwen3.8-max",
     "provider_model_slug": "qwen-3-8-max",
@@ -3683,6 +3486,54 @@
       "status": "verified",
       "checked_at": "2026-08-03T00:00:00Z",
       "notes": "Official Venice models API; model id qwen-3-8-max. Route is beta and anonymized, with supportsE2EE=false and supportsTeeAttestation=false."
+    },
+    "rate_limits": []
+  },
+  {
+    "api_model_id": "qwen/qwen3.7-plus",
+    "provider_api_model_id": "venice:qwen/qwen3.7-plus",
+    "provider_model_slug": "qwen-3-7-plus",
+    "internal_model_id": "qwen/qwen3.7-plus",
+    "is_active_gateway": true,
+    "quantization_scheme": null,
+    "input_modalities": "text,image,video",
+    "output_modalities": "text",
+    "context_length": 1000000,
+    "max_output_tokens": 65536,
+    "effective_from": "2026-06-08T00:00:00",
+    "effective_to": null,
+    "capabilities": [
+      {
+        "capability_id": "text.generate",
+        "status": "active",
+        "params": [],
+        "reasoning": null,
+        "tool_call": null,
+        "structured_output": null,
+        "temperature": null,
+        "attachment": null,
+        "input_modalities": null,
+        "output_modalities": null,
+        "modes": []
+      }
+    ],
+    "routing_status": "active",
+    "routable": true,
+    "regions": {
+      "execution": null,
+      "data": null
+    },
+    "service_tiers": [],
+    "api": {
+      "formats": [],
+      "endpoint": null,
+      "deployment": null
+    },
+    "sources": [],
+    "verification": {
+      "status": "unverified",
+      "checked_at": null,
+      "notes": null
     },
     "rate_limits": []
   },
@@ -4355,6 +4206,155 @@
       "status": "unverified",
       "checked_at": null,
       "notes": null
+    },
+    "rate_limits": []
+  },
+  {
+    "api_model_id": "anthropic/claude-opus-4.8",
+    "provider_api_model_id": "venice:anthropic/claude-opus-4.8",
+    "provider_model_slug": "claude-opus-4-8",
+    "internal_model_id": "anthropic/claude-opus-4.8",
+    "is_active_gateway": true,
+    "quantization_scheme": null,
+    "input_modalities": "text,image",
+    "output_modalities": "text",
+    "context_length": 1000000,
+    "max_output_tokens": 128000,
+    "effective_from": "2026-05-29T00:00:00",
+    "effective_to": null,
+    "capabilities": [
+      {
+        "capability_id": "text.generate",
+        "status": "deranked_lvl2",
+        "params": [],
+        "reasoning": null,
+        "tool_call": null,
+        "structured_output": null,
+        "temperature": null,
+        "attachment": null,
+        "input_modalities": null,
+        "output_modalities": null,
+        "modes": []
+      }
+    ],
+    "routing_status": "active",
+    "routable": true,
+    "regions": {
+      "execution": null,
+      "data": null
+    },
+    "service_tiers": [],
+    "api": {
+      "formats": [],
+      "endpoint": null,
+      "deployment": null
+    },
+    "sources": [],
+    "verification": {
+      "status": "unverified",
+      "checked_at": null,
+      "notes": null
+    },
+    "rate_limits": []
+  },
+  {
+    "api_model_id": "anthropic/claude-opus-4.8-fast",
+    "provider_api_model_id": "venice:anthropic/claude-opus-4.8-fast",
+    "provider_model_slug": "claude-opus-4-8-fast",
+    "internal_model_id": "anthropic/claude-opus-4.8",
+    "is_active_gateway": false,
+    "quantization_scheme": null,
+    "input_modalities": "text,image",
+    "output_modalities": "text",
+    "context_length": 1000000,
+    "max_output_tokens": 128000,
+    "effective_from": "2026-05-29T00:00:00",
+    "effective_to": null,
+    "capabilities": [
+      {
+        "capability_id": "text.generate",
+        "status": "deranked_lvl2",
+        "params": [],
+        "reasoning": null,
+        "tool_call": null,
+        "structured_output": null,
+        "temperature": null,
+        "attachment": null,
+        "input_modalities": null,
+        "output_modalities": null,
+        "modes": []
+      }
+    ],
+    "routing_status": null,
+    "routable": false,
+    "regions": {
+      "execution": null,
+      "data": null
+    },
+    "service_tiers": [],
+    "api": {
+      "formats": [],
+      "endpoint": null,
+      "deployment": null
+    },
+    "sources": [],
+    "verification": {
+      "status": "unverified",
+      "checked_at": null,
+      "notes": null
+    },
+    "rate_limits": []
+  },
+  {
+    "api_model_id": "bytedance/seed-2.1-turbo",
+    "provider_api_model_id": "venice:bytedance/seed-2.1-turbo",
+    "provider_model_slug": "seed-2-1-turbo",
+    "internal_model_id": "bytedance/seed-2.1-turbo",
+    "is_active_gateway": true,
+    "quantization_scheme": null,
+    "input_modalities": "text,image,video",
+    "output_modalities": "text",
+    "context_length": 256000,
+    "max_output_tokens": 65536,
+    "effective_from": "2026-07-24T00:00:00",
+    "effective_to": null,
+    "capabilities": [
+      {
+        "capability_id": "text.generate",
+        "status": "active",
+        "params": [],
+        "reasoning": true,
+        "tool_call": true,
+        "structured_output": true,
+        "temperature": null,
+        "attachment": true,
+        "input_modalities": null,
+        "output_modalities": null,
+        "modes": []
+      }
+    ],
+    "routing_status": "active",
+    "routable": true,
+    "regions": {
+      "execution": null,
+      "data": null
+    },
+    "service_tiers": [],
+    "api": {
+      "formats": [],
+      "endpoint": null,
+      "deployment": null
+    },
+    "sources": [
+      {
+        "url": "https://api.venice.ai/api/v1/models",
+        "kind": "api"
+      }
+    ],
+    "verification": {
+      "status": "verified",
+      "checked_at": "2026-07-24T00:00:00Z",
+      "notes": "Official Venice models API; model id seed-2-1-turbo."
     },
     "rate_limits": []
   }

--- a/packages/data/catalog/src/data/pricing/novita/qwen-qwen3.8-max/text.generate/pricing.json
+++ b/packages/data/catalog/src/data/pricing/novita/qwen-qwen3.8-max/text.generate/pricing.json
@@ -1,0 +1,69 @@
+{
+  "key": "novita:qwen/qwen3.8-max:text.generate",
+  "api_provider_id": "novita",
+  "provider_slug": "novita",
+  "api_model_id": "qwen/qwen3.8-max",
+  "capability_id": "text.generate",
+  "rules": [
+    {
+      "meter": "input_text_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 2,
+      "currency": "USD",
+      "pricing_plan": "standard",
+      "note": "Novita published pricing verified 2026-08-03.",
+      "match": [],
+      "priority": 100,
+      "region": null,
+      "cache_duration_seconds": null,
+      "conditions": [],
+      "source": "https://novita.ai/pricing"
+    },
+    {
+      "meter": "cached_read_text_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 0.25,
+      "currency": "USD",
+      "pricing_plan": "standard",
+      "note": "Novita published pricing verified 2026-08-03.",
+      "match": [],
+      "priority": 100,
+      "region": null,
+      "cache_duration_seconds": null,
+      "conditions": [],
+      "source": "https://novita.ai/pricing"
+    },
+    {
+      "meter": "output_text_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 6,
+      "currency": "USD",
+      "pricing_plan": "standard",
+      "note": "Novita published pricing verified 2026-08-03.",
+      "match": [],
+      "priority": 100,
+      "region": null,
+      "cache_duration_seconds": null,
+      "conditions": [],
+      "source": "https://novita.ai/pricing"
+    }
+  ],
+  "regions": [],
+  "service_tiers": [
+    "standard"
+  ],
+  "sources": [
+    {
+      "url": "https://novita.ai/pricing",
+      "kind": "pricing"
+    }
+  ],
+  "verification": {
+    "status": "verified",
+    "checked_at": "2026-08-03T00:00:00Z",
+    "notes": "Pricing verified against Novita's official pricing page."
+  }
+}

--- a/packages/data/catalog/src/data/pricing/venice/qwen-qwen3.8-max/text.generate/pricing.json
+++ b/packages/data/catalog/src/data/pricing/venice/qwen-qwen3.8-max/text.generate/pricing.json
@@ -1,0 +1,84 @@
+{
+  "key": "venice:qwen/qwen3.8-max:text.generate",
+  "api_provider_id": "venice",
+  "provider_slug": "venice",
+  "api_model_id": "qwen/qwen3.8-max",
+  "capability_id": "text.generate",
+  "rules": [
+    {
+      "meter": "input_text_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 2.5,
+      "currency": "USD",
+      "pricing_plan": "standard",
+      "note": "Venice published pricing verified 2026-08-03.",
+      "match": [],
+      "priority": 100,
+      "region": null,
+      "cache_duration_seconds": null,
+      "conditions": [],
+      "source": "https://api.venice.ai/api/v1/models"
+    },
+    {
+      "meter": "cached_read_text_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 0.3125,
+      "currency": "USD",
+      "pricing_plan": "standard",
+      "note": "Venice published pricing verified 2026-08-03.",
+      "match": [],
+      "priority": 100,
+      "region": null,
+      "cache_duration_seconds": null,
+      "conditions": [],
+      "source": "https://api.venice.ai/api/v1/models"
+    },
+    {
+      "meter": "cached_write_text_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 3.125,
+      "currency": "USD",
+      "pricing_plan": "standard",
+      "note": "Venice published pricing verified 2026-08-03.",
+      "match": [],
+      "priority": 100,
+      "region": null,
+      "cache_duration_seconds": null,
+      "conditions": [],
+      "source": "https://api.venice.ai/api/v1/models"
+    },
+    {
+      "meter": "output_text_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 7.5,
+      "currency": "USD",
+      "pricing_plan": "standard",
+      "note": "Venice published pricing verified 2026-08-03.",
+      "match": [],
+      "priority": 100,
+      "region": null,
+      "cache_duration_seconds": null,
+      "conditions": [],
+      "source": "https://api.venice.ai/api/v1/models"
+    }
+  ],
+  "regions": [],
+  "service_tiers": [
+    "standard"
+  ],
+  "sources": [
+    {
+      "url": "https://api.venice.ai/api/v1/models",
+      "kind": "api"
+    }
+  ],
+  "verification": {
+    "status": "verified",
+    "checked_at": "2026-08-03T00:00:00Z",
+    "notes": "Pricing read from the official Venice models API for qwen-3-8-max."
+  }
+}


### PR DESCRIPTION
## Summary

- add Qwen 3.8 Max provider routes for Venice and Novita
- record 1M context, 131,072 max output, multimodal input, reasoning and tool support
- add provider-specific token and cache pricing
- explicitly record that Venice marks its route as anonymized, **not E2EE**, and without TEE attestation

## Pricing (USD per 1M tokens)

| Provider | Input | Cached input | Cache write | Output |
| --- | ---: | ---: | ---: | ---: |
| Novita | $2.00 | $0.25 | — | $6.00 |
| Venice | $2.50 | $0.3125 | $3.125 | $7.50 |

## Verification

- Venice: official `/api/v1/models` response for `qwen-3-8-max`
- Novita: official pricing and model-detail listings for `qwen/qwen3.8-max`
- all four changed JSON files parse successfully

Venice currently marks its route as beta (`betaModel: true`), with `privacy: anonymized`, `supportsE2EE: false`, and `supportsTeeAttestation: false`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the Qwen 3.8 Max model to the Novita and Venice catalogs.
  * Added support metadata for multimodal inputs, long-context processing, reasoning, tool calling, and attachments.
  * Added verified text-generation pricing for both providers, including input, cached-token, and output rates.

* **Chores**
  * Reformatted metadata for existing catalog entries without changing their behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->