### PR TITLE
Refresh provider contracts

### DIFF
--- a/packages/testing/provider-mock/contracts/deepinfra/openapi.json
+++ b/packages/testing/provider-mock/contracts/deepinfra/openapi.json
@@ -328,6 +328,12 @@
             ],
             "description": "The service tier used for processing the request. 'priority' processes the request with higher priority (premium rate); 'flex' processes it at lower priority for a discount, served only when spare capacity exists and may be retried/timed out under load. Both apply only to models that support the respective tier."
           },
+          "fail_fast": {
+            "type": "boolean",
+            "title": "Fail Fast",
+            "description": "If true, the request is rejected immediately with HTTP 429 when the model has no spare capacity, instead of waiting in the queue. Opt-in; the default (false) keeps standard queueing behavior.",
+            "default": false
+          },
           "model": {
             "type": "string",
             "title": "Model",
@@ -470,7 +476,7 @@
             "anyOf": [
               {
                 "items": {
-                  "$ref": "#/components/schemas/ChatTools"
+                  "$ref": "#/components/schemas/FunctionTool"
                 },
                 "type": "array"
               },
@@ -487,7 +493,7 @@
                 "type": "string"
               },
               {
-                "$ref": "#/components/schemas/ChatTools"
+                "$ref": "#/components/schemas/FunctionTool"
               },
               {
                 "type": "null"
@@ -579,11 +585,13 @@
               {
                 "type": "string",
                 "enum": [
+                  "none",
+                  "minimal",
                   "low",
                   "medium",
                   "high",
                   "xhigh",
-                  "none"
+                  "max"
                 ]
               },
               {
@@ -591,7 +599,7 @@
               }
             ],
             "title": "Reasoning Effort",
-            "description": "Constrains effort on reasoning for reasoning models. Currently supported values are none, low, medium, high, and xhigh. Reducing reasoning effort can result in faster responses and fewer tokens used on reasoning in a response. Setting to none disables reasoning entirely if the model supports."
+            "description": "Constrains effort on reasoning for reasoning models. Currently supported values are none, minimal, low, medium, high, xhigh, and max. Reducing reasoning effort can result in faster responses and fewer tokens used on reasoning in a response. Setting to none disables reasoning entirely if the model supports."
           },
           "reasoning": {
             "anyOf": [
@@ -615,6 +623,17 @@
             ],
             "title": "Prompt Cache Key",
             "description": "A key to identify prompt cache for reuse across requests. If provided, the prompt will be cached and can be reused in subsequent requests with the same key."
+          },
+          "prompt_cache_options": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/PromptCacheOptions"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Prompt cache options for this request's prefix, e.g. {\"ttl\": \"1h\"}."
           },
           "chat_template_kwargs": {
             "anyOf": [
@@ -640,6 +659,18 @@
             ],
             "title": "Continue Final Message",
             "description": "If set, the final assistant message is used as a prefix for the model to continue generating from, rather than starting a new turn. Only applicable when the last message in the conversation is an assistant message."
+          },
+          "ignore_eos": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Ignore Eos",
+            "description": "Keep generating until max_tokens instead of stopping at the end-of-sequence token. Only honoured on models tagged with the allow_ignore_eos feature flag; ignored otherwise. Intended for benchmarking, where a fixed output length is needed."
           }
         },
         "type": "object",
@@ -674,6 +705,12 @@
               }
             ],
             "description": "The service tier used for processing the request. 'priority' processes the request with higher priority (premium rate); 'flex' processes it at lower priority for a discount, served only when spare capacity exists and may be retried/timed out under load. Both apply only to models that support the respective tier."
+          },
+          "fail_fast": {
+            "type": "boolean",
+            "title": "Fail Fast",
+            "description": "If true, the request is rejected immediately with HTTP 429 when the model has no spare capacity, instead of waiting in the queue. Opt-in; the default (false) keeps standard queueing behavior.",
+            "default": false
           },
           "model": {
             "type": "string",
@@ -1067,7 +1104,7 @@
         ],
         "title": "ChatCompletionSystemMessage"
       },
-      "ChatTools": {
+      "FunctionTool": {
         "properties": {
           "cache_control": {
             "anyOf": [
@@ -1095,7 +1132,7 @@
         "required": [
           "function"
         ],
-        "title": "ChatTools"
+        "title": "FunctionTool"
       },
       "TextResponseFormat": {
         "properties": {
@@ -1185,11 +1222,13 @@
               {
                 "type": "string",
                 "enum": [
+                  "none",
+                  "minimal",
                   "low",
                   "medium",
                   "high",
                   "xhigh",
-                  "none"
+                  "max"
                 ]
               },
               {
@@ -1214,6 +1253,44 @@
         },
         "type": "object",
         "title": "ChatReasoningSettings"
+      },
+      "PromptCacheOptions": {
+        "properties": {
+          "mode": {
+            "anyOf": [
+              {
+                "type": "string",
+                "enum": [
+                  "explicit",
+                  "implicit"
+                ]
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Mode",
+            "description": "Prompt caching mode; 'explicit' requests explicit caching."
+          },
+          "ttl": {
+            "anyOf": [
+              {
+                "type": "string",
+                "enum": [
+                  "5m",
+                  "1h"
+                ]
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Ttl",
+            "description": "Requested cache retention for this request's prefix."
+          }
+        },
+        "type": "object",
+        "title": "PromptCacheOptions"
       },
       "ValidationError": {
         "properties": {
@@ -1258,6 +1335,17 @@
           "text": {
             "type": "string",
             "title": "Text"
+          },
+          "prompt_cache_breakpoint": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/PromptCacheBreakpoint"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Marks the end of the prefix that prompt_cache_options retention applies to."
           }
         },
         "type": "object",
@@ -1449,6 +1537,25 @@
           "schema"
         ],
         "title": "JsonSchema"
+      },
+      "PromptCacheBreakpoint": {
+        "properties": {
+          "mode": {
+            "anyOf": [
+              {
+                "type": "string",
+                "const": "explicit"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Mode",
+            "description": "Breakpoint mode; 'explicit' bounds cache retention to the prompt prefix ending at this content part."
+          }
+        },
+        "type": "object",
+        "title": "PromptCacheBreakpoint"
       },
       "ImageURL": {
         "properties": {

--- a/packages/testing/provider-mock/contracts/deepinfra/provenance.json
+++ b/packages/testing/provider-mock/contracts/deepinfra/provenance.json
@@ -1,7 +1,7 @@
 {
   "sourceUrl": "https://api.deepinfra.com/openapi.json",
-  "sourceSha256": "610da191cbe755652f4f452b9bec5cddb4bddeb3523d54c2e94f909e8f4ca870",
-  "bundleSha256": "06e573e70e4da912d693dbc866aabbcd6f04c4ae8b8bab1eb6d69ab4d1a3b025",
+  "sourceSha256": "33fc01be77456b5e1542a174f7b6d4e3911dd7715c321ee34df5356713671a1b",
+  "bundleSha256": "109c584cfe2d17282d247e492ebe82c35c6a893608ca9911b08af1d36f09174e",
   "openapiVersion": "3.1.0",
   "apiVersion": "1.0.0",
   "gatewayPathMappings": [

--- a/packages/testing/provider-mock/contracts/fireworks/openapi.json
+++ b/packages/testing/provider-mock/contracts/fireworks/openapi.json
@@ -2,7 +2,7 @@
   "openapi": "3.1.0",
   "info": {
     "title": "Gateway REST API",
-    "version": "4.259.0"
+    "version": "5.10.0"
   },
   "paths": {
     "/inference/v1/chat/completions": {
@@ -100,7 +100,7 @@
           }
         },
         "tags": [
-          "responses.openapi_other"
+          "responses-harmonized.openapi_other"
         ]
       }
     },
@@ -167,7 +167,7 @@
             },
             "type": "array",
             "title": "Messages",
-            "description": "A list of messages comprising the conversation so far."
+            "description": "A list of messages comprising the conversation so far. When ``prompt_token_ids`` is supplied this field is ignored (the caller is taking responsibility for chat-template rendering and tokenization upstream)."
           },
           "tools": {
             "items": {
@@ -308,6 +308,17 @@
             "title": "Perf Metrics In Response",
             "description": "Whether to include performance metrics in the response body.\n\n**Non-streaming requests:** Performance metrics are always included in response headers (e.g., `fireworks-prompt-tokens`, `fireworks-server-time-to-first-token`). Setting this to `true` additionally includes the same metrics in the response body under the `perf_metrics` field.\n\n**Streaming requests:** Performance metrics are only included in the response body under the `perf_metrics` field in the final chunk (when `finish_reason` is set). This is because headers may not be accessible during streaming.\n\nThe response body `perf_metrics` field contains the following metrics:\n\n**Basic Metrics (all deployments):**\n\n- `prompt-tokens`: Number of tokens in the prompt\n- `cached-prompt-tokens`: Number of cached prompt tokens\n- `server-time-to-first-token`: Time from request start to first token (in seconds)\n- `server-processing-time`: Total processing time (in seconds, only for completed requests)\n\n**Predicted Outputs Metrics:**\n\n- `speculation-prompt-tokens`: Number of speculative prompt tokens\n- `speculation-prompt-matched-tokens`: Number of matched speculative prompt tokens (for completed requests)\n\n**Dedicated Deployment Only Metrics:**\n\n- `speculation-generated-tokens`: Number of speculative generated tokens (for completed requests)\n- `speculation-acceptance`: Speculation acceptance rates by position\n- `backend-host`: Hostname of the backend server\n- `num-concurrent-requests`: Number of concurrent requests\n- `deployment`: Deployment name\n- `tokenizer-queue-duration`: Time spent in tokenizer queue\n- `tokenizer-duration`: Time spent in tokenizer\n- `prefill-queue-duration`: Time spent in prefill queue\n- `prefill-duration`: Time spent in prefill\n- `generation-queue-duration`: Time spent in generation queue\n- `generation-duration`: Time spent in generation",
             "default": false
+          },
+          "stream_options": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/StreamOptions"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Options for streaming responses. Only valid with ``stream=true``. Fireworks includes a final SSE chunk carrying usage totals by default; set ``include_usage=false`` to opt out. The ``buffer_tokens`` / ``buffer_ms`` / ``buffer_mode`` fields coalesce SSE chunks by token count and/or time (vLLM backend; override the deployment default)."
           },
           "n": {
             "type": "integer",
@@ -490,7 +501,7 @@
               }
             ],
             "title": "Logprobs",
-            "description": "Include log probabilities in the response. This accepts either a boolean or an integer:\n\nIf set to `true`, log probabilities are included and the number of alternatives can be controlled via `top_logprobs` (OpenAI-compatible behavior).\n\nIf set to an integer N (0-5), include log probabilities for up to N most likely tokens per position in the legacy format.\n\nThe API will always return the logprob of the sampled token, so there may be up to `logprobs+1` elements in the response when an integer is used. The maximum value for the integer form is 5."
+            "description": "Include log probabilities in the response. This accepts either a boolean or an integer:\n\nIf set to `true`, log probabilities are included and the number of alternatives can be controlled via `top_logprobs` (OpenAI-compatible behavior).\n\nIf set to an integer N, include log probabilities for up to N most likely tokens per position in the legacy format. N must be between 0 and the deployment's `--max-logprobs` limit (5 by default).\n\nThe API will always return the logprob of the sampled token, so there may be up to `logprobs+1` elements in the response when an integer is used."
           },
           "top_logprobs": {
             "anyOf": [
@@ -502,7 +513,7 @@
               }
             ],
             "title": "Top Logprobs",
-            "description": "An integer between 0 and 5 specifying the number of most likely tokens to return at each token position, each with an associated log probability. The minimum value is 0 and the maximum value is 5.\n\nWhen `logprobs` is set, `top_logprobs` can be used to modify how many top log probabilities are returned. If `top_logprobs` is not set, the API will return up to `logprobs` tokens per position.\n\nRequired range: `0 <= x <= 5`"
+            "description": "An integer specifying the number of most likely tokens to return at each token position, each with an associated log probability. Must be between 0 and the deployment's `--max-logprobs` limit (5 by default).\n\nWhen `logprobs` is set, `top_logprobs` can be used to modify how many top log probabilities are returned. If `top_logprobs` is not set, the API will return up to `logprobs` tokens per position."
           },
           "sampling_mask": {
             "anyOf": [
@@ -667,7 +678,7 @@
               }
             ],
             "title": "Reasoning History",
-            "description": "Controls how historical assistant reasoning content is included in the prompt for multi-turn conversations.\n\n**Accepted values:**\n\n- `null`: Use model/template default behavior (for **GLM-4.7**, the model/template default is `'interleaved'`, i.e. historical reasoning is cleared by default)\n- `'disabled'`: Strip `reasoning_content` from all messages before prompt construction\n- `'interleaved'`: Strip `reasoning_content` from messages up to (and including) the last user message\n- `'preserved'`: Preserve historical `reasoning_content` across the conversation\n\n**Model support:**\n\n| Model | Default | Supported values |\n| --- | --- | --- |\n| Kimi K2.7 | `'preserved'` | `'disabled'`, `'interleaved'`, `'preserved'` |\n| Kimi K2.6 | `'interleaved'` | `'disabled'`, `'interleaved'`, `'preserved'` |\n| Kimi K2 Instruct | `'preserved'` | `'disabled'`, `'interleaved'`, `'preserved'` |\n| MiniMax M2 | `'interleaved'` | `'disabled'`, `'interleaved'` |\n| GLM-4.7 | `'interleaved'` | `'disabled'`, `'interleaved'`, `'preserved'` |\n| GLM-4.6 | `'interleaved'` | `'disabled'`, `'interleaved'` |\n| Qwen 3.6 | `'preserved'` | `'disabled'`, `'preserved'` |\n| DeepSeek V4 | `'interleaved'` | `'interleaved'` |\n\nFor other models, refer to the model provider's documentation.\n\n**Note:** This parameter controls prompt formatting only. To disable reasoning computation entirely, use `reasoning_effort='none'`."
+            "description": "Controls how historical assistant reasoning content is included in the prompt for multi-turn conversations.\n\n**Accepted values:**\n\n- `null`: Use model/template default behavior (for **GLM-4.7**, the model/template default is `'interleaved'`, i.e. historical reasoning is cleared by default)\n- `'disabled'`: Strip `reasoning_content` from all messages before prompt construction\n- `'interleaved'`: Strip `reasoning_content` from messages up to (and including) the last user message\n- `'preserved'`: Preserve historical `reasoning_content` across the conversation\n\n**Model support:**\n\n| Model | Default | Supported values |\n| --- | --- | --- |\n| Kimi K2.7 | `'preserved'` | `'disabled'`, `'interleaved'`, `'preserved'` |\n| Kimi K2.6 | `'interleaved'` | `'disabled'`, `'interleaved'`, `'preserved'` |\n| Kimi K2 Instruct | `'preserved'` | `'disabled'`, `'interleaved'`, `'preserved'` |\n| MiniMax M2 | `'interleaved'` | `'disabled'`, `'interleaved'` |\n| GLM-5.2 | `'interleaved'` | `'disabled'`, `'interleaved'`, `'preserved'` |\n| GLM-4.7 | `'interleaved'` | `'disabled'`, `'interleaved'`, `'preserved'` |\n| GLM-4.6 | `'interleaved'` | `'disabled'`, `'interleaved'` |\n| Qwen 3.6 | `'preserved'` | `'disabled'`, `'preserved'` |\n| DeepSeek V4 | `'interleaved'` | `'interleaved'` |\n\nFor other models, refer to the model provider's documentation.\n\n**Note:** This parameter controls prompt formatting only. To disable reasoning computation entirely, use `reasoning_effort='none'`."
           },
           "thinking": {
             "anyOf": [
@@ -685,7 +696,7 @@
               }
             ],
             "title": "Thinking",
-            "description": "Configuration for enabling extended thinking (Anthropic-compatible format). This is an alternative to `reasoning_effort` for controlling reasoning behavior.\n\n**Format:**\n\n- `{\"type\": \"enabled\"}` - Enable thinking (equivalent to `reasoning_effort: true`)\n- `{\"type\": \"enabled\", \"budget_tokens\": <int>}` - Enable thinking with a token budget (equivalent to `reasoning_effort: <int>`). Must be >= 1024.\n- `{\"type\": \"enabled\", \"keep\": \"all\"}` - Enable thinking and preserve all historical reasoning content in the prompt (equivalent to `reasoning_history: \"preserved\"`).\n- `{\"type\": \"disabled\"}` - Disable thinking (equivalent to `reasoning_effort: \"none\"`)\n\n**Note:** Cannot be specified together with `reasoning_effort`. If both are provided, a validation error will be raised."
+            "description": "Configuration for enabling extended thinking (Anthropic-compatible format). This is an alternative to `reasoning_effort` for controlling reasoning behavior.\n\n**Format:**\n\n- `{\"type\": \"enabled\"}` - Enable thinking (equivalent to `reasoning_effort: true`)\n- `{\"type\": \"enabled\", \"budget_tokens\": <int>}` - Enable thinking with a token budget (equivalent to `reasoning_effort: <int>`). Must be >= 1024.\n- `{\"type\": \"enabled\", \"keep\": \"all\"}` - Enable thinking and preserve all historical reasoning content in the prompt (equivalent to `reasoning_history: \"preserved\"`).\n- `{\"type\": \"disabled\"}` - Disable thinking (equivalent to `reasoning_effort: \"none\"`)\n\n**Precedence with `reasoning_effort`:** `thinking.effort` (when set) overrides `reasoning_effort`; otherwise, for `type=enabled`, `reasoning_effort` is used as the effort level. `type=disabled` always disables thinking."
           },
           "return_token_ids": {
             "anyOf": [
@@ -699,6 +710,21 @@
             "title": "Return Token Ids",
             "description": "Return token IDs alongside text to avoid retokenization drift.",
             "default": false
+          },
+          "prompt_token_ids": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "integer"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Prompt Token Ids",
+            "description": "Pre-tokenized prompt. When set, the server skips chat-template rendering and tokenization for the input — the supplied token IDs are fed directly to generation. Generation, the response formatter (incl. ``--formatter-backend vllm`` parsers), and tool-call routing all run as usual on the model's output.\n\nIntended for upstream gateways (e.g. dynamo) that own the tokenizer and chat template, and want this server only to generate and format. Mutually exclusive with ``messages``: passing both is a 400."
           },
           "functions": {
             "items": {
@@ -743,7 +769,7 @@
               }
             ],
             "title": "Safe Tokenization",
-            "description": "When true, special tokens in user-provided content are never interpreted as actual special tokens during tokenization. This prevents prompt injection via special token strings (e.g. <|im_start|>, <｜User｜>). Supported for models using Jinja or HuggingFace chat templates with HuggingFace tokenizers. Returns an error if the model does not support it, or if combined with custom_chat_template on HuggingFace-backed models. Note: prompt_truncate_len is not applied when safe_tokenization is enabled."
+            "description": "When true, special tokens in user-provided content are never interpreted as actual special tokens during tokenization. This prevents prompt injection via special token strings (e.g. <|im_start|>, <｜User｜>). Supported for models using Jinja or HuggingFace chat templates with HuggingFace tokenizers. Explicit true returns an error if the model does not support it, or if combined with custom_chat_template on HuggingFace-backed models. Note: prompt_truncate_len is not applied when safe_tokenization is enabled. When omitted, safe tokenization is enabled by default on a best-effort basis: it is applied only where the model supports it and the request is text-only with no custom_chat_template and no prompt_truncate_len, and otherwise falls back to normal tokenization."
           },
           "function_call": {
             "anyOf": [
@@ -769,7 +795,6 @@
         "additionalProperties": false,
         "type": "object",
         "required": [
-          "messages",
           "model"
         ],
         "title": "ChatCompletionRequest"
@@ -2036,6 +2061,80 @@
         ],
         "title": "ResponseFormat"
       },
+      "StreamOptions": {
+        "properties": {
+          "include_usage": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Include Usage",
+            "description": "Whether to include a trailing SSE chunk with usage totals (with an empty `choices` array). Unlike the OpenAI spec, Fireworks includes usage by default for streaming responses; set this to `false` to opt out. When emitted, usage rides a separate final chunk (before `data: [DONE]`), not the chunk carrying `finish_reason`."
+          },
+          "include_internal_content": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Include Internal Content",
+            "description": "When true, include an `internal_content` object (currently `token_id`) inside each streaming delta — equivalent to `return_token_ids`, emitted under `choices[].delta.internal_content`. Omitted entirely from response chunks when false.",
+            "default": false
+          },
+          "buffer_tokens": {
+            "anyOf": [
+              {
+                "type": "integer",
+                "minimum": 0
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Buffer Tokens",
+            "description": "Coalesce streaming SSE chunks until this many text deltas (~tokens) accumulate before flushing a merged chunk. 0 disables the token threshold. Honored only on the vLLM backend; overrides the deployment default when set."
+          },
+          "buffer_ms": {
+            "anyOf": [
+              {
+                "type": "number",
+                "minimum": 0
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Buffer Ms",
+            "description": "Coalesce streaming SSE chunks for up to this many milliseconds before flushing a merged chunk. 0 disables the time threshold. Honored only on the vLLM backend; overrides the deployment default when set."
+          },
+          "buffer_mode": {
+            "anyOf": [
+              {
+                "type": "string",
+                "enum": [
+                  "any",
+                  "all"
+                ]
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Buffer Mode",
+            "description": "When both buffer_tokens and buffer_ms are set: 'any' flushes when either threshold is reached; 'all' flushes only when both are. Overrides the deployment default when set; defaults to 'any'."
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "title": "StreamOptions"
+      },
       "PredictedOutput": {
         "properties": {
           "content": {
@@ -2072,7 +2171,8 @@
           "type": {
             "type": "string",
             "const": "enabled",
-            "title": "Type"
+            "title": "Type",
+            "default": "enabled"
           },
           "budget_tokens": {
             "anyOf": [
@@ -2110,13 +2210,37 @@
             ],
             "title": "Budget End Str",
             "description": "Natural-language transition phrase that the model is forced to emit just before the end-thinking token (`</think>`) when `budget_tokens` is exhausted. This produces a more natural conclusion than a hard token slam (matches vLLM's `reasoning_end_str` behavior). Defaults to a built-in phrase. Set to \"\" to disable the bridge and force `</think>` immediately. Only meaningful when `budget_tokens` is set."
+          },
+          "effort": {
+            "anyOf": [
+              {
+                "type": "string",
+                "enum": [
+                  "low",
+                  "medium",
+                  "high",
+                  "xhigh",
+                  "max",
+                  "none",
+                  "adaptive"
+                ]
+              },
+              {
+                "type": "integer"
+              },
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Effort",
+            "description": "Reasoning effort level (Kimi/Moonshot spec). Accepts the same values as top-level `reasoning_effort`; when set it takes precedence over (overwrites) `reasoning_effort`."
           }
         },
         "additionalProperties": false,
         "type": "object",
-        "required": [
-          "type"
-        ],
         "title": "ThinkingConfigEnabled",
         "description": "Configuration for enabling extended thinking (Anthropic-compatible format)."
       },
@@ -2418,6 +2542,18 @@
             "default": null,
             "description": "Token IDs for this chunk (when return_token_ids=true)",
             "title": "Token Ids"
+          },
+          "usage": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/UsageInfo"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Usage for this choice, emitted on its final (finish) chunk (deployment-gated extension)."
           }
         },
         "required": [
@@ -3601,6 +3737,18 @@
             "description": "The contents of the chunk message",
             "title": "Content"
           },
+          "internal_content": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/InternalContent"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Internal model content (currently token_id) when include_internal_content=true."
+          },
           "reasoning_content": {
             "anyOf": [
               {
@@ -4619,6 +4767,30 @@
           "text_offset"
         ],
         "title": "NewLogProbsContent",
+        "type": "object"
+      },
+      "InternalContent": {
+        "additionalProperties": false,
+        "description": "Fireworks extension: internal model content surfaced inside the streaming\ndelta when ``stream_options.include_internal_content=true``.",
+        "properties": {
+          "token_id": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "integer"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Token IDs for this chunk's delta (when include_internal_content=true)",
+            "title": "Token Id"
+          }
+        },
+        "title": "InternalContent",
         "type": "object"
       },
       "AnthropicResponseCharLocationCitation": {

--- a/packages/testing/provider-mock/contracts/fireworks/provenance.json
+++ b/packages/testing/provider-mock/contracts/fireworks/provenance.json
@@ -1,9 +1,9 @@
 {
   "sourceUrl": "https://docs.fireworks.ai/merged.openapi.yaml",
-  "sourceSha256": "bd0551f1ad9915da1ecc7372d087223938426ca066da5f8f463f46baea4b6dd1",
-  "bundleSha256": "bac1a70dff112568f33dc62008bfc890f45418a655ffed91edc27b18ec39828a",
+  "sourceSha256": "db2028e7c089d13f301ebd72b0e72e393a0c03f76b184639fb1fc03e48cf62b3",
+  "bundleSha256": "27867a3c203aedddd91f0253d594578d2e807a0ff893feeadeaa6fcfed82d938",
   "openapiVersion": "3.1.0",
-  "apiVersion": "4.259.0",
+  "apiVersion": "5.10.0",
   "gatewayPathMappings": [
     {
       "sourcePath": "/v1/chat/completions",

--- a/packages/testing/provider-mock/contracts/friendli/openapi.json
+++ b/packages/testing/provider-mock/contracts/friendli/openapi.json
@@ -2231,59 +2231,40 @@
             "type": "string",
             "title": "Id"
           },
+          "hugging_face_id": {
+            "type": "string",
+            "title": "Hugging Face Id",
+            "description": "Required when the model is hosted on Hugging Face",
+            "default": ""
+          },
           "name": {
             "type": "string",
             "title": "Name"
           },
-          "max_completion_tokens": {
+          "created": {
             "type": "integer",
-            "title": "Max Completion Tokens"
+            "title": "Created"
           },
           "context_length": {
             "type": "integer",
             "title": "Context Length"
           },
-          "functionality": {
-            "$ref": "#/components/schemas/Functionality",
-            "description": "Model functionality"
+          "max_completion_tokens": {
+            "type": "integer",
+            "title": "Max Completion Tokens"
           },
           "pricing": {
             "$ref": "#/components/schemas/PricingModel",
             "title": "Pricing",
             "description": "Token prices for input and output"
           },
-          "hugging_face_url": {
-            "type": "string",
-            "minLength": 1,
-            "format": "uri",
-            "title": "Hugging Face Url"
+          "functionality": {
+            "$ref": "#/components/schemas/Functionality",
+            "description": "Model functionality"
           },
           "description": {
             "type": "string",
             "title": "Description"
-          },
-          "license": {
-            "type": "string",
-            "minLength": 1,
-            "format": "uri",
-            "title": "License"
-          },
-          "policy": {
-            "anyOf": [
-              {
-                "type": "string",
-                "minLength": 1,
-                "format": "uri"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Policy"
-          },
-          "created": {
-            "type": "integer",
-            "title": "Created"
           },
           "deprecation_date": {
             "anyOf": [
@@ -2295,7 +2276,19 @@
               }
             ],
             "title": "Deprecation Date",
-            "description": "YYYY-MM-DD (UTC date)"
+            "description": "ISO 8601 UTC hour (YYYY-MM-DDTHH:00:00Z)"
+          },
+          "hugging_face_url": {
+            "type": "string",
+            "minLength": 1,
+            "format": "uri",
+            "title": "Hugging Face Url"
+          },
+          "license": {
+            "type": "string",
+            "minLength": 1,
+            "format": "uri",
+            "title": "License"
           },
           "discount_to_user": {
             "anyOf": [
@@ -2314,14 +2307,14 @@
         "required": [
           "id",
           "name",
-          "max_completion_tokens",
+          "created",
           "context_length",
-          "functionality",
+          "max_completion_tokens",
           "pricing",
-          "hugging_face_url",
+          "functionality",
           "description",
-          "license",
-          "created"
+          "hugging_face_url",
+          "license"
         ],
         "title": "ModelCatalogResponseItem",
         "description": "Model listing in `/v1/models` API."
@@ -3405,6 +3398,63 @@
         ],
         "title": "MessagesResponseToolUseBlock"
       },
+      "PricingModel": {
+        "properties": {
+          "input": {
+            "type": "string",
+            "title": "Input",
+            "description": "Price per input token in USD"
+          },
+          "output": {
+            "type": "string",
+            "title": "Output",
+            "description": "Price per output token in USD"
+          },
+          "prompt": {
+            "type": "string",
+            "title": "Prompt",
+            "description": "Price per input token in USD (alias of input)"
+          },
+          "completion": {
+            "type": "string",
+            "title": "Completion",
+            "description": "Price per output token in USD (alias of output)"
+          },
+          "input_cache_read": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Input Cache Read",
+            "description": "Price per cached input token read in USD"
+          },
+          "audio_minute": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Audio Minute",
+            "description": "Price per audio minute in USD"
+          }
+        },
+        "type": "object",
+        "required": [
+          "input",
+          "output",
+          "prompt",
+          "completion"
+        ],
+        "title": "PricingModel",
+        "description": "Pricing model for token-based pricing."
+      },
       "Functionality": {
         "properties": {
           "tool_call": {
@@ -3433,81 +3483,6 @@
         ],
         "title": "Functionality",
         "description": "Functionality of the model."
-      },
-      "PricingModel": {
-        "properties": {
-          "input": {
-            "type": "number",
-            "minimum": 0,
-            "title": "Input",
-            "description": "Price per input token"
-          },
-          "output": {
-            "type": "number",
-            "minimum": 0,
-            "title": "Output",
-            "description": "Price per output token"
-          },
-          "prompt": {
-            "type": "number",
-            "minimum": 0,
-            "title": "Prompt",
-            "description": "Price per input token (alias of input)"
-          },
-          "completion": {
-            "type": "number",
-            "minimum": 0,
-            "title": "Completion",
-            "description": "Price per output token (alias of output)"
-          },
-          "input_cache_read": {
-            "anyOf": [
-              {
-                "type": "number",
-                "minimum": 0
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Input Cache Read",
-            "description": "Price per cached input token read"
-          },
-          "response_time": {
-            "type": "number",
-            "minimum": 0,
-            "title": "Response Time",
-            "description": "Price per response time in seconds",
-            "default": 0
-          },
-          "audio_minute": {
-            "anyOf": [
-              {
-                "type": "number",
-                "minimum": 0
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Audio Minute",
-            "description": "Price per audio minute"
-          },
-          "unit_type": {
-            "$ref": "#/components/schemas/ServerlessPriceUnitType",
-            "description": "Pricing unit type (TOKEN / SECOND / AUDIO_MINUTE)",
-            "default": "TOKEN"
-          }
-        },
-        "type": "object",
-        "required": [
-          "input",
-          "output",
-          "prompt",
-          "completion"
-        ],
-        "title": "PricingModel",
-        "description": "Pricing model supporting both token-based and time-based pricing."
       },
       "UserMessageContentMultiModal": {
         "oneOf": [
@@ -4050,16 +4025,6 @@
           "type"
         ],
         "title": "MessagesCompatibilityBlock"
-      },
-      "ServerlessPriceUnitType": {
-        "type": "string",
-        "enum": [
-          "TOKEN",
-          "SECOND",
-          "AUDIO_MINUTE"
-        ],
-        "title": "ServerlessPriceUnitType",
-        "description": "Serverless price unit type."
       },
       "TextContent": {
         "properties": {

--- a/packages/testing/provider-mock/contracts/friendli/provenance.json
+++ b/packages/testing/provider-mock/contracts/friendli/provenance.json
@@ -1,7 +1,7 @@
 {
   "sourceUrl": "https://raw.githubusercontent.com/friendliai/friendli-openapi/refs/heads/main/openapi.yaml",
-  "sourceSha256": "e354750f15a5410ef64b48af841930cacb85514b0b3022ae41df49d21f2b6793",
-  "bundleSha256": "004bfdeb3a4b8345d49e17a522ab044b2677c2a91a0906f0a45b7e663bf04fbe",
+  "sourceSha256": "9c8861c37586920b6237a864784bdd0172e662053e45d2ff2637e1d3dad8cc9c",
+  "bundleSha256": "a84d918e6a6cf03b08fad21ad3ba8cd59b353e50904c31d56c2458ad4da94b39",
   "openapiVersion": "3.1.0",
   "apiVersion": "0.1.0",
   "gatewayPathMappings": [

--- a/packages/testing/provider-mock/contracts/mistral/openapi.json
+++ b/packages/testing/provider-mock/contracts/mistral/openapi.json
@@ -2,8 +2,8 @@
   "openapi": "3.1.0",
   "info": {
     "title": "Mistral AI API",
-    "description": "Our Chat Completion and Embeddings APIs specification. Create your account on [La Plateforme](https://console.mistral.ai) to get access and read the [docs](https://docs.mistral.ai) to learn how to use it.",
-    "version": "1.0.0"
+    "version": "1.0.0",
+    "description": "Our Chat Completion and Embeddings APIs specification. Create your account on [La Plateforme](https://console.mistral.ai) to get access and read the [docs](https://docs.mistral.ai) to learn how to use it."
   },
   "paths": {
     "/v1/chat/completions": {
@@ -13,7 +13,6 @@
         "tags": [
           "chat"
         ],
-        "security": [],
         "requestBody": {
           "content": {
             "application/json": {
@@ -50,7 +49,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Chat Completion"
       }
     },
     "/v1/embeddings": {
@@ -61,7 +61,6 @@
         "tags": [
           "embeddings"
         ],
-        "security": [],
         "requestBody": {
           "content": {
             "application/json": {
@@ -136,9 +135,12 @@
     },
     "/v1/models": {
       "get": {
+        "operationId": "list_models_v1_models_get",
         "summary": "List Models",
         "description": "List all models available to the user.",
-        "operationId": "list_models_v1_models_get",
+        "tags": [
+          "models"
+        ],
         "parameters": [
           {
             "name": "provider",
@@ -220,11 +222,7 @@
               }
             }
           }
-        },
-        "tags": [
-          "models"
-        ],
-        "security": []
+        }
       }
     },
     "/v1/ocr": {
@@ -234,7 +232,6 @@
         "tags": [
           "ocr"
         ],
-        "security": [],
         "requestBody": {
           "content": {
             "application/json": {
@@ -353,7 +350,8 @@
               }
             }
           }
-        }
+        },
+        "description": "OCR"
       }
     },
     "/v1/audio/transcriptions": {
@@ -363,7 +361,6 @@
         "tags": [
           "audio.transcriptions"
         ],
-        "security": [],
         "requestBody": {
           "content": {
             "multipart/form-data": {
@@ -401,7 +398,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Create Transcription"
       }
     }
   },
@@ -766,16 +764,16 @@
         }
       },
       "HTTPValidationError": {
+        "type": "object",
         "properties": {
           "detail": {
+            "type": "array",
             "items": {
               "$ref": "#/components/schemas/ValidationError"
             },
-            "type": "array",
             "title": "Detail"
           }
         },
-        "type": "object",
         "title": "HTTPValidationError"
       },
       "EmbeddingRequest": {
@@ -875,6 +873,7 @@
         ]
       },
       "ModelList": {
+        "type": "object",
         "properties": {
           "object": {
             "type": "string",
@@ -882,6 +881,7 @@
             "default": "list"
           },
           "data": {
+            "type": "array",
             "items": {
               "oneOf": [
                 {
@@ -899,11 +899,9 @@
                 }
               }
             },
-            "type": "array",
             "title": "Data"
           }
         },
-        "type": "object",
         "title": "ModelList"
       },
       "OCRRequest": {
@@ -1041,18 +1039,20 @@
           "extract_header": {
             "type": "boolean",
             "title": "Extract Header",
+            "description": "Extract the page header into the response's `header` field and remove it from the markdown content",
             "default": false
           },
           "extract_footer": {
             "type": "boolean",
             "title": "Extract Footer",
+            "description": "Extract the page footer into the response's `footer` field and remove it from the markdown content",
             "default": false
           },
           "include_blocks": {
             "type": "boolean",
             "title": "Include Blocks",
             "description": "Return paragraph-level bounding boxes for all content blocks in the response",
-            "default": false
+            "default": true
           },
           "confidence_scores_granularity": {
             "anyOf": [
@@ -1067,7 +1067,7 @@
                 "type": "null"
               }
             ],
-            "description": "Granularity for confidence scores: 'word' (per-word scores) or 'page' (aggregate only). Defaults to None (no confidence scores) to keep response payload small."
+            "description": "Granularity for confidence scores: 'page' (aggregate only), 'word' (per-word scores). Defaults to None (no confidence scores) to keep response payload small."
           }
         },
         "title": "OCRRequest",
@@ -1115,8 +1115,7 @@
           "pages",
           "model",
           "usage_info"
-        ],
-        "additionalProperties": false
+        ]
       },
       "AudioTranscriptionRequest": {
         "type": "object",
@@ -1905,8 +1904,10 @@
         }
       },
       "ValidationError": {
+        "type": "object",
         "properties": {
           "loc": {
+            "type": "array",
             "items": {
               "anyOf": [
                 {
@@ -1917,7 +1918,6 @@
                 }
               ]
             },
-            "type": "array",
             "title": "Location"
           },
           "msg": {
@@ -1936,13 +1936,12 @@
             "title": "Context"
           }
         },
-        "type": "object",
+        "title": "ValidationError",
         "required": [
           "loc",
           "msg",
           "type"
-        ],
-        "title": "ValidationError"
+        ]
       },
       "EmbeddingDtype": {
         "type": "string",
@@ -2030,6 +2029,7 @@
         ]
       },
       "BaseModelCard": {
+        "type": "object",
         "properties": {
           "id": {
             "type": "string",
@@ -2080,10 +2080,10 @@
             "default": 32768
           },
           "aliases": {
+            "type": "array",
             "items": {
               "type": "string"
             },
-            "type": "array",
             "title": "Aliases",
             "default": []
           },
@@ -2121,21 +2121,26 @@
             ],
             "title": "Default Model Temperature"
           },
+          "internal": {
+            "type": "boolean",
+            "title": "Internal",
+            "default": false
+          },
           "type": {
             "type": "string",
-            "const": "base",
             "title": "Type",
-            "default": "base"
+            "default": "base",
+            "const": "base"
           }
         },
-        "type": "object",
+        "title": "BaseModelCard",
         "required": [
           "id",
           "capabilities"
-        ],
-        "title": "BaseModelCard"
+        ]
       },
       "FTModelCard": {
+        "type": "object",
         "properties": {
           "id": {
             "type": "string",
@@ -2186,10 +2191,10 @@
             "default": 32768
           },
           "aliases": {
+            "type": "array",
             "items": {
               "type": "string"
             },
-            "type": "array",
             "title": "Aliases",
             "default": []
           },
@@ -2227,11 +2232,16 @@
             ],
             "title": "Default Model Temperature"
           },
+          "internal": {
+            "type": "boolean",
+            "title": "Internal",
+            "default": false
+          },
           "type": {
             "type": "string",
-            "const": "fine-tuned",
             "title": "Type",
-            "default": "fine-tuned"
+            "default": "fine-tuned",
+            "const": "fine-tuned"
           },
           "job": {
             "type": "string",
@@ -2247,14 +2257,13 @@
             "default": false
           }
         },
-        "type": "object",
+        "title": "FTModelCard",
         "required": [
           "id",
           "capabilities",
           "job",
           "root"
         ],
-        "title": "FTModelCard",
         "description": "Extra fields for fine-tuned models."
       },
       "FileChunk": {
@@ -2502,8 +2511,7 @@
           "markdown",
           "images",
           "dimensions"
-        ],
-        "additionalProperties": false
+        ]
       },
       "OCRUsageInfo": {
         "type": "object",
@@ -2530,8 +2538,7 @@
         "title": "OCRUsageInfo",
         "required": [
           "pages_processed"
-        ],
-        "additionalProperties": false
+        ]
       },
       "File": {
         "type": "string",
@@ -3086,6 +3093,7 @@
         }
       },
       "ModelCapabilities": {
+        "type": "object",
         "properties": {
           "completion_chat": {
             "type": "boolean",
@@ -3151,9 +3159,13 @@
             "type": "boolean",
             "title": "Audio Speech",
             "default": false
+          },
+          "unified_resources": {
+            "type": "boolean",
+            "title": "Unified Resources",
+            "default": false
           }
         },
-        "type": "object",
         "title": "ModelCapabilities",
         "description": "This is populated by Harmattan, but some fields have a name\nthat we don't want to expose in the API."
       },
@@ -3273,8 +3285,7 @@
           "top_left_y",
           "bottom_right_x",
           "bottom_right_y"
-        ],
-        "additionalProperties": false
+        ]
       },
       "OCRTableObject": {
         "type": "object",
@@ -3319,8 +3330,7 @@
           "id",
           "content",
           "format"
-        ],
-        "additionalProperties": false
+        ]
       },
       "OCRPageDimensions": {
         "type": "object",
@@ -3349,8 +3359,7 @@
           "dpi",
           "height",
           "width"
-        ],
-        "additionalProperties": false
+        ]
       },
       "OCRPageConfidenceScores": {
         "type": "object",
@@ -3383,7 +3392,6 @@
           "average_page_confidence_score",
           "minimum_page_confidence_score"
         ],
