### PR TITLE
catalog: add rumoured GLM 5.3

### DIFF
--- a/packages/data/catalog/src/data/models/z-ai/glm-5.3/model.json
+++ b/packages/data/catalog/src/data/models/z-ai/glm-5.3/model.json
@@ -1,0 +1,99 @@
+{
+  "model_id": "z-ai/glm-5.3",
+  "organisation_id": "z-ai",
+  "name": "GLM 5.3",
+  "status": "Rumoured",
+  "previous_model_id": "z-ai/glm-5.2",
+  "description": "GLM 5.3 is an unreleased Z.AI model whose identifier appears in a dedicated development branch of Z.AI's official Java SDK. Z.AI has not yet announced its release date, final specifications, pricing, licence, weights, or API availability.",
+  "announced_date": null,
+  "release_date": null,
+  "deprecation_date": null,
+  "retirement_date": null,
+  "license": null,
+  "input_types": "text",
+  "output_types": "text",
+  "api_model_id": "z-ai/glm-5.3",
+  "links": [
+    {
+      "title": "Official Java SDK development branch",
+      "kind": "repository",
+      "url": "https://github.com/zai-org/z-ai-sdk-java/tree/glm-5.3"
+    },
+    {
+      "title": "SDK branch comparison",
+      "kind": "repository",
+      "url": "https://github.com/zai-org/z-ai-sdk-java/compare/main...glm-5.3"
+    }
+  ],
+  "details": [
+    {
+      "name": "release_status",
+      "value": "Pre-release evidence only; no official model announcement or routable API endpoint has been verified."
+    },
+    {
+      "name": "sdk_evidence",
+      "value": "Z.AI's official Java SDK has a glm-5.3 branch four commits ahead of main. Its README and runnable chat examples call model identifier glm-5.3, and the branch prepares SDK version 0.3.6."
+    },
+    {
+      "name": "release_window",
+      "value": "No official date. Historical Java SDK support for GLM-4.6 through GLM-5.2 reached main within approximately one day of each model's public release; this is contextual evidence, not a release-date commitment."
+    }
+  ],
+  "benchmarks": [],
+  "family_id": null,
+  "page_notice": {
+    "tone": "info",
+    "markdown": "GLM 5.3 is **unreleased**. Its model identifier is present in a development branch of Z.AI's official Java SDK, but Z.AI has not announced a release date, final specifications, pricing, licence, weights, or API availability."
+  },
+  "model_type": null,
+  "knowledge_cutoff": null,
+  "limits": {
+    "context": null,
+    "input": null,
+    "output": null
+  },
+  "modalities": {
+    "input": [
+      "text"
+    ],
+    "output": [
+      "text"
+    ]
+  },
+  "reasoning": {
+    "supported": null,
+    "options": []
+  },
+  "capabilities": {
+    "attachment": null,
+    "tool_call": null,
+    "structured_output": null,
+    "temperature": null,
+    "streaming": null,
+    "web_search": null
+  },
+  "open_weights": null,
+  "sources": [
+    {
+      "kind": "repository",
+      "url": "https://github.com/zai-org/z-ai-sdk-java/tree/glm-5.3",
+      "accessed_at": "2026-08-03T00:00:00Z",
+      "notes": "Official Z.AI Java SDK development branch using glm-5.3 in README and runnable samples."
+    },
+    {
+      "kind": "repository",
+      "url": "https://github.com/zai-org/z-ai-sdk-java/compare/main...glm-5.3",
+      "accessed_at": "2026-08-03T00:00:00Z",
+      "notes": "Branch is four commits ahead of main and prepares SDK version 0.3.6 plus JSON Schema response-format support."
+    }
+  ],
+  "verification": {
+    "status": "verified",
+    "checked_at": "2026-08-03T00:00:00Z",
+    "notes": "The official SDK evidence and model identifier are verified. Release, provider availability, specifications, pricing, licence and weights remain unverified."
+  },
+  "last_updated": "2026-08-03T00:00:00Z",
+  "removal_date": null,
+  "replacement_model_id": null,
+  "license_url": null
+}


### PR DESCRIPTION
## Summary

- add `z-ai/glm-5.3` as a rumoured, unreleased model
- cite Z.AI's official Java SDK `glm-5.3` development branch and branch comparison
- record the verified SDK evidence without assigning an announcement or release date
- leave parameters, pricing, licence, weights, limits and provider availability unknown

## Evidence

- the official Java SDK repository contains a public `glm-5.3` branch
- the branch is four commits ahead of `main`
- README and runnable chat samples use the model identifier `glm-5.3`
- the branch prepares SDK version 0.3.6 and JSON Schema response-format support

## Deliberate exclusions

- no Z.AI provider route until the model is publicly available
- no pricing or specifications inferred from GLM 5.2
- no estimated date stored as an announcement or release date
- no assumption that the model will be open-weight or MIT licensed

## Validation

- model JSON parses successfully
- branch is based on current `main` and changes one catalogue file only