### PR TITLE
Add scoped repository agent guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 # Repository Guidelines
 
 ## Project Structure & Module Organization
-- Monorepo managed by pnpm + turbo: `apps/web` (Next.js 15 App Router, Tailwind UI in `src/components` and `components/ui`), `apps/api` (Cloudflare Workers + Hono), `apps/docs` (Mintlify site).
+- Monorepo managed by pnpm + turbo: `apps/web` (Next.js 16 App Router, React 19, Tailwind 4, shared UI in `src/components` and `src/components/ui`), `apps/api` (Cloudflare Workers + Hono), `apps/docs` (Mintlify site).
 - SDKs: `packages/sdk/sdk-ts` TypeScript client (`src`, generated `src/oapi-gen`, builds to `dist`); `packages/sdk/sdk-py` Python client (`src`, tests in `packages/sdk/sdk-py/tests`).
 - Shared tooling lives in `scripts/`, release metadata in `.changeset/`; canonical data/benchmarks sit under `packages/data/catalog/src/data` with Jest cases nearby.
 
@@ -21,7 +21,7 @@
 - Styling via Tailwind; keep globals lean. Follow lint output for spacing/quotes since no repo-wide formatter is enforced.
 
 ## Testing Guidelines
-- Jest for `apps/web` with `*.test.ts(x)` or nearby `__tests__`; cover new logic and data validations with deterministic fixtures.
+- Jest for `apps/web` with `*.test.ts(x)` or nearby `__tests__`; Playwright suites live in `apps/web/tests/e2e`. Cover new logic and data validations with deterministic fixtures.
 - Python SDK tests rely on pytest and `httpx.MockTransport`; keep async cases isolated.
 - TS SDK has local `vitest` compatibility coverage plus optional smoke checks; add targeted unit or smoke tests when changing behavior.
 

--- a/apps/api/AGENTS.md
+++ b/apps/api/AGENTS.md
@@ -1,0 +1,47 @@
+# Gateway API Overrides
+
+These instructions apply to `apps/api` and extend the repository-level `AGENTS.md`.
+
+## Runtime and Architecture
+
+- The gateway runs on Cloudflare Workers with Hono, TypeScript, Wrangler, and Vitest. Do not introduce Node-only APIs unless the target Worker runtime explicitly supports them.
+- Preserve the existing boundaries: `protocols` decode and encode public wire formats, `pipeline` owns shared request flow, `core` owns the internal representation and orchestration, `executors` translate IR to providers, `providers` declare provider capabilities and endpoints, and `routes` expose HTTP surfaces.
+- Normalize public requests into the internal representation before provider execution. Do not leak provider-specific request shapes into shared pipeline or protocol code.
+- Keep provider quirks localized to the provider or executor compatibility layer. A provider workaround must not silently change behavior for every provider.
+- Reuse runtime environment types and binding-key registries when adding Worker bindings. Keep secrets out of source, fixtures, logs, and error responses.
+
+## Protocol and Contract Changes
+
+- Treat OpenAI Chat, Responses, Anthropic Messages, embeddings, rerank, media, batches, and streaming behavior as public compatibility contracts.
+- Preserve request validation, tool-choice semantics, structured-output behavior, finish reasons, usage accounting, error shapes, and streaming event order unless the change intentionally updates the public contract.
+- Add focused decode, encode, executor, and surface tests when changing a protocol field. Cover streaming and non-streaming paths where both exist.
+- Capability checks belong before execution. Reject unsupported parameters explicitly rather than dropping or forwarding them unpredictably.
+- Keep billing reservations, usage reconciliation, idempotency, and post-response notifications correct across success, provider error, client disconnect, and partial-stream failure paths.
+- Public contract changes require synchronized OpenAPI, generated SDK, documentation, and compatibility-test updates under the root workflow.
+
+## Providers and Executors
+
+- Declare capabilities and endpoint support in the established provider registry; do not infer broad support from one successful model or endpoint.
+- Keep request mapping, response mapping, retry/fallback policy, and provider authentication independently testable.
+- Preserve raw provider diagnostics internally while returning safe normalized errors to clients.
+- Never add an implicit provider fallback, model substitution, parameter downgrade, or billing fallback without an explicit product policy and observable telemetry.
+- For streaming adapters, test fragmented chunks, multi-event chunks, malformed data, terminal events, usage-only events, and cancellation where relevant.
+
+## Commands and Tests
+
+- Development: `pnpm --filter @phaseo/gateway-api dev`
+- Lint/type-check: `pnpm --filter @phaseo/gateway-api lint`
+- Unit and contract tests: `pnpm --filter @phaseo/gateway-api test`
+- Worker dry-run build: `pnpm --filter @phaseo/gateway-api build`
+- AI mock suite: `pnpm --filter @phaseo/gateway-api test:aimock`
+
+- Run the narrowest Vitest files while iterating, then the relevant protocol/provider matrix before handoff.
+- Tests named `*.live.spec.ts`, `test:live:*`, recording commands, and provider scripts can contact external services, consume quota, or update fixtures. Do not run them without explicit task need, credentials, and user authorization.
+- Prefer AI mock contracts and deterministic fixtures for ordinary development. Record new external contracts only through the established recording workflow and review the resulting provenance and secrets exposure.
+
+## Reliability and Security
+
+- Treat tool arguments, URLs, files, webhook targets, media references, and model-produced structured data as untrusted input.
+- Preserve rate limits, SSRF protections, authorization, workspace isolation, audit events, and sensitive-data redaction when changing request flow.
+- Avoid unbounded buffering in Worker memory. Stream or cap large text, media, batch, and multipart payloads.
+- Include stable request/provider context in structured telemetry, but never log credentials, full sensitive payloads, or private customer content by default.