-        "additionalProperties": false,
         "description": "Confidence scores for an OCR page at various granularities.\n\nNote on page-level stats:\n- For 'page' granularity: average/minimum are computed from per-token exp(logprob).\n- For 'word' granularity: average/minimum are computed from per-word confidence,\n  where each word's confidence is exp(mean(token_logprobs)) — a geometric mean\n  over the word's subword tokens."
       },
       "OCRTextBlock": {
@@ -3428,8 +3436,7 @@
           "bottom_right_x",
           "bottom_right_y",
           "content"
-        ],
-        "additionalProperties": false
+        ]
       },
       "OCRListBlock": {
         "type": "object",
@@ -3473,8 +3480,7 @@
           "bottom_right_x",
           "bottom_right_y",
           "content"
-        ],
-        "additionalProperties": false
+        ]
       },
       "OCRImageBlock": {
         "type": "object",
@@ -3524,8 +3530,7 @@
           "bottom_right_y",
           "content",
           "image_id"
-        ],
-        "additionalProperties": false
+        ]
       },
       "OCRTableBlock": {
         "type": "object",
@@ -3581,8 +3586,7 @@
           "bottom_right_x",
           "bottom_right_y",
           "content"
-        ],
-        "additionalProperties": false
+        ]
       },
       "OCRTitleBlock": {
         "type": "object",
@@ -3626,8 +3630,7 @@
           "bottom_right_x",
           "bottom_right_y",
           "content"
-        ],
-        "additionalProperties": false
+        ]
       },
       "OCREquationBlock": {
         "type": "object",
@@ -3671,8 +3674,7 @@
           "bottom_right_x",
           "bottom_right_y",
           "content"
-        ],
-        "additionalProperties": false
+        ]
       },
       "OCRCaptionBlock": {
         "type": "object",
@@ -3716,8 +3718,7 @@
           "bottom_right_x",
           "bottom_right_y",
           "content"
-        ],
-        "additionalProperties": false
+        ]
       },
       "OCRCodeBlock": {
         "type": "object",
@@ -3761,8 +3762,7 @@
           "bottom_right_x",
           "bottom_right_y",
           "content"
-        ],
-        "additionalProperties": false
+        ]
       },
       "OCRReferencesBlock": {
         "type": "object",
@@ -3806,8 +3806,7 @@
           "bottom_right_x",
           "bottom_right_y",
           "content"
-        ],
-        "additionalProperties": false
+        ]
       },
       "OCRAsideTextBlock": {
         "type": "object",
@@ -3851,8 +3850,7 @@
           "bottom_right_x",
           "bottom_right_y",
           "content"
-        ],
-        "additionalProperties": false
+        ]
       },
       "OCRHeaderBlock": {
         "type": "object",
@@ -3896,8 +3894,7 @@
           "bottom_right_x",
           "bottom_right_y",
           "content"
-        ],
-        "additionalProperties": false
+        ]
       },
       "OCRFooterBlock": {
         "type": "object",
@@ -3941,8 +3938,7 @@
           "bottom_right_x",
           "bottom_right_y",
           "content"
-        ],
-        "additionalProperties": false
+        ]
       },
       "OCRSignatureBlock": {
         "type": "object",
@@ -3987,7 +3983,6 @@
           "bottom_right_y",
           "content"
         ],
-        "additionalProperties": false,
         "description": "Signature region. ``content`` is the transcribed name when legible, else ``\"\"``."
       },
       "TextChunk": {
@@ -4423,7 +4418,6 @@
           "confidence",
           "start_index"
         ],
-        "additionalProperties": false,
         "description": "Confidence score for a token or word in OCR output."
       },
       "ToolReferenceChunk": {

--- a/packages/testing/provider-mock/contracts/mistral/provenance.json
+++ b/packages/testing/provider-mock/contracts/mistral/provenance.json
@@ -1,7 +1,7 @@
 {
   "sourceUrl": "https://docs.mistral.ai/openapi.yaml",
-  "sourceSha256": "5a5c361558bb93e7abde3b7b0d2a2a9eaaa3ab870c77dc199565bc0107cf3282",
-  "bundleSha256": "fdbbb5c809cfb0018421f68f55fa532aa72c012f53179c4a0c3b6c413a60c6d2",
+  "sourceSha256": "933c4ebdcd720d84a343fceddf6cb61d91de44873158d7b134cfdc05109b5a2c",
+  "bundleSha256": "8183250713ef90328db29f96753b2b95408bd55ce1ddb159e6ae77d3d693e6cd",
   "openapiVersion": "3.1.0",
   "apiVersion": "1.0.0",
   "gatewayPathMappings": [

--- a/packages/testing/provider-mock/contracts/openai-eu/manifest.json
+++ b/packages/testing/provider-mock/contracts/openai-eu/manifest.json
@@ -107,6 +107,7 @@
       "method": "post",
       "path": "/rerank",
       "operationId": "openai_rerank_1",
+      "sourceOverlay": true,
       "notes": "Derived from the enabled Phaseo executor URL and provider API reference."
     }
   ],

--- a/packages/testing/provider-mock/contracts/openai-eu/openapi.json
+++ b/packages/testing/provider-mock/contracts/openai-eu/openapi.json
@@ -11,7 +11,7 @@
     },
     "license": {
       "name": "MIT",
-      "url": "https://github.com/openai/openai-openapi/blob/master/LICENSE"
+      "identifier": "MIT"
     }
   },
   "servers": [
@@ -572,45 +572,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "type": "object",
-                "required": [
-                  "input_file_id",
-                  "endpoint",
-                  "completion_window"
-                ],
-                "properties": {
-                  "input_file_id": {
-                    "type": "string",
-                    "description": "The ID of an uploaded file that contains requests for the new batch.\n\nSee [upload file](/docs/api-reference/files/create) for how to upload a file.\n\nYour input file must be formatted as a [JSONL file](/docs/api-reference/batch/request-input), and must be uploaded with the purpose `batch`. The file can contain up to 50,000 requests, and can be up to 200 MB in size.\n"
-                  },
-                  "endpoint": {
-                    "type": "string",
-                    "enum": [
-                      "/v1/responses",
-                      "/v1/chat/completions",
-                      "/v1/embeddings",
-                      "/v1/completions",
-                      "/v1/moderations",
-                      "/v1/images/generations",
-                      "/v1/images/edits",
-                      "/v1/videos"
-                    ],
-                    "description": "The endpoint to be used for all requests in the batch. Currently `/v1/responses`, `/v1/chat/completions`, `/v1/embeddings`, `/v1/completions`, `/v1/moderations`, `/v1/images/generations`, `/v1/images/edits`, and `/v1/videos` are supported. Note that `/v1/embeddings` batches are also restricted to a maximum of 50,000 embedding inputs across all requests in the batch."
-                  },
-                  "completion_window": {
-                    "type": "string",
-                    "enum": [
-                      "24h"
-                    ],
-                    "description": "The time frame within which the batch should be processed. Currently only `24h` is supported."
-                  },
-                  "metadata": {
-                    "$ref": "#/components/schemas/Metadata"
-                  },
-                  "output_expires_after": {
-                    "$ref": "#/components/schemas/BatchFileExpirationAfter"
-                  }
-                }
+                "$ref": "#/components/schemas/CreateBatchRequest"
               }
             }
           }
