### PR TITLE
Fix xAI TTS response decoding

### DIFF
--- a/apps/api/src/providers/x-ai/__tests__/audio-speech.test.ts
+++ b/apps/api/src/providers/x-ai/__tests__/audio-speech.test.ts
@@ -52,4 +52,35 @@ describe("xAI audio.speech endpoint", () => {
 		expect(result.upstream.status).toBe(400);
 		expect((await result.upstream.json() as any).error.param).toBe("response_format");
 	});
+
+	it("preserves successful binary audio responses", async () => {
+		const mock = installFetchMock([{
+			match: (url) => url.endsWith("/v1/tts"),
+			response: new Response(new Uint8Array([5, 6, 7]), {
+				status: 200,
+				headers: { "Content-Type": "audio/mpeg" },
+			}),
+		}]);
+
+		const result = await exec(args({ response_format: "mp3" }));
+		mock.restore();
+
+		expect(result.upstream.status).toBe(200);
+		expect([...new Uint8Array(await result.upstream.arrayBuffer())]).toEqual([5, 6, 7]);
+	});
+
+	it.each([
+		["null JSON", null],
+		["invalid base64", { audio: "not base64!" }],
+	])("returns a protocol error for %s", async (_label, payload) => {
+		const mock = installFetchMock([{
+			match: (url) => url.endsWith("/v1/tts"),
+			response: jsonResponse(payload),
+		}]);
+
+		const result = await exec(args({ response_format: "mp3" }));
+		mock.restore();
+
+		expect(result.upstream.status).toBe(502);
+	});
 });

--- a/apps/api/src/providers/x-ai/__tests__/audio-speech.test.ts
+++ b/apps/api/src/providers/x-ai/__tests__/audio-speech.test.ts
@@ -1,0 +1,55 @@
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { setupTestRuntime, teardownTestRuntime } from "../../../../tests/helpers/runtime";
+import { installFetchMock, jsonResponse } from "../../../../tests/helpers/mock-fetch";
+import { exec } from "../endpoints/audio-speech";
+
+beforeAll(() => setupTestRuntime());
+afterAll(() => teardownTestRuntime());
+
+function args(body: Record<string, unknown>) {
+	return {
+		endpoint: "audio.speech",
+		model: "x-ai/grok-tts",
+		body: { model: "x-ai/grok-tts", input: "Hello", voice: "eve", ...body },
+		meta: { requestId: "req_xai_tts", apiKeyId: "key", apiKeyRef: "kid", apiKeyKid: "kid" },
+		workspaceId: "team_test",
+		providerId: "x-ai",
+		byokMeta: [],
+		pricingCard: { provider: "x-ai", model: "grok-tts", endpoint: "audio.speech", currency: "USD", rules: [] },
+		providerModelSlug: "grok-tts",
+		stream: false,
+	} as any;
+}
+
+describe("xAI audio.speech endpoint", () => {
+	it("decodes the REST JSON envelope into an audio response", async () => {
+		let requestBody: any;
+		const audio = Buffer.from([1, 2, 3, 4]).toString("base64");
+		const mock = installFetchMock([{
+			match: (url) => url.endsWith("/v1/tts"),
+			response: jsonResponse({ audio, content_type: "audio/wav", duration: 1.25 }),
+			onRequest: (call) => { requestBody = call.bodyJson; },
+		}]);
+
+		const result = await exec(args({ response_format: "wav", speed: 1.2 }));
+		mock.restore();
+
+		expect(requestBody).toMatchObject({
+			text: "Hello",
+			voice_id: "eve",
+			language: "auto",
+			speed: 1.2,
+			output_format: { codec: "wav" },
+		});
+		expect(result.upstream.headers.get("content-type")).toBe("audio/wav");
+		expect([...new Uint8Array(await result.upstream.arrayBuffer())]).toEqual([1, 2, 3, 4]);
+		expect(result.normalized?.audio?.data).toBe(audio);
+		expect(result.normalized?.usage?.output_seconds).toBe(1.25);
+	});
+
+	it("rejects codecs outside xAI's documented set", async () => {
+		const result = await exec(args({ response_format: "flac" }));
+		expect(result.upstream.status).toBe(400);
+		expect((await result.upstream.json() as any).error.param).toBe("response_format");
+	});
+});