--- a/apps/docs/AGENTS.md
+++ b/apps/docs/AGENTS.md
@@ -1,0 +1,32 @@
+# Documentation Overrides
+
+These instructions apply to `apps/docs` and extend the repository-level `AGENTS.md`.
+
+## Mintlify Structure
+
+- The documentation site uses Mintlify. Pages are Markdown/MDX under `v1`; navigation, redirects, tabs, and API-reference configuration live in `docs.json`.
+- Place a page in the existing information architecture before adding it to navigation. Reuse established MDX components and frontmatter conventions.
+- Use concise task-oriented titles, descriptive headings, and copy-pasteable examples. Explain prerequisites and expected results before edge cases.
+- Prefer links to canonical pages over repeating the same explanation in multiple sections.
+
+## Public Contract and Generated Surfaces
+
+- `openapi/v1/openapi.yaml` is the canonical documentation input for the v1 API reference. Keep endpoint descriptions, schemas, examples, authentication, and error behavior aligned with the gateway implementation.
+- SDK reference pages must match the current handwritten wrappers and generated operations for their language. Do not claim convenience helpers or parity that the package does not provide.
+- When an API contract changes, update the OpenAPI document, affected guides/examples, generated SDKs, and language reference pages together.
+- Do not manually patch generated SDK source to make a documentation example true; fix the specification or handwritten wrapper and regenerate.
+
+## Validation
+
+- Link check: `pnpm docs:links`
+- Mintlify validation/build: `pnpm docs:build`
+- Run both for navigation changes, renamed pages, API-reference changes, or broad link edits.
+- Verify code examples use current Phaseo URLs, model IDs, SDK package names, and authentication conventions. Never include real keys or production customer data.
+- Preserve redirects when moving published pages and update inbound links in the same change.
+
+## Writing and Safety
+
+- Separate conceptual explanation, procedures, reference material, and troubleshooting rather than mixing all four into one page.
+- State whether examples are production-ready, illustrative, preview-only, or require live-provider credentials.
+- Treat tool-calling, redirects, uploads, webhooks, and model-generated arguments as security-sensitive topics; include safe defaults and validation guidance.
+- Add changelog entries only for user-visible shipped behavior, and keep historical statements historically accurate.

--- a/apps/web/AGENTS.md
+++ b/apps/web/AGENTS.md
@@ -1,42 +1,55 @@
-# Repository Guidelines
+# Web App Overrides
 
-## Project Structure & Module Organization
-- App Router: use `app/`. Co-locate route components — `app/.../page.tsx` with a matching `actions.ts` for server actions.
-- API routes: store handlers in `app/api/<route>/route.ts` (one `route.ts` per endpoint).
-- Components: keep shared UI in `components/` with ShadCN primitives under `components/ui`. Always start from these primitives.
-- Shared code: `hooks/`, `lib/`, and `utils/` (TypeScript, named exports).
-- Static assets: `public/` (served from `/`).
-- Tests: none exist yet; when contributing, add tests near the changed code.
+These instructions apply only to `apps/web` and extend the repository-level `AGENTS.md`. Keep shared monorepo policy, Git workflow, and general testing guidance in the root file.
 