@@ -735,6 +697,33 @@
           {
             "type": "object",
             "properties": {
+              "truncation": {
+                "deprecated": true,
+                "anyOf": [
+                  {
+                    "type": "string",
+                    "description": "The truncation strategy to use for the model response.\n- `auto`: If the input to this Response exceeds\n  the model's context window size, the model will truncate the\n  response to fit the context window by dropping items from the beginning of the conversation.\n- `disabled` (default): If the input size will exceed the context window\n  size for a model, the request will fail with a 400 error.\n",
+                    "enum": [
+                      "auto",
+                      "disabled"
+                    ],
+                    "default": "disabled"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "reasoning": {
+                "anyOf": [
+                  {
+                    "$ref": "#/components/schemas/Reasoning"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
               "input": {
                 "$ref": "#/components/schemas/InputParam"
               },
@@ -781,6 +770,17 @@
                   {
                     "type": "string",
                     "description": "A system (or developer) message inserted into the model's context.\n\nWhen using along with `previous_response_id`, the instructions from a previous\nresponse will not be carried over to the next response. This makes it simple\nto swap out system (or developer) messages in new responses.\n"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "moderation": {
+                "anyOf": [
+                  {
+                    "$ref": "#/components/schemas/ModerationParam",
+                    "description": "Configuration for running moderation on the input and output of this response.\n"
                   },
                   {
                     "type": "null"
@@ -855,6 +855,22 @@
           {
             "type": "object",
             "properties": {
+              "truncation": {
+                "anyOf": [
+                  {
+                    "type": "string",
+                    "description": "The truncation strategy to use for the model response.\n- `auto`: If the input to this Response exceeds\n  the model's context window size, the model will truncate the\n  response to fit the context window by dropping items from the beginning of the conversation.\n- `disabled` (default): If the input size will exceed the context window\n  size for a model, the request will fail with a 400 error.\n",
+                    "enum": [
+                      "auto",
+                      "disabled"
+                    ],
+                    "default": "disabled"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
               "id": {
                 "type": "string",
                 "description": "Unique identifier for this Response.\n"
@@ -927,6 +943,16 @@
                   "$ref": "#/components/schemas/OutputItem"
                 }
               },
+              "reasoning": {
+                "anyOf": [
+                  {
+                    "$ref": "#/components/schemas/Reasoning"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
               "instructions": {
                 "anyOf": [
                   {
@@ -969,6 +995,20 @@
               "usage": {
                 "$ref": "#/components/schemas/ResponseUsage"
               },
+              "prompt_cache_options": {
+                "$ref": "#/components/schemas/PromptCacheOptions"
+              },
+              "moderation": {
+                "anyOf": [
+                  {
+                    "$ref": "#/components/schemas/Moderation",
+                    "description": "Moderation results for the response input and output, if moderated completions were requested.\n"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
               "parallel_tool_calls": {
                 "type": "boolean",
                 "description": "Whether to allow the model to run tool calls in parallel.\n",
@@ -978,7 +1018,7 @@
                 "anyOf": [
                   {
                     "default": null,
-                    "$ref": "#/components/schemas/Conversation-2"
+                    "$ref": "#/components/schemas/ResponseConversation"
                   },
                   {
                     "type": "null"
@@ -1045,7 +1085,8 @@
           "previous_response_id": null,
           "reasoning": {
             "effort": null,
-            "summary": null
+            "summary": null,
+            "context": null
           },
           "store": true,
           "temperature": 1,
@@ -1061,7 +1102,8 @@
           "usage": {
             "input_tokens": 328,
             "input_tokens_details": {
-              "cached_tokens": 0
+              "cached_tokens": 0,
+              "cache_write_tokens": 0
             },
             "output_tokens": 52,
             "output_tokens_details": {
@@ -1378,6 +1420,17 @@
                 "nullable": true,
                 "description": "Whether or not to store the output of this chat completion request for\nuse in our [model distillation](/docs/guides/distillation) or\n[evals](/docs/guides/evals) products.\n\nSupports text and image inputs. Note: image inputs over 8MB will be dropped.\n"
               },
+              "moderation": {
+                "anyOf": [
+                  {
+                    "$ref": "#/components/schemas/ModerationParam",
+                    "description": "Configuration for running moderation on the request input and generated output.\n"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
               "stream": {
                 "description": "If set to true, the model response data will be streamed to the client\nas it is generated using [server-sent events](https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events/Using_server-sent_events#Event_stream_format).\nSee the [Streaming section below](/docs/api-reference/chat/streaming)\nfor more information, along with the [streaming responses](/docs/guides/streaming-responses)\nguide for more information on how to handle the streaming events.\n",
                 "type": "boolean",
@@ -1515,7 +1568,7 @@
               "properties": {
                 "finish_reason": {
                   "type": "string",
-                  "description": "The reason the model stopped generating tokens. This will be `stop` if the model hit a natural stop point or a provided stop sequence,\n`length` if the maximum number of tokens specified in the request was reached,\n`content_filter` if content was omitted due to a flag from our content filters,\n`tool_calls` if the model called a tool, or `function_call` (deprecated) if the model called a function.\n",
+                  "description": "The reason the model stopped generating tokens. This will be `stop` if the model hit a natural stop point or a provided stop sequence,\n`length` if the maximum number of tokens specified in the request was reached,\n`content_filter` if content was omitted due to a flag from our content filters,\n`tool_calls` if the model called a tool, or `function_call` (deprecated) if the model called a function.\nRead the [Model Spec](https://model-spec.openai.com/2025-12-18.html) for more.\n",
                   "enum": [
                     "stop",
                     "length",
@@ -1606,6 +1659,17 @@
           },
           "usage": {
             "$ref": "#/components/schemas/CompletionUsage"
+          },
+          "moderation": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ChatCompletionModeration",
+                "description": "Moderation results for the request input and generated output, if moderated\ncompletions were requested.\n"
+              },
+              {
+                "type": "null"
+              }
+            ]
           }
         },
         "required": [
@@ -1713,6 +1777,17 @@
             "$ref": "#/components/schemas/CompletionUsage",
             "nullable": true,
             "description": "An optional field that will only be present when you set\n`stream_options: {\"include_usage\": true}` in your request. When present, it\ncontains a null value **except for the last chunk** which contains the\ntoken usage statistics for the entire request.\n\n**NOTE:** If the stream is interrupted or cancelled, you may not\nreceive the final usage chunk which contains the total token usage for\nthe request.\n"
+          },
+          "moderation": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ChatCompletionModeration",
+                "description": "Moderation results for the request input and generated output. Present\non the moderation chunk when moderated completions are requested.\n"
+              },
+              {
+                "type": "null"
+              }
+            ]
           }
         },
         "required": [
@@ -3067,7 +3142,7 @@
             "format": "binary"
           },
           "model": {
-            "description": "ID of the model to use. The options are `gpt-4o-transcribe`, `gpt-4o-mini-transcribe`, `gpt-4o-mini-transcribe-2025-12-15`, `whisper-1` (which is powered by our open source Whisper V2 model), and `gpt-4o-transcribe-diarize`.\n",
+            "description": "ID of the model to use. The options are `gpt-transcribe`, `gpt-4o-transcribe`, `gpt-4o-mini-transcribe`, `gpt-4o-mini-transcribe-2025-12-15`, `whisper-1` (which is powered by our open source Whisper V2 model), and `gpt-4o-transcribe-diarize`.\n",
             "example": "gpt-4o-transcribe",
             "anyOf": [
               {
@@ -3077,6 +3152,7 @@
                 "type": "string",
                 "enum": [
                   "whisper-1",
+                  "gpt-transcribe",
                   "gpt-4o-transcribe",
                   "gpt-4o-mini-transcribe",
                   "gpt-4o-mini-transcribe-2025-12-15",
@@ -3090,6 +3166,21 @@
           "language": {
             "description": "The language of the input audio. Supplying the input language in [ISO-639-1](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes) (e.g. `en`) format will improve accuracy and latency.\n",
             "type": "string"
+          },
+          "languages": {
+            "description": "Possible languages of the input audio, in [ISO-639-1](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes) format. Supported by `gpt-transcribe`.\n",
+            "type": "array",
+            "minItems": 1,
+            "items": {
+              "type": "string"
+            }
+          },
+          "keywords": {
+            "description": "Words or phrases to guide transcription of the input audio. Supported by `gpt-transcribe`.\n",
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
           },
           "prompt": {
             "description": "An optional text to guide the model's style or continue a previous audio segment. The [prompt](/docs/guides/speech-to-text#prompting) should match the audio language. This field is not supported when using `gpt-4o-transcribe-diarize`.\n",
@@ -3190,6 +3281,13 @@
           "text": {
             "type": "string",
             "description": "The transcribed text."
+          },
+          "languages": {
+            "type": "array",
+            "description": "The languages detected in the audio. Returned by `gpt-transcribe`. An empty array indicates that no language could be reliably detected.\n",
+            "items": {
+              "$ref": "#/components/schemas/TranscriptionLanguage"
+            }
           },
           "logprobs": {
             "type": "array",
@@ -3460,7 +3558,8 @@
                 "description": "Optional reference asset upload or reference object that guides generation."
               },
               {
-                "$ref": "#/components/schemas/ImageRefParam-2"
+                "$ref": "#/components/schemas/ImageRefParam-2",
+                "description": "Optional reference asset upload or reference object that guides generation. Provide exactly one of `image_url` or `file_id` when using an object."
               }
             ]
           },
@@ -3666,46 +3765,46 @@
           "spritesheet"
         ]
       },
-      "Metadata": {
-        "anyOf": [
-          {
-            "type": "object",
-            "description": "Set of 16 key-value pairs that can be attached to an object. This can be\nuseful for storing additional information about the object in a structured\nformat, and querying for objects via API or the dashboard.\n\nKeys are strings with a maximum length of 64 characters. Values are strings\nwith a maximum length of 512 characters.\n",
-            "additionalProperties": {
-              "type": "string"
-            },
-            "x-oaiTypeLabel": "map"
-          },
-          {
-            "type": "null"
-          }
-        ]
-      },
-      "BatchFileExpirationAfter": {
+      "CreateBatchRequest": {
         "type": "object",
-        "title": "File expiration policy",
-        "description": "The expiration policy for the output and/or error file that are generated for a batch.",
+        "required": [
+          "input_file_id",
+          "endpoint",
+          "completion_window"
+        ],
         "properties": {
-          "anchor": {
-            "description": "Anchor timestamp after which the expiration policy applies. Supported anchors: `created_at`. Note that the anchor is the file creation time, not the time the batch is created.",
+          "input_file_id": {
+            "type": "string",
+            "description": "The ID of an uploaded file that contains requests for the new batch.\n\nSee [upload file](/docs/api-reference/files/create) for how to upload a file.\n\nYour input file must be formatted as a [JSONL file](/docs/api-reference/batch/request-input), and must be uploaded with the purpose `batch`. The file can contain up to 50,000 requests, and can be up to 200 MB in size.\n"
+          },
+          "endpoint": {
             "type": "string",
             "enum": [
-              "created_at"
+              "/v1/responses",
+              "/v1/chat/completions",
+              "/v1/embeddings",
+              "/v1/completions",
+              "/v1/moderations",
+              "/v1/images/generations",
+              "/v1/images/edits",
+              "/v1/videos"
             ],
-            "x-stainless-const": true
+            "description": "The endpoint to be used for all requests in the batch. Currently `/v1/responses`, `/v1/chat/completions`, `/v1/embeddings`, `/v1/completions`, `/v1/moderations`, `/v1/images/generations`, `/v1/images/edits`, and `/v1/videos` are supported. Note that `/v1/embeddings` batches are also restricted to a maximum of 50,000 embedding inputs across all requests in the batch."
           },
-          "seconds": {
-            "description": "The number of seconds after the anchor time that the file will expire. Must be between 3600 (1 hour) and 2592000 (30 days).",
-            "type": "integer",
-            "format": "int64",
-            "minimum": 3600,
-            "maximum": 2592000
+          "completion_window": {
+            "type": "string",
+            "enum": [
+              "24h"
+            ],
+            "description": "The time frame within which the batch should be processed. Currently only `24h` is supported."
+          },
+          "metadata": {
+            "$ref": "#/components/schemas/Metadata"
+          },
+          "output_expires_after": {
+            "$ref": "#/components/schemas/BatchFileExpirationAfter"
           }
-        },
-        "required": [
-          "anchor",
-          "seconds"
-        ]
+        }
       },
       "Batch": {
         "type": "object",
@@ -3739,39 +3838,7 @@
               "data": {
                 "type": "array",
                 "items": {
-                  "type": "object",
-                  "properties": {
-                    "code": {
-                      "type": "string",
-                      "description": "An error code identifying the error type."
-                    },
-                    "message": {
-                      "type": "string",
-                      "description": "A human-readable message providing more details about the error."
-                    },
-                    "param": {
-                      "anyOf": [
-                        {
-                          "type": "string",
-                          "description": "The name of the parameter that caused the error, if applicable."
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ]
-                    },
-                    "line": {
-                      "anyOf": [
-                        {
-                          "type": "integer",
-                          "description": "The line number of the input file where the error occurred, if applicable."
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ]
-                    }
-                  }
+                  "$ref": "#/components/schemas/BatchError"
                 }
               }
             }
@@ -3852,27 +3919,7 @@
             "description": "The Unix timestamp (in seconds) for when the batch was cancelled."
           },
           "request_counts": {
-            "type": "object",
-            "properties": {
-              "total": {
-                "type": "integer",
-                "description": "Total number of requests in the batch."
-              },
-              "completed": {
-                "type": "integer",
-                "description": "Number of requests that have been completed successfully."
-              },
-              "failed": {
-                "type": "integer",
-                "description": "Number of requests that have failed."
-              }
-            },
-            "required": [
-              "total",
-              "completed",
-              "failed"
-            ],
-            "description": "The request counts for different statuses within the batch."
+            "$ref": "#/components/schemas/BatchRequestCounts"
           },
           "usage": {
             "type": "object",
@@ -3947,6 +3994,9 @@
           {
             "type": "object",
             "properties": {
+              "prompt_cache_options": {
+                "$ref": "#/components/schemas/PromptCacheOptionsParam"
+              },
               "top_logprobs": {
                 "description": "An integer between 0 and 20 specifying the maximum number of most likely\ntokens to return at each token position, each with an associated log\nprobability. In some cases, the number of returned tokens may be fewer than\nrequested.\n",
                 "type": "integer",
@@ -3974,16 +4024,6 @@
           "model": {
             "description": "Model ID used to generate the response, like `gpt-4o` or `o3`. OpenAI\noffers a wide range of models with different capabilities, performance\ncharacteristics, and price points. Refer to the [model guide](/docs/models)\nto browse and compare available models.\n",
             "$ref": "#/components/schemas/ModelIdsResponses"
-          },
-          "reasoning": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/Reasoning"
-              },
-              {
-                "type": "null"
-              }
-            ]
           },
           "background": {
             "anyOf": [
@@ -4019,17 +4059,64 @@
           },
           "prompt": {
             "$ref": "#/components/schemas/Prompt"
+          }
+        }
+      },
+      "Reasoning": {
+        "type": "object",
+        "description": "**gpt-5 and o-series models only**\n\nConfiguration options for\n[reasoning models](https://platform.openai.com/docs/guides/reasoning).\n",
+        "title": "Reasoning",
+        "properties": {
+          "mode": {
+            "$ref": "#/components/schemas/ReasoningModeEnum",
+            "description": "Controls the reasoning execution mode for the request.\n\nWhen returned on a response, this is the effective execution mode.\n"
           },
-          "truncation": {
+          "effort": {
+            "$ref": "#/components/schemas/ReasoningEffort"
+          },
+          "summary": {
             "anyOf": [
               {
                 "type": "string",
-                "description": "The truncation strategy to use for the model response.\n- `auto`: If the input to this Response exceeds\n  the model's context window size, the model will truncate the\n  response to fit the context window by dropping items from the beginning of the conversation.\n- `disabled` (default): If the input size will exceed the context window\n  size for a model, the request will fail with a 400 error.\n",
+                "description": "A summary of the reasoning performed by the model. This can be\nuseful for debugging and understanding the model's reasoning process.\nOne of `auto`, `concise`, or `detailed`.\n\n`concise` is supported for `computer-use-preview` models and all reasoning models after `gpt-5`.\n",
                 "enum": [
                   "auto",
-                  "disabled"
-                ],
-                "default": "disabled"
+                  "concise",
+                  "detailed"
+                ]
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "context": {
+            "anyOf": [
+              {
+                "type": "string",
+                "description": "Controls which reasoning items are rendered back to the model on later turns.\nIf omitted or set to `auto`, the model determines the context mode. The\n`gpt-5.6` model family defaults to `all_turns`; earlier models default to\n`current_turn`.\n\nWhen returned on a response, this is the effective reasoning context mode\nused for the response.\n",
+                "enum": [
+                  "auto",
+                  "current_turn",
+                  "all_turns"
+                ]
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "generate_summary": {
+            "anyOf": [
+              {
+                "type": "string",
+                "deprecated": true,
+                "description": "**Deprecated:** use `summary` instead.\n\nA summary of the reasoning performed by the model. This can be\nuseful for debugging and understanding the model's reasoning process.\nOne of `auto`, `concise`, or `detailed`.\n",
+                "enum": [
+                  "auto",
+                  "concise",
+                  "detailed"
+                ]
               },
               {
                 "type": "null"
@@ -4069,6 +4156,30 @@
           "message.output_text.logprobs"
         ],
         "description": "Specify additional output data to include in the model response. Currently supported values are:\n- `web_search_call.results`: Include the search results of the web search tool call.\n- `web_search_call.action.sources`: Include the sources of the web search tool call.\n- `code_interpreter_call.outputs`: Includes the outputs of python code execution in code interpreter tool call items.\n- `computer_call_output.output.image_url`: Include image urls from the computer call output.\n- `file_search_call.results`: Include the search results of the file search tool call.\n- `message.input_image.image_url`: Include image urls from the input message.\n- `message.output_text.logprobs`: Include logprobs with assistant messages.\n- `reasoning.encrypted_content`: Includes an encrypted version of reasoning tokens in reasoning item outputs. This enables reasoning items to be used in multi-turn conversations when using the Responses API statelessly (like when the `store` parameter is set to `false`, or when an organization is enrolled in the zero data retention program)."
+      },
+      "ModerationParam": {
+        "properties": {
+          "model": {
+            "type": "string",
+            "description": "The moderation model to use for moderated completions, e.g. 'omni-moderation-latest'."
+          },
+          "policy": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ModerationPolicyParam",
+                "description": "The policy to apply to moderated response input and output."
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        },
+        "type": "object",
+        "required": [
+          "model"
+        ],
+        "description": "Configuration for running moderation on the input and output of this response."
       },
       "ResponseStreamOptions": {
         "anyOf": [
@@ -4182,20 +4293,35 @@
             "description": "This field is being replaced by `safety_identifier` and `prompt_cache_key`. Use `prompt_cache_key` instead to maintain caching optimizations.\nA stable identifier for your end-users.\nUsed to boost cache hit rates by better bucketing similar requests and  to help OpenAI detect and prevent abuse. [Learn more](/docs/guides/safety-best-practices#safety-identifiers).\n"
           },
           "safety_identifier": {
-            "type": "string",
-            "maxLength": 64,
-            "example": "safety-identifier-1234",
-            "description": "A stable identifier used to help detect users of your application that may be violating OpenAI's usage policies.\nThe IDs should be a string that uniquely identifies each user, with a maximum length of 64 characters. We recommend hashing their username or email address, in order to avoid sending us any identifying information. [Learn more](/docs/guides/safety-best-practices#safety-identifiers).\n"
+            "anyOf": [
+              {
+                "type": "string",
+                "maxLength": 64,
+                "example": "safety-identifier-1234",
+                "description": "A stable identifier used to help detect users of your application that may be violating OpenAI's usage policies.\nThe IDs should be a string that uniquely identifies each user, with a maximum length of 64 characters. We recommend hashing their username or email address, in order to avoid sending us any identifying information. [Learn more](/docs/guides/safety-best-practices#safety-identifiers).\n"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "prompt_cache_key": {
-            "type": "string",
-            "example": "prompt-cache-key-1234",
-            "description": "Used by OpenAI to cache responses for similar requests to optimize your cache hit rates. Replaces the `user` field. [Learn more](/docs/guides/prompt-caching).\n"
+            "anyOf": [
+              {
+                "type": "string",
+                "example": "prompt-cache-key-1234",
+                "description": "Used by OpenAI to cache responses for similar requests to optimize your cache hit rates. Replaces the `user` field. [Learn more](/docs/guides/prompt-caching).\n"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "service_tier": {
             "$ref": "#/components/schemas/ServiceTier"
           },
           "prompt_cache_retention": {
+            "deprecated": true,
             "anyOf": [
               {
                 "type": "string",
@@ -4203,7 +4329,7 @@
                   "in_memory",
                   "24h"
                 ],
-                "description": "The retention policy for the prompt cache. Set to `24h` to enable extended prompt caching, which keeps cached prefixes active for longer, up to a maximum of 24 hours. [Learn more](/docs/guides/prompt-caching#prompt-cache-retention).\n"
+                "description": "Deprecated. Use `prompt_cache_options.ttl` instead.\n\nThe retention policy for the prompt cache. Set to `24h` to enable extended prompt caching, which keeps cached prefixes active for longer, up to a maximum of 24 hours. [Learn more](/docs/guides/prompt-caching#prompt-cache-retention).\nThis field expresses a maximum retention policy, while\n`prompt_cache_options.ttl` expresses a minimum cache lifetime. The two\nfields are independent and do not interact.\nFor `gpt-5.5`, `gpt-5.5-pro`, and future models, only `24h` is supported.\n\nFor older models that support both `in_memory` and `24h`, the default depends on your organization's data retention policy:\n  - Organizations without ZDR enabled default to `24h`.\n  - Organizations with ZDR enabled default to `in_memory` when `prompt_cache_retention` is not specified.\n"
               },
               {
                 "type": "null"
@@ -4263,10 +4389,19 @@
             "$ref": "#/components/schemas/ReasoningItem"
           },
           {
+            "$ref": "#/components/schemas/Program"
+          },
+          {
+            "$ref": "#/components/schemas/ProgramOutput"
+          },
+          {
             "$ref": "#/components/schemas/ToolSearchCall"
           },
           {
             "$ref": "#/components/schemas/ToolSearchOutput"
+          },
+          {
+            "$ref": "#/components/schemas/AdditionalTools"
           },
           {
             "$ref": "#/components/schemas/CompactionBody"
@@ -4330,7 +4465,16 @@
             "$ref": "#/components/schemas/Item"
           },
           {
+            "$ref": "#/components/schemas/CompactionTriggerItemParam"
+          },
+          {
             "$ref": "#/components/schemas/ItemReferenceParam"
+          },
+          {
+            "$ref": "#/components/schemas/ProgramItemParam"
+          },
+          {
+            "$ref": "#/components/schemas/ProgramOutputItemParam"
           }
         ],
         "discriminator": {
@@ -4352,10 +4496,15 @@
               "cached_tokens": {
                 "type": "integer",
                 "description": "The number of tokens that were retrieved from the cache. \n[More on prompt caching](/docs/guides/prompt-caching).\n"
+              },
+              "cache_write_tokens": {
+                "type": "integer",
+                "description": "The number of input tokens that were written to the cache."
               }
             },
             "required": [
-              "cached_tokens"
+              "cached_tokens",
+              "cache_write_tokens"
             ]
           },
           "output_tokens": {
@@ -4388,7 +4537,65 @@
           "total_tokens"
         ]
       },
-      "Conversation-2": {
+      "PromptCacheOptions": {
+        "properties": {
+          "ttl": {
+            "$ref": "#/components/schemas/PromptCacheTTLEnum",
+            "description": "The minimum lifetime applied to each cache breakpoint."
+          },
+          "mode": {
+            "$ref": "#/components/schemas/PromptCacheModeEnum",
+            "description": "Whether implicit prompt-cache breakpoints were enabled."
+          }
+        },
+        "type": "object",
+        "required": [
+          "ttl",
+          "mode"
+        ],
+        "title": "Prompt cache options",
+        "description": "The prompt-caching options that were applied to the response. Supported for `gpt-5.6` and later models."
+      },
+      "Moderation": {
+        "properties": {
+          "input": {
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/ModerationResultBody"
+              },
+              {
+                "$ref": "#/components/schemas/ModerationErrorBody"
+              }
+            ],
+            "description": "Moderation for the response input.",
+            "discriminator": {
+              "propertyName": "type"
+            }
+          },
+          "output": {
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/ModerationResultBody"
+              },
+              {
+                "$ref": "#/components/schemas/ModerationErrorBody"
+              }
+            ],
+            "description": "Moderation for the response output.",
+            "discriminator": {
+              "propertyName": "type"
+            }
+          }
+        },
+        "type": "object",
+        "required": [
+          "input",
+          "output"
+        ],
+        "title": "Moderation",
+        "description": "Moderation results or errors for the response input and output."
+      },
+      "ResponseConversation": {
         "properties": {
           "id": {
             "type": "string",
@@ -5264,6 +5471,13 @@
           "summary_index": {
             "type": "integer",
             "description": "The index of the summary part within the reasoning summary.\n"
+          },
+          "status": {
+            "type": "string",
+            "description": "The completion status of the summary part. Omitted when the part completed\nnormally and set to `incomplete` when generation was interrupted.\n",
+            "enum": [
+              "incomplete"
+            ]
           },
           "sequence_number": {
             "type": "integer",
@@ -6351,6 +6565,10 @@
           {
             "type": "string",
             "enum": [
+              "gpt-5.6-sol",
+              "gpt-5.6-terra",
+              "gpt-5.6-luna",
+              "gpt-5.5",
               "gpt-5.4",
               "gpt-5.4-mini",
               "gpt-5.4-nano",
@@ -6461,7 +6679,7 @@
               "high"
             ],
             "default": "medium",
-            "description": "Constrains the verbosity of the model's response. Lower values will result in\nmore concise responses, while higher values will result in more verbose responses.\nCurrently supported values are `low`, `medium`, and `high`.\n"
+            "description": "Constrains the verbosity of the model's response. Lower values will result in\nmore concise responses, while higher values will result in more verbose responses.\nCurrently supported values are `low`, `medium`, and `high`. The default is\n`medium`.\n"
           },
           {
             "type": "null"
@@ -6478,10 +6696,11 @@
               "low",
               "medium",
               "high",
-              "xhigh"
+              "xhigh",
+              "max"
             ],
             "default": "medium",
-            "description": "Constrains effort on reasoning for\n[reasoning models](https://platform.openai.com/docs/guides/reasoning).\nCurrently supported values are `none`, `minimal`, `low`, `medium`, `high`, and `xhigh`. Reducing\nreasoning effort can result in faster responses and fewer tokens used\non reasoning in a response.\n\n- `gpt-5.1` defaults to `none`, which does not perform reasoning. The supported reasoning values for `gpt-5.1` are `none`, `low`, `medium`, and `high`. Tool calls are supported for all reasoning values in gpt-5.1.\n- All models before `gpt-5.1` default to `medium` reasoning effort, and do not support `none`.\n- The `gpt-5-pro` model defaults to (and only supports) `high` reasoning effort.\n- `xhigh` is supported for all models after `gpt-5.1-codex-max`.\n"
+            "description": "Constrains effort on reasoning for reasoning models. Currently supported\nvalues are `none`, `minimal`, `low`, `medium`, `high`, `xhigh`, and `max`.\nReducing reasoning effort can result in faster responses and fewer tokens\nused on reasoning in a response. Not all reasoning models support every\nvalue. See the\n[reasoning guide](https://platform.openai.com/docs/guides/reasoning)\nfor model-specific support.\n"
           },
           {
             "type": "null"
@@ -7126,13 +7345,14 @@
         "anyOf": [
           {
             "type": "string",
-            "description": "Specifies the processing type used for serving the request.\n  - If set to 'auto', then the request will be processed with the service tier configured in the Project settings. Unless otherwise configured, the Project will use 'default'.\n  - If set to 'default', then the request will be processed with the standard pricing and performance for the selected model.\n  - If set to '[flex](/docs/guides/flex-processing)' or '[priority](https://openai.com/api-priority-processing/)', then the request will be processed with the corresponding service tier.\n  - When not set, the default behavior is 'auto'.\n\n  When the `service_tier` parameter is set, the response body will include the `service_tier` value based on the processing mode actually used to serve the request. This response value may be different from the value set in the parameter.\n",
+            "description": "Specifies the processing type used for serving the request.\n  - If set to 'auto', then the request will be processed with the service tier configured in the Project settings. Unless otherwise configured, the Project will use 'default'.\n  - If set to 'default', then the request will be processed with the standard pricing and performance for the selected model.\n  - If set to '[flex](/docs/guides/flex-processing)', then the request will be processed with the Flex Processing service tier.\n  - To opt-in to [Fast mode](/api/docs/guides/fast-mode) at the request level, include the `service_tier=fast` or `service_tier=priority` parameter for Responses or Chat Completions. The response will show `service_tier=priority` regardless of if you specify `service_tier=fast` or `priority` in your request.\n  - When not set, the default behavior is 'auto'.\n\n  When the `service_tier` parameter is set, the response body will include the `service_tier` value based on the processing mode actually used to serve the request. This response value may be different from the value set in the parameter.\n",
             "enum": [
               "auto",
               "default",
               "flex",
               "scale",
-              "priority"
+              "priority",
+              "fast"
             ],
             "default": "auto"
           },
@@ -7199,6 +7419,11 @@
                 "type": "integer",
                 "default": 0,
                 "description": "Cached tokens present in the prompt."
+              },
+              "cache_write_tokens": {
+                "type": "integer",
+                "default": 0,
+                "description": "The unadjusted number of prompt tokens written to cache."
               }
             }
           }
@@ -7207,6 +7432,44 @@
           "prompt_tokens",
           "completion_tokens",
           "total_tokens"
+        ]
+      },
+      "ChatCompletionModeration": {
+        "type": "object",
+        "description": "Moderation results or errors for the request input and generated output.",
+        "properties": {
+          "input": {
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/ChatCompletionModerationResults"
+              },
+              {
+                "$ref": "#/components/schemas/ChatCompletionModerationError"
+              }
+            ],
+            "discriminator": {
+              "propertyName": "type"
+            },
+            "description": "Moderation for the request input."
+          },
+          "output": {
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/ChatCompletionModerationResults"
+              },
+              {
+                "$ref": "#/components/schemas/ChatCompletionModerationError"
+              }
+            ],
+            "discriminator": {
+              "propertyName": "type"
+            },
+            "description": "Moderation for the generated output."
+          }
+        },
+        "required": [
+          "input",
+          "output"
         ]
       },
       "ChatCompletionStreamResponseDelta": {
@@ -7822,6 +8085,19 @@
           }
         }
       },
+      "TranscriptionLanguage": {
+        "type": "object",
+        "description": "A language detected in transcribed audio.",
+        "properties": {
+          "code": {
+            "type": "string",
+            "description": "The code of a language detected in the audio."
+          }
+        },
+        "required": [
+          "code"
+        ]
+      },
       "TranscriptTextUsageTokens": {
         "type": "object",
         "title": "Token Usage",
@@ -8137,6 +8413,13 @@
             "type": "string",
             "description": "The text that was transcribed.\n"
           },
+          "languages": {
+            "type": "array",
+            "description": "The languages detected in the audio. Returned by `gpt-transcribe`. An empty array indicates that no language could be reliably detected.\n",
+            "items": {
+              "$ref": "#/components/schemas/TranscriptionLanguage"
+            }
+          },
           "logprobs": {
             "type": "array",
             "description": "The log probabilities of the individual tokens in the transcription. Only included if you [create a transcription](/docs/api-reference/audio/create-transcription) with the `include[]` parameter set to `logprobs`.\n",
@@ -8248,6 +8531,121 @@
         "title": "Error",
         "description": "An error that occurred while generating the response."
       },
+      "Metadata": {
+        "anyOf": [
+          {
+            "type": "object",
+            "description": "Set of 16 key-value pairs that can be attached to an object. This can be\nuseful for storing additional information about the object in a structured\nformat, and querying for objects via API or the dashboard.\n\nKeys are strings with a maximum length of 64 characters. Values are strings\nwith a maximum length of 512 characters.\n",
+            "additionalProperties": {
+              "type": "string"
+            },
+            "x-oaiTypeLabel": "map"
+          },
+          {
+            "type": "null"
+          }
+        ]
+      },
+      "BatchFileExpirationAfter": {
+        "type": "object",
+        "title": "File expiration policy",
+        "description": "The expiration policy for the output and/or error file that are generated for a batch.",
+        "properties": {
+          "anchor": {
+            "description": "Anchor timestamp after which the expiration policy applies. Supported anchors: `created_at`. Note that the anchor is the file creation time, not the time the batch is created.",
+            "type": "string",
+            "enum": [
+              "created_at"
+            ],
+            "x-stainless-const": true
+          },
+          "seconds": {
+            "description": "The number of seconds after the anchor time that the file will expire. Must be between 3600 (1 hour) and 2592000 (30 days).",
+            "type": "integer",
+            "format": "int64",
+            "minimum": 3600,
+            "maximum": 2592000
+          }
+        },
+        "required": [
+          "anchor",
+          "seconds"
+        ]
+      },
+      "BatchError": {
+        "type": "object",
+        "properties": {
+          "code": {
+            "type": "string",
+            "description": "An error code identifying the error type."
+          },
+          "message": {
+            "type": "string",
+            "description": "A human-readable message providing more details about the error."
+          },
+          "param": {
+            "anyOf": [
+              {
+                "type": "string",
+                "description": "The name of the parameter that caused the error, if applicable."
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "line": {
+            "anyOf": [
+              {
+                "type": "integer",
+                "description": "The line number of the input file where the error occurred, if applicable."
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        }
+      },
+      "BatchRequestCounts": {
+        "type": "object",
+        "properties": {
+          "total": {
+            "type": "integer",
+            "description": "Total number of requests in the batch."
+          },
+          "completed": {
+            "type": "integer",
+            "description": "Number of requests that have been completed successfully."
+          },
+          "failed": {
+            "type": "integer",
+            "description": "Number of requests that have failed."
+          }
+        },
+        "required": [
+          "total",
+          "completed",
+          "failed"
+        ],
+        "description": "The request counts for different statuses within the batch."
+      },
+      "PromptCacheOptionsParam": {
+        "properties": {
+          "ttl": {
+            "$ref": "#/components/schemas/PromptCacheTTLEnum",
+            "description": "The minimum lifetime applied to every implicit and explicit cache breakpoint written by the request. Defaults to `30m`, which is currently the only supported value. The backend may retain cache entries for longer."
+          },
+          "mode": {
+            "$ref": "#/components/schemas/PromptCacheModeEnum",
+            "description": "Controls whether OpenAI automatically creates an implicit cache breakpoint. Defaults to `implicit`. With `implicit`, OpenAI creates one implicit breakpoint and writes up to the latest three explicit breakpoints in the request. With `explicit`, OpenAI does not create an implicit breakpoint and writes up to the latest four explicit breakpoints. If there are no explicit breakpoints, the request does not use prompt caching."
+          }
+        },
+        "type": "object",
+        "required": [],
+        "title": "Prompt cache options",
+        "description": "Options for prompt caching. Supported for `gpt-5.6` and later models. By default, OpenAI automatically chooses one implicit cache breakpoint. You can add explicit breakpoints to content blocks with `prompt_cache_breakpoint`. Each request can write up to four breakpoints. For cache matching, OpenAI considers up to the latest 80 breakpoints in the conversation, without a content-block lookback limit. Set `mode` to `explicit` to disable the implicit breakpoint. The `ttl` defaults to `30m`, which is currently the only supported value. See the [prompt caching guide](/docs/guides/prompt-caching) for current details."
+      },
       "ModelIdsResponses": {
         "example": "gpt-5.1",
         "anyOf": [
@@ -8275,49 +8673,6 @@
             ]
           }
         ]
-      },
-      "Reasoning": {
-        "type": "object",
-        "description": "**gpt-5 and o-series models only**\n\nConfiguration options for\n[reasoning models](https://platform.openai.com/docs/guides/reasoning).\n",
-        "title": "Reasoning",
-        "properties": {
-          "effort": {
-            "$ref": "#/components/schemas/ReasoningEffort"
-          },
-          "summary": {
-            "anyOf": [
-              {
-                "type": "string",
-                "description": "A summary of the reasoning performed by the model. This can be\nuseful for debugging and understanding the model's reasoning process.\nOne of `auto`, `concise`, or `detailed`.\n\n`concise` is supported for `computer-use-preview` models and all reasoning models after `gpt-5`.\n",
-                "enum": [
-                  "auto",
-                  "concise",
-                  "detailed"
-                ]
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "generate_summary": {
-            "anyOf": [
-              {
-                "type": "string",
-                "deprecated": true,
-                "description": "**Deprecated:** use `summary` instead.\n\nA summary of the reasoning performed by the model. This can be\nuseful for debugging and understanding the model's reasoning process.\nOne of `auto`, `concise`, or `detailed`.\n",
-                "enum": [
-                  "auto",
-                  "concise",
-                  "detailed"
-                ]
-              },
-              {
-                "type": "null"
-              }
-            ]
-          }
-        }
       },
       "ResponseTextParam": {
         "type": "object",
@@ -8358,6 +8713,9 @@
           },
           {
             "$ref": "#/components/schemas/ToolChoiceCustom"
+          },
+          {
+            "$ref": "#/components/schemas/SpecificProgrammaticToolCallingParam"
           },
           {
             "$ref": "#/components/schemas/SpecificApplyPatchParam"
@@ -8401,6 +8759,49 @@
           }
         ]
       },
+      "ReasoningModeEnum": {
+        "anyOf": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "string",
+            "enum": [
+              "standard",
+              "pro"
+            ]
+          }
+        ]
+      },
+      "ModerationPolicyParam": {
+        "properties": {
+          "input": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ModerationConfigParam",
+                "description": "The moderation policy for the response input."
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "output": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ModerationConfigParam",
+                "description": "The moderation policy for the response output."
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        },
+        "type": "object",
+        "required": [],
+        "description": "The policy to apply to moderated response input and output."
+      },
       "ConversationParam-2": {
         "properties": {
           "id": {
@@ -8423,6 +8824,8 @@
           "server_error",
           "rate_limit_exceeded",
           "invalid_prompt",
+          "data_residency_mismatch",
+          "bio_policy",
           "vector_store_timeout",
           "invalid_image",
           "invalid_image_format",
@@ -8599,6 +9002,16 @@
           "call_id": {
             "type": "string",
             "description": "The unique ID of the function tool call generated by the model.\n"
+          },
+          "caller": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ToolCallCaller"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "namespace": {
             "type": "string",
@@ -8811,7 +9224,7 @@
             "anyOf": [
               {
                 "type": "string",
-                "description": "The encrypted content of the reasoning item - populated when a response is\ngenerated with `reasoning.encrypted_content` in the `include` parameter.\n"
+                "description": "The encrypted content of the reasoning item. This is populated by default\nfor reasoning items returned by `POST /v1/responses` and WebSocket\n`response.create` requests.\n"
               },
               {
                 "type": "null"
@@ -8846,6 +9259,80 @@
           "id",
           "summary",
           "type"
+        ]
+      },
+      "Program": {
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "program"
+            ],
+            "description": "The type of the item. Always `program`.",
+            "default": "program",
+            "x-stainless-const": true
+          },
+          "id": {
+            "type": "string",
+            "description": "The unique ID of the program item."
+          },
+          "call_id": {
+            "type": "string",
+            "description": "The stable call ID of the program item."
+          },
+          "code": {
+            "type": "string",
+            "description": "The JavaScript source executed by programmatic tool calling."
+          },
+          "fingerprint": {
+            "type": "string",
+            "description": "Opaque program replay fingerprint that must be round-tripped."
+          }
+        },
+        "type": "object",
+        "required": [
+          "type",
+          "id",
+          "call_id",
+          "code",
+          "fingerprint"
+        ]
+      },
+      "ProgramOutput": {
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "program_output"
+            ],
+            "description": "The type of the item. Always `program_output`.",
+            "default": "program_output",
+            "x-stainless-const": true
+          },
+          "id": {
+            "type": "string",
+            "description": "The unique ID of the program output item."
+          },
+          "call_id": {
+            "type": "string",
+            "description": "The call ID of the program item."
+          },
+          "result": {
+            "type": "string",
+            "description": "The result produced by the program item."
+          },
+          "status": {
+            "$ref": "#/components/schemas/ProgramOutputStatus",
+            "description": "The terminal status of the program output item."
+          }
+        },
+        "type": "object",
+        "required": [
+          "type",
+          "id",
+          "call_id",
+          "result",
+          "status"
         ]
       },
       "ToolSearchCall": {
@@ -8954,6 +9441,41 @@
           "execution",
           "tools",
           "status"
+        ]
+      },
+      "AdditionalTools": {
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "additional_tools"
+            ],
+            "description": "The type of the item. Always `additional_tools`.",
+            "default": "additional_tools",
+            "x-stainless-const": true
+          },
+          "id": {
+            "type": "string",
+            "description": "The unique ID of the additional tools item."
+          },
+          "role": {
+            "$ref": "#/components/schemas/MessageRole",
+            "description": "The role that provided the additional tools."
+          },
+          "tools": {
+            "items": {
+              "$ref": "#/components/schemas/Tool"
+            },
+            "type": "array",
+            "description": "The additional tool definitions made available at this item."
+          }
+        },
+        "type": "object",
+        "required": [
+          "type",
+          "id",
+          "role",
+          "tools"
         ]
       },
       "CompactionBody": {
@@ -9222,6 +9744,17 @@
             "type": "string",
             "description": "The unique ID of the shell tool call generated by the model."
           },
+          "caller": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ToolCallCaller",
+                "description": "The execution context that produced this tool call."
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "action": {
             "$ref": "#/components/schemas/FunctionShellAction",
             "description": "The shell commands and limits that describe how to run the tool call."
@@ -9286,6 +9819,17 @@
             "type": "string",
             "description": "The unique ID of the shell tool call generated by the model."
           },
+          "caller": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ToolCallCaller",
+                "description": "The execution context that produced this tool call."
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "status": {
             "$ref": "#/components/schemas/FunctionShellCallOutputStatusEnum",
             "description": "The status of the shell call output. One of `in_progress`, `completed`, or `incomplete`."
@@ -9344,6 +9888,17 @@
             "type": "string",
             "description": "The unique ID of the apply patch tool call generated by the model."
           },
+          "caller": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ToolCallCaller",
+                "description": "The execution context that produced this tool call."
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "status": {
             "$ref": "#/components/schemas/ApplyPatchCallStatus",
             "description": "The status of the apply patch tool call. One of `in_progress` or `completed`."
@@ -9400,6 +9955,17 @@
           "call_id": {
             "type": "string",
             "description": "The unique ID of the apply patch tool call generated by the model."
+          },
+          "caller": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ToolCallCaller",
+                "description": "The execution context that produced this tool call."
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "status": {
             "$ref": "#/components/schemas/ApplyPatchCallOutputStatus",
@@ -9657,6 +10223,16 @@
             "type": "string",
             "description": "An identifier used to map this custom tool call to a tool call output.\n"
           },
+          "caller": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ToolCallCaller"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "namespace": {
             "type": "string",
             "description": "The namespace of the custom tool being called.\n"
@@ -9793,6 +10369,9 @@
             "$ref": "#/components/schemas/ToolSearchOutputItemParam"
           },
           {
+            "$ref": "#/components/schemas/AdditionalToolsItemParam"
+          },
+          {
             "$ref": "#/components/schemas/ReasoningItem"
           },
           {
@@ -9845,6 +10424,25 @@
           "propertyName": "type"
         }
       },
+      "CompactionTriggerItemParam": {
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "compaction_trigger"
+            ],
+            "description": "The type of the item. Always `compaction_trigger`.",
+            "default": "compaction_trigger",
+            "x-stainless-const": true
+          }
+        },
+        "type": "object",
+        "required": [
+          "type"
+        ],
+        "title": "Compaction trigger",
+        "description": "Compacts the current context. Must be the final input item."
+      },
       "ItemReferenceParam": {
         "properties": {
           "type": {
@@ -9874,6 +10472,190 @@
         ],
         "title": "Item reference",
         "description": "An internal identifier for an item to reference."
+      },
+      "ProgramItemParam": {
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "The unique ID of this program item.",
+            "example": "cm_123"
+          },
+          "type": {
+            "type": "string",
+            "enum": [
+              "program"
+            ],
+            "description": "The item type. Always `program`.",
+            "default": "program",
+            "x-stainless-const": true
+          },
+          "call_id": {
+            "type": "string",
+            "maxLength": 64,
+            "minLength": 1,
+            "description": "The stable call ID of the program item."
+          },
+          "code": {
+            "type": "string",
+            "maxLength": 10485760,
+            "description": "The JavaScript source executed by programmatic tool calling."
+          },
+          "fingerprint": {
+            "type": "string",
+            "maxLength": 10485760,
+            "description": "Opaque program replay fingerprint that must be round-tripped."
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "type",
+          "call_id",
+          "code",
+          "fingerprint"
+        ]
+      },
+      "ProgramOutputItemParam": {
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "The unique ID of this program output item.",
+            "example": "cmo_123"
+          },
+          "type": {
+            "type": "string",
+            "enum": [
+              "program_output"
+            ],
+            "description": "The item type. Always `program_output`.",
+            "default": "program_output",
+            "x-stainless-const": true
+          },
+          "call_id": {
+            "type": "string",
+            "maxLength": 64,
+            "minLength": 1,
+            "description": "The call ID of the program item."
+          },
+          "result": {
+            "type": "string",
+            "maxLength": 10485760,
+            "description": "The result produced by the program item."
+          },
+          "status": {
+            "$ref": "#/components/schemas/ProgramOutputItemStatus",
+            "description": "The terminal status of the program output."
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "type",
+          "call_id",
+          "result",
+          "status"
+        ]
+      },
+      "PromptCacheTTLEnum": {
+        "type": "string",
+        "enum": [
+          "30m"
+        ]
+      },
+      "PromptCacheModeEnum": {
+        "type": "string",
+        "enum": [
+          "implicit",
+          "explicit"
+        ]
+      },
+      "ModerationResultBody": {
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "moderation_result"
+            ],
+            "description": "The object type, which was always `moderation_result` for successful moderation results.",
+            "default": "moderation_result",
+            "x-stainless-const": true
+          },
+          "model": {
+            "type": "string",
+            "description": "The moderation model that produced this result."
+          },
+          "flagged": {
+            "type": "boolean",
+            "description": "A boolean indicating whether the content was flagged by any category."
+          },
+          "categories": {
+            "additionalProperties": {
+              "type": "boolean"
+            },
+            "type": "object",
+            "description": "A dictionary of moderation categories to booleans, True if the input is flagged under this category.",
+            "x-oaiTypeLabel": "map"
+          },
+          "category_scores": {
+            "additionalProperties": {
+              "type": "number"
+            },
+            "type": "object",
+            "description": "A dictionary of moderation categories to scores.",
+            "x-oaiTypeLabel": "map"
+          },
+          "category_applied_input_types": {
+            "additionalProperties": {
+              "items": {
+                "$ref": "#/components/schemas/ModerationInputType"
+              },
+              "type": "array"
+            },
+            "type": "object",
+            "description": "Which modalities of input are reflected by the score for each category.",
+            "x-oaiTypeLabel": "map"
+          }
+        },
+        "type": "object",
+        "required": [
+          "type",
+          "model",
+          "flagged",
+          "categories",
+          "category_scores",
+          "category_applied_input_types"
+        ],
+        "title": "Moderation result",
+        "description": "A moderation result produced for the response input or output."
+      },
+      "ModerationErrorBody": {
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "error"
+            ],
+            "description": "The object type, which was always `error` for moderation failures.",
+            "default": "error",
+            "x-stainless-const": true
+          },
+          "code": {
+            "type": "string",
+            "description": "The error code."
+          },
+          "message": {
+            "type": "string",
+            "description": "The error message."
+          }
+        },
+        "type": "object",
+        "required": [
+          "type",
+          "code",
+          "message"
+        ],
+        "title": "Moderation error",
+        "description": "An error produced while attempting moderation for the response input or output."
       },
       "OutputContent": {
         "oneOf": [
@@ -10282,6 +11064,9 @@
           "text": {
             "type": "string",
             "description": "The text content."
+          },
+          "prompt_cache_breakpoint": {
+            "$ref": "#/components/schemas/PromptCacheBreakpointParam"
           }
         },
         "required": [
@@ -10425,6 +11210,63 @@
             "propertyName": "type"
           }
         }
+      },
+      "ChatCompletionModerationResults": {
+        "type": "object",
+        "description": "Successful moderation results for the request input or generated output.",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "moderation_results"
+            ],
+            "description": "The object type, which is always `moderation_results`.",
+            "x-stainless-const": true
+          },
+          "model": {
+            "type": "string",
+            "description": "The moderation model used to generate the results."
+          },
+          "results": {
+            "type": "array",
+            "description": "A list of moderation results.",
+            "items": {
+              "$ref": "#/components/schemas/ModerationResultBody"
+            }
+          }
+        },
+        "required": [
+          "type",
+          "model",
+          "results"
+        ]
+      },
+      "ChatCompletionModerationError": {
+        "type": "object",
+        "description": "An error produced while attempting moderation.",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "error"
+            ],
+            "description": "The object type, which is always `error`.",
+            "x-stainless-const": true
+          },
+          "code": {
+            "type": "string",
+            "description": "The error code."
+          },
+          "message": {
+            "type": "string",
+            "description": "The error message."
+          }
+        },
+        "required": [
+          "type",
+          "code",
+          "message"
+        ]
       },
       "ChatCompletionMessageToolCallChunk": {
         "type": "object",
@@ -10582,6 +11424,9 @@
           },
           {
             "$ref": "#/components/schemas/CodeInterpreterTool"
+          },
+          {
+            "$ref": "#/components/schemas/ProgrammaticToolCallingParam"
           },
           {
             "$ref": "#/components/schemas/ImageGenTool"
@@ -10761,6 +11606,23 @@
           "name"
         ]
       },
+      "SpecificProgrammaticToolCallingParam": {
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "programmatic_tool_calling"
+            ],
+            "description": "The tool to call. Always `programmatic_tool_calling`.",
+            "default": "programmatic_tool_calling",
+            "x-stainless-const": true
+          }
+        },
+        "type": "object",
+        "required": [
+          "type"
+        ]
+      },
       "SpecificApplyPatchParam": {
         "properties": {
           "type": {
@@ -10831,6 +11693,18 @@
           }
         ]
       },
+      "ModerationConfigParam": {
+        "properties": {
+          "mode": {
+            "$ref": "#/components/schemas/ModerationMode"
+          }
+        },
+        "type": "object",
+        "required": [
+          "mode"
+        ],
+        "description": "The moderation policy for the response input."
+      },
       "OutputMessageContent": {
         "oneOf": [
           {
@@ -10883,6 +11757,20 @@
           }
         ]
       },
+      "ToolCallCaller": {
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/DirectToolCallCaller"
+          },
+          {
+            "$ref": "#/components/schemas/ProgramToolCallCaller"
+          }
+        ],
+        "description": "The execution context that produced this tool call.",
+        "discriminator": {
+          "propertyName": "type"
+        }
+      },
       "FunctionToolCallOutput": {
         "type": "object",
         "title": "Function tool call output",
@@ -10903,6 +11791,24 @@
           "call_id": {
             "type": "string",
             "description": "The unique ID of the function tool call generated by the model.\n"
+          },
+          "name": {
+            "type": "string",
+            "description": "The name of the tool that produced the output.\n"
+          },
+          "namespace": {
+            "type": "string",
+            "description": "The namespace of the tool that produced the output.\n"
+          },
+          "caller": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ToolCallCallerParam"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "output": {
             "description": "The output from the function call generated by your code.\nCan be a string or an list of output content.\n",
@@ -10961,7 +11867,8 @@
           },
           "query": {
             "type": "string",
-            "description": "[DEPRECATED] The search query.\n"
+            "deprecated": true,
+            "description": "The search query.\n"
           },
           "queries": {
             "type": "array",
@@ -11003,8 +11910,7 @@
           }
         },
         "required": [
-          "type",
-          "query"
+          "type"
         ]
       },
       "WebSearchActionOpenPage": {
@@ -11247,6 +12153,13 @@
         "title": "Reasoning text",
         "description": "Reasoning text from the model."
       },
+      "ProgramOutputStatus": {
+        "type": "string",
+        "enum": [
+          "completed",
+          "incomplete"
+        ]
+      },
       "ToolSearchExecutionType": {
         "type": "string",
         "enum": [
@@ -11260,6 +12173,19 @@
           "in_progress",
           "completed",
           "incomplete"
+        ]
+      },
+      "MessageRole": {
+        "type": "string",
+        "enum": [
+          "unknown",
+          "user",
+          "assistant",
+          "system",
+          "critic",
+          "discriminator",
+          "developer",
+          "tool"
         ]
       },
       "CodeInterpreterOutputLogs": {
@@ -11686,6 +12612,16 @@
             "type": "string",
             "description": "The call ID, used to map this custom tool call output to a custom tool call.\n"
           },
+          "caller": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ToolCallCallerParam"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "output": {
             "description": "The output from the custom tool call generated by your code.\nCan be a string or an list of output content.\n",
             "oneOf": [
@@ -11886,6 +12822,44 @@
             ],
             "description": "Text, image, or file output of the function tool call."
           },
+          "name": {
+            "anyOf": [
+              {
+                "type": "string",
+                "maxLength": 128,
+                "minLength": 1,
+                "description": "The name of the tool that produced the output."
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "namespace": {
+            "anyOf": [
+              {
+                "type": "string",
+                "maxLength": 64,
+                "minLength": 1,
+                "pattern": "^[a-zA-Z0-9_-]+$",
+                "description": "The namespace of the tool that produced the output."
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "caller": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ToolCallCallerParam",
+                "description": "The execution context that produced this tool call."
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "status": {
             "anyOf": [
               {
@@ -12034,6 +13008,53 @@
           "tools"
         ]
       },
+      "AdditionalToolsItemParam": {
+        "properties": {
+          "id": {
+            "anyOf": [
+              {
+                "type": "string",
+                "description": "The unique ID of this additional tools item.",
+                "example": "at_123"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "type": {
+            "type": "string",
+            "enum": [
+              "additional_tools"
+            ],
+            "description": "The item type. Always `additional_tools`.",
+            "default": "additional_tools",
+            "x-stainless-const": true
+          },
+          "role": {
+            "type": "string",
+            "enum": [
+              "developer"
+            ],
+            "description": "The role that provided the additional tools. Only `developer` is supported.",
+            "default": "developer",
+            "x-stainless-const": true
+          },
+          "tools": {
+            "items": {
+              "$ref": "#/components/schemas/Tool"
+            },
+            "type": "array",
+            "description": "A list of additional tools made available at this item."
+          }
+        },
+        "type": "object",
+        "required": [
+          "type",
+          "role",
+          "tools"
+        ]
+      },
       "CompactionSummaryItemParam": {
         "properties": {
           "id": {
@@ -12090,6 +13111,17 @@
             "maxLength": 64,
             "minLength": 1,
             "description": "The unique ID of the shell tool call generated by the model."
+          },
+          "caller": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ToolCallCallerParam",
+                "description": "The execution context that produced this tool call."
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "type": {
             "type": "string",
@@ -12165,6 +13197,17 @@
             "maxLength": 64,
             "minLength": 1,
             "description": "The unique ID of the shell tool call generated by the model."
+          },
+          "caller": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ToolCallCallerParam",
+                "description": "The execution context that produced this tool call."
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "type": {
             "type": "string",
@@ -12243,6 +13286,17 @@
             "minLength": 1,
             "description": "The unique ID of the apply patch tool call generated by the model."
           },
+          "caller": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ToolCallCallerParam",
+                "description": "The execution context that produced this tool call."
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "status": {
             "$ref": "#/components/schemas/ApplyPatchCallStatusParam",
             "description": "The status of the apply patch tool call. One of `in_progress` or `completed`."
@@ -12290,6 +13344,17 @@
             "maxLength": 64,
             "minLength": 1,
             "description": "The unique ID of the apply patch tool call generated by the model."
+          },
+          "caller": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ToolCallCallerParam",
+                "description": "The execution context that produced this tool call."
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "status": {
             "$ref": "#/components/schemas/ApplyPatchCallOutputStatusParam",
@@ -12366,6 +13431,20 @@
           "request_id",
           "approve",
           "approval_request_id"
+        ]
+      },
+      "ProgramOutputItemStatus": {
+        "type": "string",
+        "enum": [
+          "completed",
+          "incomplete"
+        ]
+      },
+      "ModerationInputType": {
+        "type": "string",
+        "enum": [
+          "text",
+          "image"
         ]
       },
       "OutputTextContent": {
@@ -12473,6 +13552,25 @@
             "$ref": "#/components/schemas/ChatCompletionRequestMessageContentPartText"
           }
         ]
+      },
+      "PromptCacheBreakpointParam": {
+        "properties": {
+          "mode": {
+            "type": "string",
+            "enum": [
+              "explicit"
+            ],
+            "description": "The breakpoint mode. Always `explicit`.",
+            "default": "explicit",
+            "x-stainless-const": true
+          }
+        },
+        "type": "object",
+        "required": [
+          "mode"
+        ],
+        "title": "Prompt cache breakpoint",
+        "description": "Marks the exact end of a reusable prompt prefix. The breakpoint inherits its TTL from the request's `prompt_cache_options.ttl`; the boundary is not rounded to a token block."
       },
       "ChatCompletionAllowedTools": {
         "type": "object",
@@ -12669,11 +13767,24 @@
               }
             ]
           },
+          "output_schema": {
+            "anyOf": [
+              {
+                "additionalProperties": {},
+                "type": "object",
+                "description": "A JSON schema object describing the JSON value encoded in string outputs for this function.",
+                "x-oaiTypeLabel": "map"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "strict": {
             "anyOf": [
               {
                 "type": "boolean",
-                "description": "Whether to enforce strict parameter validation. Default `true`."
+                "description": "Whether strict parameter validation is enforced for this function tool."
               },
               {
                 "type": "null"
@@ -12683,6 +13794,20 @@
           "defer_loading": {
             "type": "boolean",
             "description": "Whether this function is deferred and loaded via tool search."
+          },
+          "allowed_callers": {
+            "anyOf": [
+              {
+                "items": {
+                  "$ref": "#/components/schemas/CallableToolAllowedCaller"
+                },
+                "type": "array",
+                "description": "The tool invocation context(s)."
+              },
+              {
+                "type": "null"
+              }
+            ]
           }
         },
         "type": "object",
@@ -12876,7 +14001,7 @@
           "server_url": {
             "type": "string",
             "format": "uri",
-            "description": "The URL for the MCP server. One of `server_url` or `connector_id` must be\nprovided.\n"
+            "description": "The URL for the MCP server. One of `server_url`, `connector_id`, or\n`tunnel_id` must be provided.\n"
           },
           "connector_id": {
             "type": "string",
@@ -12890,7 +14015,12 @@
               "connector_outlookemail",
               "connector_sharepoint"
             ],
-            "description": "Identifier for service connectors, like those available in ChatGPT. One of\n`server_url` or `connector_id` must be provided. Learn more about service\nconnectors [here](/docs/guides/tools-remote-mcp#connectors).\n\nCurrently supported `connector_id` values are:\n\n- Dropbox: `connector_dropbox`\n- Gmail: `connector_gmail`\n- Google Calendar: `connector_googlecalendar`\n- Google Drive: `connector_googledrive`\n- Microsoft Teams: `connector_microsoftteams`\n- Outlook Calendar: `connector_outlookcalendar`\n- Outlook Email: `connector_outlookemail`\n- SharePoint: `connector_sharepoint`\n"
+            "description": "Identifier for service connectors, like those available in ChatGPT. One of\n`server_url`, `connector_id`, or `tunnel_id` must be provided. Learn more\nabout service connectors [here](/docs/guides/tools-remote-mcp#connectors).\n\nCurrently supported `connector_id` values are:\n\n- Dropbox: `connector_dropbox`\n- Gmail: `connector_gmail`\n- Google Calendar: `connector_googlecalendar`\n- Google Drive: `connector_googledrive`\n- Microsoft Teams: `connector_microsoftteams`\n- Outlook Calendar: `connector_outlookcalendar`\n- Outlook Email: `connector_outlookemail`\n- SharePoint: `connector_sharepoint`\n"
+          },
+          "tunnel_id": {
+            "type": "string",
+            "pattern": "^tunnel_[a-z0-9]{32}$",
+            "description": "The Secure MCP Tunnel ID to use instead of a direct server URL. One of\n`server_url`, `connector_id`, or `tunnel_id` must be provided.\n"
           },
           "authorization": {
             "type": "string",
@@ -12931,6 +14061,21 @@
                     "$ref": "#/components/schemas/MCPToolFilter"
                   }
                 ]
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "allowed_callers": {
+            "anyOf": [
+              {
+                "type": "array",
+                "minItems": 1,
+                "items": {
+                  "$ref": "#/components/schemas/CallableToolAllowedCaller"
+                },
+                "description": "The tool invocation context(s)."
               },
               {
                 "type": "null"
@@ -13007,11 +14152,43 @@
                 "$ref": "#/components/schemas/AutoCodeInterpreterToolParam"
               }
             ]
+          },
+          "allowed_callers": {
+            "anyOf": [
+              {
+                "type": "array",
+                "minItems": 1,
+                "items": {
+                  "$ref": "#/components/schemas/CallableToolAllowedCaller"
+                },
+                "description": "The tool invocation context(s)."
+              },
+              {
+                "type": "null"
+              }
+            ]
           }
         },
         "required": [
           "type",
           "container"
+        ]
+      },
+      "ProgrammaticToolCallingParam": {
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "programmatic_tool_calling"
+            ],
+            "description": "The type of the tool. Always `programmatic_tool_calling`.",
+            "default": "programmatic_tool_calling",
+            "x-stainless-const": true
+          }
+        },
+        "type": "object",
+        "required": [
+          "type"
         ]
       },
       "ImageGenTool": {
@@ -13203,6 +14380,21 @@
                 "type": "null"
               }
             ]
+          },
+          "allowed_callers": {
+            "anyOf": [
+              {
+                "items": {
+                  "$ref": "#/components/schemas/CallableToolAllowedCaller"
+                },
+                "type": "array",
+                "minItems": 1,
+                "description": "The tool invocation context(s)."
+              },
+              {
+                "type": "null"
+              }
+            ]
           }
         },
         "type": "object",
@@ -13248,6 +14440,21 @@
           "defer_loading": {
             "type": "boolean",
             "description": "Whether this tool should be deferred and discovered via tool search."
+          },
+          "allowed_callers": {
+            "anyOf": [
+              {
+                "items": {
+                  "$ref": "#/components/schemas/CallableToolAllowedCaller"
+                },
+                "type": "array",
+                "minItems": 1,
+                "description": "The tool invocation context(s)."
+              },
+              {
+                "type": "null"
+              }
+            ]
           }
         },
         "type": "object",
@@ -13405,6 +14612,21 @@
             "description": "The type of the tool. Always `apply_patch`.",
             "default": "apply_patch",
             "x-stainless-const": true
+          },
+          "allowed_callers": {
+            "anyOf": [
+              {
+                "items": {
+                  "$ref": "#/components/schemas/CallableToolAllowedCaller"
+                },
+                "type": "array",
+                "minItems": 1,
+                "description": "The tool invocation context(s)."
+              },
+              {
+                "type": "null"
+              }
+            ]
           }
         },
         "type": "object",
@@ -13428,6 +14650,9 @@
           "text": {
             "type": "string",
             "description": "The text input to the model."
+          },
+          "prompt_cache_breakpoint": {
+            "$ref": "#/components/schemas/PromptCacheBreakpointConfig"
           }
         },
         "type": "object",
@@ -13475,6 +14700,9 @@
           "detail": {
             "$ref": "#/components/schemas/ImageDetail",
             "description": "The detail level of the image to be sent to the model. One of `high`, `low`, `auto`, or `original`. Defaults to `auto`."
+          },
+          "prompt_cache_breakpoint": {
+            "$ref": "#/components/schemas/PromptCacheBreakpointConfig"
           }
         },
         "type": "object",
@@ -13515,6 +14743,9 @@
             "type": "string",
             "description": "The content of the file to be sent to the model.\n"
           },
+          "prompt_cache_breakpoint": {
+            "$ref": "#/components/schemas/PromptCacheBreakpointConfig"
+          },
           "file_url": {
             "type": "string",
             "format": "uri",
@@ -13522,7 +14753,7 @@
           },
           "detail": {
             "$ref": "#/components/schemas/FileInputDetail",
-            "description": "The detail level of the file to be sent to the model. Use `low` for the default rendering behavior, or `high` to render the file at higher quality. Defaults to `low`."
+            "description": "The detail level of the file to be sent to the model. Use `auto` to let the system select the detail level; for GPT-5.6 and later models, `auto` uses high-quality rendering, which may increase input token usage. Use `low` for lower-cost rendering, or `high` to render the file at higher quality. Defaults to `auto`."
           }
         },
         "type": "object",
