### PR TITLE
Add MiniMax H3 weights and license

### DIFF
--- a/packages/data/catalog/src/data/models/minimax/h3/model.json
+++ b/packages/data/catalog/src/data/models/minimax/h3/model.json
@@ -9,7 +9,7 @@
   "release_date": "2026-07-31T00:00:00",
   "deprecation_date": null,
   "retirement_date": null,
-  "license": "Proprietary",
+  "license": "MiniMax H3 Community License Agreement",
   "input_types": "text,image,video,audio",
   "output_types": "video",
   "api_model_id": "minimax/h3",
@@ -34,6 +34,16 @@
       "title": "Pricing",
       "kind": "pricing",
       "url": "https://platform.minimax.io/docs/guides/pricing-paygo"
+    },
+    {
+      "title": "Weights",
+      "kind": "weights",
+      "url": "https://huggingface.co/MiniMaxAI/MiniMax-H3"
+    },
+    {
+      "title": "License",
+      "kind": "license",
+      "url": "https://huggingface.co/MiniMaxAI/MiniMax-H3/blob/main/LICENSE"
     }
   ],
   "details": [
@@ -93,7 +103,7 @@
     "streaming": false,
     "web_search": false
   },
-  "open_weights": false,
+  "open_weights": true,
   "sources": [
     {
       "kind": "announcement",
@@ -112,15 +122,27 @@
       "url": "https://platform.minimax.io/docs/guides/pricing-paygo",
       "accessed_at": "2026-07-31T00:00:00Z",
       "notes": "Official 768P and 2K per-second output and input-material pricing."
+    },
+    {
+      "kind": "weights",
+      "url": "https://huggingface.co/MiniMaxAI/MiniMax-H3",
+      "accessed_at": "2026-08-03T00:00:00Z",
+      "notes": "Official open-weight MiniMax H3 repository."
+    },
+    {
+      "kind": "license",
+      "url": "https://huggingface.co/MiniMaxAI/MiniMax-H3/blob/main/LICENSE",
+      "accessed_at": "2026-08-03T00:00:00Z",
+      "notes": "Official MiniMax H3 Community License Agreement. The standard open-weight grant excludes the EU, UK, South Korea and United States."
     }
   ],
   "verification": {
     "status": "verified",
-    "checked_at": "2026-07-31T00:00:00Z",
-    "notes": "Release, model identifier MiniMax-H3, V2 endpoint, supported modalities, output specifications and pricing verified against MiniMax's official documentation."
+    "checked_at": "2026-08-03T00:00:00Z",
+    "notes": "Release, model identifier MiniMax-H3, V2 endpoint, modalities, output specifications, pricing, official weights and license verified against MiniMax sources. MiniMax separately states that its hosted API remains globally available despite the open-weight license's excluded territories."
   },
-  "last_updated": "2026-07-31T00:00:00Z",
+  "last_updated": "2026-08-03T00:00:00Z",
   "removal_date": null,
   "replacement_model_id": null,
-  "license_url": null
+  "license_url": "https://huggingface.co/MiniMaxAI/MiniMax-H3/blob/main/LICENSE"
 }


### PR DESCRIPTION
## What changed

- add the official MiniMax H3 Hugging Face weights link
- add the official MiniMax H3 Community License Agreement link
- update the catalogue from proprietary/closed weights to the released community licence and open weights
- record the licence's excluded territories and distinguish that restriction from MiniMax's globally available hosted API
- refresh verification metadata

## Why

MiniMax has now published the H3 weights and licence. The existing catalogue entry predates that release and therefore still reports H3 as proprietary with no open weights.

## Impact

Model pages and catalogue consumers will expose the authoritative weights and licence references and accurately represent the open-weight release. Users can also see the territorial caveat without incorrectly concluding that MiniMax's hosted API is unavailable.

## Validation

- verified the official weights repository and licence published by MiniMax
- confirmed the branch changes exactly one model catalogue file
- confirmed the branch is one commit ahead of `main`