-## Build, Test, and Development Commands
-- Dev: `npm run dev` — start Next.js with HMR.
-- Build: `npm run build` — production build.
-- Start: `npm run start` — serve the production build.
-- Lint: `npm run lint` — ESLint for Next.js + TS.
-- Format: `npm run format` — Prettier (project standard).
-- Type-check: `npm run typecheck` — `tsc --noEmit`.
-- Tests (once added): `npm test` (unit), `npm run e2e` (Playwright, optional).
+## Stack and Structure
 
-## Coding Style & Naming Conventions
-- Language: TypeScript-only; 4-space indentation; rely on Prettier for formatting.
-- Files: components `PascalCase.tsx`; hooks `useSomething.ts`; utilities `camelCase.ts`.
-- Routes: dynamic segments `[id]`; API handlers live under `app/api/.../route.ts`.
-- CSS: Tailwind ONLY for component styling. Avoid CSS Modules and ad-hoc global CSS (keep `app/globals.css` minimal).
-- UI: compose from ShadCN components in `components/ui`; extend via lightweight wrappers in `components/`.
+- Next.js 16 App Router with React 19, TypeScript 6 strict mode, Tailwind CSS 4, ShadCN/Base UI primitives, and Cache Components.
+- Routes, layouts, metadata, route handlers, and server actions live under `src/app`; route groups such as `(auth)` and `(dashboard)` organize routes without changing URLs.
+- Shared components live in `src/components`, with reusable primitives in `src/components/ui`. Shared hooks, domain logic, types, and utilities live in `src/hooks`, `src/lib`, `src/types`, and `src/utils`.
+- Keep feature-specific code close to its route or domain. Promote it to a shared directory only after it has a genuine second consumer.
+- Canonical model, provider, pricing, and benchmark data belongs to `packages/data/catalog`; do not create a competing web-only source of truth.
+- Use the `@/` alias and prefer direct implementation imports over new barrel files.
 
-## Testing Guidelines
-- Current state: no tests. Add tests for new functionality and bug fixes.
-- Unit/integration: colocate `*.test.ts(x)` with the source or under a nearby `__tests__/`.
-- Use `@testing-library/react` for DOM behavior; mock `next/navigation` as needed.
-- Coverage: target ≥ 80% for changed lines to start.
-- Commands: `npm test -- --watch` locally; `npm test -- --coverage` in CI.
+## Scoped Commands
 
-## Commit & Pull Request Guidelines
-- Commits: conventional style (`feat:`, `fix:`, `docs:`, `refactor:`, `test:`, `chore:`). Imperative subject ≤ 72 chars.
-- PRs: include a clear description, linked issues, and screenshots/GIFs for UI changes. Note accessibility/performance impacts.
-- Checks: PRs must pass lint, type-check, build, and tests (when present). Update docs when behavior changes.
+- Development: `pnpm --filter @phaseo/web dev` (port 3100)
+- Lint: `pnpm --filter @phaseo/web lint`
+- Type-check: `pnpm --filter @phaseo/web typecheck`
+- Tests: `pnpm --filter @phaseo/web test`
+- Build: `pnpm --filter @phaseo/web build`
+- Playwright: `pnpm --filter @phaseo/web exec playwright test`
 