@@ -13531,6 +14762,64 @@
         ],
         "title": "Input file",
         "description": "A file input to the model."
+      },
+      "ModerationMode": {
+        "type": "string",
+        "enum": [
+          "score",
+          "block"
+        ]
+      },
+      "DirectToolCallCaller": {
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "direct"
+            ],
+            "default": "direct",
+            "x-stainless-const": true
+          }
+        },
+        "type": "object",
+        "required": [
+          "type"
+        ]
+      },
+      "ProgramToolCallCaller": {
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "program"
+            ],
+            "default": "program",
+            "x-stainless-const": true
+          },
+          "caller_id": {
+            "type": "string",
+            "description": "The call ID of the program item that produced this tool call."
+          }
+        },
+        "type": "object",
+        "required": [
+          "type",
+          "caller_id"
+        ]
+      },
+      "ToolCallCallerParam": {
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/DirectToolCallCallerParam"
+          },
+          {
+            "$ref": "#/components/schemas/ProgramToolCallCallerParam"
+          }
+        ],
+        "description": "The execution context that produced this tool call.",
+        "discriminator": {
+          "propertyName": "type"
+        }
       },
       "FunctionAndCustomToolCallOutput": {
         "oneOf": [
@@ -13976,6 +15265,16 @@
             "type": "string",
             "maxLength": 10485760,
             "description": "The text input to the model."
+          },
+          "prompt_cache_breakpoint": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/PromptCacheBreakpointParam"
+              },
+              {
+                "type": "null"
+              }
+            ]
           }
         },
         "type": "object",
@@ -14027,6 +15326,16 @@
               {
                 "$ref": "#/components/schemas/DetailEnum",
                 "description": "The detail level of the image to be sent to the model. One of `high`, `low`, `auto`, or `original`. Defaults to `auto`."
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "prompt_cache_breakpoint": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/PromptCacheBreakpointParam"
               },
               {
                 "type": "null"
@@ -14101,7 +15410,17 @@
           },
           "detail": {
             "$ref": "#/components/schemas/FileDetailEnum",
-            "description": "The detail level of the file to be sent to the model. Use `low` for the default rendering behavior, or `high` to render the file at higher quality. Defaults to `low`."
+            "description": "The detail level of the file to be sent to the model. Use `auto` to let the system select the detail level; for GPT-5.6 and later models, `auto` uses high-quality rendering, which may increase input token usage. Use `low` for lower-cost rendering, or `high` to render the file at higher quality. Defaults to `auto`."
+          },
+          "prompt_cache_breakpoint": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/PromptCacheBreakpointParam"
+              },
+              {
+                "type": "null"
+              }
+            ]
           }
         },
         "type": "object",
@@ -14361,6 +15680,9 @@
             "required": [
               "url"
             ]
+          },
+          "prompt_cache_breakpoint": {
+            "$ref": "#/components/schemas/PromptCacheBreakpointParam"
           }
         },
         "required": [
@@ -14401,6 +15723,9 @@
               "data",
               "format"
             ]
+          },
+          "prompt_cache_breakpoint": {
+            "$ref": "#/components/schemas/PromptCacheBreakpointParam"
           }
         },
         "required": [
@@ -14437,6 +15762,9 @@
                 "description": "The ID of an uploaded file to use as input.\n"
               }
             }
+          },
+          "prompt_cache_breakpoint": {
+            "$ref": "#/components/schemas/PromptCacheBreakpointParam"
           }
         },
         "required": [
@@ -14464,6 +15792,13 @@
         "required": [
           "type",
           "refusal"
+        ]
+      },
+      "CallableToolAllowedCaller": {
+        "type": "string",
+        "enum": [
+          "direct",
+          "programmatic"
         ]
       },
       "RankingOptions": {
@@ -14801,7 +16136,8 @@
           "strict": {
             "anyOf": [
               {
-                "type": "boolean"
+                "type": "boolean",
+                "description": "Whether to enforce strict parameter validation. If omitted, Responses attempts to use strict validation when the schema is compatible, and falls back to non-strict validation otherwise."
               },
               {
                 "type": "null"
@@ -14816,9 +16152,37 @@
             "default": "function",
             "x-stainless-const": true
           },
+          "output_schema": {
+            "anyOf": [
+              {
+                "additionalProperties": {},
+                "type": "object",
+                "description": "A JSON Schema describing the JSON value encoded in string outputs for this function tool. This does not describe content-array outputs.",
+                "x-oaiTypeLabel": "map"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "defer_loading": {
             "type": "boolean",
             "description": "Whether this function should be deferred and discovered via tool search."
+          },
+          "allowed_callers": {
+            "anyOf": [
+              {
+                "items": {
+                  "$ref": "#/components/schemas/CallableToolAllowedCaller"
+                },
+                "type": "array",
+                "minItems": 1,
+                "description": "The tool invocation context(s)."
+              },
+              {
+                "type": "null"
+              }
+            ]
           }
         },
         "type": "object",
@@ -14903,6 +16267,25 @@
           "image"
         ]
       },
+      "PromptCacheBreakpointConfig": {
+        "properties": {
+          "mode": {
+            "type": "string",
+            "enum": [
+              "explicit"
+            ],
+            "description": "The breakpoint mode. Always `explicit`.",
+            "default": "explicit",
+            "x-stainless-const": true
+          }
+        },
+        "type": "object",
+        "required": [
+          "mode"
+        ],
+        "title": "Prompt cache breakpoint",
+        "description": "Marks the exact end of a reusable prompt prefix. The breakpoint inherits its TTL from the request's `prompt_cache_options.ttl`; the boundary is not rounded to a token block."
+      },
       "ImageDetail": {
         "type": "string",
         "enum": [
@@ -14915,8 +16298,50 @@
       "FileInputDetail": {
         "type": "string",
         "enum": [
+          "auto",
           "low",
           "high"
+        ]
+      },
+      "DirectToolCallCallerParam": {
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "direct"
+            ],
+            "description": "The caller type. Always `direct`.",
+            "default": "direct",
+            "x-stainless-const": true
+          }
+        },
+        "type": "object",
+        "required": [
+          "type"
+        ]
+      },
+      "ProgramToolCallCallerParam": {
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "program"
+            ],
+            "description": "The caller type. Always `program`.",
+            "default": "program",
+            "x-stainless-const": true
+          },
+          "caller_id": {
+            "type": "string",
+            "maxLength": 64,
+            "minLength": 1,
+            "description": "The call ID of the program item that produced this tool call."
+          }
+        },
+        "type": "object",
+        "required": [
+          "type",
+          "caller_id"
         ]
       },
       "ClickButtonType": {
@@ -14960,6 +16385,7 @@
       "FileDetailEnum": {
         "type": "string",
         "enum": [
+          "auto",
           "low",
           "high"
         ]

--- a/packages/testing/provider-mock/contracts/openai-eu/provenance.json
+++ b/packages/testing/provider-mock/contracts/openai-eu/provenance.json
@@ -6,5 +6,5 @@
     "repository": "https://github.com/openai/openai-openapi",
     "license": "MIT"
   },
-  "bundleSha256": "ab0532a9418d4e42617120a469ba24a5a929106e4795cfbaa6e6499dcee4661f"
+  "bundleSha256": "fca1be766d19eaddd40be88e1becbb8b9bdb27088aff0b010905eefef4056b5d"
 }

--- a/packages/testing/provider-mock/contracts/openai/manifest.json
+++ b/packages/testing/provider-mock/contracts/openai/manifest.json
@@ -109,6 +109,7 @@
       "method": "post",
       "path": "/rerank",
       "operationId": "openai_rerank_1",
+      "sourceOverlay": true,
       "notes": "Derived from the enabled Phaseo executor URL and provider API reference."
     }
   ],

--- a/packages/testing/provider-mock/contracts/openai/openapi.json
+++ b/packages/testing/provider-mock/contracts/openai/openapi.json
@@ -11,7 +11,7 @@
     },
     "license": {
       "name": "MIT",
-      "url": "https://github.com/openai/openai-openapi/blob/master/LICENSE"
+      "identifier": "MIT"
     }
   },
   "servers": [
@@ -572,45 +572,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "type": "object",
-                "required": [
-                  "input_file_id",
-                  "endpoint",
-                  "completion_window"
-                ],
-                "properties": {
-                  "input_file_id": {
-                    "type": "string",
-                    "description": "The ID of an uploaded file that contains requests for the new batch.\n\nSee [upload file](/docs/api-reference/files/create) for how to upload a file.\n\nYour input file must be formatted as a [JSONL file](/docs/api-reference/batch/request-input), and must be uploaded with the purpose `batch`. The file can contain up to 50,000 requests, and can be up to 200 MB in size.\n"
-                  },
-                  "endpoint": {
-                    "type": "string",
-                    "enum": [
-                      "/v1/responses",
-                      "/v1/chat/completions",
-                      "/v1/embeddings",
-                      "/v1/completions",
-                      "/v1/moderations",
-                      "/v1/images/generations",
-                      "/v1/images/edits",
-                      "/v1/videos"
-                    ],
-                    "description": "The endpoint to be used for all requests in the batch. Currently `/v1/responses`, `/v1/chat/completions`, `/v1/embeddings`, `/v1/completions`, `/v1/moderations`, `/v1/images/generations`, `/v1/images/edits`, and `/v1/videos` are supported. Note that `/v1/embeddings` batches are also restricted to a maximum of 50,000 embedding inputs across all requests in the batch."
-                  },
-                  "completion_window": {
-                    "type": "string",
-                    "enum": [
-                      "24h"
-                    ],
-                    "description": "The time frame within which the batch should be processed. Currently only `24h` is supported."
-                  },
-                  "metadata": {
-                    "$ref": "#/components/schemas/Metadata"
-                  },
-                  "output_expires_after": {
-                    "$ref": "#/components/schemas/BatchFileExpirationAfter"
-                  }
-                }
+                "$ref": "#/components/schemas/CreateBatchRequest"
               }
             }
           }
