### PR TITLE
Add database-driven provider adapter foundation

### DIFF
--- a/apps/api/docs/database-driven-provider-adapters.md
+++ b/apps/api/docs/database-driven-provider-adapters.md
@@ -1,0 +1,125 @@
+# Database-driven provider adapters
+
+## Decision
+
+Phaseo will move provider identity, capability assignment, endpoints, model
+restrictions, routing policy, parameter support and compatibility rules into a
+versioned database control plane. Application code remains a finite, versioned
+library of safe protocol mechanics. Arbitrary code is never stored or executed
+from the database.
+
+The gateway data plane executes immutable compiled plans. It does not join or
+interpret draft control-plane tables on the request path.
+
+## Ownership boundary
+
+The database owns:
+
+- provider, offer and model-route identity;
+- provider-by-capability adapter selection;
+- endpoints, API versions and logical auth-profile references;
+- native, emulated, ignored, unsupported and unknown parameter support;
+- declarative parameter-combination constraints;
+- regional and service-tier variants;
+- evidence provenance and review timestamps;
+- immutable release and rollback state.
+
+Code owns:
+
+- request and response codecs;
+- stream parsers;
+- authentication signers;
+- bounded HTTP transport and retry mechanics;
+- usage and error normalisation;
+- asynchronous job mechanics;
+- validation and compilation of control-plane data.
+
+The target invariant is:
+
+> No provider identity, capability assignment, endpoint, model restriction,
+> routing decision or compatibility policy is hard-coded in application code.
+
+## Primitive catalogue
+
+Every executable mechanism has a stable, versioned key such as
+`openai.chat.request.v1`, `anthropic.messages.request.v1`, `bearer.v1` or
+`aws.sigv4.v1`. `v2_adapter_primitives` is an allowlist of keys implemented in
+the deployed gateway. A release cannot publish if it references a missing,
+disabled or schema-incompatible primitive.
+
+Provider-capability rows assemble these primitives with declarative config.
+Adding an API-compatible provider should only require control-plane data. A code
+deployment is required only for a genuinely new protocol, authentication method,
+wire format or asynchronous execution mechanism.
+
+## Precedence
+
+Configuration is compiled from lowest to highest precedence:
+
+1. capability defaults;
+2. capability-adapter defaults;
+3. provider family;
+4. provider offer or data-policy variant;
+5. provider-model route;
+6. provider-capability route;
+7. region and service-tier variant.
+
+Objects merge recursively; arrays and scalar values replace lower-precedence
+values. Equal precedence is a validation error so compilation stays deterministic.
+
+## Constraint language
+
+Compatibility rules use a small fail-closed expression language. The only
+operators are `all`, `any`, `not`, `exists`, `equals` and `in`. Outcomes are
+`reject`, `warn` or an allowlisted transform. The database cannot contain
+JavaScript, SQL fragments, template expressions or arbitrary function names.
+
+Transforms are likewise a finite code-owned set: rename, move, set a constant,
+map an enum, clamp, scale, omit, conditionally include, wrap, unwrap and map an
+array. Each transform is schema-validated before release publication.
+
+## Release lifecycle
+
+1. An editor creates a draft release and changes control-plane rows.
+2. Static validation checks foreign keys, schemas, primitive availability,
+   endpoint/auth consistency, evidence freshness and conflicting precedence.
+3. Contract tests compile every affected plan and compare generated requests
+   and normalised responses with fixtures.
+4. Live synthetic tests exercise representative provider-model routes.
+5. A reviewer other than the author validates the release.
+6. Publication compiles canonical JSON plans, records their hashes and advances
+   the single active release pointer atomically.
+7. Rollback republishes the last-known-good release pointer; plans are immutable.
+
+An emergency provider, route or capability kill switch remains separate from
+ordinary release publication.
+
+## Runtime and caching
+
+The plan key contains release sequence, provider-model route, capability and
+route variant. Runtime lookup uses:
+
+- L1: Worker-isolate memory;
+- L2: Cloudflare configuration cache;
+- L3: the compiled plan in Supabase.
+
+The gateway retains a last-known-good plan and fails closed when a requested
+capability has no valid published plan. Draft rows are never read by request
+execution.
+
+## Migration sequence
+
+1. Land the additive schema, typed plan contract and compiler boundary.
+2. Register existing code mechanics in the primitive catalogue.
+3. Import current executor registrations, endpoints and quirks as draft data.
+4. Compile plans and run them in shadow mode beside current executors.
+5. Migrate representative protocol families: OpenAI-compatible, Anthropic,
+   Cohere, Venice, Cloudflare, MiniMax and Bedrock.
+6. Cut over gradually by provider, capability, model, workspace and percentage.
+7. Add the administrative diff, evidence, test, publish and rollback workflow.
+8. Remove hard-coded executor registration, provider aliases, global quirks and
+   duplicated endpoint/capability fixtures after full parity is demonstrated.
+
+The first migration is additive and grants no access to `anon` or
+`authenticated`. RLS is enabled as defence in depth; gateway/admin access uses
+explicit service-role grants.

--- a/apps/api/src/control-plane/execution-plan.test.ts
+++ b/apps/api/src/control-plane/execution-plan.test.ts
@@ -90,7 +90,14 @@ describe("compileExecutionPlan", () => {
 
 	it("builds a release-addressed cache key", () => {
 		expect(executionPlanCacheKey(compileExecutionPlan(source))).toBe(
-			"execution-plan:7:example/model-a:text.generate:default",
+			'execution-plan:[7,"example/model-a","text.generate",null]',
 		);
+	});
+
+	it("does not collide when variable fields contain colons", () => {
+		const left = compileExecutionPlan({ ...source, providerModelId: "a:b", capabilityId: "c" });
+		const right = compileExecutionPlan({ ...source, providerModelId: "a", capabilityId: "b:c" });
+
+		expect(executionPlanCacheKey(left)).not.toBe(executionPlanCacheKey(right));
 	});
 });

--- a/apps/api/src/control-plane/execution-plan.test.ts
+++ b/apps/api/src/control-plane/execution-plan.test.ts
@@ -78,6 +78,16 @@ describe("compileExecutionPlan", () => {
 		})).toThrow("unique precedence");
 	});
 