-## Security & Configuration Tips
-- Secrets: never commit. Use `.env.local` for development and provide `env.example` placeholders.
-- Images: whitelist domains in `next.config.js` via `images.domains`.
-- Headers: add security headers via `next.config.js` or middleware.
+Run the narrowest relevant checks while iterating. Run a production build when a change can affect routing, rendering, caching, or bundling.
+
+## Next.js and React
+
+- Prefer Server Components. Add `"use client"` only at the smallest boundary requiring browser APIs, local state, event handlers, or client-only libraries.
+- Keep secrets, privileged clients, billing logic, and admin Supabase access in server-only modules. Authenticate and authorize every mutation at the server boundary.
+- Start independent asynchronous work together and await it with `Promise.all`; use Suspense to stream independent dynamic sections.
+- Minimize data serialized into Client Components. Dynamically import large client-only charts, editors, 3D, PDF, or media features when deferral improves initial load.
+- Preserve accessibility, keyboard behavior, focus management, and reduced-motion preferences.
+
+## Cache Components
+
+- `cacheComponents: true` is enabled. Treat freshness and invalidation as explicit product behavior.
+- Use `"use cache"` only for shareable asynchronous work, with intentional `cacheLife` and `cacheTag` policies.
+- Do not access `cookies()`, `headers()`, or request `searchParams` inside a shared cache scope; read them outside and pass the minimum serializable arguments.
+- Use `updateTag` for read-your-own-writes behavior and `revalidateTag` for stale-while-revalidate. Reuse the central helpers in `src/lib/cache`.
+- Do not introduce `force-dynamic`, `force-static`, `unstable_cache`, or ad hoc cache-busting without checking the existing Cache Components design.
+
+## UI and Client State
+
+- Start with existing `src/components/ui` primitives and the configured ShadCN registries before adding a primitive or dependency.
+- Use Tailwind utilities and established tokens; keep `src/app/globals.css` for tokens, resets, and truly global behavior.
+- Keep product copy concise. Add helper text only when it prevents a likely misunderstanding.
+- Prefer URL state for shareable filters, searches, tabs, and pagination, using existing `nuqs` patterns. Use SWR for client revalidation and request deduplication.
+- Keep transient state local, derive values during render where possible, and avoid effects that merely synchronize duplicate state.
+
+## Web Testing and Safety
+
+- Jest uses a Node environment by default. Add DOM-specific setup only when a test genuinely needs it.
+- Use Playwright under `tests/e2e` for critical browser journeys and performance regressions.
+- Mock network and time at clear boundaries; unit tests must not call live providers, production Supabase, billing, or analytics services.
+- Treat redirect URLs, webhook payloads, uploaded content, Markdown/HTML, and external URLs as untrusted. Reuse existing validation and sanitization utilities.
+- Scripts for imports, outreach, provisioning, reconciliation, or database updates may have external side effects; inspect their options and environment requirements before running them.

--- a/packages/data/catalog/AGENTS.md
+++ b/packages/data/catalog/AGENTS.md
@@ -1,0 +1,34 @@
+# Data Catalog Overrides
+
+These instructions apply to `packages/data/catalog` and extend the repository-level `AGENTS.md`.
+
+## Ownership and Shape
+
+- This package is the canonical source for models, API providers, organisations, benchmarks, pricing, aliases, families, and subscription plans.
+- Follow the existing JSON/schema shape and directory naming conventions. Do not add web-only presentation fields or duplicate a fact that already has a canonical owner.
+- Keep stable canonical IDs separate from provider route IDs, aliases, display names, and marketing labels. Preserve historical IDs unless an intentional migration updates every consumer.
+- Prefer explicit source-backed values over inference. If a fact is unknown, omit it or use the schema-supported unknown state rather than inventing a value.
+
+## Models, Providers, and Pricing
+
+- A model record describes the canonical model; provider files describe callable routes, availability, capabilities, and provider-specific pricing or limits.
+- Keep modalities, parameters, context/output limits, lifecycle dates, and provider capabilities internally consistent.
+- Pricing units must be explicit and normalized through the established schema. Check input, cached-input, output, image, audio, video, batch, and tiered dimensions independently where applicable.
+- When adding or renaming a provider/model, update aliases, logos/references, route mappings, tests, documentation, gateway validation, and generated helper surfaces that consume the ID.
+- Do not mark a model callable merely because it exists in a provider catalog; gateway support requires a compatible active route and executor capability.
+
+## Validation and Tests
+
+- Structure validation: `pnpm validate:data`
+- Pricing validation: `pnpm validate:pricing`
+- Gateway compatibility: `pnpm validate:gateway`
+- Focused catalog tests live beside `src/data` and under `src/data/__tests__`.
+- Run all three validations for provider, route, capability, pricing, or canonical-ID changes.
+- Add deterministic regression coverage for new schema rules, alias resolution, pricing normalization, lifecycle handling, or cross-file invariants.
+
+## Change Safety
+
+- Keep edits targeted to the affected records; avoid bulk formatting or key reordering across unrelated JSON.
+- Never overwrite newer or more authoritative provenance with an older secondary source. Record source/provenance fields when the schema supports them.
+- Catalog changes can propagate into the web app, gateway, OpenAPI, SDKs, docs, and provider mocks. Regenerate dependent artifacts through root scripts rather than hand-editing generated outputs.
+- Add an appropriate changeset when a catalog change alters a published SDK/API surface or other versioned consumer.