@@ -735,6 +697,33 @@
           {
             "type": "object",
             "properties": {
+              "truncation": {
+                "deprecated": true,
+                "anyOf": [
+                  {
+                    "type": "string",
+                    "description": "The truncation strategy to use for the model response.\n- `auto`: If the input to this Response exceeds\n  the model's context window size, the model will truncate the\n  response to fit the context window by dropping items from the beginning of the conversation.\n- `disabled` (default): If the input size will exceed the context window\n  size for a model, the request will fail with a 400 error.\n",
+                    "enum": [
+                      "auto",
+                      "disabled"
+                    ],
+                    "default": "disabled"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "reasoning": {
+                "anyOf": [
+                  {
+                    "$ref": "#/components/schemas/Reasoning"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
               "input": {
                 "$ref": "#/components/schemas/InputParam"
               },
@@ -781,6 +770,17 @@
                   {
                     "type": "string",
                     "description": "A system (or developer) message inserted into the model's context.\n\nWhen using along with `previous_response_id`, the instructions from a previous\nresponse will not be carried over to the next response. This makes it simple\nto swap out system (or developer) messages in new responses.\n"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "moderation": {
+                "anyOf": [
+                  {
+                    "$ref": "#/components/schemas/ModerationParam",
+                    "description": "Configuration for running moderation on the input and output of this response.\n"
                   },
                   {
                     "type": "null"
@@ -855,6 +855,22 @@
           {
             "type": "object",
             "properties": {
+              "truncation": {
+                "anyOf": [
+                  {
+                    "type": "string",
+                    "description": "The truncation strategy to use for the model response.\n- `auto`: If the input to this Response exceeds\n  the model's context window size, the model will truncate the\n  response to fit the context window by dropping items from the beginning of the conversation.\n- `disabled` (default): If the input size will exceed the context window\n  size for a model, the request will fail with a 400 error.\n",
+                    "enum": [
+                      "auto",
+                      "disabled"
+                    ],
+                    "default": "disabled"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
               "id": {
                 "type": "string",
                 "description": "Unique identifier for this Response.\n"
@@ -927,6 +943,16 @@
                   "$ref": "#/components/schemas/OutputItem"
                 }
               },
+              "reasoning": {
+                "anyOf": [
+                  {
+                    "$ref": "#/components/schemas/Reasoning"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
               "instructions": {
                 "anyOf": [
                   {
@@ -969,6 +995,20 @@
               "usage": {
                 "$ref": "#/components/schemas/ResponseUsage"
               },
+              "prompt_cache_options": {
+                "$ref": "#/components/schemas/PromptCacheOptions"
+              },
+              "moderation": {
+                "anyOf": [
+                  {
+                    "$ref": "#/components/schemas/Moderation",
+                    "description": "Moderation results for the response input and output, if moderated completions were requested.\n"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
               "parallel_tool_calls": {
                 "type": "boolean",
                 "description": "Whether to allow the model to run tool calls in parallel.\n",
@@ -978,7 +1018,7 @@
                 "anyOf": [
                   {
                     "default": null,
-                    "$ref": "#/components/schemas/Conversation-2"
+                    "$ref": "#/components/schemas/ResponseConversation"
                   },
                   {
                     "type": "null"
@@ -1045,7 +1085,8 @@
           "previous_response_id": null,
           "reasoning": {
             "effort": null,
-            "summary": null
+            "summary": null,
+            "context": null
           },
           "store": true,
           "temperature": 1,
@@ -1061,7 +1102,8 @@
           "usage": {
             "input_tokens": 328,
             "input_tokens_details": {
-              "cached_tokens": 0
+              "cached_tokens": 0,
+              "cache_write_tokens": 0
             },
             "output_tokens": 52,
             "output_tokens_details": {
@@ -1378,6 +1420,17 @@
                 "nullable": true,
                 "description": "Whether or not to store the output of this chat completion request for\nuse in our [model distillation](/docs/guides/distillation) or\n[evals](/docs/guides/evals) products.\n\nSupports text and image inputs. Note: image inputs over 8MB will be dropped.\n"
               },
+              "moderation": {
+                "anyOf": [
+                  {
+                    "$ref": "#/components/schemas/ModerationParam",
+                    "description": "Configuration for running moderation on the request input and generated output.\n"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
               "stream": {
                 "description": "If set to true, the model response data will be streamed to the client\nas it is generated using [server-sent events](https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events/Using_server-sent_events#Event_stream_format).\nSee the [Streaming section below](/docs/api-reference/chat/streaming)\nfor more information, along with the [streaming responses](/docs/guides/streaming-responses)\nguide for more information on how to handle the streaming events.\n",
                 "type": "boolean",
@@ -1515,7 +1568,7 @@
               "properties": {
                 "finish_reason": {
                   "type": "string",
-                  "description": "The reason the model stopped generating tokens. This will be `stop` if the model hit a natural stop point or a provided stop sequence,\n`length` if the maximum number of tokens specified in the request was reached,\n`content_filter` if content was omitted due to a flag from our content filters,\n`tool_calls` if the model called a tool, or `function_call` (deprecated) if the model called a function.\n",
+                  "description": "The reason the model stopped generating tokens. This will be `stop` if the model hit a natural stop point or a provided stop sequence,\n`length` if the maximum number of tokens specified in the request was reached,\n`content_filter` if content was omitted due to a flag from our content filters,\n`tool_calls` if the model called a tool, or `function_call` (deprecated) if the model called a function.\nRead the [Model Spec](https://model-spec.openai.com/2025-12-18.html) for more.\n",
                   "enum": [
                     "stop",
                     "length",
@@ -1606,6 +1659,17 @@
           },
           "usage": {
             "$ref": "#/components/schemas/CompletionUsage"
+          },
+          "moderation": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ChatCompletionModeration",
+                "description": "Moderation results for the request input and generated output, if moderated\ncompletions were requested.\n"
+              },
+              {
+                "type": "null"
+              }
+            ]
           }
         },
         "required": [
@@ -1713,6 +1777,17 @@
             "$ref": "#/components/schemas/CompletionUsage",
             "nullable": true,
             "description": "An optional field that will only be present when you set\n`stream_options: {\"include_usage\": true}` in your request. When present, it\ncontains a null value **except for the last chunk** which contains the\ntoken usage statistics for the entire request.\n\n**NOTE:** If the stream is interrupted or cancelled, you may not\nreceive the final usage chunk which contains the total token usage for\nthe request.\n"
+          },
+          "moderation": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ChatCompletionModeration",
+                "description": "Moderation results for the request input and generated output. Present\non the moderation chunk when moderated completions are requested.\n"
+              },
+              {
+                "type": "null"
+              }
+            ]
           }
         },
         "required": [
@@ -3067,7 +3142,7 @@
             "format": "binary"
           },
           "model": {
-            "description": "ID of the model to use. The options are `gpt-4o-transcribe`, `gpt-4o-mini-transcribe`, `gpt-4o-mini-transcribe-2025-12-15`, `whisper-1` (which is powered by our open source Whisper V2 model), and `gpt-4o-transcribe-diarize`.\n",
+            "description": "ID of the model to use. The options are `gpt-transcribe`, `gpt-4o-transcribe`, `gpt-4o-mini-transcribe`, `gpt-4o-mini-transcribe-2025-12-15`, `whisper-1` (which is powered by our open source Whisper V2 model), and `gpt-4o-transcribe-diarize`.\n",
             "example": "gpt-4o-transcribe",
             "anyOf": [
               {
@@ -3077,6 +3152,7 @@
                 "type": "string",
                 "enum": [
                   "whisper-1",
+                  "gpt-transcribe",
                   "gpt-4o-transcribe",
                   "gpt-4o-mini-transcribe",
                   "gpt-4o-mini-transcribe-2025-12-15",
@@ -3090,6 +3166,21 @@
           "language": {
             "description": "The language of the input audio. Supplying the input language in [ISO-639-1](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes) (e.g. `en`) format will improve accuracy and latency.\n",
             "type": "string"
+          },
+          "languages": {
+            "description": "Possible languages of the input audio, in [ISO-639-1](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes) format. Supported by `gpt-transcribe`.\n",
+            "type": "array",
+            "minItems": 1,
+            "items": {
+              "type": "string"
+            }
+          },
+          "keywords": {
+            "description": "Words or phrases to guide transcription of the input audio. Supported by `gpt-transcribe`.\n",
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
           },
           "prompt": {
             "description": "An optional text to guide the model's style or continue a previous audio segment. The [prompt](/docs/guides/speech-to-text#prompting) should match the audio language. This field is not supported when using `gpt-4o-transcribe-diarize`.\n",
@@ -3190,6 +3281,13 @@
           "text": {
             "type": "string",
             "description": "The transcribed text."
+          },
+          "languages": {
+            "type": "array",
+            "description": "The languages detected in the audio. Returned by `gpt-transcribe`. An empty array indicates that no language could be reliably detected.\n",
+            "items": {
+              "$ref": "#/components/schemas/TranscriptionLanguage"
+            }
           },
           "logprobs": {
             "type": "array",
@@ -3460,7 +3558,8 @@
                 "description": "Optional reference asset upload or reference object that guides generation."
               },
               {
-                "$ref": "#/components/schemas/ImageRefParam-2"
+                "$ref": "#/components/schemas/ImageRefParam-2",
+                "description": "Optional reference asset upload or reference object that guides generation. Provide exactly one of `image_url` or `file_id` when using an object."
               }
             ]
           },
@@ -3666,46 +3765,46 @@
           "spritesheet"
         ]
       },
-      "Metadata": {
-        "anyOf": [
-          {
-            "type": "object",
-            "description": "Set of 16 key-value pairs that can be attached to an object. This can be\nuseful for storing additional information about the object in a structured\nformat, and querying for objects via API or the dashboard.\n\nKeys are strings with a maximum length of 64 characters. Values are strings\nwith a maximum length of 512 characters.\n",
-            "additionalProperties": {
-              "type": "string"
-            },
-            "x-oaiTypeLabel": "map"
-          },
-          {
-            "type": "null"
-          }
-        ]
-      },
-      "BatchFileExpirationAfter": {
+      "CreateBatchRequest": {
         "type": "object",
-        "title": "File expiration policy",
-        "description": "The expiration policy for the output and/or error file that are generated for a batch.",
+        "required": [
+          "input_file_id",
+          "endpoint",
+          "completion_window"
+        ],
         "properties": {
-          "anchor": {
-            "description": "Anchor timestamp after which the expiration policy applies. Supported anchors: `created_at`. Note that the anchor is the file creation time, not the time the batch is created.",
+          "input_file_id": {
+            "type": "string",
+            "description": "The ID of an uploaded file that contains requests for the new batch.\n\nSee [upload file](/docs/api-reference/files/create) for how to upload a file.\n\nYour input file must be formatted as a [JSONL file](/docs/api-reference/batch/request-input), and must be uploaded with the purpose `batch`. The file can contain up to 50,000 requests, and can be up to 200 MB in size.\n"
+          },
+          "endpoint": {
             "type": "string",
             "enum": [
-              "created_at"
+              "/v1/responses",
+              "/v1/chat/completions",
+              "/v1/embeddings",
+              "/v1/completions",
+              "/v1/moderations",
+              "/v1/images/generations",
+              "/v1/images/edits",
+              "/v1/videos"
             ],
-            "x-stainless-const": true
+            "description": "The endpoint to be used for all requests in the batch. Currently `/v1/responses`, `/v1/chat/completions`, `/v1/embeddings`, `/v1/completions`, `/v1/moderations`, `/v1/images/generations`, `/v1/images/edits`, and `/v1/videos` are supported. Note that `/v1/embeddings` batches are also restricted to a maximum of 50,000 embedding inputs across all requests in the batch."
           },
-          "seconds": {
-            "description": "The number of seconds after the anchor time that the file will expire. Must be between 3600 (1 hour) and 2592000 (30 days).",
-            "type": "integer",
-            "format": "int64",
-            "minimum": 3600,
-            "maximum": 2592000
+          "completion_window": {
+            "type": "string",
+            "enum": [
+              "24h"
+            ],
+            "description": "The time frame within which the batch should be processed. Currently only `24h` is supported."
+          },
+          "metadata": {
+            "$ref": "#/components/schemas/Metadata"
+          },
+          "output_expires_after": {
+            "$ref": "#/components/schemas/BatchFileExpirationAfter"
           }
-        },
-        "required": [
-          "anchor",
-          "seconds"
-        ]
+        }
       },
       "Batch": {
         "type": "object",
@@ -3739,39 +3838,7 @@
               "data": {
                 "type": "array",
                 "items": {
-                  "type": "object",
-                  "properties": {
-                    "code": {
-                      "type": "string",
-                      "description": "An error code identifying the error type."
-                    },
-                    "message": {
-                      "type": "string",
-                      "description": "A human-readable message providing more details about the error."
-                    },
-                    "param": {
-                      "anyOf": [
-                        {
-                          "type": "string",
-                          "description": "The name of the parameter that caused the error, if applicable."
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ]
-                    },
-                    "line": {
-                      "anyOf": [
-                        {
-                          "type": "integer",
-                          "description": "The line number of the input file where the error occurred, if applicable."
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ]
-                    }
-                  }
+                  "$ref": "#/components/schemas/BatchError"
                 }
               }
             }
@@ -3852,27 +3919,7 @@
             "description": "The Unix timestamp (in seconds) for when the batch was cancelled."
           },
           "request_counts": {
-            "type": "object",
-            "properties": {
-              "total": {
-                "type": "integer",
-                "description": "Total number of requests in the batch."
-              },
-              "completed": {
-                "type": "integer",
-                "description": "Number of requests that have been completed successfully."
-              },
-              "failed": {
-                "type": "integer",
-                "description": "Number of requests that have failed."
-              }
-            },
-            "required": [
-              "total",
-              "completed",
-              "failed"
-            ],
-            "description": "The request counts for different statuses within the batch."
+            "$ref": "#/components/schemas/BatchRequestCounts"
           },
           "usage": {
             "type": "object",
@@ -3947,6 +3994,9 @@
           {
             "type": "object",
             "properties": {
+              "prompt_cache_options": {
+                "$ref": "#/components/schemas/PromptCacheOptionsParam"
+              },
               "top_logprobs": {
                 "description": "An integer between 0 and 20 specifying the maximum number of most likely\ntokens to return at each token position, each with an associated log\nprobability. In some cases, the number of returned tokens may be fewer than\nrequested.\n",
                 "type": "integer",
@@ -3974,16 +4024,6 @@
           "model": {
             "description": "Model ID used to generate the response, like `gpt-4o` or `o3`. OpenAI\noffers a wide range of models with different capabilities, performance\ncharacteristics, and price points. Refer to the [model guide](/docs/models)\nto browse and compare available models.\n",
             "$ref": "#/components/schemas/ModelIdsResponses"
-          },
-          "reasoning": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/Reasoning"
-              },
-              {
-                "type": "null"
-              }
-            ]
           },
           "background": {
             "anyOf": [
@@ -4019,17 +4059,64 @@
           },
           "prompt": {
             "$ref": "#/components/schemas/Prompt"
+          }
+        }
+      },
+      "Reasoning": {
+        "type": "object",
+        "description": "**gpt-5 and o-series models only**\n\nConfiguration options for\n[reasoning models](https://platform.openai.com/docs/guides/reasoning).\n",
+        "title": "Reasoning",
+        "properties": {
+          "mode": {
+            "$ref": "#/components/schemas/ReasoningModeEnum",
+            "description": "Controls the reasoning execution mode for the request.\n\nWhen returned on a response, this is the effective execution mode.\n"
           },
-          "truncation": {
+          "effort": {
+            "$ref": "#/components/schemas/ReasoningEffort"
+          },
+          "summary": {
             "anyOf": [
               {
                 "type": "string",
-                "description": "The truncation strategy to use for the model response.\n- `auto`: If the input to this Response exceeds\n  the model's context window size, the model will truncate the\n  response to fit the context window by dropping items from the beginning of the conversation.\n- `disabled` (default): If the input size will exceed the context window\n  size for a model, the request will fail with a 400 error.\n",
+                "description": "A summary of the reasoning performed by the model. This can be\nuseful for debugging and understanding the model's reasoning process.\nOne of `auto`, `concise`, or `detailed`.\n\n`concise` is supported for `computer-use-preview` models and all reasoning models after `gpt-5`.\n",
                 "enum": [
                   "auto",
-                  "disabled"
-                ],
-                "default": "disabled"
+                  "concise",
+                  "detailed"
+                ]
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "context": {
+            "anyOf": [
+              {
+                "type": "string",
+                "description": "Controls which reasoning items are rendered back to the model on later turns.\nIf omitted or set to `auto`, the model determines the context mode. The\n`gpt-5.6` model family defaults to `all_turns`; earlier models default to\n`current_turn`.\n\nWhen returned on a response, this is the effective reasoning context mode\nused for the response.\n",
+                "enum": [
+                  "auto",
+                  "current_turn",
+                  "all_turns"
+                ]
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "generate_summary": {
+            "anyOf": [
+              {
+                "type": "string",
+                "deprecated": true,
+                "description": "**Deprecated:** use `summary` instead.\n\nA summary of the reasoning performed by the model. This can be\nuseful for debugging and understanding the model's reasoning process.\nOne of `auto`, `concise`, or `detailed`.\n",
+                "enum": [
+                  "auto",
+                  "concise",
+                  "detailed"
+                ]
               },
               {
                 "type": "null"
@@ -4069,6 +4156,30 @@
           "message.output_text.logprobs"
         ],
         "description": "Specify additional output data to include in the model response. Currently supported values are:\n- `web_search_call.results`: Include the search results of the web search tool call.\n- `web_search_call.action.sources`: Include the sources of the web search tool call.\n- `code_interpreter_call.outputs`: Includes the outputs of python code execution in code interpreter tool call items.\n- `computer_call_output.output.image_url`: Include image urls from the computer call output.\n- `file_search_call.results`: Include the search results of the file search tool call.\n- `message.input_image.image_url`: Include image urls from the input message.\n- `message.output_text.logprobs`: Include logprobs with assistant messages.\n- `reasoning.encrypted_content`: Includes an encrypted version of reasoning tokens in reasoning item outputs. This enables reasoning items to be used in multi-turn conversations when using the Responses API statelessly (like when the `store` parameter is set to `false`, or when an organization is enrolled in the zero data retention program)."
+      },
+      "ModerationParam": {
+        "properties": {
+          "model": {
+            "type": "string",
+            "description": "The moderation model to use for moderated completions, e.g. 'omni-moderation-latest'."
+          },
+          "policy": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ModerationPolicyParam",
+                "description": "The policy to apply to moderated response input and output."
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        },
+        "type": "object",
+        "required": [
+          "model"
+        ],
+        "description": "Configuration for running moderation on the input and output of this response."
       },
       "ResponseStreamOptions": {
         "anyOf": [
@@ -4182,20 +4293,35 @@
             "description": "This field is being replaced by `safety_identifier` and `prompt_cache_key`. Use `prompt_cache_key` instead to maintain caching optimizations.\nA stable identifier for your end-users.\nUsed to boost cache hit rates by better bucketing similar requests and  to help OpenAI detect and prevent abuse. [Learn more](/docs/guides/safety-best-practices#safety-identifiers).\n"
           },
           "safety_identifier": {
-            "type": "string",
-            "maxLength": 64,
-            "example": "safety-identifier-1234",
-            "description": "A stable identifier used to help detect users of your application that may be violating OpenAI's usage policies.\nThe IDs should be a string that uniquely identifies each user, with a maximum length of 64 characters. We recommend hashing their username or email address, in order to avoid sending us any identifying information. [Learn more](/docs/guides/safety-best-practices#safety-identifiers).\n"
+            "anyOf": [
+              {
+                "type": "string",
+                "maxLength": 64,
+                "example": "safety-identifier-1234",
+                "description": "A stable identifier used to help detect users of your application that may be violating OpenAI's usage policies.\nThe IDs should be a string that uniquely identifies each user, with a maximum length of 64 characters. We recommend hashing their username or email address, in order to avoid sending us any identifying information. [Learn more](/docs/guides/safety-best-practices#safety-identifiers).\n"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "prompt_cache_key": {
-            "type": "string",
-            "example": "prompt-cache-key-1234",
-            "description": "Used by OpenAI to cache responses for similar requests to optimize your cache hit rates. Replaces the `user` field. [Learn more](/docs/guides/prompt-caching).\n"
+            "anyOf": [
+              {
+                "type": "string",
+                "example": "prompt-cache-key-1234",
+                "description": "Used by OpenAI to cache responses for similar requests to optimize your cache hit rates. Replaces the `user` field. [Learn more](/docs/guides/prompt-caching).\n"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "service_tier": {
             "$ref": "#/components/schemas/ServiceTier"
           },
           "prompt_cache_retention": {
+            "deprecated": true,
             "anyOf": [
               {
                 "type": "string",
@@ -4203,7 +4329,7 @@
                   "in_memory",
                   "24h"
                 ],
-                "description": "The retention policy for the prompt cache. Set to `24h` to enable extended prompt caching, which keeps cached prefixes active for longer, up to a maximum of 24 hours. [Learn more](/docs/guides/prompt-caching#prompt-cache-retention).\n"
+                "description": "Deprecated. Use `prompt_cache_options.ttl` instead.\n\nThe retention policy for the prompt cache. Set to `24h` to enable extended prompt caching, which keeps cached prefixes active for longer, up to a maximum of 24 hours. [Learn more](/docs/guides/prompt-caching#prompt-cache-retention).\nThis field expresses a maximum retention policy, while\n`prompt_cache_options.ttl` expresses a minimum cache lifetime. The two\nfields are independent and do not interact.\nFor `gpt-5.5`, `gpt-5.5-pro`, and future models, only `24h` is supported.\n\nFor older models that support both `in_memory` and `24h`, the default depends on your organization's data retention policy:\n  - Organizations without ZDR enabled default to `24h`.\n  - Organizations with ZDR enabled default to `in_memory` when `prompt_cache_retention` is not specified.\n"
               },
               {
                 "type": "null"
@@ -4263,10 +4389,19 @@
             "$ref": "#/components/schemas/ReasoningItem"
           },
           {
+            "$ref": "#/components/schemas/Program"
+          },
+          {
+            "$ref": "#/components/schemas/ProgramOutput"
+          },
+          {
             "$ref": "#/components/schemas/ToolSearchCall"
           },
           {
             "$ref": "#/components/schemas/ToolSearchOutput"
+          },
+          {
+            "$ref": "#/components/schemas/AdditionalTools"
           },
           {
             "$ref": "#/components/schemas/CompactionBody"
@@ -4330,7 +4465,16 @@
             "$ref": "#/components/schemas/Item"
           },
           {
+            "$ref": "#/components/schemas/CompactionTriggerItemParam"
+          },
+          {
             "$ref": "#/components/schemas/ItemReferenceParam"
+          },
+          {
+            "$ref": "#/components/schemas/ProgramItemParam"
+          },
+          {
+            "$ref": "#/components/schemas/ProgramOutputItemParam"
           }
         ],
         "discriminator": {
@@ -4352,10 +4496,15 @@
               "cached_tokens": {
                 "type": "integer",
                 "description": "The number of tokens that were retrieved from the cache. \n[More on prompt caching](/docs/guides/prompt-caching).\n"
+              },
+              "cache_write_tokens": {
+                "type": "integer",
+                "description": "The number of input tokens that were written to the cache."
               }
             },
             "required": [
-              "cached_tokens"
+              "cached_tokens",
+              "cache_write_tokens"
             ]
           },
           "output_tokens": {
@@ -4388,7 +4537,65 @@
           "total_tokens"
         ]
       },
-      "Conversation-2": {
+      "PromptCacheOptions": {
+        "properties": {
+          "ttl": {
+            "$ref": "#/components/schemas/PromptCacheTTLEnum",
+            "description": "The minimum lifetime applied to each cache breakpoint."
+          },
+          "mode": {
+            "$ref": "#/components/schemas/PromptCacheModeEnum",
+            "description": "Whether implicit prompt-cache breakpoints were enabled."
+          }
+        },
+        "type": "object",
+        "required": [
+          "ttl",
+          "mode"
+        ],
+        "title": "Prompt cache options",
+        "description": "The prompt-caching options that were applied to the response. Supported for `gpt-5.6` and later models."
+      },
+      "Moderation": {
+        "properties": {
+          "input": {
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/ModerationResultBody"
+              },
+              {
+                "$ref": "#/components/schemas/ModerationErrorBody"
+              }
+            ],
+            "description": "Moderation for the response input.",
+            "discriminator": {
+              "propertyName": "type"
+            }
+          },
+          "output": {
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/ModerationResultBody"
+              },
+              {
+                "$ref": "#/components/schemas/ModerationErrorBody"
+              }
+            ],
+            "description": "Moderation for the response output.",
+            "discriminator": {
+              "propertyName": "type"
+            }
+          }
+        },
+        "type": "object",
+        "required": [
+          "input",
+          "output"
+        ],
+        "title": "Moderation",
+        "description": "Moderation results or errors for the response input and output."
+      },
+      "ResponseConversation": {
         "properties": {
           "id": {
             "type": "string",
@@ -5264,6 +5471,13 @@
           "summary_index": {
             "type": "integer",
             "description": "The index of the summary part within the reasoning summary.\n"
+          },
+          "status": {
+            "type": "string",
+            "description": "The completion status of the summary part. Omitted when the part completed\nnormally and set to `incomplete` when generation was interrupted.\n",
+            "enum": [
+              "incomplete"
+            ]
           },
           "sequence_number": {
             "type": "integer",
@@ -6351,6 +6565,10 @@
           {
             "type": "string",
             "enum": [
+              "gpt-5.6-sol",
+              "gpt-5.6-terra",
+              "gpt-5.6-luna",
+              "gpt-5.5",
               "gpt-5.4",
               "gpt-5.4-mini",
               "gpt-5.4-nano",
@@ -6461,7 +6679,7 @@
               "high"
             ],
             "default": "medium",
-            "description": "Constrains the verbosity of the model's response. Lower values will result in\nmore concise responses, while higher values will result in more verbose responses.\nCurrently supported values are `low`, `medium`, and `high`.\n"
+            "description": "Constrains the verbosity of the model's response. Lower values will result in\nmore concise responses, while higher values will result in more verbose responses.\nCurrently supported values are `low`, `medium`, and `high`. The default is\n`medium`.\n"
           },
           {
             "type": "null"
@@ -6478,10 +6696,11 @@
               "low",
               "medium",
               "high",
-              "xhigh"
+              "xhigh",
+              "max"
             ],
             "default": "medium",
-            "description": "Constrains effort on reasoning for\n[reasoning models](https://platform.openai.com/docs/guides/reasoning).\nCurrently supported values are `none`, `minimal`, `low`, `medium`, `high`, and `xhigh`. Reducing\nreasoning effort can result in faster responses and fewer tokens used\non reasoning in a response.\n\n- `gpt-5.1` defaults to `none`, which does not perform reasoning. The supported reasoning values for `gpt-5.1` are `none`, `low`, `medium`, and `high`. Tool calls are supported for all reasoning values in gpt-5.1.\n- All models before `gpt-5.1` default to `medium` reasoning effort, and do not support `none`.\n- The `gpt-5-pro` model defaults to (and only supports) `high` reasoning effort.\n- `xhigh` is supported for all models after `gpt-5.1-codex-max`.\n"
+            "description": "Constrains effort on reasoning for reasoning models. Currently supported\nvalues are `none`, `minimal`, `low`, `medium`, `high`, `xhigh`, and `max`.\nReducing reasoning effort can result in faster responses and fewer tokens\nused on reasoning in a response. Not all reasoning models support every\nvalue. See the\n[reasoning guide](https://platform.openai.com/docs/guides/reasoning)\nfor model-specific support.\n"
           },
           {
             "type": "null"
@@ -7126,13 +7345,14 @@
         "anyOf": [
           {
             "type": "string",
-            "description": "Specifies the processing type used for serving the request.\n  - If set to 'auto', then the request will be processed with the service tier configured in the Project settings. Unless otherwise configured, the Project will use 'default'.\n  - If set to 'default', then the request will be processed with the standard pricing and performance for the selected model.\n  - If set to '[flex](/docs/guides/flex-processing)' or '[priority](https://openai.com/api-priority-processing/)', then the request will be processed with the corresponding service tier.\n  - When not set, the default behavior is 'auto'.\n\n  When the `service_tier` parameter is set, the response body will include the `service_tier` value based on the processing mode actually used to serve the request. This response value may be different from the value set in the parameter.\n",
+            "description": "Specifies the processing type used for serving the request.\n  - If set to 'auto', then the request will be processed with the service tier configured in the Project settings. Unless otherwise configured, the Project will use 'default'.\n  - If set to 'default', then the request will be processed with the standard pricing and performance for the selected model.\n  - If set to '[flex](/docs/guides/flex-processing)', then the request will be processed with the Flex Processing service tier.\n  - To opt-in to [Fast mode](/api/docs/guides/fast-mode) at the request level, include the `service_tier=fast` or `service_tier=priority` parameter for Responses or Chat Completions. The response will show `service_tier=priority` regardless of if you specify `service_tier=fast` or `priority` in your request.\n  - When not set, the default behavior is 'auto'.\n\n  When the `service_tier` parameter is set, the response body will include the `service_tier` value based on the processing mode actually used to serve the request. This response value may be different from the value set in the parameter.\n",
             "enum": [
               "auto",
               "default",
               "flex",
               "scale",
-              "priority"
+              "priority",
+              "fast"
             ],
             "default": "auto"
           },
@@ -7199,6 +7419,11 @@
                 "type": "integer",
                 "default": 0,
                 "description": "Cached tokens present in the prompt."
+              },
+              "cache_write_tokens": {
+                "type": "integer",
+                "default": 0,
+                "description": "The unadjusted number of prompt tokens written to cache."
               }
             }
           }
@@ -7207,6 +7432,44 @@
           "prompt_tokens",
           "completion_tokens",
           "total_tokens"
+        ]
+      },
+      "ChatCompletionModeration": {
+        "type": "object",
+        "description": "Moderation results or errors for the request input and generated output.",
+        "properties": {
+          "input": {
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/ChatCompletionModerationResults"
+              },
+              {
+                "$ref": "#/components/schemas/ChatCompletionModerationError"
+              }
+            ],
+            "discriminator": {
+              "propertyName": "type"
+            },
+            "description": "Moderation for the request input."
+          },
+          "output": {
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/ChatCompletionModerationResults"
+              },
+              {
+                "$ref": "#/components/schemas/ChatCompletionModerationError"
+              }
+            ],
+            "discriminator": {
+              "propertyName": "type"
+            },
+            "description": "Moderation for the generated output."
+          }
+        },
+        "required": [
+          "input",
+          "output"
         ]
       },
       "ChatCompletionStreamResponseDelta": {
@@ -7822,6 +8085,19 @@
           }
         }
       },
+      "TranscriptionLanguage": {
+        "type": "object",
+        "description": "A language detected in transcribed audio.",
+        "properties": {
+          "code": {
+            "type": "string",
+            "description": "The code of a language detected in the audio."
+          }
+        },
+        "required": [
+          "code"
+        ]
+      },
       "TranscriptTextUsageTokens": {
         "type": "object",
         "title": "Token Usage",
@@ -8137,6 +8413,13 @@
             "type": "string",
             "description": "The text that was transcribed.\n"
           },
+          "languages": {
+            "type": "array",
+            "description": "The languages detected in the audio. Returned by `gpt-transcribe`. An empty array indicates that no language could be reliably detected.\n",
+            "items": {
+              "$ref": "#/components/schemas/TranscriptionLanguage"
+            }
+          },
           "logprobs": {
             "type": "array",
             "description": "The log probabilities of the individual tokens in the transcription. Only included if you [create a transcription](/docs/api-reference/audio/create-transcription) with the `include[]` parameter set to `logprobs`.\n",
@@ -8248,6 +8531,121 @@
         "title": "Error",
         "description": "An error that occurred while generating the response."
       },
+      "Metadata": {
+        "anyOf": [
+          {
+            "type": "object",
+            "description": "Set of 16 key-value pairs that can be attached to an object. This can be\nuseful for storing additional information about the object in a structured\nformat, and querying for objects via API or the dashboard.\n\nKeys are strings with a maximum length of 64 characters. Values are strings\nwith a maximum length of 512 characters.\n",
+            "additionalProperties": {
+              "type": "string"
+            },
+            "x-oaiTypeLabel": "map"
+          },
+          {
+            "type": "null"
+          }
+        ]
+      },
+      "BatchFileExpirationAfter": {
+        "type": "object",
+        "title": "File expiration policy",
+        "description": "The expiration policy for the output and/or error file that are generated for a batch.",
+        "properties": {
+          "anchor": {
+            "description": "Anchor timestamp after which the expiration policy applies. Supported anchors: `created_at`. Note that the anchor is the file creation time, not the time the batch is created.",
+            "type": "string",
+            "enum": [
+              "created_at"
+            ],
+            "x-stainless-const": true
+          },
+          "seconds": {
+            "description": "The number of seconds after the anchor time that the file will expire. Must be between 3600 (1 hour) and 2592000 (30 days).",
+            "type": "integer",
+            "format": "int64",
+            "minimum": 3600,
+            "maximum": 2592000
+          }
+        },
+        "required": [
+          "anchor",
+          "seconds"
+        ]
+      },
+      "BatchError": {
+        "type": "object",
+        "properties": {
+          "code": {
+            "type": "string",
+            "description": "An error code identifying the error type."
+          },
+          "message": {
+            "type": "string",
+            "description": "A human-readable message providing more details about the error."
+          },
+          "param": {
+            "anyOf": [
+              {
+                "type": "string",
+                "description": "The name of the parameter that caused the error, if applicable."
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "line": {
+            "anyOf": [
+              {
+                "type": "integer",
+                "description": "The line number of the input file where the error occurred, if applicable."
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        }
+      },
+      "BatchRequestCounts": {
+        "type": "object",
+        "properties": {
+          "total": {
+            "type": "integer",
+            "description": "Total number of requests in the batch."
+          },
+          "completed": {
+            "type": "integer",
+            "description": "Number of requests that have been completed successfully."
+          },
+          "failed": {
+            "type": "integer",
+            "description": "Number of requests that have failed."
+          }
+        },
+        "required": [
+          "total",
+          "completed",
+          "failed"
+        ],
+        "description": "The request counts for different statuses within the batch."
+      },
+      "PromptCacheOptionsParam": {
+        "properties": {
+          "ttl": {
+            "$ref": "#/components/schemas/PromptCacheTTLEnum",
+            "description": "The minimum lifetime applied to every implicit and explicit cache breakpoint written by the request. Defaults to `30m`, which is currently the only supported value. The backend may retain cache entries for longer."
+          },
+          "mode": {
+            "$ref": "#/components/schemas/PromptCacheModeEnum",
+            "description": "Controls whether OpenAI automatically creates an implicit cache breakpoint. Defaults to `implicit`. With `implicit`, OpenAI creates one implicit breakpoint and writes up to the latest three explicit breakpoints in the request. With `explicit`, OpenAI does not create an implicit breakpoint and writes up to the latest four explicit breakpoints. If there are no explicit breakpoints, the request does not use prompt caching."
+          }
+        },
+        "type": "object",
+        "required": [],
+        "title": "Prompt cache options",
+        "description": "Options for prompt caching. Supported for `gpt-5.6` and later models. By default, OpenAI automatically chooses one implicit cache breakpoint. You can add explicit breakpoints to content blocks with `prompt_cache_breakpoint`. Each request can write up to four breakpoints. For cache matching, OpenAI considers up to the latest 80 breakpoints in the conversation, without a content-block lookback limit. Set `mode` to `explicit` to disable the implicit breakpoint. The `ttl` defaults to `30m`, which is currently the only supported value. See the [prompt caching guide](/docs/guides/prompt-caching) for current details."
+      },
       "ModelIdsResponses": {
         "example": "gpt-5.1",
         "anyOf": [
@@ -8275,49 +8673,6 @@
             ]
           }
         ]
-      },
-      "Reasoning": {
-        "type": "object",
-        "description": "**gpt-5 and o-series models only**\n\nConfiguration options for\n[reasoning models](https://platform.openai.com/docs/guides/reasoning).\n",
-        "title": "Reasoning",
-        "properties": {
-          "effort": {
-            "$ref": "#/components/schemas/ReasoningEffort"
-          },
-          "summary": {
-            "anyOf": [
-              {
-                "type": "string",
-                "description": "A summary of the reasoning performed by the model. This can be\nuseful for debugging and understanding the model's reasoning process.\nOne of `auto`, `concise`, or `detailed`.\n\n`concise` is supported for `computer-use-preview` models and all reasoning models after `gpt-5`.\n",
-                "enum": [
-                  "auto",
-                  "concise",
-                  "detailed"
-                ]
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "generate_summary": {
-            "anyOf": [
-              {
-                "type": "string",
-                "deprecated": true,
-                "description": "**Deprecated:** use `summary` instead.\n\nA summary of the reasoning performed by the model. This can be\nuseful for debugging and understanding the model's reasoning process.\nOne of `auto`, `concise`, or `detailed`.\n",
-                "enum": [
-                  "auto",
-                  "concise",
-                  "detailed"
-                ]
-              },
-              {
-                "type": "null"
-              }
-            ]
-          }
-        }
       },
       "ResponseTextParam": {
         "type": "object",
@@ -8358,6 +8713,9 @@
           },
           {
             "$ref": "#/components/schemas/ToolChoiceCustom"
+          },
+          {
+            "$ref": "#/components/schemas/SpecificProgrammaticToolCallingParam"
           },
           {
             "$ref": "#/components/schemas/SpecificApplyPatchParam"
@@ -8401,6 +8759,49 @@
           }
         ]
       },
+      "ReasoningModeEnum": {
+        "anyOf": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "string",
+            "enum": [
+              "standard",
+              "pro"
+            ]
+          }
+        ]
+      },
+      "ModerationPolicyParam": {
+        "properties": {
+          "input": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ModerationConfigParam",
+                "description": "The moderation policy for the response input."
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "output": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ModerationConfigParam",
+                "description": "The moderation policy for the response output."
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        },
+        "type": "object",
+        "required": [],
+        "description": "The policy to apply to moderated response input and output."
+      },
       "ConversationParam-2": {
         "properties": {
           "id": {
@@ -8423,6 +8824,8 @@
           "server_error",
           "rate_limit_exceeded",
           "invalid_prompt",
+          "data_residency_mismatch",
+          "bio_policy",
           "vector_store_timeout",
           "invalid_image",
           "invalid_image_format",
@@ -8599,6 +9002,16 @@
           "call_id": {
             "type": "string",
             "description": "The unique ID of the function tool call generated by the model.\n"
+          },
+          "caller": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ToolCallCaller"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "namespace": {
             "type": "string",
@@ -8811,7 +9224,7 @@
             "anyOf": [
               {
                 "type": "string",
-                "description": "The encrypted content of the reasoning item - populated when a response is\ngenerated with `reasoning.encrypted_content` in the `include` parameter.\n"
+                "description": "The encrypted content of the reasoning item. This is populated by default\nfor reasoning items returned by `POST /v1/responses` and WebSocket\n`response.create` requests.\n"
               },
               {
                 "type": "null"
@@ -8846,6 +9259,80 @@
           "id",
           "summary",
           "type"
+        ]
+      },
+      "Program": {
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "program"
+            ],
+            "description": "The type of the item. Always `program`.",
+            "default": "program",
+            "x-stainless-const": true
+          },
+          "id": {
+            "type": "string",
+            "description": "The unique ID of the program item."
+          },
+          "call_id": {
+            "type": "string",
+            "description": "The stable call ID of the program item."
+          },
+          "code": {
+            "type": "string",
+            "description": "The JavaScript source executed by programmatic tool calling."
+          },
+          "fingerprint": {
+            "type": "string",
+            "description": "Opaque program replay fingerprint that must be round-tripped."
+          }
+        },
+        "type": "object",
+        "required": [
+          "type",
+          "id",
+          "call_id",
+          "code",
+          "fingerprint"
+        ]
+      },
+      "ProgramOutput": {
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "program_output"
+            ],
+            "description": "The type of the item. Always `program_output`.",
+            "default": "program_output",
+            "x-stainless-const": true
+          },
+          "id": {
+            "type": "string",
+            "description": "The unique ID of the program output item."
+          },
+          "call_id": {
+            "type": "string",
+            "description": "The call ID of the program item."
+          },
+          "result": {
+            "type": "string",
+            "description": "The result produced by the program item."
+          },
+          "status": {
+            "$ref": "#/components/schemas/ProgramOutputStatus",
+            "description": "The terminal status of the program output item."
+          }
+        },
+        "type": "object",
+        "required": [
+          "type",
+          "id",
+          "call_id",
+          "result",
+          "status"
         ]
       },
       "ToolSearchCall": {
@@ -8954,6 +9441,41 @@
           "execution",
           "tools",
           "status"
+        ]
+      },
+      "AdditionalTools": {
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "additional_tools"
+            ],
+            "description": "The type of the item. Always `additional_tools`.",
+            "default": "additional_tools",
+            "x-stainless-const": true
+          },
+          "id": {
+            "type": "string",
+            "description": "The unique ID of the additional tools item."
+          },
+          "role": {
+            "$ref": "#/components/schemas/MessageRole",
+            "description": "The role that provided the additional tools."
+          },
+          "tools": {
+            "items": {
+              "$ref": "#/components/schemas/Tool"
+            },
+            "type": "array",
+            "description": "The additional tool definitions made available at this item."
+          }
+        },
+        "type": "object",
+        "required": [
+          "type",
+          "id",
+          "role",
+          "tools"
         ]
       },
       "CompactionBody": {
@@ -9222,6 +9744,17 @@
             "type": "string",
             "description": "The unique ID of the shell tool call generated by the model."
           },
+          "caller": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ToolCallCaller",
+                "description": "The execution context that produced this tool call."
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "action": {
             "$ref": "#/components/schemas/FunctionShellAction",
             "description": "The shell commands and limits that describe how to run the tool call."
@@ -9286,6 +9819,17 @@
             "type": "string",
             "description": "The unique ID of the shell tool call generated by the model."
           },
+          "caller": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ToolCallCaller",
+                "description": "The execution context that produced this tool call."
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "status": {
             "$ref": "#/components/schemas/FunctionShellCallOutputStatusEnum",
             "description": "The status of the shell call output. One of `in_progress`, `completed`, or `incomplete`."
@@ -9344,6 +9888,17 @@
             "type": "string",
             "description": "The unique ID of the apply patch tool call generated by the model."
           },
+          "caller": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ToolCallCaller",
+                "description": "The execution context that produced this tool call."
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "status": {
             "$ref": "#/components/schemas/ApplyPatchCallStatus",
             "description": "The status of the apply patch tool call. One of `in_progress` or `completed`."
@@ -9400,6 +9955,17 @@
           "call_id": {
             "type": "string",
             "description": "The unique ID of the apply patch tool call generated by the model."
+          },
+          "caller": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ToolCallCaller",
+                "description": "The execution context that produced this tool call."
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "status": {
             "$ref": "#/components/schemas/ApplyPatchCallOutputStatus",
@@ -9657,6 +10223,16 @@
             "type": "string",
             "description": "An identifier used to map this custom tool call to a tool call output.\n"
           },
+          "caller": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ToolCallCaller"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "namespace": {
             "type": "string",
             "description": "The namespace of the custom tool being called.\n"
@@ -9793,6 +10369,9 @@
             "$ref": "#/components/schemas/ToolSearchOutputItemParam"
           },
           {
+            "$ref": "#/components/schemas/AdditionalToolsItemParam"
+          },
+          {
             "$ref": "#/components/schemas/ReasoningItem"
           },
           {
@@ -9845,6 +10424,25 @@
           "propertyName": "type"
         }
       },
+      "CompactionTriggerItemParam": {
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "compaction_trigger"
+            ],
+            "description": "The type of the item. Always `compaction_trigger`.",
+            "default": "compaction_trigger",
+            "x-stainless-const": true
+          }
+        },
+        "type": "object",
+        "required": [
+          "type"
+        ],
+        "title": "Compaction trigger",
+        "description": "Compacts the current context. Must be the final input item."
+      },
       "ItemReferenceParam": {
         "properties": {
           "type": {
@@ -9874,6 +10472,190 @@
         ],
         "title": "Item reference",
         "description": "An internal identifier for an item to reference."
+      },
+      "ProgramItemParam": {
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "The unique ID of this program item.",
+            "example": "cm_123"
+          },
+          "type": {
+            "type": "string",
+            "enum": [
+              "program"
+            ],
+            "description": "The item type. Always `program`.",
+            "default": "program",
+            "x-stainless-const": true
+          },
+          "call_id": {
+            "type": "string",
+            "maxLength": 64,
+            "minLength": 1,
+            "description": "The stable call ID of the program item."
+          },
+          "code": {
+            "type": "string",
+            "maxLength": 10485760,
+            "description": "The JavaScript source executed by programmatic tool calling."
+          },
+          "fingerprint": {
+            "type": "string",
+            "maxLength": 10485760,
+            "description": "Opaque program replay fingerprint that must be round-tripped."
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "type",
+          "call_id",
+          "code",
+          "fingerprint"
+        ]
+      },
+      "ProgramOutputItemParam": {
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "The unique ID of this program output item.",
+            "example": "cmo_123"
+          },
+          "type": {
+            "type": "string",
+            "enum": [
+              "program_output"
+            ],
+            "description": "The item type. Always `program_output`.",
+            "default": "program_output",
+            "x-stainless-const": true
+          },
+          "call_id": {
+            "type": "string",
+            "maxLength": 64,
+            "minLength": 1,
+            "description": "The call ID of the program item."
+          },
+          "result": {
+            "type": "string",
+            "maxLength": 10485760,
+            "description": "The result produced by the program item."
+          },
+          "status": {
+            "$ref": "#/components/schemas/ProgramOutputItemStatus",
+            "description": "The terminal status of the program output."
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "type",
+          "call_id",
+          "result",
+          "status"
+        ]
+      },
+      "PromptCacheTTLEnum": {
+        "type": "string",
+        "enum": [
+          "30m"
+        ]
+      },
+      "PromptCacheModeEnum": {
+        "type": "string",
+        "enum": [
+          "implicit",
+          "explicit"
+        ]
+      },
+      "ModerationResultBody": {
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "moderation_result"
+            ],
+            "description": "The object type, which was always `moderation_result` for successful moderation results.",
+            "default": "moderation_result",
+            "x-stainless-const": true
+          },
+          "model": {
+            "type": "string",
+            "description": "The moderation model that produced this result."
+          },
+          "flagged": {
+            "type": "boolean",
+            "description": "A boolean indicating whether the content was flagged by any category."
+          },
+          "categories": {
+            "additionalProperties": {
+              "type": "boolean"
+            },
+            "type": "object",
+            "description": "A dictionary of moderation categories to booleans, True if the input is flagged under this category.",
+            "x-oaiTypeLabel": "map"
+          },
+          "category_scores": {
+            "additionalProperties": {
+              "type": "number"
+            },
+            "type": "object",
+            "description": "A dictionary of moderation categories to scores.",
+            "x-oaiTypeLabel": "map"
+          },
+          "category_applied_input_types": {
+            "additionalProperties": {
+              "items": {
+                "$ref": "#/components/schemas/ModerationInputType"
+              },
+              "type": "array"
+            },
+            "type": "object",
+            "description": "Which modalities of input are reflected by the score for each category.",
+            "x-oaiTypeLabel": "map"
+          }
+        },
+        "type": "object",
+        "required": [
+          "type",
+          "model",
+          "flagged",
+          "categories",
+          "category_scores",
+          "category_applied_input_types"
+        ],
+        "title": "Moderation result",
+        "description": "A moderation result produced for the response input or output."
+      },
+      "ModerationErrorBody": {
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "error"
+            ],
+            "description": "The object type, which was always `error` for moderation failures.",
+            "default": "error",
+            "x-stainless-const": true
+          },
+          "code": {
+            "type": "string",
+            "description": "The error code."
+          },
+          "message": {
+            "type": "string",
+            "description": "The error message."
+          }
+        },
+        "type": "object",
+        "required": [
+          "type",
+          "code",
+          "message"
+        ],
+        "title": "Moderation error",
+        "description": "An error produced while attempting moderation for the response input or output."
       },
       "OutputContent": {
         "oneOf": [
@@ -10282,6 +11064,9 @@
           "text": {
             "type": "string",
             "description": "The text content."
+          },
+          "prompt_cache_breakpoint": {
+            "$ref": "#/components/schemas/PromptCacheBreakpointParam"
           }
         },
         "required": [
@@ -10425,6 +11210,63 @@
             "propertyName": "type"
           }
         }
+      },
+      "ChatCompletionModerationResults": {
+        "type": "object",
+        "description": "Successful moderation results for the request input or generated output.",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "moderation_results"
+            ],
+            "description": "The object type, which is always `moderation_results`.",
+            "x-stainless-const": true
+          },
+          "model": {
+            "type": "string",
+            "description": "The moderation model used to generate the results."
+          },
+          "results": {
+            "type": "array",
+            "description": "A list of moderation results.",
+            "items": {
+              "$ref": "#/components/schemas/ModerationResultBody"
+            }
+          }
+        },
+        "required": [
+          "type",
+          "model",
+          "results"
+        ]
+      },
+      "ChatCompletionModerationError": {
+        "type": "object",
+        "description": "An error produced while attempting moderation.",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "error"
+            ],
+            "description": "The object type, which is always `error`.",
+            "x-stainless-const": true
+          },
+          "code": {
+            "type": "string",
+            "description": "The error code."
+          },
+          "message": {
+            "type": "string",
+            "description": "The error message."
+          }
+        },
+        "required": [
+          "type",
+          "code",
+          "message"
+        ]
       },
       "ChatCompletionMessageToolCallChunk": {
         "type": "object",
@@ -10582,6 +11424,9 @@
           },
           {
             "$ref": "#/components/schemas/CodeInterpreterTool"
+          },
+          {
+            "$ref": "#/components/schemas/ProgrammaticToolCallingParam"
           },
           {
             "$ref": "#/components/schemas/ImageGenTool"
@@ -10761,6 +11606,23 @@
           "name"
         ]
       },
+      "SpecificProgrammaticToolCallingParam": {
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "programmatic_tool_calling"
+            ],
+            "description": "The tool to call. Always `programmatic_tool_calling`.",
+            "default": "programmatic_tool_calling",
+            "x-stainless-const": true
+          }
+        },
+        "type": "object",
+        "required": [
+          "type"
+        ]
+      },
       "SpecificApplyPatchParam": {
         "properties": {
           "type": {
@@ -10831,6 +11693,18 @@
           }
         ]
       },
+      "ModerationConfigParam": {
+        "properties": {
+          "mode": {
+            "$ref": "#/components/schemas/ModerationMode"
+          }
+        },
+        "type": "object",
+        "required": [
+          "mode"
+        ],
+        "description": "The moderation policy for the response input."
+      },
       "OutputMessageContent": {
         "oneOf": [
           {
@@ -10883,6 +11757,20 @@
           }
         ]
       },
+      "ToolCallCaller": {
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/DirectToolCallCaller"
+          },
+          {
+            "$ref": "#/components/schemas/ProgramToolCallCaller"
+          }
+        ],
+        "description": "The execution context that produced this tool call.",
+        "discriminator": {
+          "propertyName": "type"
+        }
+      },
       "FunctionToolCallOutput": {
         "type": "object",
         "title": "Function tool call output",
@@ -10903,6 +11791,24 @@
           "call_id": {
             "type": "string",
             "description": "The unique ID of the function tool call generated by the model.\n"
+          },
+          "name": {
+            "type": "string",
+            "description": "The name of the tool that produced the output.\n"
+          },
+          "namespace": {
+            "type": "string",
+            "description": "The namespace of the tool that produced the output.\n"
+          },
+          "caller": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ToolCallCallerParam"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "output": {
             "description": "The output from the function call generated by your code.\nCan be a string or an list of output content.\n",
@@ -10961,7 +11867,8 @@
           },
           "query": {
             "type": "string",
-            "description": "[DEPRECATED] The search query.\n"
+            "deprecated": true,
+            "description": "The search query.\n"
           },
           "queries": {
             "type": "array",
@@ -11003,8 +11910,7 @@
           }
         },
         "required": [
-          "type",
-          "query"
+          "type"
         ]
       },
       "WebSearchActionOpenPage": {
@@ -11247,6 +12153,13 @@
         "title": "Reasoning text",
         "description": "Reasoning text from the model."
       },
+      "ProgramOutputStatus": {
+        "type": "string",
+        "enum": [
+          "completed",
+          "incomplete"
+        ]
+      },
       "ToolSearchExecutionType": {
         "type": "string",
         "enum": [
@@ -11260,6 +12173,19 @@
           "in_progress",
           "completed",
           "incomplete"
+        ]
+      },
+      "MessageRole": {
+        "type": "string",
+        "enum": [
+          "unknown",
+          "user",
+          "assistant",
+          "system",
+          "critic",
+          "discriminator",
+          "developer",
+          "tool"
         ]
       },
       "CodeInterpreterOutputLogs": {
@@ -11686,6 +12612,16 @@
             "type": "string",
             "description": "The call ID, used to map this custom tool call output to a custom tool call.\n"
           },
+          "caller": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ToolCallCallerParam"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "output": {
             "description": "The output from the custom tool call generated by your code.\nCan be a string or an list of output content.\n",
             "oneOf": [
@@ -11886,6 +12822,44 @@
             ],
             "description": "Text, image, or file output of the function tool call."
           },
+          "name": {
+            "anyOf": [
+              {
+                "type": "string",
+                "maxLength": 128,
+                "minLength": 1,
+                "description": "The name of the tool that produced the output."
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "namespace": {
+            "anyOf": [
+              {
+                "type": "string",
+                "maxLength": 64,
+                "minLength": 1,
+                "pattern": "^[a-zA-Z0-9_-]+$",
+                "description": "The namespace of the tool that produced the output."
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "caller": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ToolCallCallerParam",
+                "description": "The execution context that produced this tool call."
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "status": {
             "anyOf": [
               {
@@ -12034,6 +13008,53 @@
           "tools"
         ]
       },
+      "AdditionalToolsItemParam": {
+        "properties": {
+          "id": {
+            "anyOf": [
+              {
+                "type": "string",
+                "description": "The unique ID of this additional tools item.",
+                "example": "at_123"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "type": {
+            "type": "string",
+            "enum": [
+              "additional_tools"
+            ],
+            "description": "The item type. Always `additional_tools`.",
+            "default": "additional_tools",
+            "x-stainless-const": true
+          },
+          "role": {
+            "type": "string",
+            "enum": [
+              "developer"
+            ],
+            "description": "The role that provided the additional tools. Only `developer` is supported.",
+            "default": "developer",
+            "x-stainless-const": true
+          },
+          "tools": {
+            "items": {
+              "$ref": "#/components/schemas/Tool"
+            },
+            "type": "array",
+            "description": "A list of additional tools made available at this item."
+          }
+        },
+        "type": "object",
+        "required": [
+          "type",
+          "role",
+          "tools"
+        ]
+      },
       "CompactionSummaryItemParam": {
         "properties": {
           "id": {
@@ -12090,6 +13111,17 @@
             "maxLength": 64,
             "minLength": 1,
             "description": "The unique ID of the shell tool call generated by the model."
+          },
+          "caller": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ToolCallCallerParam",
+                "description": "The execution context that produced this tool call."
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "type": {
             "type": "string",
@@ -12165,6 +13197,17 @@
             "maxLength": 64,
             "minLength": 1,
             "description": "The unique ID of the shell tool call generated by the model."
+          },
+          "caller": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ToolCallCallerParam",
+                "description": "The execution context that produced this tool call."
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "type": {
             "type": "string",
@@ -12243,6 +13286,17 @@
             "minLength": 1,
             "description": "The unique ID of the apply patch tool call generated by the model."
           },
+          "caller": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ToolCallCallerParam",
+                "description": "The execution context that produced this tool call."
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "status": {
             "$ref": "#/components/schemas/ApplyPatchCallStatusParam",
             "description": "The status of the apply patch tool call. One of `in_progress` or `completed`."
@@ -12290,6 +13344,17 @@
             "maxLength": 64,
             "minLength": 1,
             "description": "The unique ID of the apply patch tool call generated by the model."
+          },
+          "caller": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ToolCallCallerParam",
+                "description": "The execution context that produced this tool call."
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "status": {
             "$ref": "#/components/schemas/ApplyPatchCallOutputStatusParam",
@@ -12366,6 +13431,20 @@
           "request_id",
           "approve",
           "approval_request_id"
+        ]
+      },
+      "ProgramOutputItemStatus": {
+        "type": "string",
+        "enum": [
+          "completed",
+          "incomplete"
+        ]
+      },
+      "ModerationInputType": {
+        "type": "string",
+        "enum": [
+          "text",
+          "image"
         ]
       },
       "OutputTextContent": {
@@ -12473,6 +13552,25 @@
             "$ref": "#/components/schemas/ChatCompletionRequestMessageContentPartText"
           }
         ]
+      },
+      "PromptCacheBreakpointParam": {
+        "properties": {
+          "mode": {
+            "type": "string",
+            "enum": [
+              "explicit"
+            ],
+            "description": "The breakpoint mode. Always `explicit`.",
+            "default": "explicit",
+            "x-stainless-const": true
+          }
+        },
+        "type": "object",
+        "required": [
+          "mode"
+        ],
+        "title": "Prompt cache breakpoint",
+        "description": "Marks the exact end of a reusable prompt prefix. The breakpoint inherits its TTL from the request's `prompt_cache_options.ttl`; the boundary is not rounded to a token block."
       },
       "ChatCompletionAllowedTools": {
         "type": "object",
@@ -12669,11 +13767,24 @@
               }
             ]
           },
+          "output_schema": {
+            "anyOf": [
+              {
+                "additionalProperties": {},
+                "type": "object",
+                "description": "A JSON schema object describing the JSON value encoded in string outputs for this function.",
+                "x-oaiTypeLabel": "map"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "strict": {
             "anyOf": [
               {
                 "type": "boolean",
-                "description": "Whether to enforce strict parameter validation. Default `true`."
+                "description": "Whether strict parameter validation is enforced for this function tool."
               },
               {
                 "type": "null"
@@ -12683,6 +13794,20 @@
           "defer_loading": {
             "type": "boolean",
             "description": "Whether this function is deferred and loaded via tool search."
+          },
+          "allowed_callers": {
+            "anyOf": [
+              {
+                "items": {
+                  "$ref": "#/components/schemas/CallableToolAllowedCaller"
+                },
+                "type": "array",
+                "description": "The tool invocation context(s)."
+              },
+              {
+                "type": "null"
+              }
+            ]
           }
         },
         "type": "object",
@@ -12876,7 +14001,7 @@
           "server_url": {
             "type": "string",
             "format": "uri",
-            "description": "The URL for the MCP server. One of `server_url` or `connector_id` must be\nprovided.\n"
+            "description": "The URL for the MCP server. One of `server_url`, `connector_id`, or\n`tunnel_id` must be provided.\n"
           },
           "connector_id": {
             "type": "string",
@@ -12890,7 +14015,12 @@
               "connector_outlookemail",
               "connector_sharepoint"
             ],
-            "description": "Identifier for service connectors, like those available in ChatGPT. One of\n`server_url` or `connector_id` must be provided. Learn more about service\nconnectors [here](/docs/guides/tools-remote-mcp#connectors).\n\nCurrently supported `connector_id` values are:\n\n- Dropbox: `connector_dropbox`\n- Gmail: `connector_gmail`\n- Google Calendar: `connector_googlecalendar`\n- Google Drive: `connector_googledrive`\n- Microsoft Teams: `connector_microsoftteams`\n- Outlook Calendar: `connector_outlookcalendar`\n- Outlook Email: `connector_outlookemail`\n- SharePoint: `connector_sharepoint`\n"
+            "description": "Identifier for service connectors, like those available in ChatGPT. One of\n`server_url`, `connector_id`, or `tunnel_id` must be provided. Learn more\nabout service connectors [here](/docs/guides/tools-remote-mcp#connectors).\n\nCurrently supported `connector_id` values are:\n\n- Dropbox: `connector_dropbox`\n- Gmail: `connector_gmail`\n- Google Calendar: `connector_googlecalendar`\n- Google Drive: `connector_googledrive`\n- Microsoft Teams: `connector_microsoftteams`\n- Outlook Calendar: `connector_outlookcalendar`\n- Outlook Email: `connector_outlookemail`\n- SharePoint: `connector_sharepoint`\n"
+          },
+          "tunnel_id": {
+            "type": "string",
+            "pattern": "^tunnel_[a-z0-9]{32}$",
+            "description": "The Secure MCP Tunnel ID to use instead of a direct server URL. One of\n`server_url`, `connector_id`, or `tunnel_id` must be provided.\n"
           },
           "authorization": {
             "type": "string",
@@ -12931,6 +14061,21 @@
                     "$ref": "#/components/schemas/MCPToolFilter"
                   }
                 ]
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "allowed_callers": {
+            "anyOf": [
+              {
+                "type": "array",
+                "minItems": 1,
+                "items": {
+                  "$ref": "#/components/schemas/CallableToolAllowedCaller"
+                },
+                "description": "The tool invocation context(s)."
               },
               {
                 "type": "null"
@@ -13007,11 +14152,43 @@
                 "$ref": "#/components/schemas/AutoCodeInterpreterToolParam"
               }
             ]
+          },
+          "allowed_callers": {
+            "anyOf": [
+              {
+                "type": "array",
+                "minItems": 1,
+                "items": {
+                  "$ref": "#/components/schemas/CallableToolAllowedCaller"
+                },
+                "description": "The tool invocation context(s)."
+              },
+              {
+                "type": "null"
+              }
+            ]
           }
         },
         "required": [
           "type",
           "container"
+        ]
+      },
+      "ProgrammaticToolCallingParam": {
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "programmatic_tool_calling"
+            ],
+            "description": "The type of the tool. Always `programmatic_tool_calling`.",
+            "default": "programmatic_tool_calling",
+            "x-stainless-const": true
+          }
+        },
+        "type": "object",
+        "required": [
+          "type"
         ]
       },
       "ImageGenTool": {
@@ -13203,6 +14380,21 @@
                 "type": "null"
               }
             ]
+          },
+          "allowed_callers": {
+            "anyOf": [
+              {
+                "items": {
+                  "$ref": "#/components/schemas/CallableToolAllowedCaller"
+                },
+                "type": "array",
+                "minItems": 1,
+                "description": "The tool invocation context(s)."
+              },
+              {
+                "type": "null"
+              }
+            ]
           }
         },
         "type": "object",
@@ -13248,6 +14440,21 @@
           "defer_loading": {
             "type": "boolean",
             "description": "Whether this tool should be deferred and discovered via tool search."
+          },
+          "allowed_callers": {
+            "anyOf": [
+              {
+                "items": {
+                  "$ref": "#/components/schemas/CallableToolAllowedCaller"
+                },
+                "type": "array",
+                "minItems": 1,
+                "description": "The tool invocation context(s)."
+              },
+              {
+                "type": "null"
+              }
+            ]
           }
         },
         "type": "object",
@@ -13405,6 +14612,21 @@
             "description": "The type of the tool. Always `apply_patch`.",
             "default": "apply_patch",
             "x-stainless-const": true
+          },
+          "allowed_callers": {
+            "anyOf": [
+              {
+                "items": {
+                  "$ref": "#/components/schemas/CallableToolAllowedCaller"
+                },
+                "type": "array",
+                "minItems": 1,
+                "description": "The tool invocation context(s)."
+              },
+              {
+                "type": "null"
+              }
+            ]
           }
         },
         "type": "object",
@@ -13428,6 +14650,9 @@
           "text": {
             "type": "string",
             "description": "The text input to the model."
+          },
+          "prompt_cache_breakpoint": {
+            "$ref": "#/components/schemas/PromptCacheBreakpointConfig"
           }
         },
         "type": "object",
@@ -13475,6 +14700,9 @@
           "detail": {
             "$ref": "#/components/schemas/ImageDetail",
             "description": "The detail level of the image to be sent to the model. One of `high`, `low`, `auto`, or `original`. Defaults to `auto`."
+          },
+          "prompt_cache_breakpoint": {
+            "$ref": "#/components/schemas/PromptCacheBreakpointConfig"
           }
         },
         "type": "object",
@@ -13515,6 +14743,9 @@
             "type": "string",
             "description": "The content of the file to be sent to the model.\n"
           },
+          "prompt_cache_breakpoint": {
+            "$ref": "#/components/schemas/PromptCacheBreakpointConfig"
+          },
           "file_url": {
             "type": "string",
             "format": "uri",
@@ -13522,7 +14753,7 @@
           },
           "detail": {
             "$ref": "#/components/schemas/FileInputDetail",
-            "description": "The detail level of the file to be sent to the model. Use `low` for the default rendering behavior, or `high` to render the file at higher quality. Defaults to `low`."
+            "description": "The detail level of the file to be sent to the model. Use `auto` to let the system select the detail level; for GPT-5.6 and later models, `auto` uses high-quality rendering, which may increase input token usage. Use `low` for lower-cost rendering, or `high` to render the file at higher quality. Defaults to `auto`."
           }
         },
         "type": "object",
