### PR TITLE
catalog: add Qwen 3.8 Max on DeepInfra

### DIFF
--- a/packages/data/catalog/src/data/api_providers/deepinfra/models.json
+++ b/packages/data/catalog/src/data/api_providers/deepinfra/models.json
@@ -3365,12 +3365,14 @@
       "execution": null,
       "data": null
     },
-    "service_tiers": [],
+    "service_tiers": [
+      "standard"
+    ],
     "api": {
       "formats": [
-        "openai"
+        "openai.chat.completions"
       ],
-      "endpoint": "https://api.deepinfra.com/v1/openai/chat/completions",
+      "endpoint": null,
       "deployment": null
     },
     "sources": [
@@ -3381,7 +3383,7 @@
         "notes": "Official live model metadata and pricing."
       },
       {
-        "kind": "docs",
+        "kind": "pricing",
         "url": "https://deepinfra.com/Qwen/Qwen3.8-Max",
         "accessed_at": "2026-08-03T00:00:00Z",
         "notes": "Official DeepInfra model page."

--- a/packages/data/catalog/src/data/api_providers/deepinfra/models.json
+++ b/packages/data/catalog/src/data/api_providers/deepinfra/models.json
@@ -609,15 +609,9 @@
       "execution": null,
       "data": null
     },
-    "service_tiers": [
-      "standard",
-      "priority",
-      "flex"
-    ],
+    "service_tiers": ["standard", "priority", "flex"],
     "api": {
-      "formats": [
-        "openai.chat.completions"
-      ],
+      "formats": ["openai.chat.completions"],
       "endpoint": null,
       "deployment": null
     },