+	it("rejects prototype-manipulation keys in config layers", () => {
+		const unsafeConfig = JSON.parse('{"nested":{"__proto__":{"polluted":true}}}') as Record<string, unknown>;
+
+		expect(() => compileExecutionPlan({
+			...source,
+			configLayers: [{ precedence: 100, config: unsafeConfig }],
+		})).toThrow("unsafe key: __proto__");
+		expect(({} as { polluted?: boolean }).polluted).toBeUndefined();
+	});
+
 	it("builds a release-addressed cache key", () => {
 		expect(executionPlanCacheKey(compileExecutionPlan(source))).toBe(
 			"execution-plan:7:example/model-a:text.generate:default",

--- a/apps/api/src/control-plane/execution-plan.test.ts
+++ b/apps/api/src/control-plane/execution-plan.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from "vitest";
+import {
+	compileExecutionPlan,
+	executionPlanCacheKey,
+	type ExecutionPlanSource,
+} from "./execution-plan";
+
+const source: ExecutionPlanSource = {
+	releaseSequence: 7,
+	providerModelId: "example/model-a",
+	providerId: "example",
+	capabilityId: "text.generate",
+	routeVariantId: null,
+	endpoint: {
+		baseUrl: "https://api.example.com",
+		pathTemplate: "/v1/chat/completions",
+		apiVersion: null,
+		timeoutMs: 120_000,
+	},
+	primitives: {
+		requestMapper: "openai.chat.request.v1",
+		responseParser: "openai.chat.response.v1",
+		streamParser: "openai.chat.sse.v1",
+		authSigner: "bearer.v1",
+		transport: "http.fetch.v1",
+		usageNormalizer: "openai.usage.v1",
+		errorNormalizer: "openai.error.v1",
+	},
+	configLayers: [
+		{ precedence: 300, config: { request: { parallelTools: false }, provider: "route" } },
+		{ precedence: 100, config: { request: { strictJson: true, parallelTools: true }, provider: "default" } },
+	],
+	parameterSupport: {
+		tools: { level: "native", config: {} },
+		response_format: { level: "emulated", config: { mode: "json_object" } },
+	},
+	constraints: [
+		{
+			key: "no-parallel-tools-with-schema",
+			expression: {
+				all: [
+					{ path: "parallelToolCalls", op: "equals", value: true },
+					{ path: "responseFormat.type", op: "equals", value: "json_schema" },
+				],
+			},
+			outcome: "reject",
+			message: "Parallel tools cannot be combined with JSON Schema.",
+			priority: 20,
+		},
+	],
+	evidenceCheckedAt: "2026-08-03T12:00:00.000Z",
+};
+
+describe("compileExecutionPlan", () => {
+	it("applies low-to-high precedence without losing nested defaults", () => {
+		const plan = compileExecutionPlan(source);
+
+		expect(plan.config).toEqual({
+			request: { strictJson: true, parallelTools: false },
+			provider: "route",
+		});
+	});
+
+	it("rejects unknown primitive binding fields", () => {
+		expect(() => compileExecutionPlan({
+			...source,
+			primitives: { ...source.primitives, arbitraryCode: "nope" } as ExecutionPlanSource["primitives"],
+		})).toThrow();
+	});
+
+	it("rejects ambiguous config precedence", () => {
+		expect(() => compileExecutionPlan({
+			...source,
+			configLayers: [
+				{ precedence: 100, config: { first: true } },
+				{ precedence: 100, config: { second: true } },
+			],
+		})).toThrow("unique precedence");
+	});
+
+	it("builds a release-addressed cache key", () => {
+		expect(executionPlanCacheKey(compileExecutionPlan(source))).toBe(
+			"execution-plan:7:example/model-a:text.generate:default",
+		);
+	});
+});

--- a/apps/api/src/control-plane/execution-plan.ts
+++ b/apps/api/src/control-plane/execution-plan.ts
@@ -115,7 +115,8 @@ export function compileExecutionPlan(source: ExecutionPlanSource): ExecutionPlan
 	}
 
 	const config = source.configLayers
-		.toSorted((left, right) => left.precedence - right.precedence)
+		.slice()
+		.sort((left, right) => left.precedence - right.precedence)
 		.reduce<Record<string, unknown>>(
 			(accumulator, layer) => mergeConfig(accumulator, layer.config),
 			{},
@@ -132,7 +133,9 @@ export function compileExecutionPlan(source: ExecutionPlanSource): ExecutionPlan
 		primitives: source.primitives,
 		config,
 		parameterSupport: source.parameterSupport,
-		constraints: source.constraints.toSorted((left, right) => left.priority - right.priority),
+		constraints: source.constraints
+			.slice()
+			.sort((left, right) => left.priority - right.priority),
 		evidenceCheckedAt: source.evidenceCheckedAt,
 	});
 }

--- a/apps/api/src/control-plane/execution-plan.ts
+++ b/apps/api/src/control-plane/execution-plan.ts
@@ -85,6 +85,16 @@ export type ExecutionPlanSource = {
 	evidenceCheckedAt: string | null;
 };
 