@@ -13531,6 +14762,64 @@
         ],
         "title": "Input file",
         "description": "A file input to the model."
+      },
+      "ModerationMode": {
+        "type": "string",
+        "enum": [
+          "score",
+          "block"
+        ]
+      },
+      "DirectToolCallCaller": {
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "direct"
+            ],
+            "default": "direct",
+            "x-stainless-const": true
+          }
+        },
+        "type": "object",
+        "required": [
+          "type"
+        ]
+      },
+      "ProgramToolCallCaller": {
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "program"
+            ],
+            "default": "program",
+            "x-stainless-const": true
+          },
+          "caller_id": {
+            "type": "string",
+            "description": "The call ID of the program item that produced this tool call."
+          }
+        },
+        "type": "object",
+        "required": [
+          "type",
+          "caller_id"
+        ]
+      },
+      "ToolCallCallerParam": {
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/DirectToolCallCallerParam"
+          },
+          {
+            "$ref": "#/components/schemas/ProgramToolCallCallerParam"
+          }
+        ],
+        "description": "The execution context that produced this tool call.",
+        "discriminator": {
+          "propertyName": "type"
+        }
       },
       "FunctionAndCustomToolCallOutput": {
         "oneOf": [
@@ -13976,6 +15265,16 @@
             "type": "string",
             "maxLength": 10485760,
             "description": "The text input to the model."
+          },
+          "prompt_cache_breakpoint": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/PromptCacheBreakpointParam"
+              },
+              {
+                "type": "null"
+              }
+            ]
           }
         },
         "type": "object",
