### PR TITLE
Align OpenAI audio contracts

### DIFF
--- a/.changeset/openai-diarized-transcription.md
+++ b/.changeset/openai-diarized-transcription.md
@@ -1,0 +1,6 @@
+---
+"@phaseo/gateway-api": patch
+"@phaseo/sdk": patch
+---
+
+Add current OpenAI diarized transcription controls and reject unsupported transcription and translation parameter combinations before sending them upstream.

--- a/apps/api/src/core/ir.ts
+++ b/apps/api/src/core/ir.ts
@@ -515,6 +515,14 @@ export type IRAudioTranscriptionRequest = {
 	responseFormat?: string;
 	timestampGranularities?: Array<"word" | "segment">;
 	include?: string[];
+	chunkingStrategy?: "auto" | {
+		type: "server_vad";
+		prefix_padding_ms?: number;
+		silence_duration_ms?: number;
+		threshold?: number;
+	};
+	knownSpeakerNames?: string[];
+	knownSpeakerReferences?: string[];
 	rawRequest?: any;
 };
 

--- a/apps/api/src/core/schemas.ts
+++ b/apps/api/src/core/schemas.ts
@@ -1124,6 +1124,17 @@ export const AudioTranscriptionSchema = z.object({
     response_format: z.string().optional(),
     timestamp_granularities: z.array(z.enum(["word", "segment"])).optional(),
     include: z.array(z.string()).optional(),
+    chunking_strategy: z.union([
+        z.literal("auto"),
+        z.object({
+            type: z.literal("server_vad"),
+            prefix_padding_ms: z.number().int().nonnegative().optional(),
+            silence_duration_ms: z.number().int().nonnegative().optional(),
+            threshold: z.number().min(0).max(1).optional(),
+        }),
+    ]).optional(),
+    known_speaker_names: z.array(z.string().min(1)).max(4).optional(),
+    known_speaker_references: z.array(z.string().min(1)).max(4).optional(),
     echo_upstream_request: z.boolean().optional(),
     debug: DebugOptionsSchema,
     beta: BetaOptionsSchema,

--- a/apps/api/src/executors/_shared/non-text/adapter-bridge.test.ts
+++ b/apps/api/src/executors/_shared/non-text/adapter-bridge.test.ts
@@ -37,6 +37,44 @@ afterAll(() => {
 });
 
 describe("non-text adapter bridge", () => {
+	it("forwards diarization controls through the transcription IR bridge", async () => {
+		let capturedForm: FormData | undefined;
+		const mock = installFetchMock([{
+			match: (url, init) => {
+				capturedForm = init?.body as FormData;
+				return url.includes("/audio/transcriptions");
+			},
+			response: jsonResponse({ text: "hello" }),
+		}]);
+
+		await executeNonTextAdapter({
+			ir: {
+				type: "audio.transcription",
+				model: "openai/gpt-4o-transcribe-diarize",
+				file: new File(["audio"], "sample.wav", { type: "audio/wav" }),
+				responseFormat: "diarized_json",
+				chunkingStrategy: { type: "server_vad", silence_duration_ms: 500 },
+				knownSpeakerNames: ["agent"],
+				knownSpeakerReferences: ["data:audio/wav;base64,AQID"],
+			},
+			requestId: "req_non_text_transcription_1",
+			workspaceId: "team_test",
+			providerId: "openai",
+			endpoint: "audio.transcription",
+			providerModelSlug: "gpt-4o-transcribe-diarize",
+			byokMeta: [],
+			pricingCard: { ...PRICING_CARD, provider: "openai", endpoint: "audio.transcription" },
+			meta: {},
+		} as any);
+
+		mock.restore();
+		expect(capturedForm?.get("chunking_strategy")).toBe(
+			JSON.stringify({ type: "server_vad", silence_duration_ms: 500 }),
+		);
+		expect(capturedForm?.getAll("known_speaker_names[]")).toEqual(["agent"]);
+		expect(capturedForm?.getAll("known_speaker_references[]")).toEqual(["data:audio/wav;base64,AQID"]);
+	});
+
 	it("routes google-ai-studio images to the dedicated provider adapter", async () => {
 		let capturedUrl = "";
 		const mock = installFetchMock([

--- a/apps/api/src/executors/_shared/non-text/adapter-bridge.ts
+++ b/apps/api/src/executors/_shared/non-text/adapter-bridge.ts
@@ -231,6 +231,9 @@ function irToAdapterBody(endpoint: NonTextEndpoint, ir: ExecutorExecuteArgs["ir"
 				response_format: request.responseFormat,
 				timestamp_granularities: request.timestampGranularities,
 				include: request.include,
+				chunking_strategy: request.chunkingStrategy,
+				known_speaker_names: request.knownSpeakerNames,
+				known_speaker_references: request.knownSpeakerReferences,
 			};
 		}
 

--- a/apps/api/src/pipeline/before/guards.test.ts
+++ b/apps/api/src/pipeline/before/guards.test.ts
@@ -10,6 +10,7 @@ describe("guardJson", () => {
 		form.append("include[]", "logprobs");
 		form.append("include", "timestamps");
 		form.append("timestamp_granularities[]", "word");
+		form.append("chunking_strategy", JSON.stringify({ type: "server_vad", silence_duration_ms: 500 }));
 		form.append("provider", JSON.stringify({ order: ["openai"] }));
 
 		const req = new Request("https://gateway.local/v1/audio/transcriptions", {
@@ -25,6 +26,7 @@ describe("guardJson", () => {
 		expect(Array.isArray(result.value.include)).toBe(true);
 		expect(result.value.include).toEqual(["logprobs", "timestamps"]);
 		expect(result.value.timestamp_granularities).toEqual(["word"]);
+		expect(result.value.chunking_strategy).toEqual({ type: "server_vad", silence_duration_ms: 500 });
 		expect(result.value.provider).toEqual({ order: ["openai"] });
 		expect(typeof File !== "undefined" && result.value.file instanceof File).toBe(true);
 	});

--- a/apps/api/src/pipeline/before/guards.ts
+++ b/apps/api/src/pipeline/before/guards.ts
@@ -25,7 +25,7 @@ import type { PriceCard } from "../pricing";
 
 const MIN_CREDIT_AMOUNT = 1.0;
 const TRUTHY_VALUES = new Set(["1", "true", "yes"]);
-const FORM_JSON_FIELDS = new Set(["provider", "debug", "include", "timestamp_granularities"]);
+const FORM_JSON_FIELDS = new Set(["provider", "debug", "include", "timestamp_granularities", "chunking_strategy"]);
 const FORM_FORCE_ARRAY_FIELDS = new Set(["include", "timestamp_granularities"]);
 const DEFAULT_REQUEST_BODY_LIMIT_BYTES = 16 * 1024 * 1024;
 const MULTIPART_REQUEST_BODY_LIMIT_BYTES = 32 * 1024 * 1024;

--- a/apps/api/src/pipeline/surfaces/non-text.ts
+++ b/apps/api/src/pipeline/surfaces/non-text.ts
@@ -216,6 +216,9 @@ function decodeNonTextRequest(endpoint: NonTextEndpoint, body: any): NonTextIRRe
 					? body.timestamp_granularities
 					: undefined,
 				include: Array.isArray(body?.include) ? body.include : undefined,
+				chunkingStrategy: body?.chunking_strategy,
+				knownSpeakerNames: Array.isArray(body?.known_speaker_names) ? body.known_speaker_names : undefined,
+				knownSpeakerReferences: Array.isArray(body?.known_speaker_references) ? body.known_speaker_references : undefined,
 				rawRequest: body,
 			};
 		case "audio.translations":

--- a/apps/api/src/providers/openai/__tests__/media-endpoints.test.ts
+++ b/apps/api/src/providers/openai/__tests__/media-endpoints.test.ts
@@ -838,7 +838,7 @@ describe("OpenAI media endpoints", () => {
 		expect(payload?.error?.param).toBe("format");
 	});
 
-	it("defaults transcriptions to json for GPT transcribe and forwards include/timestamp fields", async () => {
+	it("defaults transcriptions to json for GPT transcribe and forwards logprobs", async () => {
 		let responseFormat: string | null = null;
 		let includes: string[] = [];
 		let granularities: string[] = [];
@@ -871,7 +871,6 @@ describe("OpenAI media endpoints", () => {
 				model: "openai/gpt-4o-transcribe",
 				file: audioFile,
 				include: ["logprobs"],
-				timestamp_granularities: ["segment", "word"],
 			},
 			meta: REQUEST_META,
 			workspaceId: "team_test",
@@ -888,8 +887,47 @@ describe("OpenAI media endpoints", () => {
 		expect(result.normalized?.text).toBe("hello");
 		expect(responseFormat).toBe("json");
 		expect(includes).toEqual(["logprobs"]);
-		expect(granularities).toEqual(["segment", "word"]);
+		expect(granularities).toEqual([]);
 		expect(fileName).toBe("audio.wav");
+	});
+
+	it("supports diarized transcription formats and speaker controls", async () => {
+		let capturedForm: FormData | undefined;
+		const mock = installFetchMock([{
+			match: (url, init) => {
+				if (!url.includes("/audio/transcriptions")) return false;
+				capturedForm = init?.body as FormData;
+				return true;
+			},
+			response: jsonResponse({ text: "Agent: hello", segments: [] }),
+		}]);
+
+		const result = await execTranscription({
+			endpoint: "audio.transcription",
+			model: "openai/gpt-4o-transcribe-diarize",
+			body: {
+				model: "openai/gpt-4o-transcribe-diarize",
+				file: makeAudioFile(),
+				response_format: "diarized_json",
+				chunking_strategy: "auto",
+				known_speaker_names: ["agent"],
+				known_speaker_references: ["data:audio/wav;base64,AQID"],
+			},
+			meta: REQUEST_META,
+			workspaceId: "team_test",
+			providerId: "openai",
+			byokMeta: [],
+			pricingCard: { ...PRICING_CARD, endpoint: "audio.transcription" },
+			providerModelSlug: null,
+			stream: false,
+		} as any);
+		mock.restore();
+
+		expect(result.upstream.status).toBe(200);
+		expect(capturedForm?.get("response_format")).toBe("diarized_json");
+		expect(capturedForm?.get("chunking_strategy")).toBe("auto");
+		expect(capturedForm?.getAll("known_speaker_names[]")).toEqual(["agent"]);
+		expect(capturedForm?.getAll("known_speaker_references[]")).toEqual(["data:audio/wav;base64,AQID"]);
 	});
 
 	it("defaults transcriptions to verbose_json for whisper-1", async () => {
@@ -968,9 +1006,9 @@ describe("OpenAI media endpoints", () => {
 		const audioFile = makeAudioFile();
 		const transcription = await execTranscription({
 			endpoint: "audio.transcription",
-			model: "openai/gpt-4o-mini-transcribe",
+			model: "openai/whisper-1",
 			body: {
-				model: "openai/gpt-4o-mini-transcribe",
+				model: "openai/whisper-1",
 				file: audioFile,
 				response_format: "text",
 			},
@@ -985,9 +1023,9 @@ describe("OpenAI media endpoints", () => {
 
 		const translation = await execTranslation({
 			endpoint: "audio.translations",
-			model: "openai/gpt-4o-transcribe",
+			model: "openai/whisper-1",
 			body: {
-				model: "openai/gpt-4o-transcribe",
+				model: "openai/whisper-1",
 				file: audioFile,
 				response_format: "text",
 			},
@@ -1043,9 +1081,9 @@ describe("OpenAI media endpoints", () => {
 
 		const translation = await execTranslation({
 			endpoint: "audio.translations",
-			model: "openai/gpt-4o-mini-transcribe",
+			model: "openai/whisper-1",
 			body: {
-				model: "openai/gpt-4o-mini-transcribe",
+				model: "openai/whisper-1",
 				file: audioFile,
 				prompt: "translate to english",
 			},

--- a/apps/api/src/providers/openai/endpoints/audio-transcription.ts
+++ b/apps/api/src/providers/openai/endpoints/audio-transcription.ts
@@ -24,6 +24,23 @@ function defaultTranscriptionResponseFormat(model?: string | null): string {
     return "verbose_json";
 }
 
+function invalidParameterResponse(param: string, message: string): Response {
+    return new Response(
+        JSON.stringify({ error: { type: "invalid_request_error", message, param } }),
+        { status: 400, headers: { "Content-Type": "application/json" } },
+    );
+}
+
+function emptyBill() {
+    return {
+        cost_cents: 0,
+        currency: "USD" as const,
+        usage: undefined as any,
+        upstream_id: null,
+        finish_reason: null,
+    };
+}
+
 async function parseAudioTextPayload(response: Response): Promise<Record<string, any> | undefined> {
     const contentType = (response.headers.get("content-type") || "").toLowerCase();
     if (contentType.includes("application/json")) {
@@ -48,6 +65,109 @@ export async function exec(args: ProviderExecuteArgs): Promise<AdapterResult> {
         model: args.providerModelSlug || adapterPayload.model,
     };
 
+    const modelName = normalizeModelName(body.model).toLowerCase();
+    const responseFormat = body.response_format ?? defaultTranscriptionResponseFormat(body.model);
+    const isGptTranscribe = modelName.includes("transcribe") && modelName !== "whisper-1";
+    const isDiarize = modelName.includes("transcribe-diarize");
+    const supportedGptFormats = isDiarize
+        ? new Set(["json", "text", "diarized_json"])
+        : new Set(["json"]);
+    if (isGptTranscribe && !supportedGptFormats.has(responseFormat)) {
+        return {
+            kind: "completed",
+            upstream: invalidParameterResponse(
+                "response_format",
+                isDiarize
+                    ? `${modelName} supports response_format="json", "text", or "diarized_json".`
+                    : `${modelName} only supports response_format="json".`,
+            ),
+            bill: emptyBill(),
+            keySource: keyInfo.source,
+            byokKeyId: keyInfo.byokId,
+        };
+    }
+    if (isGptTranscribe && (body.timestamp_granularities?.length ?? 0) > 0) {
+        return {
+            kind: "completed",
+            upstream: invalidParameterResponse(
+                "timestamp_granularities",
+                `${modelName} does not support timestamp_granularities; use whisper-1 with verbose_json.`,
+            ),
+            bill: emptyBill(),
+            keySource: keyInfo.source,
+            byokKeyId: keyInfo.byokId,
+        };
+    }
+    if (isDiarize && body.prompt) {
+        return {
+            kind: "completed",
+            upstream: invalidParameterResponse("prompt", `${modelName} does not support prompt.`),
+            bill: emptyBill(),
+            keySource: keyInfo.source,
+            byokKeyId: keyInfo.byokId,
+        };
+    }
+    if (isDiarize && (body.include?.length ?? 0) > 0) {
+        return {
+            kind: "completed",
+            upstream: invalidParameterResponse("include", `${modelName} does not support include.`),
+            bill: emptyBill(),
+            keySource: keyInfo.source,
+            byokKeyId: keyInfo.byokId,
+        };
+    }
+    if (isGptTranscribe && !isDiarize) {
+        const unsupported = body.include?.find((entry) => entry !== "logprobs");
+        if (unsupported) {
+            return {
+                kind: "completed",
+                upstream: invalidParameterResponse("include", `${modelName} only supports include=["logprobs"].`),
+                bill: emptyBill(),
+                keySource: keyInfo.source,
+                byokKeyId: keyInfo.byokId,
+            };
+        }
+    }
+    if (modelName === "whisper-1") {
+        const supportedFormats = new Set(["json", "text", "srt", "verbose_json", "vtt"]);
+        if (!supportedFormats.has(responseFormat)) {
+            return {
+                kind: "completed",
+                upstream: invalidParameterResponse(
+                    "response_format",
+                    `whisper-1 does not support response_format="${responseFormat}".`,
+                ),
+                bill: emptyBill(),
+                keySource: keyInfo.source,
+                byokKeyId: keyInfo.byokId,
+            };
+        }
+        if ((body.include?.length ?? 0) > 0) {
+            return {
+                kind: "completed",
+                upstream: invalidParameterResponse(
+                    "include",
+                    "whisper-1 does not support include; log probabilities require a GPT transcription model.",
+                ),
+                bill: emptyBill(),
+                keySource: keyInfo.source,
+                byokKeyId: keyInfo.byokId,
+            };
+        }
+        if ((body.timestamp_granularities?.length ?? 0) > 0 && responseFormat !== "verbose_json") {
+            return {
+                kind: "completed",
+                upstream: invalidParameterResponse(
+                    "timestamp_granularities",
+                    "whisper-1 timestamp_granularities require response_format=\"verbose_json\".",
+                ),
+                bill: emptyBill(),
+                keySource: keyInfo.source,
+                byokKeyId: keyInfo.byokId,
+            };
+        }
+    }
+
     const form = new FormData();
     form.append("model", body.model);
     const filename = typeof File !== "undefined" && body.file instanceof File && body.file.name
@@ -57,7 +177,7 @@ export async function exec(args: ProviderExecuteArgs): Promise<AdapterResult> {
     if (body.language) form.append("language", body.language);
     if (body.prompt) form.append("prompt", body.prompt);
     if (typeof body.temperature === "number") form.append("temperature", String(body.temperature));
-    form.append("response_format", body.response_format ?? defaultTranscriptionResponseFormat(body.model));
+    form.append("response_format", responseFormat);
     if (Array.isArray(body.timestamp_granularities)) {
         for (const entry of body.timestamp_granularities) {
             if (entry === "word" || entry === "segment") {
@@ -71,6 +191,20 @@ export async function exec(args: ProviderExecuteArgs): Promise<AdapterResult> {
                 form.append("include[]", entry);
             }
         }
+    }
+    if (body.chunking_strategy !== undefined) {
+        form.append(
+            "chunking_strategy",
+            typeof body.chunking_strategy === "string"
+                ? body.chunking_strategy
+                : JSON.stringify(body.chunking_strategy),
+        );
+    }
+    for (const name of body.known_speaker_names ?? []) {
+        form.append("known_speaker_names[]", name);
+    }
+    for (const reference of body.known_speaker_references ?? []) {
+        form.append("known_speaker_references[]", reference);
     }
 
     const headers = openAICompatHeaders(args.providerId, keyInfo.key, upstreamTestHeaders(args.meta));

--- a/apps/api/src/providers/openai/endpoints/audio-translation.ts
+++ b/apps/api/src/providers/openai/endpoints/audio-translation.ts
@@ -23,6 +23,13 @@ function defaultTranslationResponseFormat(model?: string | null): string {
     return "verbose_json";
 }
 
+function invalidParameterResponse(param: string, message: string): Response {
+    return new Response(
+        JSON.stringify({ error: { type: "invalid_request_error", message, param } }),
+        { status: 400, headers: { "Content-Type": "application/json" } },
+    );
+}
+
 async function parseAudioTextPayload(response: Response): Promise<Record<string, any> | undefined> {
     const contentType = (response.headers.get("content-type") || "").toLowerCase();
     if (contentType.includes("application/json")) {
@@ -47,6 +54,31 @@ export async function exec(args: ProviderExecuteArgs): Promise<AdapterResult> {
         model: args.providerModelSlug || adapterPayload.model,
     };
 
+    const modelName = normalizeModelName(body.model).toLowerCase();
+    const responseFormat = body.response_format ?? defaultTranslationResponseFormat(body.model);
+    const isOpenAI = args.providerId === "openai" || args.providerId === "openai-eu";
+    if (isOpenAI && modelName !== "whisper-1") {
+        return {
+            kind: "completed",
+            upstream: invalidParameterResponse("model", "OpenAI audio translations support only whisper-1."),
+            bill: { cost_cents: 0, currency: "USD", usage: undefined, upstream_id: null, finish_reason: null },
+            keySource: keyInfo.source,
+            byokKeyId: keyInfo.byokId,
+        };
+    }
+    if (modelName === "whisper-1" && !new Set(["json", "text", "srt", "verbose_json", "vtt"]).has(responseFormat)) {
+        return {
+            kind: "completed",
+            upstream: invalidParameterResponse(
+                "response_format",
+                `whisper-1 translations do not support response_format="${responseFormat}".`,
+            ),
+            bill: { cost_cents: 0, currency: "USD", usage: undefined, upstream_id: null, finish_reason: null },
+            keySource: keyInfo.source,
+            byokKeyId: keyInfo.byokId,
+        };
+    }
+
     const form = new FormData();
     form.append("model", body.model);
     const filename = typeof File !== "undefined" && body.file instanceof File && body.file.name
@@ -55,7 +87,7 @@ export async function exec(args: ProviderExecuteArgs): Promise<AdapterResult> {
     form.append("file", body.file, filename);
     if (body.prompt) form.append("prompt", body.prompt);
     if (typeof body.temperature === "number") form.append("temperature", String(body.temperature));
-    form.append("response_format", body.response_format ?? defaultTranslationResponseFormat(body.model));
+    form.append("response_format", responseFormat);
 
     const headers = openAICompatHeaders(args.providerId, keyInfo.key, upstreamTestHeaders(args.meta));
     delete (headers as any)["Content-Type"];

--- a/apps/docs/openapi/v1/openapi.yaml
+++ b/apps/docs/openapi/v1/openapi.yaml
@@ -4891,39 +4891,6 @@ components:
           type: array
           items:
             type: string
-        chunking_strategy:
-          oneOf:
-            - type: string
-              enum:
-                - auto
-            - type: object
-              required:
-                - type
-              properties:
-                type:
-                  type: string
-                  enum:
-                    - server_vad
-                prefix_padding_ms:
-                  type: integer
-                  minimum: 0
-                silence_duration_ms:
-                  type: integer
-                  minimum: 0
-                threshold:
-                  type: number
-                  minimum: 0
-                  maximum: 1
-        known_speaker_names:
-          type: array
-          maxItems: 4
-          items:
-            type: string
-        known_speaker_references:
-          type: array
-          maxItems: 4
-          items:
-            type: string
         instructions:
           type: string
         max_output_tokens:
@@ -5681,6 +5648,39 @@ components:
           type: string
         language:
           type: string
+        chunking_strategy:
+          oneOf:
+            - type: string
+              enum:
+                - auto
+            - type: object
+              required:
+                - type
+              properties:
+                type:
+                  type: string
+                  enum:
+                    - server_vad
+                prefix_padding_ms:
+                  type: integer
+                  minimum: 0
+                silence_duration_ms:
+                  type: integer
+                  minimum: 0
+                threshold:
+                  type: number
+                  minimum: 0
+                  maximum: 1
+        known_speaker_names:
+          type: array
+          maxItems: 4
+          items:
+            type: string
+        known_speaker_references:
+          type: array
+          maxItems: 4
+          items:
+            type: string
         provider:
           $ref: '#/components/schemas/ProviderRoutingOptions'
     AudioTranscriptionResponse:

--- a/apps/docs/openapi/v1/openapi.yaml
+++ b/apps/docs/openapi/v1/openapi.yaml
@@ -4891,6 +4891,39 @@ components:
           type: array
           items:
             type: string
+        chunking_strategy:
+          oneOf:
+            - type: string
+              enum:
+                - auto
+            - type: object
+              required:
+                - type
+              properties:
+                type:
+                  type: string
+                  enum:
+                    - server_vad
+                prefix_padding_ms:
+                  type: integer
+                  minimum: 0
+                silence_duration_ms:
+                  type: integer
+                  minimum: 0
+                threshold:
+                  type: number
+                  minimum: 0
+                  maximum: 1
+        known_speaker_names:
+          type: array
+          maxItems: 4
+          items:
+            type: string
+        known_speaker_references:
+          type: array
+          maxItems: 4
+          items:
+            type: string
         instructions:
           type: string
         max_output_tokens:

--- a/packages/sdk/sdk-cpp/src/gen/models.hpp
+++ b/packages/sdk/sdk-cpp/src/gen/models.hpp
@@ -238,6 +238,9 @@ struct AudioSpeechRequest {
 struct AudioTranscriptionRequest {
 	std::string audio_b64;
 	std::string audio_url;
+	std::any chunking_strategy;
+	std::vector<std::string> known_speaker_names;
+	std::vector<std::string> known_speaker_references;
 	std::string language;
 	std::string model;
 	std::map<std::string, std::any> provider;

--- a/packages/sdk/sdk-csharp/src/gen/Models.cs
+++ b/packages/sdk/sdk-csharp/src/gen/Models.cs
@@ -570,6 +570,15 @@ public sealed class AudioTranscriptionRequest
 	[JsonPropertyName("audio_url")]
 	public string? AudioUrl { get; set; }
 
+	[JsonPropertyName("chunking_strategy")]
+	public object? ChunkingStrategy { get; set; }
+
+	[JsonPropertyName("known_speaker_names")]
+	public List<string>? KnownSpeakerNames { get; set; }
+
+	[JsonPropertyName("known_speaker_references")]
+	public List<string>? KnownSpeakerReferences { get; set; }
+
 	[JsonPropertyName("language")]
 	public string? Language { get; set; }
 

--- a/packages/sdk/sdk-go/src/gen/models.go
+++ b/packages/sdk/sdk-go/src/gen/models.go
@@ -232,6 +232,9 @@ type AudioSpeechRequest struct {
 type AudioTranscriptionRequest struct {
 	AudioB64 *string `json:"audio_b64,omitempty"`
 	AudioUrl *string `json:"audio_url,omitempty"`
+	ChunkingStrategy interface{} `json:"chunking_strategy,omitempty"`
+	KnownSpeakerNames *[]string `json:"known_speaker_names,omitempty"`
+	KnownSpeakerReferences *[]string `json:"known_speaker_references,omitempty"`
 	Language *string `json:"language,omitempty"`
 	Model string `json:"model"`
 	Provider *map[string]interface{} `json:"provider,omitempty"`

--- a/packages/sdk/sdk-java/src/app/phaseo/gen/Models.java
+++ b/packages/sdk/sdk-java/src/app/phaseo/gen/Models.java
@@ -236,6 +236,9 @@ public final class Models {
 	public static class AudioTranscriptionRequest {
 		public String audio_b64;
 		public String audio_url;
+		public Object chunking_strategy;
+		public java.util.List<String> known_speaker_names;
+		public java.util.List<String> known_speaker_references;
 		public String language;
 		public String model;
 		public Object provider;

--- a/packages/sdk/sdk-php/src/gen/Models.php
+++ b/packages/sdk/sdk-php/src/gen/Models.php
@@ -415,6 +415,12 @@ class AudioTranscriptionRequest
 	public $audio_b64;
 	/** @var string|null */
 	public $audio_url;
+	/** @var string|array<string, mixed>|null */
+	public $chunking_strategy;
+	/** @var array|null */
+	public $known_speaker_names;
+	/** @var array|null */
+	public $known_speaker_references;
 	/** @var string|null */
 	public $language;
 	/** @var string */

--- a/packages/sdk/sdk-py/src/gen/models.py
+++ b/packages/sdk/sdk-py/src/gen/models.py
@@ -210,6 +210,9 @@ class AudioSpeechRequest(TypedDict):
 class AudioTranscriptionRequest(TypedDict):
 	audio_b64: NotRequired[str]
 	audio_url: NotRequired[str]
+	chunking_strategy: NotRequired[Union[Literal["auto"], Dict[str, Any]]]
+	known_speaker_names: NotRequired[List[str]]
+	known_speaker_references: NotRequired[List[str]]
 	language: NotRequired[str]
 	model: str
 	provider: NotRequired[Dict[str, Any]]

--- a/packages/sdk/sdk-ruby/lib/gen/models.rb
+++ b/packages/sdk/sdk-ruby/lib/gen/models.rb
@@ -334,13 +334,19 @@ module Phaseo
     #   @return [String, nil]
     # @!attribute [rw] audio_url
     #   @return [String, nil]
+    # @!attribute [rw] chunking_strategy
+    #   @return [String, Hash{String => Object}, nil]
+    # @!attribute [rw] known_speaker_names
+    #   @return [Array<String>, nil]
+    # @!attribute [rw] known_speaker_references
+    #   @return [Array<String>, nil]
     # @!attribute [rw] language
     #   @return [String, nil]
     # @!attribute [rw] model
     #   @return [String]
     # @!attribute [rw] provider
     #   @return [Hash{String => Object}, nil]
-    AudioTranscriptionRequest = Struct.new(:audio_b64, :audio_url, :language, :model, :provider, keyword_init: true)
+    AudioTranscriptionRequest = Struct.new(:audio_b64, :audio_url, :chunking_strategy, :known_speaker_names, :known_speaker_references, :language, :model, :provider, keyword_init: true)
     # @!attribute [rw] text
     #   @return [String, nil]
     AudioTranscriptionResponse = Struct.new(:text, keyword_init: true)

--- a/packages/sdk/sdk-rust/src/gen/models.rs
+++ b/packages/sdk/sdk-rust/src/gen/models.rs
@@ -234,6 +234,9 @@ pub struct AudioSpeechRequest {
 pub struct AudioTranscriptionRequest {
 	pub audio_b64: Option<String>,
 	pub audio_url: Option<String>,
+	pub chunking_strategy: Option<String>,
+	pub known_speaker_names: Option<Vec<String>>,
+	pub known_speaker_references: Option<Vec<String>>,
 	pub language: Option<String>,
 	pub model: String,
 	pub provider: Option<HashMap<String, String>>,

--- a/packages/sdk/sdk-ts/src/oapi-gen/client/default.ts
+++ b/packages/sdk/sdk-ts/src/oapi-gen/client/default.ts
@@ -3672,6 +3672,16 @@ export type CreateTranscriptionParams = {
   body?: {
     audio_b64?: string;
     audio_url?: string;
+    chunking_strategy?:
+      | "auto"
+      | {
+          prefix_padding_ms?: number;
+          silence_duration_ms?: number;
+          threshold?: number;
+          type: "server_vad";
+        };
+    known_speaker_names?: string[];
+    known_speaker_references?: string[];
     language?: string;
     model: string;
     provider?: {

--- a/packages/sdk/sdk-ts/src/oapi-gen/models/AudioTranscriptionRequest.ts
+++ b/packages/sdk/sdk-ts/src/oapi-gen/models/AudioTranscriptionRequest.ts
@@ -1,4 +1,6 @@
 export interface AudioTranscriptionRequest {
+  audio_b64?: string;
+  audio_url?: string;
   chunking_strategy?:
     | "auto"
     | {
@@ -7,11 +9,9 @@ export interface AudioTranscriptionRequest {
         threshold?: number;
         type: "server_vad";
       };
-  audio_b64?: string;
-  audio_url?: string;
-  language?: string;
   known_speaker_names?: string[];
   known_speaker_references?: string[];
+  language?: string;
   model: string;
   provider?: {
     allow_fallbacks?: boolean | null;

--- a/packages/sdk/sdk-ts/src/oapi-gen/models/AudioTranscriptionRequest.ts
+++ b/packages/sdk/sdk-ts/src/oapi-gen/models/AudioTranscriptionRequest.ts
@@ -1,7 +1,17 @@
 export interface AudioTranscriptionRequest {
+  chunking_strategy?:
+    | "auto"
+    | {
+        prefix_padding_ms?: number;
+        silence_duration_ms?: number;
+        threshold?: number;
+        type: "server_vad";
+      };
   audio_b64?: string;
   audio_url?: string;
   language?: string;
+  known_speaker_names?: string[];
+  known_speaker_references?: string[];
   model: string;
   provider?: {
     allow_fallbacks?: boolean | null;


### PR DESCRIPTION
## Summary
- support OpenAI diarized transcription response formats, chunking strategy, and known-speaker fields
- preserve the new multipart fields through gateway validation and the TypeScript SDK model
- reject invalid GPT transcription timestamp/format combinations
- reject non-Whisper OpenAI translation requests and unsupported Whisper formats

## Validation
- `pnpm --filter @phaseo/gateway-api exec vitest run src/providers/openai/__tests__/media-endpoints.test.ts` (21/21)
- `pnpm --filter @phaseo/gateway-api typecheck`
- `pnpm exec spectral lint apps/docs/openapi/v1/openapi.yaml` (0 errors)
- `pnpm --filter @phaseo/sdk test` (55/55)

Created with Codex