+function assertSafeConfigValue(value: unknown): void {
+	if (!value || typeof value !== "object") return;
+	for (const [key, nestedValue] of Object.entries(value)) {
+		if (["__proto__", "prototype", "constructor"].includes(key)) {
+			throw new Error(`Execution-plan config contains unsafe key: ${key}`);
+		}
+		assertSafeConfigValue(nestedValue);
+	}
+}
+
 function mergeConfig(
 	base: Record<string, unknown>,
 	override: Record<string, unknown>,
@@ -94,6 +104,7 @@ function mergeConfig(
 		if (["__proto__", "prototype", "constructor"].includes(key)) {
 			throw new Error(`Execution-plan config contains unsafe key: ${key}`);
 		}
+		assertSafeConfigValue(value);
 		const previous = merged[key];
 		if (
 			previous && value &&
@@ -144,11 +155,10 @@ export function compileExecutionPlan(source: ExecutionPlanSource): ExecutionPlan
 }
 
 export function executionPlanCacheKey(plan: ExecutionPlan): string {
-	return [
-		"execution-plan",
+	return `execution-plan:${JSON.stringify([
 		plan.releaseSequence,
 		plan.providerModelId,
 		plan.capabilityId,
-		plan.routeVariantId ?? "default",
-	].join(":");
+		plan.routeVariantId,
+	])}`;
 }

--- a/apps/api/src/control-plane/execution-plan.ts
+++ b/apps/api/src/control-plane/execution-plan.ts
@@ -91,6 +91,9 @@ function mergeConfig(
 ): Record<string, unknown> {
 	const merged = { ...base };
 	for (const [key, value] of Object.entries(override)) {
+		if (["__proto__", "prototype", "constructor"].includes(key)) {
+			throw new Error(`Execution-plan config contains unsafe key: ${key}`);
+		}
 		const previous = merged[key];
 		if (
 			previous && value &&

--- a/apps/api/src/control-plane/execution-plan.ts
+++ b/apps/api/src/control-plane/execution-plan.ts
@@ -1,0 +1,148 @@
+import { z } from "zod";
+
+const JsonObjectSchema = z.record(z.string(), z.unknown());
+
+export const PrimitiveBindingsSchema = z.object({
+	requestMapper: z.string().min(1),
+	responseParser: z.string().min(1),
+	streamParser: z.string().min(1).optional(),
+	authSigner: z.string().min(1),
+	transport: z.string().min(1),
+	usageNormalizer: z.string().min(1),
+	errorNormalizer: z.string().min(1),
+	jobHandler: z.string().min(1).optional(),
+}).strict();
+
+export const ParameterSupportLevelSchema = z.enum([
+	"native",
+	"emulated",
+	"ignored",
+	"unsupported",
+	"unknown",
+]);
+
+export const ConstraintExpressionSchema: z.ZodType<ConstraintExpression> = z.lazy(() =>
+	z.union([
+		z.object({ all: z.array(ConstraintExpressionSchema).min(1) }).strict(),
+		z.object({ any: z.array(ConstraintExpressionSchema).min(1) }).strict(),
+		z.object({ not: ConstraintExpressionSchema }).strict(),
+		z.object({ path: z.string().min(1), op: z.literal("exists") }).strict(),
+		z.object({ path: z.string().min(1), op: z.enum(["equals", "in"]), value: z.unknown() }).strict(),
+	]),
+);
+
+export type ConstraintExpression =
+	| { all: ConstraintExpression[] }
+	| { any: ConstraintExpression[] }
+	| { not: ConstraintExpression }
+	| { path: string; op: "exists" }
+	| { path: string; op: "equals" | "in"; value: unknown };
+
+export const CompiledConstraintSchema = z.object({
+	key: z.string().min(1),
+	expression: ConstraintExpressionSchema,
+	outcome: z.enum(["reject", "warn", "transform"]),
+	message: z.string().min(1),
+	priority: z.number().int(),
+}).strict();
+
+export const ExecutionPlanSchema = z.object({
+	planVersion: z.literal(1),
+	releaseSequence: z.number().int().positive(),
+	providerModelId: z.string().min(1),
+	providerId: z.string().min(1),
+	capabilityId: z.string().min(1),
+	routeVariantId: z.string().uuid().nullable(),
+	endpoint: z.object({
+		baseUrl: z.string().url(),
+		pathTemplate: z.string().min(1),
+		apiVersion: z.string().nullable(),
+		timeoutMs: z.number().int().positive().max(900_000),
+	}).strict(),
+	primitives: PrimitiveBindingsSchema,
+	config: JsonObjectSchema,
+	parameterSupport: z.record(z.string(), z.object({
+		level: ParameterSupportLevelSchema,
+		config: JsonObjectSchema,
+	}).strict()),
+	constraints: z.array(CompiledConstraintSchema),
+	evidenceCheckedAt: z.string().datetime().nullable(),
+}).strict();
+
+export type ExecutionPlan = z.infer<typeof ExecutionPlanSchema>;
+
+export type ExecutionPlanSource = {
+	releaseSequence: number;
+	providerModelId: string;
+	providerId: string;
+	capabilityId: string;
+	routeVariantId: string | null;
+	endpoint: ExecutionPlan["endpoint"];
+	primitives: ExecutionPlan["primitives"];
+	configLayers: Array<{ precedence: number; config: Record<string, unknown> }>;
+	parameterSupport: ExecutionPlan["parameterSupport"];
+	constraints: ExecutionPlan["constraints"];
+	evidenceCheckedAt: string | null;
+};
+
+function mergeConfig(
+	base: Record<string, unknown>,
+	override: Record<string, unknown>,
+): Record<string, unknown> {
+	const merged = { ...base };
+	for (const [key, value] of Object.entries(override)) {
+		const previous = merged[key];
+		if (
+			previous && value &&
+			typeof previous === "object" && !Array.isArray(previous) &&
+			typeof value === "object" && !Array.isArray(value)
+		) {
+			merged[key] = mergeConfig(
+				previous as Record<string, unknown>,
+				value as Record<string, unknown>,
+			);
+		} else {
+			merged[key] = value;
+		}
+	}
+	return merged;
+}
+
+export function compileExecutionPlan(source: ExecutionPlanSource): ExecutionPlan {
+	const precedences = source.configLayers.map((layer) => layer.precedence);
+	if (new Set(precedences).size !== precedences.length) {
+		throw new Error("Execution-plan config layers must have unique precedence values");
+	}
+
+	const config = source.configLayers
+		.toSorted((left, right) => left.precedence - right.precedence)
+		.reduce<Record<string, unknown>>(
+			(accumulator, layer) => mergeConfig(accumulator, layer.config),
+			{},
+		);
+
+	return ExecutionPlanSchema.parse({
+		planVersion: 1,
+		releaseSequence: source.releaseSequence,
+		providerModelId: source.providerModelId,
+		providerId: source.providerId,
+		capabilityId: source.capabilityId,
+		routeVariantId: source.routeVariantId,
+		endpoint: source.endpoint,
+		primitives: source.primitives,
+		config,
+		parameterSupport: source.parameterSupport,
+		constraints: source.constraints.toSorted((left, right) => left.priority - right.priority),
+		evidenceCheckedAt: source.evidenceCheckedAt,
+	});
+}
+
+export function executionPlanCacheKey(plan: ExecutionPlan): string {
+	return [
+		"execution-plan",
+		plan.releaseSequence,
+		plan.providerModelId,
+		plan.capabilityId,
+		plan.routeVariantId ?? "default",
+	].join(":");
+}

--- a/supabase/migrations/20260803120000_provider_adapter_control_plane.sql
+++ b/supabase/migrations/20260803120000_provider_adapter_control_plane.sql
@@ -33,6 +33,7 @@ create table if not exists public.v2_capability_adapters (
   created_at timestamptz not null default now(),
   updated_at timestamptz not null default now(),
   constraint v2_capability_adapters_key unique (adapter_key, adapter_version),
+  constraint v2_capability_adapters_capability_key unique (capability_id, capability_adapter_id),
   constraint v2_capability_adapters_adapter_key_check check (adapter_key ~ '^[a-z0-9][a-z0-9._-]*$'),
   constraint v2_capability_adapters_version_check check (adapter_version > 0),
   constraint v2_capability_adapters_bindings_check check (jsonb_typeof(primitive_bindings) = 'object'),
@@ -80,6 +81,7 @@ create table if not exists public.v2_provider_endpoints (
   updated_at timestamptz not null default now(),
   constraint v2_provider_endpoints_key unique (provider_slug, endpoint_key),
   constraint v2_provider_endpoints_provider_key unique (provider_slug, provider_endpoint_id),
+  constraint v2_provider_endpoints_capability_key unique (provider_slug, capability_id, provider_endpoint_id),
   foreign key (provider_slug, auth_profile_id)
     references public.v2_provider_auth_profiles(provider_slug, auth_profile_id) on delete restrict,
   constraint v2_provider_endpoints_timeout_check check (timeout_ms > 0 and timeout_ms <= 900000),
@@ -94,7 +96,7 @@ create table if not exists public.v2_provider_capability_adapters (
   provider_capability_adapter_id uuid primary key default gen_random_uuid(),
   provider_slug text not null references public.v2_providers(provider_slug) on delete cascade,
   capability_id text not null,
-  capability_adapter_id uuid not null references public.v2_capability_adapters(capability_adapter_id) on delete restrict,
+  capability_adapter_id uuid not null,
   provider_endpoint_id uuid not null,
   config jsonb not null default '{}'::jsonb,
   status text not null default 'draft',
@@ -103,8 +105,10 @@ create table if not exists public.v2_provider_capability_adapters (
   created_at timestamptz not null default now(),
   updated_at timestamptz not null default now(),
   constraint v2_provider_capability_adapters_key unique (provider_slug, capability_id, capability_adapter_id, provider_endpoint_id),
-  foreign key (provider_slug, provider_endpoint_id)
-    references public.v2_provider_endpoints(provider_slug, provider_endpoint_id) on delete restrict,
+  foreign key (capability_id, capability_adapter_id)
+    references public.v2_capability_adapters(capability_id, capability_adapter_id) on delete restrict,
+  foreign key (provider_slug, capability_id, provider_endpoint_id)
+    references public.v2_provider_endpoints(provider_slug, capability_id, provider_endpoint_id) on delete restrict,
   constraint v2_provider_capability_adapters_config_check check (jsonb_typeof(config) = 'object'),
   constraint v2_provider_capability_adapters_status_check check (status in ('draft', 'active', 'deprecated', 'disabled')),
   constraint v2_provider_capability_adapters_window_check check (effective_to is null or effective_from is null or effective_to > effective_from)
@@ -144,6 +148,10 @@ create table if not exists public.v2_route_parameter_support (
 create index if not exists v2_route_parameter_support_lookup_idx
   on public.v2_route_parameter_support (capability_id, parameter_key, support_level, provider_model_id);
 
+alter table public.v2_model_provider_routes
+  add constraint v2_model_provider_routes_provider_model_key
+  unique (provider_slug, provider_model_id);
+
 create table if not exists public.v2_capability_constraints (
   constraint_id uuid primary key default gen_random_uuid(),
   provider_slug text references public.v2_providers(provider_slug) on delete cascade,
@@ -158,6 +166,8 @@ create table if not exists public.v2_capability_constraints (
   created_at timestamptz not null default now(),
   updated_at timestamptz not null default now(),
   constraint v2_capability_constraints_scope_check check (provider_slug is not null or provider_model_id is not null),
+  foreign key (provider_slug, provider_model_id)
+    references public.v2_model_provider_routes(provider_slug, provider_model_id) on delete cascade,
   constraint v2_capability_constraints_expression_check check (jsonb_typeof(expression) = 'object'),
   constraint v2_capability_constraints_outcome_check check (outcome in ('reject', 'warn', 'transform')),
   constraint v2_capability_constraints_status_check check (status in ('draft', 'active', 'deprecated', 'disabled')),
@@ -181,6 +191,8 @@ create table if not exists public.v2_capability_evidence (
   notes text,
   created_at timestamptz not null default now(),
   constraint v2_capability_evidence_scope_check check (provider_slug is not null or provider_model_id is not null),
+  foreign key (provider_slug, provider_model_id)
+    references public.v2_model_provider_routes(provider_slug, provider_model_id) on delete cascade,
   constraint v2_capability_evidence_source_check check (source_url ~ '^https://'),
   constraint v2_capability_evidence_type_check check (source_type in ('official_docs', 'official_sdk', 'live_test', 'provider_support', 'inference')),
   constraint v2_capability_evidence_confidence_check check (confidence in ('confirmed', 'high', 'medium', 'low'))
@@ -201,10 +213,11 @@ create table if not exists public.v2_control_plane_releases (
   created_at timestamptz not null default now(),
   reviewed_at timestamptz,
   published_at timestamptz,
+  published_once_at timestamptz,
   superseded_at timestamptz,
   constraint v2_control_plane_releases_status_check check (status in ('draft', 'validated', 'published', 'superseded', 'rejected')),
   constraint v2_control_plane_releases_review_check check (reviewed_by is null or created_by is null or reviewed_by <> created_by),
-  constraint v2_control_plane_releases_publish_check check (status <> 'published' or (reviewed_by is not null and published_at is not null and content_hash is not null))
+  constraint v2_control_plane_releases_publish_check check (status <> 'published' or (reviewed_by is not null and published_at is not null and published_once_at is not null and content_hash is not null))
 );
 
 create unique index if not exists v2_control_plane_single_published_idx
@@ -241,7 +254,7 @@ language plpgsql
 set search_path = public
 as $$
 begin
-  if old.status = 'published' then
+  if old.published_once_at is not null then
     if tg_op = 'UPDATE'
       and new.status = 'superseded'
       and new.superseded_at is not null
@@ -250,6 +263,9 @@ begin
       return new;
     end if;
     raise exception 'Published control-plane releases are immutable';
+  end if;
+  if tg_op = 'UPDATE' and new.status = 'published' then
+    new.published_once_at := coalesce(new.published_once_at, new.published_at, now());
   end if;
   if tg_op = 'DELETE' then
     return old;
@@ -268,21 +284,21 @@ language plpgsql
 set search_path = public
 as $$
 declare
-  old_release_status text;
-  new_release_status text;
+  old_release_published_at timestamptz;
+  new_release_published_at timestamptz;
 begin
   if tg_op in ('UPDATE', 'DELETE') then
-    select status into old_release_status
+    select published_once_at into old_release_published_at
       from public.v2_control_plane_releases where release_id = old.release_id;
-    if old_release_status = 'published' then
+    if old_release_published_at is not null then
       raise exception 'Execution plans in published releases are immutable';
     end if;
   end if;
 
   if tg_op in ('INSERT', 'UPDATE') then
-    select status into new_release_status
+    select published_once_at into new_release_published_at
       from public.v2_control_plane_releases where release_id = new.release_id;
-    if new_release_status = 'published' then
+    if new_release_published_at is not null then
       raise exception 'Execution plans in published releases are immutable';
     end if;
   end if;

--- a/supabase/migrations/20260803120000_provider_adapter_control_plane.sql
+++ b/supabase/migrations/20260803120000_provider_adapter_control_plane.sql
@@ -1,0 +1,268 @@
+-- Provider adapter control plane.
+--
+-- These tables are intentionally not exposed to anon or authenticated roles.
+-- Runtime consumers read immutable, published execution plans with service-role
+-- credentials; draft configuration remains an internal administrative surface.
+
+create table if not exists public.v2_adapter_primitives (
+  primitive_key text primary key,
+  primitive_kind text not null,
+  code_version integer not null default 1,
+  config_schema jsonb not null default '{}'::jsonb,
+  status text not null default 'active',
+  description text,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  constraint v2_adapter_primitives_key_check check (primitive_key ~ '^[a-z0-9][a-z0-9._-]*$'),
+  constraint v2_adapter_primitives_kind_check check (primitive_kind in (
+    'request_mapper', 'response_parser', 'stream_parser', 'auth_signer',
+    'transport', 'usage_normalizer', 'error_normalizer', 'job_handler'
+  )),
+  constraint v2_adapter_primitives_status_check check (status in ('active', 'deprecated', 'disabled')),
+  constraint v2_adapter_primitives_schema_check check (jsonb_typeof(config_schema) = 'object')
+);
+
+create table if not exists public.v2_capability_adapters (
+  capability_adapter_id uuid primary key default gen_random_uuid(),
+  capability_id text not null,
+  adapter_key text not null,
+  adapter_version integer not null default 1,
+  primitive_bindings jsonb not null,
+  default_config jsonb not null default '{}'::jsonb,
+  status text not null default 'draft',
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  constraint v2_capability_adapters_key unique (adapter_key, adapter_version),
+  constraint v2_capability_adapters_adapter_key_check check (adapter_key ~ '^[a-z0-9][a-z0-9._-]*$'),
+  constraint v2_capability_adapters_version_check check (adapter_version > 0),
+  constraint v2_capability_adapters_bindings_check check (jsonb_typeof(primitive_bindings) = 'object'),
+  constraint v2_capability_adapters_config_check check (jsonb_typeof(default_config) = 'object'),
+  constraint v2_capability_adapters_status_check check (status in ('draft', 'active', 'deprecated', 'disabled'))
+);
+
+create index if not exists v2_capability_adapters_lookup_idx
+  on public.v2_capability_adapters (capability_id, status, adapter_key, adapter_version desc);
+
+create table if not exists public.v2_provider_auth_profiles (
+  auth_profile_id uuid primary key default gen_random_uuid(),
+  provider_slug text not null references public.v2_providers(provider_slug) on delete cascade,
+  profile_key text not null,
+  auth_primitive_key text not null references public.v2_adapter_primitives(primitive_key) on delete restrict,
+  secret_reference_key text not null,
+  config jsonb not null default '{}'::jsonb,
+  status text not null default 'active',
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  constraint v2_provider_auth_profiles_key unique (provider_slug, profile_key),
+  constraint v2_provider_auth_profiles_config_check check (jsonb_typeof(config) = 'object'),
+  constraint v2_provider_auth_profiles_status_check check (status in ('active', 'deprecated', 'disabled'))
+);
+
+comment on column public.v2_provider_auth_profiles.secret_reference_key is
+  'Logical secret lookup key only. Secret values must never be stored in the control plane.';
+
+create table if not exists public.v2_provider_endpoints (
+  provider_endpoint_id uuid primary key default gen_random_uuid(),
+  provider_slug text not null references public.v2_providers(provider_slug) on delete cascade,
+  endpoint_key text not null,
+  capability_id text not null,
+  base_url text not null,
+  path_template text not null,
+  api_version text,
+  auth_profile_id uuid references public.v2_provider_auth_profiles(auth_profile_id) on delete restrict,
+  region_code text,
+  service_tier_slug text references public.v2_service_tiers(service_tier_slug) on delete restrict,
+  timeout_ms integer not null default 120000,
+  retry_policy jsonb not null default '{}'::jsonb,
+  status text not null default 'active',
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  constraint v2_provider_endpoints_key unique (provider_slug, endpoint_key),
+  constraint v2_provider_endpoints_timeout_check check (timeout_ms > 0 and timeout_ms <= 900000),
+  constraint v2_provider_endpoints_retry_check check (jsonb_typeof(retry_policy) = 'object'),
+  constraint v2_provider_endpoints_status_check check (status in ('active', 'degraded', 'deprecated', 'disabled'))
+);
+
+create index if not exists v2_provider_endpoints_lookup_idx
+  on public.v2_provider_endpoints (provider_slug, capability_id, region_code, service_tier_slug, status);
+
+create table if not exists public.v2_provider_capability_adapters (
+  provider_capability_adapter_id uuid primary key default gen_random_uuid(),
+  provider_slug text not null references public.v2_providers(provider_slug) on delete cascade,
+  capability_id text not null,
+  capability_adapter_id uuid not null references public.v2_capability_adapters(capability_adapter_id) on delete restrict,
+  provider_endpoint_id uuid not null references public.v2_provider_endpoints(provider_endpoint_id) on delete restrict,
+  config jsonb not null default '{}'::jsonb,
+  status text not null default 'draft',
+  effective_from timestamptz,
+  effective_to timestamptz,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  constraint v2_provider_capability_adapters_key unique (provider_slug, capability_id, capability_adapter_id, provider_endpoint_id),
+  constraint v2_provider_capability_adapters_config_check check (jsonb_typeof(config) = 'object'),
+  constraint v2_provider_capability_adapters_status_check check (status in ('draft', 'active', 'deprecated', 'disabled')),
+  constraint v2_provider_capability_adapters_window_check check (effective_to is null or effective_from is null or effective_to > effective_from)
+);
+
+create index if not exists v2_provider_capability_adapters_lookup_idx
+  on public.v2_provider_capability_adapters (provider_slug, capability_id, status);
+
+create table if not exists public.v2_capability_parameters (
+  capability_id text not null,
+  parameter_key text not null,
+  value_schema jsonb not null default '{}'::jsonb,
+  description text,
+  primary key (capability_id, parameter_key),
+  constraint v2_capability_parameters_key_check check (parameter_key ~ '^[a-zA-Z0-9][a-zA-Z0-9._-]*$'),
+  constraint v2_capability_parameters_schema_check check (jsonb_typeof(value_schema) = 'object')
+);
+
+create table if not exists public.v2_route_parameter_support (
+  provider_model_id text not null,
+  capability_id text not null,
+  parameter_key text not null,
+  support_level text not null,
+  config jsonb not null default '{}'::jsonb,
+  notes text,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  primary key (provider_model_id, capability_id, parameter_key),
+  foreign key (provider_model_id, capability_id)
+    references public.v2_route_capabilities(provider_model_id, capability_id) on delete cascade,
+  foreign key (capability_id, parameter_key)
+    references public.v2_capability_parameters(capability_id, parameter_key) on delete restrict,
+  constraint v2_route_parameter_support_level_check check (support_level in ('native', 'emulated', 'ignored', 'unsupported', 'unknown')),
+  constraint v2_route_parameter_support_config_check check (jsonb_typeof(config) = 'object')
+);
+
+create index if not exists v2_route_parameter_support_lookup_idx
+  on public.v2_route_parameter_support (capability_id, parameter_key, support_level, provider_model_id);
+
+create table if not exists public.v2_capability_constraints (
+  constraint_id uuid primary key default gen_random_uuid(),
+  provider_slug text references public.v2_providers(provider_slug) on delete cascade,
+  provider_model_id text references public.v2_model_provider_routes(provider_model_id) on delete cascade,
+  capability_id text not null,
+  constraint_key text not null,
+  expression jsonb not null,
+  outcome text not null default 'reject',
+  message text not null,
+  priority integer not null default 100,
+  status text not null default 'draft',
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  constraint v2_capability_constraints_scope_check check (provider_slug is not null or provider_model_id is not null),
+  constraint v2_capability_constraints_expression_check check (jsonb_typeof(expression) = 'object'),
+  constraint v2_capability_constraints_outcome_check check (outcome in ('reject', 'warn', 'transform')),
+  constraint v2_capability_constraints_status_check check (status in ('draft', 'active', 'deprecated', 'disabled')),
+  constraint v2_capability_constraints_key unique nulls not distinct (provider_slug, provider_model_id, capability_id, constraint_key)
+);
+
+create index if not exists v2_capability_constraints_lookup_idx
+  on public.v2_capability_constraints (provider_slug, provider_model_id, capability_id, status, priority);
+
+create table if not exists public.v2_capability_evidence (
+  evidence_id uuid primary key default gen_random_uuid(),
+  provider_slug text references public.v2_providers(provider_slug) on delete cascade,
+  provider_model_id text references public.v2_model_provider_routes(provider_model_id) on delete cascade,
+  capability_id text not null,
+  parameter_key text,
+  source_url text not null,
+  source_type text not null default 'official_docs',
+  checked_at timestamptz not null,
+  confidence text not null default 'confirmed',
+  source_hash text,
+  notes text,
+  created_at timestamptz not null default now(),
+  constraint v2_capability_evidence_scope_check check (provider_slug is not null or provider_model_id is not null),
+  constraint v2_capability_evidence_source_check check (source_url ~ '^https://'),
+  constraint v2_capability_evidence_type_check check (source_type in ('official_docs', 'official_sdk', 'live_test', 'provider_support', 'inference')),
+  constraint v2_capability_evidence_confidence_check check (confidence in ('confirmed', 'high', 'medium', 'low'))
+);
+
+create index if not exists v2_capability_evidence_lookup_idx
+  on public.v2_capability_evidence (provider_slug, provider_model_id, capability_id, checked_at desc);
+
+create table if not exists public.v2_control_plane_releases (
+  release_id uuid primary key default gen_random_uuid(),
+  sequence bigint generated always as identity unique,
+  status text not null default 'draft',
+  change_summary text not null,
+  content_hash text,
+  created_by uuid references auth.users(id) on delete set null,
+  reviewed_by uuid references auth.users(id) on delete set null,
+  published_by uuid references auth.users(id) on delete set null,
+  created_at timestamptz not null default now(),
+  reviewed_at timestamptz,
+  published_at timestamptz,
+  superseded_at timestamptz,
+  constraint v2_control_plane_releases_status_check check (status in ('draft', 'validated', 'published', 'superseded', 'rejected')),
+  constraint v2_control_plane_releases_review_check check (reviewed_by is null or created_by is null or reviewed_by <> created_by),
+  constraint v2_control_plane_releases_publish_check check (status <> 'published' or (reviewed_by is not null and published_at is not null and content_hash is not null))
+);
+
+create unique index if not exists v2_control_plane_single_published_idx
+  on public.v2_control_plane_releases ((status)) where status = 'published';
+
+create table if not exists public.v2_execution_plans (
+  execution_plan_id uuid primary key default gen_random_uuid(),
+  release_id uuid not null references public.v2_control_plane_releases(release_id) on delete cascade,
+  provider_model_id text not null references public.v2_model_provider_routes(provider_model_id) on delete cascade,
+  capability_id text not null,
+  route_variant_id uuid references public.v2_route_variants(variant_id) on delete cascade,
+  plan_version integer not null default 1,
+  plan_hash text not null,
+  plan jsonb not null,
+  created_at timestamptz not null default now(),
+  foreign key (provider_model_id, capability_id)
+    references public.v2_route_capabilities(provider_model_id, capability_id) on delete cascade,
+  constraint v2_execution_plans_key unique nulls not distinct (release_id, provider_model_id, capability_id, route_variant_id),
+  constraint v2_execution_plans_version_check check (plan_version > 0),
+  constraint v2_execution_plans_plan_check check (jsonb_typeof(plan) = 'object')
+);
+
+create index if not exists v2_execution_plans_runtime_lookup_idx
+  on public.v2_execution_plans (release_id, provider_model_id, capability_id, route_variant_id);
+
+alter table public.v2_adapter_primitives enable row level security;
+alter table public.v2_capability_adapters enable row level security;
+alter table public.v2_provider_auth_profiles enable row level security;
+alter table public.v2_provider_endpoints enable row level security;
+alter table public.v2_provider_capability_adapters enable row level security;
+alter table public.v2_capability_parameters enable row level security;
+alter table public.v2_route_parameter_support enable row level security;
+alter table public.v2_capability_constraints enable row level security;
+alter table public.v2_capability_evidence enable row level security;
+alter table public.v2_control_plane_releases enable row level security;
+alter table public.v2_execution_plans enable row level security;
+
+revoke all on public.v2_adapter_primitives from anon, authenticated;
+revoke all on public.v2_capability_adapters from anon, authenticated;
+revoke all on public.v2_provider_auth_profiles from anon, authenticated;
+revoke all on public.v2_provider_endpoints from anon, authenticated;
+revoke all on public.v2_provider_capability_adapters from anon, authenticated;
+revoke all on public.v2_capability_parameters from anon, authenticated;
+revoke all on public.v2_route_parameter_support from anon, authenticated;
+revoke all on public.v2_capability_constraints from anon, authenticated;
+revoke all on public.v2_capability_evidence from anon, authenticated;
+revoke all on public.v2_control_plane_releases from anon, authenticated;
+revoke all on public.v2_execution_plans from anon, authenticated;
+
+grant all on public.v2_adapter_primitives to service_role;
+grant all on public.v2_capability_adapters to service_role;
+grant all on public.v2_provider_auth_profiles to service_role;
+grant all on public.v2_provider_endpoints to service_role;
+grant all on public.v2_provider_capability_adapters to service_role;
+grant all on public.v2_capability_parameters to service_role;
+grant all on public.v2_route_parameter_support to service_role;
+grant all on public.v2_capability_constraints to service_role;
+grant all on public.v2_capability_evidence to service_role;
+grant all on public.v2_control_plane_releases to service_role;
+grant all on public.v2_execution_plans to service_role;
+grant usage, select on sequence public.v2_control_plane_releases_sequence_seq to service_role;
+
+comment on table public.v2_adapter_primitives is 'Allowlisted, code-owned protocol mechanics available to the control-plane compiler.';
+comment on table public.v2_provider_capability_adapters is 'Provider-by-capability composition of adapter mechanics, endpoint and declarative policy.';
+comment on table public.v2_route_parameter_support is 'Truth table distinguishing native, emulated, ignored, unsupported and unknown parameter support.';
+comment on table public.v2_capability_constraints is 'Declarative compatibility rules interpreted by an allowlisted, fail-closed expression engine.';
+comment on table public.v2_execution_plans is 'Immutable, compiled data-plane input. Gateway runtime must not interpret draft control-plane rows.';

--- a/supabase/migrations/20260803120000_provider_adapter_control_plane.sql
+++ b/supabase/migrations/20260803120000_provider_adapter_control_plane.sql
@@ -54,6 +54,7 @@ create table if not exists public.v2_provider_auth_profiles (
   created_at timestamptz not null default now(),
   updated_at timestamptz not null default now(),
   constraint v2_provider_auth_profiles_key unique (provider_slug, profile_key),
+  constraint v2_provider_auth_profiles_provider_key unique (provider_slug, auth_profile_id),
   constraint v2_provider_auth_profiles_config_check check (jsonb_typeof(config) = 'object'),
   constraint v2_provider_auth_profiles_status_check check (status in ('active', 'deprecated', 'disabled'))
 );
@@ -69,7 +70,7 @@ create table if not exists public.v2_provider_endpoints (
   base_url text not null,
   path_template text not null,
   api_version text,
-  auth_profile_id uuid references public.v2_provider_auth_profiles(auth_profile_id) on delete restrict,
+  auth_profile_id uuid,
   region_code text,
   service_tier_slug text references public.v2_service_tiers(service_tier_slug) on delete restrict,
   timeout_ms integer not null default 120000,
@@ -78,6 +79,9 @@ create table if not exists public.v2_provider_endpoints (
   created_at timestamptz not null default now(),
   updated_at timestamptz not null default now(),
   constraint v2_provider_endpoints_key unique (provider_slug, endpoint_key),
+  constraint v2_provider_endpoints_provider_key unique (provider_slug, provider_endpoint_id),
+  foreign key (provider_slug, auth_profile_id)
+    references public.v2_provider_auth_profiles(provider_slug, auth_profile_id) on delete restrict,
   constraint v2_provider_endpoints_timeout_check check (timeout_ms > 0 and timeout_ms <= 900000),
   constraint v2_provider_endpoints_retry_check check (jsonb_typeof(retry_policy) = 'object'),
   constraint v2_provider_endpoints_status_check check (status in ('active', 'degraded', 'deprecated', 'disabled'))
@@ -91,7 +95,7 @@ create table if not exists public.v2_provider_capability_adapters (
   provider_slug text not null references public.v2_providers(provider_slug) on delete cascade,
   capability_id text not null,
   capability_adapter_id uuid not null references public.v2_capability_adapters(capability_adapter_id) on delete restrict,
-  provider_endpoint_id uuid not null references public.v2_provider_endpoints(provider_endpoint_id) on delete restrict,
+  provider_endpoint_id uuid not null,
   config jsonb not null default '{}'::jsonb,
   status text not null default 'draft',
   effective_from timestamptz,
@@ -99,6 +103,8 @@ create table if not exists public.v2_provider_capability_adapters (
   created_at timestamptz not null default now(),
   updated_at timestamptz not null default now(),
   constraint v2_provider_capability_adapters_key unique (provider_slug, capability_id, capability_adapter_id, provider_endpoint_id),
+  foreign key (provider_slug, provider_endpoint_id)
+    references public.v2_provider_endpoints(provider_slug, provider_endpoint_id) on delete restrict,
   constraint v2_provider_capability_adapters_config_check check (jsonb_typeof(config) = 'object'),
   constraint v2_provider_capability_adapters_status_check check (status in ('draft', 'active', 'deprecated', 'disabled')),
   constraint v2_provider_capability_adapters_window_check check (effective_to is null or effective_from is null or effective_to > effective_from)
@@ -204,18 +210,23 @@ create table if not exists public.v2_control_plane_releases (
 create unique index if not exists v2_control_plane_single_published_idx
   on public.v2_control_plane_releases ((status)) where status = 'published';
 
+create unique index if not exists v2_route_variants_provider_variant_idx
+  on public.v2_route_variants (provider_model_id, variant_id);
+
 create table if not exists public.v2_execution_plans (
   execution_plan_id uuid primary key default gen_random_uuid(),
   release_id uuid not null references public.v2_control_plane_releases(release_id) on delete cascade,
   provider_model_id text not null references public.v2_model_provider_routes(provider_model_id) on delete cascade,
   capability_id text not null,
-  route_variant_id uuid references public.v2_route_variants(variant_id) on delete cascade,
+  route_variant_id uuid,
   plan_version integer not null default 1,
   plan_hash text not null,
   plan jsonb not null,
   created_at timestamptz not null default now(),
   foreign key (provider_model_id, capability_id)
     references public.v2_route_capabilities(provider_model_id, capability_id) on delete cascade,
+  foreign key (provider_model_id, route_variant_id)
+    references public.v2_route_variants(provider_model_id, variant_id) on delete cascade,
   constraint v2_execution_plans_key unique nulls not distinct (release_id, provider_model_id, capability_id, route_variant_id),
   constraint v2_execution_plans_version_check check (plan_version > 0),
   constraint v2_execution_plans_plan_check check (jsonb_typeof(plan) = 'object')
@@ -223,6 +234,72 @@ create table if not exists public.v2_execution_plans (
 
 create index if not exists v2_execution_plans_runtime_lookup_idx
   on public.v2_execution_plans (release_id, provider_model_id, capability_id, route_variant_id);
+
+create or replace function public.prevent_published_control_plane_release_mutation()
+returns trigger
+language plpgsql
+set search_path = public
+as $$
+begin
+  if old.status = 'published' then
+    if tg_op = 'UPDATE'
+      and new.status = 'superseded'
+      and new.superseded_at is not null
+      and (to_jsonb(new) - 'status' - 'superseded_at') =
+        (to_jsonb(old) - 'status' - 'superseded_at') then
+      return new;
+    end if;
+    raise exception 'Published control-plane releases are immutable';
+  end if;
+  if tg_op = 'DELETE' then
+    return old;
+  end if;
+  return new;
+end;
+$$;
+
+create trigger prevent_published_control_plane_release_mutation
+  before update or delete on public.v2_control_plane_releases
+  for each row execute function public.prevent_published_control_plane_release_mutation();
+
+create or replace function public.prevent_published_execution_plan_mutation()
+returns trigger
+language plpgsql
+set search_path = public
+as $$
+declare
+  old_release_status text;
+  new_release_status text;
+begin
+  if tg_op in ('UPDATE', 'DELETE') then
+    select status into old_release_status
+      from public.v2_control_plane_releases where release_id = old.release_id;
+    if old_release_status = 'published' then
+      raise exception 'Execution plans in published releases are immutable';
+    end if;
+  end if;
+
+  if tg_op in ('INSERT', 'UPDATE') then
+    select status into new_release_status
+      from public.v2_control_plane_releases where release_id = new.release_id;
+    if new_release_status = 'published' then
+      raise exception 'Execution plans in published releases are immutable';
+    end if;
+  end if;
+
+  if tg_op = 'DELETE' then
+    return old;
+  end if;
+  return new;
+end;
+$$;
+
+create trigger prevent_published_execution_plan_mutation
+  before insert or update or delete on public.v2_execution_plans
+  for each row execute function public.prevent_published_execution_plan_mutation();
+
+revoke all on function public.prevent_published_control_plane_release_mutation() from public, anon, authenticated;
+revoke all on function public.prevent_published_execution_plan_mutation() from public, anon, authenticated;
 
 alter table public.v2_adapter_primitives enable row level security;
 alter table public.v2_capability_adapters enable row level security;


### PR DESCRIPTION
## What changed

- adds the private v2 provider-adapter control-plane schema
- models code-owned adapter primitives, provider-capability composition, endpoints and logical auth profiles
- distinguishes native, emulated, ignored, unsupported and unknown parameter support
- adds declarative compatibility constraints and source evidence
- introduces reviewed immutable releases and compiled execution plans
- adds a strict typed execution-plan contract, deterministic config precedence and release-addressed cache keys
- documents the ownership boundary, release lifecycle, caching and phased migration

## Why

Provider capability and compatibility policy is currently split between catalogue data and hard-coded executor registrations/quirks. This establishes an additive control-plane and compiler boundary so those decisions can move into versioned data without placing arbitrary code in the database or changing production routing immediately.

## Runtime impact

None yet. Existing executors remain authoritative. This PR creates the foundation for import and shadow-compilation work.

## Security

- all new public-schema tables have RLS enabled
- access is explicitly revoked from `anon` and `authenticated`
- only logical secret references are stored; credential values remain outside the database
- arbitrary executable code and SQL are excluded from the declarative configuration model
- publication requires review and an immutable plan hash

## Validation

- `git diff --cached --check` passed
- targeted tests and type-check were attempted, but dependency installation is blocked by the repository's existing minimum-release-age policy for five lockfile entries
- Supabase CLI migration generation/validation was attempted, but the CLI cannot initialise `/root/.supabase` in this read-only sandbox

The PR is draft because the migration still needs CI/local-Supabase validation before review.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Implemented database-driven provider adapter control plane enabling centralized configuration management
  * Added support for versioned adapter releases with validation and controlled rollback
  * Integrated configuration layering with precedence-based conflict resolution

* **Tests**
  * Added comprehensive test coverage for execution plan compilation and cache generation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->