@@ -14027,6 +15326,16 @@
               {
                 "$ref": "#/components/schemas/DetailEnum",
                 "description": "The detail level of the image to be sent to the model. One of `high`, `low`, `auto`, or `original`. Defaults to `auto`."
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "prompt_cache_breakpoint": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/PromptCacheBreakpointParam"
               },
               {
                 "type": "null"
@@ -14101,7 +15410,17 @@
           },
           "detail": {
             "$ref": "#/components/schemas/FileDetailEnum",
-            "description": "The detail level of the file to be sent to the model. Use `low` for the default rendering behavior, or `high` to render the file at higher quality. Defaults to `low`."
+            "description": "The detail level of the file to be sent to the model. Use `auto` to let the system select the detail level; for GPT-5.6 and later models, `auto` uses high-quality rendering, which may increase input token usage. Use `low` for lower-cost rendering, or `high` to render the file at higher quality. Defaults to `auto`."
+          },
+          "prompt_cache_breakpoint": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/PromptCacheBreakpointParam"
+              },
+              {
+                "type": "null"
+              }
+            ]
           }
         },
         "type": "object",
@@ -14361,6 +15680,9 @@
             "required": [
               "url"
             ]
+          },
+          "prompt_cache_breakpoint": {
+            "$ref": "#/components/schemas/PromptCacheBreakpointParam"
           }
         },
         "required": [
@@ -14401,6 +15723,9 @@
               "data",
               "format"
             ]
+          },
+          "prompt_cache_breakpoint": {
+            "$ref": "#/components/schemas/PromptCacheBreakpointParam"
           }
         },
         "required": [
@@ -14437,6 +15762,9 @@
                 "description": "The ID of an uploaded file to use as input.\n"
               }
             }
+          },
+          "prompt_cache_breakpoint": {
+            "$ref": "#/components/schemas/PromptCacheBreakpointParam"
           }
         },
         "required": [
@@ -14464,6 +15792,13 @@
         "required": [
           "type",
           "refusal"
+        ]
+      },
+      "CallableToolAllowedCaller": {
+        "type": "string",
+        "enum": [
+          "direct",
+          "programmatic"
         ]
       },
       "RankingOptions": {
@@ -14801,7 +16136,8 @@
           "strict": {
             "anyOf": [
               {
-                "type": "boolean"
+                "type": "boolean",
+                "description": "Whether to enforce strict parameter validation. If omitted, Responses attempts to use strict validation when the schema is compatible, and falls back to non-strict validation otherwise."
               },
               {
                 "type": "null"
@@ -14816,9 +16152,37 @@
             "default": "function",
             "x-stainless-const": true
           },
+          "output_schema": {
+            "anyOf": [
+              {
+                "additionalProperties": {},
+                "type": "object",
+                "description": "A JSON Schema describing the JSON value encoded in string outputs for this function tool. This does not describe content-array outputs.",
+                "x-oaiTypeLabel": "map"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "defer_loading": {
             "type": "boolean",
             "description": "Whether this function should be deferred and discovered via tool search."
+          },
+          "allowed_callers": {
+            "anyOf": [
+              {
+                "items": {
+                  "$ref": "#/components/schemas/CallableToolAllowedCaller"
+                },
+                "type": "array",
+                "minItems": 1,
+                "description": "The tool invocation context(s)."
+              },
+              {
+                "type": "null"
+              }
+            ]
           }
         },
         "type": "object",
@@ -14903,6 +16267,25 @@
           "image"
         ]
       },
+      "PromptCacheBreakpointConfig": {
+        "properties": {
+          "mode": {
+            "type": "string",
+            "enum": [
+              "explicit"
+            ],
+            "description": "The breakpoint mode. Always `explicit`.",
+            "default": "explicit",
+            "x-stainless-const": true
+          }
+        },
+        "type": "object",
+        "required": [
+          "mode"
+        ],
+        "title": "Prompt cache breakpoint",
+        "description": "Marks the exact end of a reusable prompt prefix. The breakpoint inherits its TTL from the request's `prompt_cache_options.ttl`; the boundary is not rounded to a token block."
+      },
       "ImageDetail": {
         "type": "string",
         "enum": [
@@ -14915,8 +16298,50 @@
       "FileInputDetail": {
         "type": "string",
         "enum": [
+          "auto",
           "low",
           "high"
+        ]
+      },
+      "DirectToolCallCallerParam": {
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "direct"
+            ],
+            "description": "The caller type. Always `direct`.",
+            "default": "direct",
+            "x-stainless-const": true
+          }
+        },
+        "type": "object",
+        "required": [
+          "type"
+        ]
+      },
+      "ProgramToolCallCallerParam": {
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "program"
+            ],
+            "description": "The caller type. Always `program`.",
+            "default": "program",
+            "x-stainless-const": true
+          },
+          "caller_id": {
+            "type": "string",
+            "maxLength": 64,
+            "minLength": 1,
+            "description": "The call ID of the program item that produced this tool call."
+          }
+        },
+        "type": "object",
+        "required": [
+          "type",
+          "caller_id"
         ]
       },
       "ClickButtonType": {
@@ -14960,6 +16385,7 @@
       "FileDetailEnum": {
         "type": "string",
         "enum": [
+          "auto",
           "low",
           "high"
         ]

--- a/packages/testing/provider-mock/contracts/openai/provenance.json
+++ b/packages/testing/provider-mock/contracts/openai/provenance.json
@@ -1,9 +1,11 @@
 {
   "sourceUrl": "https://raw.githubusercontent.com/openai/openai-openapi/master/openapi.yaml",
   "sourceRepository": "https://github.com/openai/openai-openapi",
-  "sourceSha256": "74cbcf73838f4cd7e209b2d3f2e9ddc9fa155f21a44360b6fac7646a6d4f5f8b",
-  "bundleSha256": "a855fcbc7ee2aff1d56443516199bbdb8309fcfcfac9a6e34af453e35ea9913d",
+  "sourceSha256": "c974959f3f1a82d0c405c7d067e0bd0a32912901cddee7ce6b3b896ac5c82a90",
+  "bundleSha256": "176782960e6b08e6604e29713da18a96c1909169ee1772841df5a1f8baeee5f2",
   "openapiVersion": "3.1.0",
   "apiVersion": "2.3.0",
-  "capabilityOverlay": true
+  "overlays": [
+    "POST /rerank"
+  ]
 }

--- a/packages/testing/provider-mock/contracts/together/openapi.json
+++ b/packages/testing/provider-mock/contracts/together/openapi.json
@@ -22,33 +22,6 @@
         ],
         "summary": "Create chat completion",
         "description": "Generate a model response for a given chat conversation. Supports single queries and multi-turn conversations with system, user, and assistant messages.",
-        "x-codeSamples": [
-          {
-            "lang": "Python",
-            "label": "Together AI SDK (v2)",
-            "source": "# Docs for v1 can be found by changing the above selector ^\nfrom together import Together\nimport os\n\nclient = Together(\n    api_key=os.environ.get(\"TOGETHER_API_KEY\"),\n)\n\nresponse = client.chat.completions.create(\n    model=\"Qwen/Qwen3.5-9B\",\n    messages=[\n        {\"role\": \"system\", \"content\": \"You are a helpful assistant.\"},\n        {\"role\": \"user\", \"content\": \"What are some fun things to do in New York?\"},\n    ],\n    reasoning={\"enabled\": False}\n)\n"
-          },
-          {
-            "lang": "Python",
-            "label": "Together AI SDK (v1)",
-            "source": "from together import Together\nimport os\n\nclient = Together(\n    api_key=os.environ.get(\"TOGETHER_API_KEY\"),\n)\n\nresponse = client.chat.completions.create(\n    model=\"Qwen/Qwen3.5-9B\",\n    messages=[\n        {\"role\": \"system\", \"content\": \"You are a helpful assistant.\"},\n        {\"role\": \"user\", \"content\": \"What are some fun things to do in New York?\"},\n    ],\n    reasoning={\"enabled\": False}\n)\n\nprint(response.choices[0].message.content)\n"
-          },
-          {
-            "lang": "TypeScript",
-            "label": "Together AI SDK (TypeScript)",
-            "source": "import Together from \"together-ai\";\n\nconst client = new Together({\n  apiKey: process.env.TOGETHER_API_KEY,\n});\n\nconst response = await client.chat.completions.create({\n  model: \"Qwen/Qwen3.5-9B\",\n  messages: [\n    { role: \"system\", content: \"You are a helpful assistant.\" },\n    { role: \"user\", \"content\": \"What are some fun things to do in New York?\" },\n  ],\n  reasoning: { enabled: false },\n});\n\nconsole.log(response.choices[0].message?.content);\n"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "Together AI SDK (JavaScript)",
-            "source": "import Together from \"together-ai\";\n\nconst client = new Together({\n  apiKey: process.env.TOGETHER_API_KEY,\n});\n\nconst response = await client.chat.completions.create({\n  model: \"Qwen/Qwen3.5-9B\",\n  messages: [\n    { role: \"system\", content: \"You are a helpful assistant.\" },\n    { role: \"user\", \"content\": \"What are some fun things to do in New York?\" },\n  ],\n  reasoning: { enabled: false },\n});\n\nconsole.log(response.choices[0].message?.content);\n"
-          },
-          {
-            "lang": "Shell",
-            "label": "cURL",
-            "source": "curl -X POST \"https://api.together.ai/v1/chat/completions\" \\\n     -H \"Authorization: Bearer $TOGETHER_API_KEY\" \\\n     -H \"Content-Type: application/json\" \\\n     -d '{\n       \"model\": \"Qwen/Qwen3.5-9B\",\n       \"messages\": [\n         {\"role\": \"system\", \"content\": \"You are a helpful assistant.\"},\n         {\"role\": \"user\", \"content\": \"What are some fun things to do in New York?\"}\n       ],\n       \"reasoning\": {\"enabled\": false}\n     }'\n"
-          }
-        ],
         "operationId": "chat-completions",
         "requestBody": {
           "content": {
@@ -136,7 +109,29 @@
             }
           }
         },
-        "deprecated": false
+        "deprecated": false,
+        "x-codeSamples": [
+          {
+            "lang": "Python",
+            "label": "Together AI SDK (Python)",
+            "source": "from together import Together\nimport os\n\nclient = Together(\n    api_key=os.environ.get(\"TOGETHER_API_KEY\"),\n)\n\nresponse = client.chat.completions.create(\n    model=\"Qwen/Qwen3.5-9B\",\n    messages=[\n        {\"role\": \"system\", \"content\": \"You are a helpful assistant.\"},\n        {\"role\": \"user\", \"content\": \"What are some fun things to do in New York?\"},\n    ],\n    reasoning={\"enabled\": False}\n)\n"
+          },
+          {
+            "lang": "TypeScript",
+            "label": "Together AI SDK (TypeScript)",
+            "source": "import Together from \"together-ai\";\n\nconst client = new Together({\n  apiKey: process.env.TOGETHER_API_KEY,\n});\n\nconst response = await client.chat.completions.create({\n  model: \"Qwen/Qwen3.5-9B\",\n  messages: [\n    { role: \"system\", content: \"You are a helpful assistant.\" },\n    { role: \"user\", \"content\": \"What are some fun things to do in New York?\" },\n  ],\n  reasoning: { enabled: false },\n});\n\nconsole.log(response.choices[0].message?.content);\n"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "Together AI SDK (JavaScript)",
+            "source": "import Together from \"together-ai\";\n\nconst client = new Together({\n  apiKey: process.env.TOGETHER_API_KEY,\n});\n\nconst response = await client.chat.completions.create({\n  model: \"Qwen/Qwen3.5-9B\",\n  messages: [\n    { role: \"system\", content: \"You are a helpful assistant.\" },\n    { role: \"user\", \"content\": \"What are some fun things to do in New York?\" },\n  ],\n  reasoning: { enabled: false },\n});\n\nconsole.log(response.choices[0].message?.content);\n"
+          },
+          {
+            "lang": "Shell",
+            "label": "cURL",
+            "source": "curl -X POST \"https://api.together.ai/v1/chat/completions\" \\\n     -H \"Authorization: Bearer $TOGETHER_API_KEY\" \\\n     -H \"Content-Type: application/json\" \\\n     -d '{\n       \"model\": \"Qwen/Qwen3.5-9B\",\n       \"messages\": [\n         {\"role\": \"system\", \"content\": \"You are a helpful assistant.\"},\n         {\"role\": \"user\", \"content\": \"What are some fun things to do in New York?\"}\n       ],\n       \"reasoning\": {\"enabled\": false}\n     }'\n"
+          }
+        ]
       }
     },
     "/v1/embeddings": {
@@ -146,33 +141,6 @@
         ],
         "summary": "Create embedding",
         "description": "Generate vector embeddings for one or more text inputs. Returns numerical arrays representing semantic meaning, useful for search, classification, and retrieval.",
-        "x-codeSamples": [
-          {
-            "lang": "Python",
-            "label": "Together AI SDK (v2)",
-            "source": "# Docs for v1 can be found by changing the above selector ^\nfrom together import Together\nimport os\n\nclient = Together(\n    api_key=os.environ.get(\"TOGETHER_API_KEY\"),\n)\n\nresponse = client.embeddings.create(\n    model=\"BAAI/bge-large-en-v1.5\",\n    input=\"New York City\",\n)\n\nprint(response.data[0].embedding)\n"
-          },
-          {
-            "lang": "Python",
-            "label": "Together AI SDK (v1)",
-            "source": "from together import Together\nimport os\n\nclient = Together(\n    api_key=os.environ.get(\"TOGETHER_API_KEY\"),\n)\n\nresponse = client.embeddings.create(\n    model=\"BAAI/bge-large-en-v1.5\",\n    input=\"New York City\",\n)\n\nprint(response.data[0].embedding)\n"
-          },
-          {
-            "lang": "TypeScript",
-            "label": "Together AI SDK (TypeScript)",
-            "source": "import Together from \"together-ai\";\n\nconst client = new Together({\n  apiKey: process.env.TOGETHER_API_KEY,\n});\n\nconst response = await client.embeddings.create({\n  model: \"BAAI/bge-large-en-v1.5\",\n  input: \"New York City\",\n});\n\nconsole.log(response.data[0].embedding);\n"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "Together AI SDK (JavaScript)",
-            "source": "import Together from \"together-ai\";\n\nconst client = new Together({\n  apiKey: process.env.TOGETHER_API_KEY,\n});\n\nconst response = await client.embeddings.create({\n  model: \"BAAI/bge-large-en-v1.5\",\n  input: \"New York City\",\n});\n\nconsole.log(response.data[0].embedding);\n"
-          },
-          {
-            "lang": "Shell",
-            "label": "cURL",
-            "source": "curl -X POST \"https://api.together.ai/v1/embeddings\" \\\n     -H \"Authorization: Bearer $TOGETHER_API_KEY\" \\\n     -H \"Content-Type: application/json\" \\\n     -d '{\n       \"model\": \"BAAI/bge-large-en-v1.5\",\n       \"input\": \"New York City\"\n     }'\n"
-          }
-        ],
         "operationId": "embeddings",
         "requestBody": {
           "content": {
@@ -255,7 +223,29 @@
             }
           }
         },
-        "deprecated": false
+        "deprecated": false,
+        "x-codeSamples": [
+          {
+            "lang": "Python",
+            "label": "Together AI SDK (Python)",
+            "source": "from together import Together\nimport os\n\nclient = Together(\n    api_key=os.environ.get(\"TOGETHER_API_KEY\"),\n)\n\nresponse = client.embeddings.create(\n    model=\"BAAI/bge-large-en-v1.5\",\n    input=\"New York City\",\n)\n\nprint(response.data[0].embedding)\n"
+          },
+          {
+            "lang": "TypeScript",
+            "label": "Together AI SDK (TypeScript)",
+            "source": "import Together from \"together-ai\";\n\nconst client = new Together({\n  apiKey: process.env.TOGETHER_API_KEY,\n});\n\nconst response = await client.embeddings.create({\n  model: \"BAAI/bge-large-en-v1.5\",\n  input: \"New York City\",\n});\n\nconsole.log(response.data[0].embedding);\n"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "Together AI SDK (JavaScript)",
+            "source": "import Together from \"together-ai\";\n\nconst client = new Together({\n  apiKey: process.env.TOGETHER_API_KEY,\n});\n\nconst response = await client.embeddings.create({\n  model: \"BAAI/bge-large-en-v1.5\",\n  input: \"New York City\",\n});\n\nconsole.log(response.data[0].embedding);\n"
+          },
+          {
+            "lang": "Shell",
+            "label": "cURL",
+            "source": "curl -X POST \"https://api.together.ai/v1/embeddings\" \\\n     -H \"Authorization: Bearer $TOGETHER_API_KEY\" \\\n     -H \"Content-Type: application/json\" \\\n     -d '{\n       \"model\": \"BAAI/bge-large-en-v1.5\",\n       \"input\": \"New York City\"\n     }'\n"
+          }
+        ]
       }
     },
     "/v1/rerank": {
@@ -265,33 +255,6 @@
         ],
         "summary": "Create a rerank request",
         "description": "Rerank a list of documents by relevance to a query. Returns a relevance score and ordering index for each document.",
-        "x-codeSamples": [
-          {
-            "lang": "Python",
-            "label": "Together AI SDK (v2)",
-            "source": "# Docs for v1 can be found by changing the above selector ^\nfrom together import Together\nimport os\n\nclient = Together(\n    api_key=os.environ.get(\"TOGETHER_API_KEY\"),\n)\n\ndocuments = [\n    {\n        \"title\": \"Llama\",\n        \"text\": \"The llama is a domesticated South American camelid, widely used as a meat and pack animal by Andean cultures since the pre-Columbian era.\"\n    },\n    {\n        \"title\": \"Panda\",\n        \"text\": \"The giant panda (Ailuropoda melanoleuca), also known as the panda bear or simply panda, is a bear species endemic to China.\"\n    },\n    {\n        \"title\": \"Guanaco\",\n        \"text\": \"The guanaco is a camelid native to South America, closely related to the llama. Guanacos are one of two wild South American camelids; the other species is the vicuña, which lives at higher elevations.\"\n    },\n    {\n        \"title\": \"Wild Bactrian camel\",\n        \"text\": \"The wild Bactrian camel (Camelus ferus) is an endangered species of camel endemic to Northwest China and southwestern Mongolia.\"\n    }\n]\n\nresponse = client.rerank.create(\n    model=\"Salesforce/Llama-Rank-v1\",\n    query=\"What animals can I find near Peru?\",\n    documents=documents,\n)\n\nfor result in response.results:\n    print(f\"Rank: {result.index + 1}\")\n    print(f\"Title: {documents[result.index]['title']}\")\n    print(f\"Text: {documents[result.index]['text']}\")\n"
-          },
-          {
-            "lang": "Python",
-            "label": "Together AI SDK (v1)",
-            "source": "from together import Together\nimport os\n\nclient = Together(\n    api_key=os.environ.get(\"TOGETHER_API_KEY\"),\n)\n\ndocuments = [\n    {\n        \"title\": \"Llama\",\n        \"text\": \"The llama is a domesticated South American camelid, widely used as a meat and pack animal by Andean cultures since the pre-Columbian era.\"\n    },\n    {\n        \"title\": \"Panda\",\n        \"text\": \"The giant panda (Ailuropoda melanoleuca), also known as the panda bear or simply panda, is a bear species endemic to China.\"\n    },\n    {\n        \"title\": \"Guanaco\",\n        \"text\": \"The guanaco is a camelid native to South America, closely related to the llama. Guanacos are one of two wild South American camelids; the other species is the vicuña, which lives at higher elevations.\"\n    },\n    {\n        \"title\": \"Wild Bactrian camel\",\n        \"text\": \"The wild Bactrian camel (Camelus ferus) is an endangered species of camel endemic to Northwest China and southwestern Mongolia.\"\n    }\n]\n\nresponse = client.rerank.create(\n    model=\"Salesforce/Llama-Rank-v1\",\n    query=\"What animals can I find near Peru?\",\n    documents=documents,\n)\n\nfor result in response.results:\n    print(f\"Rank: {result.index + 1}\")\n    print(f\"Title: {documents[result.index]['title']}\")\n    print(f\"Text: {documents[result.index]['text']}\")\n"
-          },
-          {
-            "lang": "TypeScript",
-            "label": "Together AI SDK (TypeScript)",
-            "source": "import Together from \"together-ai\";\n\nconst client = new Together({\n  apiKey: process.env.TOGETHER_API_KEY,\n});\n\nconst documents = [{\n  \"title\": \"Llama\",\n  \"text\": \"The llama is a domesticated South American camelid, widely used as a meat and pack animal by Andean cultures since the pre-Columbian era.\"\n},\n{\n  \"title\": \"Panda\",\n  \"text\": \"The giant panda (Ailuropoda melanoleuca), also known as the panda bear or simply panda, is a bear species endemic to China.\"\n},\n{\n  \"title\": \"Guanaco\",\n  \"text\": \"The guanaco is a camelid native to South America, closely related to the llama. Guanacos are one of two wild South American camelids; the other species is the vicuña, which lives at higher elevations.\"\n},\n{\n  \"title\": \"Wild Bactrian camel\",\n  \"text\": \"The wild Bactrian camel (Camelus ferus) is an endangered species of camel endemic to Northwest China and southwestern Mongolia.\"\n}];\n\nconst response = await client.rerank.create({\n  model: \"Salesforce/Llama-Rank-v1\",\n  query: \"What animals can I find near Peru?\",\n  documents,\n});\n\nfor (const result of response.results) {\n  console.log(`Rank: ${result.index + 1}`);\n  console.log(`Title: ${documents[result.index].title}`);\n  console.log(`Text: ${documents[result.index].text}`);\n}\n"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "Together AI SDK (JavaScript)",
-            "source": "import Together from \"together-ai\";\n\nconst client = new Together({\n  apiKey: process.env.TOGETHER_API_KEY,\n});\n\nconst documents = [{\n  \"title\": \"Llama\",\n  \"text\": \"The llama is a domesticated South American camelid, widely used as a meat and pack animal by Andean cultures since the pre-Columbian era.\"\n},\n{\n  \"title\": \"Panda\",\n  \"text\": \"The giant panda (Ailuropoda melanoleuca), also known as the panda bear or simply panda, is a bear species endemic to China.\"\n},\n{\n  \"title\": \"Guanaco\",\n  \"text\": \"The guanaco is a camelid native to South America, closely related to the llama. Guanacos are one of two wild South American camelids; the other species is the vicuña, which lives at higher elevations.\"\n},\n{\n  \"title\": \"Wild Bactrian camel\",\n  \"text\": \"The wild Bactrian camel (Camelus ferus) is an endangered species of camel endemic to Northwest China and southwestern Mongolia.\"\n}];\n\nconst response = await client.rerank.create({\n  model: \"Salesforce/Llama-Rank-v1\",\n  query: \"What animals can I find near Peru?\",\n  documents,\n});\n\nfor (const result of response.results) {\n  console.log(`Rank: ${result.index + 1}`);\n  console.log(`Title: ${documents[result.index].title}`);\n  console.log(`Text: ${documents[result.index].text}`);\n}\n"
-          },
-          {
-            "lang": "Shell",
-            "label": "cURL",
-            "source": "curl -X POST \"https://api.together.ai/v1/rerank\" \\\n     -H \"Authorization: Bearer $TOGETHER_API_KEY\" \\\n     -H \"Content-Type: application/json\" \\\n     -d '{\n       \"model\": \"Salesforce/Llama-Rank-v1\",\n       \"query\": \"What animals can I find near Peru?\",\n       \"documents\": [{\n          \"title\": \"Llama\",\n          \"text\": \"The llama is a domesticated South American camelid, widely used as a meat and pack animal by Andean cultures since the pre-Columbian era.\"\n        },\n        {\n          \"title\": \"Panda\",\n          \"text\": \"The giant panda (Ailuropoda melanoleuca), also known as the panda bear or simply panda, is a bear species endemic to China.\"\n        },\n        {\n          \"title\": \"Guanaco\",\n          \"text\": \"The guanaco is a camelid native to South America, closely related to the llama. Guanacos are one of two wild South American camelids; the other species is the vicuña, which lives at higher elevations.\"\n        },\n        {\n          \"title\": \"Wild Bactrian camel\",\n          \"text\": \"The wild Bactrian camel (Camelus ferus) is an endangered species of camel endemic to Northwest China and southwestern Mongolia.\"\n        }]\n     }'\n"
-          }
-        ],
         "operationId": "rerank",
         "requestBody": {
           "content": {
@@ -374,7 +337,29 @@
             }
           }
         },
-        "deprecated": false
+        "deprecated": false,
+        "x-codeSamples": [
+          {
+            "lang": "Python",
+            "label": "Together AI SDK (Python)",
+            "source": "from together import Together\nimport os\n\nclient = Together(\n    api_key=os.environ.get(\"TOGETHER_API_KEY\"),\n)\n\ndocuments = [\n    {\n        \"title\": \"Llama\",\n        \"text\": \"The llama is a domesticated South American camelid, widely used as a meat and pack animal by Andean cultures since the pre-Columbian era.\"\n    },\n    {\n        \"title\": \"Panda\",\n        \"text\": \"The giant panda (Ailuropoda melanoleuca), also known as the panda bear or simply panda, is a bear species endemic to China.\"\n    },\n    {\n        \"title\": \"Guanaco\",\n        \"text\": \"The guanaco is a camelid native to South America, closely related to the llama. Guanacos are one of two wild South American camelids; the other species is the vicuña, which lives at higher elevations.\"\n    },\n    {\n        \"title\": \"Wild Bactrian camel\",\n        \"text\": \"The wild Bactrian camel (Camelus ferus) is an endangered species of camel endemic to Northwest China and southwestern Mongolia.\"\n    }\n]\n\nresponse = client.rerank.create(\n    model=\"Salesforce/Llama-Rank-v1\",\n    query=\"What animals can I find near Peru?\",\n    documents=documents,\n)\n\nfor result in response.results:\n    print(f\"Rank: {result.index + 1}\")\n    print(f\"Title: {documents[result.index]['title']}\")\n    print(f\"Text: {documents[result.index]['text']}\")\n"
+          },
+          {
+            "lang": "TypeScript",
+            "label": "Together AI SDK (TypeScript)",
+            "source": "import Together from \"together-ai\";\n\nconst client = new Together({\n  apiKey: process.env.TOGETHER_API_KEY,\n});\n\nconst documents = [{\n  \"title\": \"Llama\",\n  \"text\": \"The llama is a domesticated South American camelid, widely used as a meat and pack animal by Andean cultures since the pre-Columbian era.\"\n},\n{\n  \"title\": \"Panda\",\n  \"text\": \"The giant panda (Ailuropoda melanoleuca), also known as the panda bear or simply panda, is a bear species endemic to China.\"\n},\n{\n  \"title\": \"Guanaco\",\n  \"text\": \"The guanaco is a camelid native to South America, closely related to the llama. Guanacos are one of two wild South American camelids; the other species is the vicuña, which lives at higher elevations.\"\n},\n{\n  \"title\": \"Wild Bactrian camel\",\n  \"text\": \"The wild Bactrian camel (Camelus ferus) is an endangered species of camel endemic to Northwest China and southwestern Mongolia.\"\n}];\n\nconst response = await client.rerank.create({\n  model: \"Salesforce/Llama-Rank-v1\",\n  query: \"What animals can I find near Peru?\",\n  documents,\n});\n\nfor (const result of response.results) {\n  console.log(`Rank: ${result.index + 1}`);\n  console.log(`Title: ${documents[result.index].title}`);\n  console.log(`Text: ${documents[result.index].text}`);\n}\n"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "Together AI SDK (JavaScript)",
+            "source": "import Together from \"together-ai\";\n\nconst client = new Together({\n  apiKey: process.env.TOGETHER_API_KEY,\n});\n\nconst documents = [{\n  \"title\": \"Llama\",\n  \"text\": \"The llama is a domesticated South American camelid, widely used as a meat and pack animal by Andean cultures since the pre-Columbian era.\"\n},\n{\n  \"title\": \"Panda\",\n  \"text\": \"The giant panda (Ailuropoda melanoleuca), also known as the panda bear or simply panda, is a bear species endemic to China.\"\n},\n{\n  \"title\": \"Guanaco\",\n  \"text\": \"The guanaco is a camelid native to South America, closely related to the llama. Guanacos are one of two wild South American camelids; the other species is the vicuña, which lives at higher elevations.\"\n},\n{\n  \"title\": \"Wild Bactrian camel\",\n  \"text\": \"The wild Bactrian camel (Camelus ferus) is an endangered species of camel endemic to Northwest China and southwestern Mongolia.\"\n}];\n\nconst response = await client.rerank.create({\n  model: \"Salesforce/Llama-Rank-v1\",\n  query: \"What animals can I find near Peru?\",\n  documents,\n});\n\nfor (const result of response.results) {\n  console.log(`Rank: ${result.index + 1}`);\n  console.log(`Title: ${documents[result.index].title}`);\n  console.log(`Text: ${documents[result.index].text}`);\n}\n"
+          },
+          {
+            "lang": "Shell",
+            "label": "cURL",
+            "source": "curl -X POST \"https://api.together.ai/v1/rerank\" \\\n     -H \"Authorization: Bearer $TOGETHER_API_KEY\" \\\n     -H \"Content-Type: application/json\" \\\n     -d '{\n       \"model\": \"Salesforce/Llama-Rank-v1\",\n       \"query\": \"What animals can I find near Peru?\",\n       \"documents\": [{\n          \"title\": \"Llama\",\n          \"text\": \"The llama is a domesticated South American camelid, widely used as a meat and pack animal by Andean cultures since the pre-Columbian era.\"\n        },\n        {\n          \"title\": \"Panda\",\n          \"text\": \"The giant panda (Ailuropoda melanoleuca), also known as the panda bear or simply panda, is a bear species endemic to China.\"\n        },\n        {\n          \"title\": \"Guanaco\",\n          \"text\": \"The guanaco is a camelid native to South America, closely related to the llama. Guanacos are one of two wild South American camelids; the other species is the vicuña, which lives at higher elevations.\"\n        },\n        {\n          \"title\": \"Wild Bactrian camel\",\n          \"text\": \"The wild Bactrian camel (Camelus ferus) is an endangered species of camel endemic to Northwest China and southwestern Mongolia.\"\n        }]\n     }'\n"
+          }
+        ]
       }
     },
     "/v1/models": {
@@ -384,33 +369,6 @@
         ],
         "summary": "List all models",
         "description": "Lists all of Together's open-source models and metadata including pricing, chat template, and context.",