--- a/packages/sdk/AGENTS.md
+++ b/packages/sdk/AGENTS.md
@@ -1,0 +1,42 @@
+# SDK Overrides
+
+These instructions apply to `packages/sdk` and extend the repository-level `AGENTS.md`.
+
+## Package Families
+
+- The tree contains generated gateway SDKs for TypeScript, Python, Go, C#, Java, PHP, Ruby, C++, and Rust, plus handwritten wrappers and language-specific Agent SDKs.
+- Preserve behavioral parity across languages where the public contract is shared, while following each language's established naming, error, async, and packaging conventions.
+- Keep high-level handwritten clients thin over generated operations. Expose raw generated clients when that is the established escape hatch rather than duplicating transport logic.
+
+## Generated Code Boundaries
+
+- Files under generated directories such as `src/oapi-gen`, `src/gen`, `lib/gen`, and `src/app/phaseo/gen`, plus files marked generated, must be changed through the canonical OpenAPI/generator pipeline.
+- Do not manually patch a generated file. Fix `apps/docs/openapi/v1/openapi.yaml`, the relevant backend under `packages/openapi-backends`, or generator/core logic, then run the scoped `pnpm openapi:gen:<language>` command.
+- A full contract change should run `pnpm openapi:gen` so every generated language remains synchronized.
+- Review generated diffs for accidental breaking changes, naming drift, missing operations, invalid nullable/union handling, and version churn.
+
+## Handwritten Clients and Compatibility
+
+- Add convenience helpers only when their behavior can be supported consistently and tested without hiding important response fields or errors.
+- Preserve authentication headers, base-URL handling, timeout/cancellation behavior, streaming, multipart uploads, pagination, and structured error information.
+- Keep OpenAI/Anthropic compatibility layers behaviorally compatible with their documented surfaces; do not silently transform unsupported features.
+- Public type or method changes require a changeset and a semver assessment. Do not update version literals manually; use the repository version-sync scripts.
+
+## Validation
+
+- TypeScript: `pnpm test:sdk-ts` and `pnpm packages:build:ts`
+- Python: `pnpm test:sdk-py` and `pnpm packages:build:py`
+- Lifecycle SDKs: `pnpm test:sdk-lifecycle`
+- Full generation: `pnpm openapi:gen`
+- Package validation: `pnpm validate:packages`
+- Version literals: `pnpm sdk:check-version-literals`
+
+- Run the scoped language test/build while iterating. For cross-language generator or OpenAPI changes, run generation and every affected language's tests.
+- Smoke and live tests can contact the deployed gateway and providers. Do not run them without explicit task need, credentials, and user authorization.
+- Use deterministic mock transports and fixtures for unit tests; cover sync/async parity, serialization, error mapping, and operation paths where applicable.
+
+## Documentation and Releases
+
+- Keep package READMEs, `SKILL.md` files, examples, and `apps/docs/v1/sdk-reference` aligned with the shipped wrapper surface.
+- Follow `packages/sdk/RELEASING.md` for release preparation. Do not edit changelog history or generated release notes as a substitute for a changeset.
+- Verify package contents with the established dry-pack/build commands so generated sources, types, licenses, and skills are included as intended.


### PR DESCRIPTION
## Summary

- update the root repository guidance for the current Next.js and Playwright setup
- replace stale web instructions with focused Next.js 16 and Cache Components guidance
- add scoped guidance for the gateway API, Mintlify documentation, data catalog, and SDK packages
- document generated-code boundaries, validation commands, live-test safety, and surface-specific architecture

## Why

The existing web guidance was outdated and the other major repository surfaces had no local instructions. This adds a concise layered structure so shared policy remains at the root while specialized rules live close to the code they govern.

## Validation

- `git diff --check`
- verified the PR contains only the six intended `AGENTS.md` files
- no runtime tests were run because the changes are documentation-only

Created with Codex

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated repository guidance to reflect the current web application framework, shared UI conventions, and end-to-end testing approach.
  * Added development and testing guidance for API, documentation, data catalog, and SDK projects.
  * Clarified standards for compatibility, security, validation, generated artifacts, documentation updates, and release preparation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->