@@ -2107,12 +2101,8 @@
     "routing_status": "active",
     "routable": false,
     "regions": {
-      "execution": [
-        "global"
-      ],
-      "data": [
-        "global"
-      ]
+      "execution": ["global"],
+      "data": ["global"]
     },
     "service_tiers": [],
     "api": {
@@ -2166,12 +2156,8 @@
     "routing_status": "active",
     "routable": false,
     "regions": {
-      "execution": [
-        "global"
-      ],
-      "data": [
-        "global"
-      ]
+      "execution": ["global"],
+      "data": ["global"]
     },
     "service_tiers": [],
     "api": {
@@ -3137,12 +3123,8 @@
     "routing_status": "active",
     "routable": false,
     "regions": {
-      "execution": [
-        "global"
-      ],
-      "data": [
-        "global"
-      ]
+      "execution": ["global"],
+      "data": ["global"]
     },
     "service_tiers": [],
     "api": {
@@ -3196,12 +3178,8 @@
     "routing_status": "active",
     "routable": false,
     "regions": {
-      "execution": [
-        "global"
-      ],
-      "data": [
-        "global"
-      ]
+      "execution": ["global"],
+      "data": ["global"]
     },
     "service_tiers": [],
     "api": {
@@ -3303,12 +3281,8 @@
     "routing_status": "active",
     "routable": false,
     "regions": {
-      "execution": [
-        "global"
-      ],
-      "data": [
-        "global"
-      ]
+      "execution": ["global"],
+      "data": ["global"]
     },
     "service_tiers": [],
     "api": {
@@ -3361,10 +3335,7 @@
     ],
     "routing_status": "active",
     "routable": true,
-    "regions": {
-      "execution": null,
-      "data": null
-    },
+    "regions": { "execution": null, "data": null },
     "service_tiers": [
       "standard"
     ],
@@ -3815,16 +3786,9 @@
       "data": null
     },
     "service_tiers": [],
-    "api": {
-      "formats": [],
-      "endpoint": null,
-      "deployment": null
-    },
+    "api": { "formats": [], "endpoint": null, "deployment": null },
     "sources": [
-      {
-        "url": "https://api.deepinfra.com/models/list",
-        "kind": "api"
-      }
+      { "url": "https://api.deepinfra.com/models/list", "kind": "api" }
     ],
     "verification": {
       "status": "verified",

--- a/packages/data/catalog/src/data/api_providers/deepinfra/models.json
+++ b/packages/data/catalog/src/data/api_providers/deepinfra/models.json
@@ -609,9 +609,15 @@
       "execution": null,
       "data": null
     },
-    "service_tiers": ["standard", "priority", "flex"],
+    "service_tiers": [
+      "standard",
+      "priority",
+      "flex"
+    ],
     "api": {
-      "formats": ["openai.chat.completions"],
+      "formats": [
+        "openai.chat.completions"
+      ],
       "endpoint": null,
       "deployment": null
     },
@@ -2101,8 +2107,12 @@
     "routing_status": "active",
     "routable": false,
     "regions": {
-      "execution": ["global"],
-      "data": ["global"]
+      "execution": [
+        "global"
+      ],
+      "data": [
+        "global"
+      ]
     },
     "service_tiers": [],
     "api": {
@@ -2156,8 +2166,12 @@
     "routing_status": "active",
     "routable": false,
     "regions": {
-      "execution": ["global"],
-      "data": ["global"]
+      "execution": [
+        "global"
+      ],
+      "data": [
+        "global"
+      ]
     },
     "service_tiers": [],
     "api": {
@@ -3123,8 +3137,12 @@
     "routing_status": "active",
     "routable": false,
     "regions": {
-      "execution": ["global"],
-      "data": ["global"]
+      "execution": [
+        "global"
+      ],
+      "data": [
+        "global"
+      ]
     },
     "service_tiers": [],
     "api": {
@@ -3178,8 +3196,12 @@
     "routing_status": "active",
     "routable": false,
     "regions": {
-      "execution": ["global"],
-      "data": ["global"]
+      "execution": [
+        "global"
+      ],
+      "data": [
+        "global"
+      ]
     },
     "service_tiers": [],
     "api": {
@@ -3281,8 +3303,12 @@
     "routing_status": "active",
     "routable": false,
     "regions": {
-      "execution": ["global"],
-      "data": ["global"]
+      "execution": [
+        "global"
+      ],
+      "data": [
+        "global"
+      ]
     },
     "service_tiers": [],
     "api": {
@@ -3302,6 +3328,69 @@
       "status": "partial",
       "checked_at": "2026-07-23T09:08:52.190Z",
       "notes": "Provider support imported from models.dev; routing remains disabled."
+    },
+    "rate_limits": []
+  },
+  {
+    "api_model_id": "qwen/qwen3.8-max",
+    "provider_api_model_id": "deepinfra:qwen/qwen3.8-max",
+    "provider_model_slug": "Qwen/Qwen3.8-Max",
+    "internal_model_id": "qwen/qwen3.8-max",
+    "is_active_gateway": true,
+    "quantization_scheme": null,
+    "input_modalities": "text",
+    "output_modalities": "text",
+    "context_length": 256000,
+    "max_output_tokens": null,
+    "effective_from": "2026-08-03T00:00:00",
+    "effective_to": null,
+    "capabilities": [
+      {
+        "capability_id": "text.generate",
+        "status": "active",
+        "params": [],
+        "reasoning": false,
+        "tool_call": true,
+        "structured_output": true,
+        "temperature": true,
+        "attachment": false,
+        "input_modalities": null,
+        "output_modalities": null,
+        "modes": []
+      }
+    ],
+    "routing_status": "active",
+    "routable": true,
+    "regions": {
+      "execution": null,
+      "data": null
+    },
+    "service_tiers": [],
+    "api": {
+      "formats": [
+        "openai"
+      ],
+      "endpoint": "https://api.deepinfra.com/v1/openai/chat/completions",
+      "deployment": null
+    },
+    "sources": [
+      {
+        "kind": "api",
+        "url": "https://api.deepinfra.com/models/Qwen/Qwen3.8-Max",
+        "accessed_at": "2026-08-03T00:00:00Z",
+        "notes": "Official live model metadata and pricing."
+      },
+      {
+        "kind": "docs",
+        "url": "https://deepinfra.com/Qwen/Qwen3.8-Max",
+        "accessed_at": "2026-08-03T00:00:00Z",
+        "notes": "Official DeepInfra model page."
+      }
+    ],
+    "verification": {
+      "status": "verified",
+      "checked_at": "2026-08-03T00:00:00Z",
+      "notes": "Official DeepInfra model API confirms the public Qwen/Qwen3.8-Max deployment, OpenAI compatibility, tools, structured outputs, non-reasoning mode, and 256K context."
     },
     "rate_limits": []
   },
@@ -3719,11 +3808,21 @@
     ],
     "routing_status": "active",
     "routable": true,
-    "regions": { "execution": null, "data": null },
+    "regions": {
+      "execution": null,
+      "data": null
+    },
     "service_tiers": [],
-    "api": { "formats": [], "endpoint": null, "deployment": null },
+    "api": {
+      "formats": [],
+      "endpoint": null,
+      "deployment": null
+    },
     "sources": [
-      { "url": "https://api.deepinfra.com/models/list", "kind": "api" }
+      {
+        "url": "https://api.deepinfra.com/models/list",
+        "kind": "api"
+      }
     ],
     "verification": {
       "status": "verified",

--- a/packages/data/catalog/src/data/pricing/deepinfra/qwen-qwen3.8-max/text.generate/pricing.json
+++ b/packages/data/catalog/src/data/pricing/deepinfra/qwen-qwen3.8-max/text.generate/pricing.json
@@ -1,0 +1,72 @@
+{
+  "key": "deepinfra:qwen/qwen3.8-max:text.generate",
+  "api_provider_id": "deepinfra",
+  "provider_slug": "deepinfra",
+  "api_model_id": "qwen/qwen3.8-max",
+  "capability_id": "text.generate",
+  "rules": [
+    {
+      "meter": "input_text_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 1.65,
+      "currency": "USD",
+      "pricing_plan": "standard",
+      "note": "Verified from DeepInfra's live model API on 2026-08-03.",
+      "match": [],
+      "priority": 100,
+      "effective_from": "2026-08-03T00:00:00Z",
+      "region": null,
+      "cache_duration_seconds": null,
+      "conditions": [],
+      "source": "https://api.deepinfra.com/models/Qwen/Qwen3.8-Max"
+    },
+    {
+      "meter": "cached_read_text_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 0.206,
+      "currency": "USD",
+      "pricing_plan": "standard",
+      "note": "Verified from DeepInfra's live model API on 2026-08-03.",
+      "match": [],
+      "priority": 100,
+      "effective_from": "2026-08-03T00:00:00Z",
+      "region": null,
+      "cache_duration_seconds": null,
+      "conditions": [],
+      "source": "https://api.deepinfra.com/models/Qwen/Qwen3.8-Max"
+    },
+    {
+      "meter": "output_text_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 4.951,
+      "currency": "USD",
+      "pricing_plan": "standard",
+      "note": "Verified from DeepInfra's live model API on 2026-08-03.",
+      "match": [],
+      "priority": 100,
+      "effective_from": "2026-08-03T00:00:00Z",
+      "region": null,
+      "cache_duration_seconds": null,
+      "conditions": [],
+      "source": "https://api.deepinfra.com/models/Qwen/Qwen3.8-Max"
+    }
+  ],
+  "regions": [],
+  "service_tiers": [
+    "standard"
+  ],
+  "sources": [
+    {
+      "url": "https://api.deepinfra.com/models/Qwen/Qwen3.8-Max",
+      "kind": "api"
+    }
+  ],
+  "verification": {
+    "status": "verified",
+    "checked_at": "2026-08-03T00:00:00Z",
+    "notes": "DeepInfra API reports 0.000165 cents per input token, 0.0004951 cents per output token, and a cached-input multiplier of 0.12484848."
+  }
+}


### PR DESCRIPTION
## Summary

- add the public DeepInfra route `Qwen/Qwen3.8-Max` for `qwen/qwen3.8-max`
- enable the route through Phaseo's existing DeepInfra gateway integration
- record DeepInfra's provider-specific 256K context deployment
- record tool calling, structured outputs and non-reasoning operation
- add standard token and prompt-cache pricing from DeepInfra's live model API

## Pricing (USD per 1M tokens)

- input: $1.65
- cached input: $0.206
- output: $4.951

## Provider-specific behaviour

- OpenAI-compatible chat completions
- text input and text output on the current DeepInfra deployment
- tools and structured output supported
- DeepInfra labels this deployment `non-reasoning`
- no dedicated maximum-output value is published, so the catalogue leaves it unknown
- priority and flex tiers are not advertised for this route

## Verification

- queried the official live endpoint: `https://api.deepinfra.com/models/Qwen/Qwen3.8-Max`
- checked the route's OpenAI chat-completions schema
- both changed JSON files parse successfully
- branch is current with `main`