-        "x-codeSamples": [
-          {
-            "lang": "Python",
-            "label": "Together AI SDK (v2)",
-            "source": "# Docs for v1 can be found by changing the above selector ^\nfrom together import Together\nimport os\n\nclient = Together(\n    api_key=os.environ.get(\"TOGETHER_API_KEY\"),\n)\n\nmodels = client.models.list()\n\nfor model in models:\n    print(model.id)\n"
-          },
-          {
-            "lang": "Python",
-            "label": "Together AI SDK (v1)",
-            "source": "from together import Together\nimport os\n\nclient = Together(\n    api_key=os.environ.get(\"TOGETHER_API_KEY\"),\n)\n\nmodels = client.models.list()\n\nfor model in models:\n    print(model.id)\n"
-          },
-          {
-            "lang": "TypeScript",
-            "label": "Together AI SDK (TypeScript)",
-            "source": "import Together from \"together-ai\";\n\nconst client = new Together({\n  apiKey: process.env.TOGETHER_API_KEY,\n});\n\nconst models = await client.models.list();\n\nfor (const model of models) {\n  console.log(model.id);\n}\n"
-          },
-          {
-            "lang": "JavaScript",
-            "label": "Together AI SDK (JavaScript)",
-            "source": "import Together from \"together-ai\";\n\nconst client = new Together({\n  apiKey: process.env.TOGETHER_API_KEY,\n});\n\nconst models = await client.models.list();\n\nfor (const model of models) {\n  console.log(model.id);\n}\n"
-          },
-          {
-            "lang": "Shell",
-            "label": "cURL",
-            "source": "curl \"https://api.together.ai/v1/models\" \\\n     -H \"Authorization: Bearer $TOGETHER_API_KEY\" \\\n     -H \"Content-Type: application/json\"\n"
-          }
-        ],
         "operationId": "models",
         "parameters": [
           {
@@ -484,7 +442,29 @@
             }
           }
         },
-        "deprecated": false
+        "deprecated": false,
+        "x-codeSamples": [
+          {
+            "lang": "Python",
+            "label": "Together AI SDK (Python)",
+            "source": "from together import Together\nimport os\n\nclient = Together(\n    api_key=os.environ.get(\"TOGETHER_API_KEY\"),\n)\n\nmodels = client.models.list()\n\nfor model in models:\n    print(model.id)\n"
+          },
+          {
+            "lang": "TypeScript",
+            "label": "Together AI SDK (TypeScript)",
+            "source": "import Together from \"together-ai\";\n\nconst client = new Together({\n  apiKey: process.env.TOGETHER_API_KEY,\n});\n\nconst models = await client.models.list();\n\nfor (const model of models) {\n  console.log(model.id);\n}\n"
+          },
+          {
+            "lang": "JavaScript",
+            "label": "Together AI SDK (JavaScript)",
+            "source": "import Together from \"together-ai\";\n\nconst client = new Together({\n  apiKey: process.env.TOGETHER_API_KEY,\n});\n\nconst models = await client.models.list();\n\nfor (const model of models) {\n  console.log(model.id);\n}\n"
+          },
+          {
+            "lang": "Shell",
+            "label": "cURL",
+            "source": "curl \"https://api.together.ai/v1/models\" \\\n     -H \"Authorization: Bearer $TOGETHER_API_KEY\" \\\n     -H \"Content-Type: application/json\"\n"
+          }
+        ]
       }
     }
   },
@@ -521,18 +501,15 @@
           },
           "temperature": {
             "type": "number",
-            "description": "A decimal number from 0-1 that determines the degree of randomness in the response. A temperature less than 1 favors more correctness and is appropriate for question answering or summarization. A value closer to 1 introduces more randomness in the output.",
-            "format": "float"
+            "description": "A decimal number from 0-1 that determines the degree of randomness in the response. A temperature less than 1 favors more correctness and is appropriate for question answering or summarization. A value closer to 1 introduces more randomness in the output."
           },
           "top_p": {
             "type": "number",
-            "description": "A percentage (also called the nucleus parameter) that's used to dynamically adjust the number of choices for each predicted token based on the cumulative probabilities. It specifies a probability threshold below which all less likely tokens are filtered out. This technique helps maintain diversity and generate more fluent and natural-sounding text.",
-            "format": "float"
+            "description": "A percentage (also called the nucleus parameter) that's used to dynamically adjust the number of choices for each predicted token based on the cumulative probabilities. It specifies a probability threshold below which all less likely tokens are filtered out. This technique helps maintain diversity and generate more fluent and natural-sounding text."
           },
           "top_k": {
             "type": "integer",
-            "description": "An integer that's used to limit the number of choices for the next predicted word or token. It specifies the maximum number of tokens to consider at each step, based on their probability of occurrence. This technique helps to speed up the generation process and can improve the quality of the generated text by focusing on the most likely options.",
-            "format": "int32"
+            "description": "An integer that's used to limit the number of choices for the next predicted word or token. It specifies the maximum number of tokens to consider at each step, based on their probability of occurrence. This technique helps to speed up the generation process and can improve the quality of the generated text by focusing on the most likely options."
           },
           "context_length_exceeded_behavior": {
             "type": "string",
@@ -569,24 +546,20 @@
           },
           "min_p": {
             "type": "number",
-            "description": "A number between 0 and 1 that can be used as an alternative to top_p and top-k.",
-            "format": "float"
+            "description": "A number between 0 and 1 that can be used as an alternative to top_p and top-k."
           },
           "presence_penalty": {
             "type": "number",
-            "description": "A number between -2.0 and 2.0 where a positive value increases the likelihood of a model talking about new topics.",
-            "format": "float"
+            "description": "A number between -2.0 and 2.0 where a positive value increases the likelihood of a model talking about new topics."
           },
           "frequency_penalty": {
             "type": "number",
-            "description": "A number between -2.0 and 2.0 where a positive value decreases the likelihood of repeating tokens that have already been mentioned.",
-            "format": "float"
+            "description": "A number between -2.0 and 2.0 where a positive value decreases the likelihood of repeating tokens that have already been mentioned."
           },
           "logit_bias": {
             "type": "object",
             "additionalProperties": {
-              "type": "number",
-              "format": "float"
+              "type": "number"
             },
             "description": "Adjusts the likelihood of specific tokens appearing in the generated output.",
             "example": {

--- a/packages/testing/provider-mock/contracts/together/provenance.json
+++ b/packages/testing/provider-mock/contracts/together/provenance.json
@@ -1,7 +1,7 @@
 {
   "sourceUrl": "https://docs.together.ai/openapi.yaml",
-  "sourceSha256": "57a72f332ec48a611e1e454b6a688950e0c0b2e3604a6958e1eb64c83cc813f5",
-  "bundleSha256": "b4401ddc777cd2cbf8deca9789ca98dfcbd8a1a6196b3c50c8ef433e2d5dadd3",
+  "sourceSha256": "43e29c4cb2798c8f5a340a123c48120f8fe6867adb82ec241f32a440b5cb0a24",
+  "bundleSha256": "c5a7320a8564d75b7c578c2c6b1a769d4376c862ab701de6696a744700a32140",
   "openapiVersion": "3.1.0",
   "apiVersion": "2.0.0",
   "gatewayPathMappings": [

--- a/packages/testing/provider-mock/contracts/venice-e2ee/openapi.json
+++ b/packages/testing/provider-mock/contracts/venice-e2ee/openapi.json
@@ -4,7 +4,7 @@
     "description": "The Venice.ai API.",
     "termsOfService": "https://venice.ai/legal/tos",
     "title": "Venice E2EE inherited provider contract",
-    "version": "20260709.204640",
+    "version": "20260804.102938",
     "x-guidance": "Venice.ai is an OpenAI-compatible inference API supporting text, image, audio, and video generation.\n\n**Authentication options:**\n- API Key: Use Bearer token in Authorization header\n- x402 Wallet: Use USDC credits via EVM or Solana wallet (no account required)\n\n**For x402 wallet access:**\n1. POST /x402/top-up without headers to get payment requirements\n2. Choose one of the returned Base or Solana payment options and sign a USDC payment using the x402 SDK\n3. POST /x402/top-up with PAYMENT-SIGNATURE header to add credits\n4. Call any inference endpoint with SIGN-IN-WITH-X header\n\n**Pricing:** Prepaid credits consumed per request. Check /models for available models and their capabilities."
   },
   "paths": {
@@ -284,6 +284,11 @@
                                     "enum": [
                                       "assistant"
                                     ]
+                                  },
+                                  "thought_signature": {
+                                    "type": "string",
+                                    "nullable": true,
+                                    "description": "Gemini thought signature returned by native GCP transport. For multi-turn conversations (especially with tool calls), pass it back exactly as received to preserve thought signatures."
                                   },
                                   "tool_calls": {
                                     "type": "array",
@@ -577,13 +582,13 @@
                           "example": [
                             {
                               "content": "What&#x27;s the scientific reason behind Earth&#x27;s sky appearing blue to the human eye? And what&#x27;s the real colour of the sky?\n\nSave 30% on the shop price when you subscribe to BBC Sky at Night Magazine today!\n\nIn this article we'll look at the science behind why the sky is blue, or at least why it appears blue to our eyes.\n\nA beautiful blue sky is the sign of a pleasant day ahead. But what makes the sky appear blue?\n\nSo, the sky appears blue because the molecules of nitrogen and oxygen in the atmosphere scatter light in short wavelengths towards the blue end of the visible spectrum.",
-                              "date": "2024-08-13T13:45:16.000Z",
+                              "date": "2024-08-13T13:45:16",
                               "title": "Why is the sky blue? | BBC Sky at Night Magazine",
                               "url": "https://www.skyatnightmagazine.com/space-science/why-is-the-sky-blue"
                             },
                             {
                               "content": "It was around 1870 when the British physicist John William Strutt, better known as Lord Rayleigh, first found an explanation for why the sky is blue: Blue light from the Sun is scattered the most when it passes through the atmosphere.\n\nPublished: January 20, 2025 8:34am EST · Daniel Freedman, University of Wisconsin-Stout · Daniel Freedman · Dean of the College of Science, Technology, Engineering, Mathematics & Management, University of Wisconsin-Stout ·\n\nThe answer has to do with molecules.\n\nIt was around 1870 when the British physicist John William Strutt, better known as Lord Rayleigh, first found an explanation for why the sky is blue: Blue light from the Sun is scattered the most when it passes through the atmosphere.\n\nWhen the Sun is near the horizon, its light passes through a lot more of the atmosphere to reach the Earth’s surface than when it is directly overhead. The blue and green light is scattered so well that you can hardly see it. The sky is colored, instead, with red and orange light.",
-                              "date": "2025-04-16T16:55:11.000Z",
+                              "date": "2025-04-16T16:55:11",
                               "title": "Why is the sky blue?",
                               "url": "https://theconversation.com/why-is-the-sky-blue-246393"
                             }
@@ -2078,6 +2083,11 @@
                         "assistant"
                       ]
                     },
+                    "thought_signature": {
+                      "type": "string",
+                      "nullable": true,
+                      "description": "Gemini thought signature returned by native GCP transport. For multi-turn conversations (especially with tool calls), pass it back exactly as received to preserve thought signatures."
+                    },
                     "tool_calls": {
                       "type": "array",
                       "nullable": true,
@@ -2503,7 +2513,7 @@
             "description": "Anthropic beta parameter for Claude Fable 5 server-side refusal fallback. Forwarded only for direct Anthropic routes; ignored for other providers.",
             "example": [
               {
-                "model": "claude-opus-5"
+                "model": "claude-opus-4-8"
               }
             ]
           },
@@ -3819,7 +3829,7 @@
             "description": "Anthropic beta parameter for Claude Fable 5 server-side refusal fallback. Forwarded only for direct Anthropic routes; ignored for other providers.",
             "example": [
               {
-                "model": "claude-opus-5"
+                "model": "claude-opus-4-8"
               }
             ]
           },
@@ -4326,7 +4336,7 @@
           "id": {
             "type": "string",
             "description": "Model ID",
-            "example": "zai-org-glm-5-2"
+            "example": "gemini-3-6-flash"
           },
           "model_spec": {
             "type": "object",
@@ -4339,7 +4349,7 @@
               "maxCompletionTokens": {
                 "type": "number",
                 "description": "The maximum number of completion tokens the model can generate. Use this to know the upper bound for the max_completion_tokens request parameter. Only applicable for text models.",
-                "example": 131072
+                "example": 65536
               },
               "beta": {
                 "type": "boolean",
@@ -4504,6 +4514,11 @@
                     "description": "Maximum number of images supported per request. Only present when supportsMultipleImages is true.",
                     "example": 10
                   },
+                  "maxVideos": {
+                    "type": "number",
+                    "description": "Maximum number of video attachments supported per chat request. Only present when supportsVideoInput is true.",
+                    "example": 4
+                  },
                   "supportsVision": {
                     "type": "boolean",
                     "description": "Does the LLM support vision?",
@@ -4656,6 +4671,16 @@
                         "type": "number",
                         "description": "The requested width and height of the image generation must be divisible by this value.",
                         "example": 8
+                      },
+                      "maxStyleReferences": {
+                        "type": "number",
+                        "description": "Maximum number of style_references accepted by POST /image/generate. Only present for models that support style references.",
+                        "example": 3
+                      },
+                      "supportsStyleReferenceStrength": {
+                        "type": "boolean",
+                        "description": "Whether per-reference `strength` is honored. When false, style_references strength is ignored. Only present for models that support style references.",
+                        "example": true
                       }
                     },
                     "required": [
@@ -4845,6 +4870,13 @@
                         "description": "Whether this model supports combining multiple input images.",
                         "example": true
                       },
+                      "maxInputImages": {
+                        "type": "integer",
+                        "minimum": 0,
+                        "exclusiveMinimum": true,
+                        "description": "Maximum number of input images accepted for combine/multi-edit. Absent means the default of 3 (or 1 when combineImages is false).",
+                        "example": 14
+                      },
                       "singleImageAspectRatio": {
                         "type": "boolean",
                         "description": "If false, output dimensions match the input on single-image edits and `aspect_ratio` is ignored. Multi-image edits are unaffected. Defaults to true.",
@@ -4906,6 +4938,11 @@
                 ],
                 "description": "Constraints that apply to this model."
               },
+              "supportsStyleReferences": {
+                "type": "boolean",
+                "description": "Whether this image model accepts `style_references` on POST /image/generate. Only present for image models.",
+                "example": true
+              },
               "description": {
                 "type": "string",
                 "description": "A human-readable description of the model and its capabilities.",
@@ -4914,12 +4951,12 @@
               "name": {
                 "type": "string",
                 "description": "The name of the model.",
-                "example": "GLM 5.2"
+                "example": "Gemini 3.6 Flash"
               },
               "modelSource": {
                 "type": "string",
                 "description": "The source of the model, such as a URL to the model repository.",
-                "example": "https://huggingface.co/zai-org/GLM-5.2"
+                "example": ""
               },
               "offline": {
                 "type": "boolean",
@@ -5768,6 +5805,11 @@
                 "description": "Whether this audio-generation model supports the force_instrumental request parameter.",
                 "example": true
               },
+              "supports_loop": {
+                "type": "boolean",
+                "description": "Whether this audio-generation model supports the loop request parameter.",
+                "example": true
+              },
               "voices": {
                 "type": "array",
                 "items": {
@@ -5832,6 +5874,11 @@
                 "type": "string",
                 "description": "Default voice for voice-enabled music models.",
                 "example": "Aria"
+              },
+              "supports_custom_voice_id": {
+                "type": "boolean",
+                "description": "Whether this model accepts a caller-supplied provider Voice ID in the `voice` parameter in addition to its curated `voices` (e.g. paste an ElevenLabs Voice ID).",
+                "example": true
               },
               "supports_language_code": {
                 "type": "boolean",

--- a/packages/testing/provider-mock/contracts/venice-e2ee/provenance.json
+++ b/packages/testing/provider-mock/contracts/venice-e2ee/provenance.json
@@ -4,5 +4,5 @@
     "kind": "official-openapi",
     "url": "https://docs.venice.ai/swagger.yaml"
   },
-  "bundleSha256": "6bcb0af11cde513959923f768ac99dead0e5068e4cf5a90c7203d2a98ce29ec1"
+  "bundleSha256": "8df76a95537c5ad7e615abeaff7817f8ba8237cbd3320270503712f666afe9c9"
 }

--- a/packages/testing/provider-mock/contracts/venice/openapi.json
+++ b/packages/testing/provider-mock/contracts/venice/openapi.json
@@ -4,7 +4,7 @@
     "description": "The Venice.ai API.",
     "termsOfService": "https://venice.ai/legal/tos",
     "title": "Venice.ai API",
-    "version": "20260709.204640",
+    "version": "20260804.102938",
     "x-guidance": "Venice.ai is an OpenAI-compatible inference API supporting text, image, audio, and video generation.\n\n**Authentication options:**\n- API Key: Use Bearer token in Authorization header\n- x402 Wallet: Use USDC credits via EVM or Solana wallet (no account required)\n\n**For x402 wallet access:**\n1. POST /x402/top-up without headers to get payment requirements\n2. Choose one of the returned Base or Solana payment options and sign a USDC payment using the x402 SDK\n3. POST /x402/top-up with PAYMENT-SIGNATURE header to add credits\n4. Call any inference endpoint with SIGN-IN-WITH-X header\n\n**Pricing:** Prepaid credits consumed per request. Check /models for available models and their capabilities."
   },
   "paths": {
@@ -284,6 +284,11 @@
                                     "enum": [
                                       "assistant"
                                     ]
+                                  },
+                                  "thought_signature": {
+                                    "type": "string",
+                                    "nullable": true,
+                                    "description": "Gemini thought signature returned by native GCP transport. For multi-turn conversations (especially with tool calls), pass it back exactly as received to preserve thought signatures."
                                   },
                                   "tool_calls": {
                                     "type": "array",
@@ -577,13 +582,13 @@
                           "example": [
                             {
                               "content": "What&#x27;s the scientific reason behind Earth&#x27;s sky appearing blue to the human eye? And what&#x27;s the real colour of the sky?\n\nSave 30% on the shop price when you subscribe to BBC Sky at Night Magazine today!\n\nIn this article we'll look at the science behind why the sky is blue, or at least why it appears blue to our eyes.\n\nA beautiful blue sky is the sign of a pleasant day ahead. But what makes the sky appear blue?\n\nSo, the sky appears blue because the molecules of nitrogen and oxygen in the atmosphere scatter light in short wavelengths towards the blue end of the visible spectrum.",
-                              "date": "2024-08-13T13:45:16.000Z",
+                              "date": "2024-08-13T13:45:16",
                               "title": "Why is the sky blue? | BBC Sky at Night Magazine",
                               "url": "https://www.skyatnightmagazine.com/space-science/why-is-the-sky-blue"
                             },
                             {
                               "content": "It was around 1870 when the British physicist John William Strutt, better known as Lord Rayleigh, first found an explanation for why the sky is blue: Blue light from the Sun is scattered the most when it passes through the atmosphere.\n\nPublished: January 20, 2025 8:34am EST · Daniel Freedman, University of Wisconsin-Stout · Daniel Freedman · Dean of the College of Science, Technology, Engineering, Mathematics & Management, University of Wisconsin-Stout ·\n\nThe answer has to do with molecules.\n\nIt was around 1870 when the British physicist John William Strutt, better known as Lord Rayleigh, first found an explanation for why the sky is blue: Blue light from the Sun is scattered the most when it passes through the atmosphere.\n\nWhen the Sun is near the horizon, its light passes through a lot more of the atmosphere to reach the Earth’s surface than when it is directly overhead. The blue and green light is scattered so well that you can hardly see it. The sky is colored, instead, with red and orange light.",
-                              "date": "2025-04-16T16:55:11.000Z",
+                              "date": "2025-04-16T16:55:11",
                               "title": "Why is the sky blue?",
                               "url": "https://theconversation.com/why-is-the-sky-blue-246393"
                             }
@@ -2078,6 +2083,11 @@
                         "assistant"
                       ]
                     },
+                    "thought_signature": {
+                      "type": "string",
+                      "nullable": true,
+                      "description": "Gemini thought signature returned by native GCP transport. For multi-turn conversations (especially with tool calls), pass it back exactly as received to preserve thought signatures."
+                    },
                     "tool_calls": {
                       "type": "array",
                       "nullable": true,
@@ -2503,7 +2513,7 @@
             "description": "Anthropic beta parameter for Claude Fable 5 server-side refusal fallback. Forwarded only for direct Anthropic routes; ignored for other providers.",
             "example": [
               {
-                "model": "claude-opus-5"
+                "model": "claude-opus-4-8"
               }
             ]
           },
@@ -3819,7 +3829,7 @@
             "description": "Anthropic beta parameter for Claude Fable 5 server-side refusal fallback. Forwarded only for direct Anthropic routes; ignored for other providers.",
             "example": [
               {
-                "model": "claude-opus-5"
+                "model": "claude-opus-4-8"
               }
             ]
           },
@@ -4326,7 +4336,7 @@
           "id": {
             "type": "string",
             "description": "Model ID",
-            "example": "zai-org-glm-5-2"
+            "example": "gemini-3-6-flash"
           },
           "model_spec": {
             "type": "object",
@@ -4339,7 +4349,7 @@
               "maxCompletionTokens": {
                 "type": "number",
                 "description": "The maximum number of completion tokens the model can generate. Use this to know the upper bound for the max_completion_tokens request parameter. Only applicable for text models.",
-                "example": 131072
+                "example": 65536
               },
               "beta": {
                 "type": "boolean",
@@ -4504,6 +4514,11 @@
                     "description": "Maximum number of images supported per request. Only present when supportsMultipleImages is true.",
                     "example": 10
                   },
+                  "maxVideos": {
+                    "type": "number",
+                    "description": "Maximum number of video attachments supported per chat request. Only present when supportsVideoInput is true.",
+                    "example": 4
+                  },
                   "supportsVision": {
                     "type": "boolean",
                     "description": "Does the LLM support vision?",
@@ -4656,6 +4671,16 @@
                         "type": "number",
                         "description": "The requested width and height of the image generation must be divisible by this value.",
                         "example": 8
+                      },
+                      "maxStyleReferences": {
+                        "type": "number",
+                        "description": "Maximum number of style_references accepted by POST /image/generate. Only present for models that support style references.",
+                        "example": 3
+                      },
+                      "supportsStyleReferenceStrength": {
+                        "type": "boolean",
+                        "description": "Whether per-reference `strength` is honored. When false, style_references strength is ignored. Only present for models that support style references.",
+                        "example": true
                       }
                     },
                     "required": [
@@ -4845,6 +4870,13 @@
                         "description": "Whether this model supports combining multiple input images.",
                         "example": true
                       },
+                      "maxInputImages": {
+                        "type": "integer",
+                        "minimum": 0,
+                        "exclusiveMinimum": true,
+                        "description": "Maximum number of input images accepted for combine/multi-edit. Absent means the default of 3 (or 1 when combineImages is false).",
+                        "example": 14
+                      },
                       "singleImageAspectRatio": {
                         "type": "boolean",
                         "description": "If false, output dimensions match the input on single-image edits and `aspect_ratio` is ignored. Multi-image edits are unaffected. Defaults to true.",
@@ -4906,6 +4938,11 @@
                 ],
                 "description": "Constraints that apply to this model."
               },
+              "supportsStyleReferences": {
+                "type": "boolean",
+                "description": "Whether this image model accepts `style_references` on POST /image/generate. Only present for image models.",
+                "example": true
+              },
               "description": {
                 "type": "string",
                 "description": "A human-readable description of the model and its capabilities.",
@@ -4914,12 +4951,12 @@
               "name": {
                 "type": "string",
                 "description": "The name of the model.",
-                "example": "GLM 5.2"
+                "example": "Gemini 3.6 Flash"
               },
               "modelSource": {
                 "type": "string",
                 "description": "The source of the model, such as a URL to the model repository.",
-                "example": "https://huggingface.co/zai-org/GLM-5.2"
+                "example": ""
               },
               "offline": {
                 "type": "boolean",
@@ -5768,6 +5805,11 @@
                 "description": "Whether this audio-generation model supports the force_instrumental request parameter.",
                 "example": true
               },
+              "supports_loop": {
+                "type": "boolean",
+                "description": "Whether this audio-generation model supports the loop request parameter.",
+                "example": true
+              },
               "voices": {
                 "type": "array",
                 "items": {
@@ -5832,6 +5874,11 @@
                 "type": "string",
                 "description": "Default voice for voice-enabled music models.",
                 "example": "Aria"
+              },
+              "supports_custom_voice_id": {
+                "type": "boolean",
+                "description": "Whether this model accepts a caller-supplied provider Voice ID in the `voice` parameter in addition to its curated `voices` (e.g. paste an ElevenLabs Voice ID).",
+                "example": true
               },
               "supports_language_code": {
                 "type": "boolean",

--- a/packages/testing/provider-mock/contracts/venice/provenance.json
+++ b/packages/testing/provider-mock/contracts/venice/provenance.json
@@ -1,9 +1,9 @@
 {
   "sourceUrl": "https://docs.venice.ai/swagger.yaml",
-  "sourceSha256": "b68096fa6725c675a4d86e7b7dc44207c8d5ca546ccb829e472f46db91f6cdaa",
-  "bundleSha256": "48c831bc195f9f6e70065200663e97388968325b7e16c288ea7330e6c30b3a24",
+  "sourceSha256": "d88b2fb81eb254cc3a2ae158de37bf014c7a616425aed20b9b22d94617d9f09e",
+  "bundleSha256": "dd83eaa4da1e36841a489667fdb9fd792510d33ea9165a9dcfe64a4c0492054d",
   "openapiVersion": "3.0.0",
-  "apiVersion": "20260709.204640",
+  "apiVersion": "20260804.102938",
   "gatewayPathMappings": [
     {
       "sourcePath": "/chat/completions",

--- a/packages/testing/provider-mock/scripts/sync-openai-contract.mjs
+++ b/packages/testing/provider-mock/scripts/sync-openai-contract.mjs
@@ -26,7 +26,12 @@ const paths = {};
 for (const expected of manifest.operations) {
   const upstream = source.paths?.[expected.path]?.[expected.method.toLowerCase()];
   const existingOverlay = existingContract.paths?.[expected.path]?.[expected.method.toLowerCase()];
-  if (!upstream && !existingOverlay) throw new Error(`OpenAI spec is missing ${expected.method.toUpperCase()} ${expected.path}`);
+  if (!upstream && !expected.sourceOverlay) {
+    throw new Error(`OpenAI spec is missing ${expected.method.toUpperCase()} ${expected.path}`);
+  }
+  if (!upstream && !existingOverlay) {
+    throw new Error(`OpenAI overlay is missing ${expected.method.toUpperCase()} ${expected.path}`);
+  }
   paths[expected.path] ??= {};
   paths[expected.path][expected.method.toLowerCase()] = stripDocumentation(upstream ?? existingOverlay);
 }
@@ -76,7 +81,7 @@ await writeFile(path.join(contractDir, "provenance.json"), `${JSON.stringify({
   openapiVersion: source.openapi,
   apiVersion: source.info?.version,
   overlays: manifest.operations
-    .filter((operation) => !source.paths?.[operation.path]?.[operation.method.toLowerCase()])
+    .filter((operation) => operation.sourceOverlay && !source.paths?.[operation.path]?.[operation.method.toLowerCase()])
     .map((operation) => `${operation.method.toUpperCase()} ${operation.path}`),
 }, null, 2)}\n`);
 console.log(`OpenAI contract synced: ${manifest.operations.length} operations, ${copied.size} referenced components, ${output.length} bytes`);

--- a/packages/testing/provider-mock/scripts/sync-openai-contract.mjs
+++ b/packages/testing/provider-mock/scripts/sync-openai-contract.mjs
@@ -7,6 +7,7 @@ import { parse } from "yaml";
 const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 const contractDir = path.join(root, "contracts", "openai");
 const manifest = JSON.parse(await readFile(path.join(contractDir, "manifest.json"), "utf8"));
+const existingContract = JSON.parse(await readFile(path.join(contractDir, "openapi.json"), "utf8"));
 
 const response = await fetch(manifest.source.url, { headers: { "user-agent": "phaseo-provider-contract-sync/1.0" } });
 if (!response.ok) throw new Error(`OpenAI contract download failed: ${response.status} ${response.statusText}`);
@@ -24,9 +25,10 @@ function stripDocumentation(value) {
 const paths = {};
 for (const expected of manifest.operations) {
   const upstream = source.paths?.[expected.path]?.[expected.method.toLowerCase()];
-  if (!upstream) throw new Error(`OpenAI spec is missing ${expected.method.toUpperCase()} ${expected.path}`);
+  const existingOverlay = existingContract.paths?.[expected.path]?.[expected.method.toLowerCase()];
+  if (!upstream && !existingOverlay) throw new Error(`OpenAI spec is missing ${expected.method.toUpperCase()} ${expected.path}`);
   paths[expected.path] ??= {};
-  paths[expected.path][expected.method.toLowerCase()] = stripDocumentation(upstream);
+  paths[expected.path][expected.method.toLowerCase()] = stripDocumentation(upstream ?? existingOverlay);
 }
 
 const refs = new Set();
@@ -73,5 +75,8 @@ await writeFile(path.join(contractDir, "provenance.json"), `${JSON.stringify({
   bundleSha256,
   openapiVersion: source.openapi,
   apiVersion: source.info?.version,
+  overlays: manifest.operations
+    .filter((operation) => !source.paths?.[operation.path]?.[operation.method.toLowerCase()])
+    .map((operation) => `${operation.method.toUpperCase()} ${operation.path}`),
 }, null, 2)}\n`);
 console.log(`OpenAI contract synced: ${manifest.operations.length} operations, ${copied.size} referenced components, ${output.length} bytes`);


### PR DESCRIPTION
## Summary
- refresh OpenAI, DeepInfra, Fireworks, Friendli, Mistral, Together, and Venice contract slices from their current official OpenAPI sources
- regenerate affected OpenAI EU and Venice E2EE inherited aliases
- preserve documented Phaseo-only OpenAI operations when the upstream spec omits them
- record omitted upstream operations explicitly as provenance overlays

## Validation
- `pnpm --filter @phaseo/provider-mock test` (118/118)
- `pnpm --filter @phaseo/provider-mock build`

Created with Codex