--- a/apps/api/src/providers/x-ai/endpoints/audio-speech.ts
+++ b/apps/api/src/providers/x-ai/endpoints/audio-speech.ts
@@ -43,6 +43,18 @@ function mimeTypeForCodec(codec: string): string {
 	}
 }
 
+function invalidParameterResponse(param: string, message: string): Response {
+	return new Response(
+		JSON.stringify({ error: { type: "invalid_request_error", message, param } }),
+		{ status: 400, headers: { "Content-Type": "application/json" } },
+	);
+}
+
+function decodeBase64Audio(value: string): ArrayBuffer {
+	const bytes = Uint8Array.from(atob(value), (character) => character.charCodeAt(0));
+	return bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength) as ArrayBuffer;
+}
+
 export async function exec(args: ProviderExecuteArgs): Promise<AdapterResult> {
 	const keyInfo = await resolveOpenAICompatKey(args);
 	const adapterPayload = buildAdapterPayload(
@@ -56,12 +68,26 @@ export async function exec(args: ProviderExecuteArgs): Promise<AdapterResult> {
 	};
 
 	const codec = body.response_format ?? body.format ?? "mp3";
+	if (!["mp3", "wav", "pcm", "mulaw", "alaw"].includes(codec)) {
+		return {
+			kind: "completed",
+			upstream: invalidParameterResponse(
+				body.response_format ? "response_format" : "format",
+				`xAI /v1/tts does not support codec "${codec}".`,
+			),
+			bill: { cost_cents: 0, currency: "USD", usage: undefined, upstream_id: null, finish_reason: null },
+			keySource: keyInfo.source,
+			byokKeyId: keyInfo.byokId,
+		};
+	}
 	const requestBody = {
 		text: body.input,
 		voice_id: extractVoiceCandidate(body.voice) ?? "eve",
+		language: "auto",
 		output_format: {
 			codec,
 		},
+		...(typeof body.speed === "number" ? { speed: body.speed } : {}),
 	};
 
 	const res = await (args.upstreamTiming?.fetch ?? fetch)(openAICompatUrl(args.providerId, "/tts"), {
@@ -75,17 +101,48 @@ export async function exec(args: ProviderExecuteArgs): Promise<AdapterResult> {
 		requests: 1,
 	};
 
-	const normalized = res.ok
-		? {
-				upstream: res.clone(),
-				mime_type: res.headers.get("content-type") ?? mimeTypeForCodec(codec),
-				usage,
-			}
-		: undefined;
+	let upstream = res;
+	let normalized: AdapterResult["normalized"];
+	if (res.ok) {
+		let payload: Record<string, unknown>;
+		try {
+			payload = await res.clone().json() as Record<string, unknown>;
+		} catch {
+			payload = {};
+		}
+		if (typeof payload.audio !== "string" || payload.audio.length === 0) {
+			upstream = new Response(JSON.stringify({
+				error: {
+					type: "upstream_protocol_error",
+					message: "xAI /v1/tts returned a successful response without base64 audio.",
+				},
+			}), { status: 502, headers: { "Content-Type": "application/json" } });
+		} else {
+			const mimeType = typeof payload.content_type === "string"
+				? payload.content_type
+				: mimeTypeForCodec(codec);
+			upstream = new Response(decodeBase64Audio(payload.audio), {
+				status: res.status,
+				headers: { "Content-Type": mimeType },
+			});
+			normalized = {
+				upstream: upstream.clone(),
+				mime_type: mimeType,
+				audio: {
+					data: payload.audio,
+					format: codec,
+				},
+				usage: {
+					...usage,
+					...(typeof payload.duration === "number" ? { output_seconds: payload.duration } : {}),
+				},
+			};
+		}
+	}
 
 	return {
 		kind: "completed",
-		upstream: res,
+		upstream,
 		bill: {
 			cost_cents: 0,
 			currency: "USD" as const,

--- a/apps/api/src/providers/x-ai/endpoints/audio-speech.ts
+++ b/apps/api/src/providers/x-ai/endpoints/audio-speech.ts
@@ -50,9 +50,14 @@ function invalidParameterResponse(param: string, message: string): Response {
 	);
 }
 
-function decodeBase64Audio(value: string): ArrayBuffer {
-	const bytes = Uint8Array.from(atob(value), (character) => character.charCodeAt(0));
-	return bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength) as ArrayBuffer;
+function decodeBase64Audio(value: string): ArrayBuffer | undefined {
+	if (value.length % 4 !== 0 || !/^[A-Za-z0-9+/]*={0,2}$/.test(value)) return undefined;
+	try {
+		const bytes = Uint8Array.from(atob(value), (character) => character.charCodeAt(0));
+		return bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength) as ArrayBuffer;
+	} catch {
+		return undefined;
+	}
 }
 
 export async function exec(args: ProviderExecuteArgs): Promise<AdapterResult> {
@@ -103,14 +108,19 @@ export async function exec(args: ProviderExecuteArgs): Promise<AdapterResult> {
 
 	let upstream = res;
 	let normalized: AdapterResult["normalized"];
-	if (res.ok) {
-		let payload: Record<string, unknown>;
+	if (res.ok && res.headers.get("content-type")?.toLowerCase().includes("json")) {
+		let payload: Record<string, unknown> = {};
 		try {
-			payload = await res.clone().json() as Record<string, unknown>;
+			const parsed: unknown = await res.clone().json();
+			if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+				payload = parsed as Record<string, unknown>;
+			}
 		} catch {
-			payload = {};
 		}
-		if (typeof payload.audio !== "string" || payload.audio.length === 0) {
+		const audio = typeof payload.audio === "string" && payload.audio.length > 0
+			? decodeBase64Audio(payload.audio)
+			: undefined;
+		if (!audio) {
 			upstream = new Response(JSON.stringify({
 				error: {
 					type: "upstream_protocol_error",
@@ -121,7 +131,7 @@ export async function exec(args: ProviderExecuteArgs): Promise<AdapterResult> {
 			const mimeType = typeof payload.content_type === "string"
 				? payload.content_type
 				: mimeTypeForCodec(codec);
-			upstream = new Response(decodeBase64Audio(payload.audio), {
+			upstream = new Response(audio, {
 				status: res.status,
 				headers: { "Content-Type": mimeType },
 			});

--- a/apps/api/tests/aimock/harness.ts
+++ b/apps/api/tests/aimock/harness.ts
@@ -347,8 +347,13 @@ function createXAiTtsMount(): Mountable {
                 return true;
             }
 
-            res.writeHead(200, { "Content-Type": mimeType });
-            res.end(Buffer.from("AIMOCK_TTS_AUDIO"));
+            const audio = Buffer.from("AIMOCK_TTS_AUDIO").toString("base64");
+            res.writeHead(200, { "Content-Type": "application/json" });
+            res.end(JSON.stringify({
+                audio,
+                content_type: mimeType,
+                duration: 1,
+            }));
             return true;
         },
     };


### PR DESCRIPTION
## Summary
- decode xAI REST TTS JSON envelopes into the binary audio response expected by the gateway
- preserve base64 audio and duration metadata in the normalized result
- send xAI's required language field and accept its documented codec set at the adapter boundary
- return a 502 protocol error when a successful upstream response contains no audio

## Validation
- `pnpm --filter @phaseo/gateway-api exec vitest run src/providers/x-ai/__tests__/audio-speech.test.ts`
- `pnpm --filter @phaseo/gateway-api typecheck`

Created with Codex

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic language detection and adjustable speed control for text-to-speech requests.
  * Implemented codec validation with clear error responses for unsupported audio formats.

* **Bug Fixes**
  * Enhanced audio response validation and error handling for malformed upstream responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->