### PR TITLE
Fix Supabase migration replay

### DIFF
--- a/supabase/migrations/20260731110000_support_included_pricing_quantity.sql
+++ b/supabase/migrations/20260731110000_support_included_pricing_quantity.sql
@@ -13,6 +13,10 @@ begin
     'public.gateway_fetch_request_context(uuid,text,text,uuid)'::regprocedure
   ) into definition;
 
+  -- Functions created from Windows-authored migrations can retain CRLF in
+  -- their stored body, while this guarded replacement is expressed with LF.
+  definition := replace(definition, chr(13) || chr(10), chr(10));
+
   if position(old_select in definition) > 0 then
     definition := replace(definition, old_select, new_select);
   elsif position(new_select in definition) = 0 then
@@ -38,6 +42,8 @@ begin
   select pg_get_functiondef(
     'public.get_v2_model_pricing(text,text,text)'::regprocedure
   ) into definition;
+
+  definition := replace(definition, chr(13) || chr(10), chr(10));
 
   if position(old_payload in definition) > 0 then
     definition := replace(definition, old_payload, new_payload);

--- a/supabase/migrations/20260801230000_harden_preset_slugs_and_private_access.sql
+++ b/supabase/migrations/20260801230000_harden_preset_slugs_and_private_access.sql
@@ -1,4 +1,4 @@
-drop index concurrently if exists public.presets_public_slug_key;
+drop index if exists public.presets_public_slug_key;
 
 -- Public presets without a publisher cannot be addressed. Preserve them as
 -- workspace presets instead of leaving unreachable marketplace rows behind.
@@ -33,11 +33,11 @@ alter table public.presets
 alter table public.presets
   validate constraint presets_public_requires_creator;
 
-create unique index concurrently if not exists presets_public_publisher_slug_key
+create unique index if not exists presets_public_publisher_slug_key
   on public.presets (created_by, lower(slug))
   where visibility = 'public';
 
-create index concurrently if not exists presets_workspace_slug_ci_idx
+create index if not exists presets_workspace_slug_ci_idx
   on public.presets (workspace_id, lower(slug));
 
 comment on index public.presets_public_publisher_slug_key is

--- a/supabase/migrations/20260802012339_add_workspace_response_healing_settings.sql
+++ b/supabase/migrations/20260802012339_add_workspace_response_healing_settings.sql
@@ -1,0 +1,19 @@
+alter table public.workspace_settings
+  add column if not exists response_healing_enabled boolean not null default false,
+  add column if not exists response_healing_locked boolean not null default false,
+  add column if not exists response_healing_mode text not null default 'safe';
+
+do $migration$
+begin
+  if not exists (
+    select 1
+    from pg_constraint
+    where conrelid = 'public.workspace_settings'::regclass
+      and conname = 'workspace_settings_response_healing_mode_check'
+  ) then
+    alter table public.workspace_settings
+      add constraint workspace_settings_response_healing_mode_check
+      check (response_healing_mode in ('safe', 'strict'));
+  end if;
+end
+$migration$;

--- a/supabase/migrations/20260802161000_geographic_usage_analytics.sql
+++ b/supabase/migrations/20260802161000_geographic_usage_analytics.sql
@@ -38,11 +38,11 @@ for each row execute function public.sync_v2_request_edge_geography();
 -- Existing facts predate edge_country in safe_metadata, so there is no useful
 -- historical backfill. New writes are populated by the trigger without a
 -- rewrite of the continuously-written fact table.
-create index concurrently if not exists v2_request_facts_workspace_country_time_idx
+create index if not exists v2_request_facts_workspace_country_time_idx
   on public.v2_request_facts (workspace_id, edge_country, occurred_at desc)
   where edge_country is not null;
 
-create index concurrently if not exists v2_request_facts_country_time_idx
+create index if not exists v2_request_facts_country_time_idx
   on public.v2_request_facts (edge_country, occurred_at desc)
   where edge_country is not null;
 
@@ -177,7 +177,7 @@ as $$
     left join request_tokens t on t.request_event_id = f.request_event_id
     group by f.edge_country
   ),
-  privacy_buckets as (
+  classified_countries as (
     select
       case
         when requests >= greatest(p_min_requests, 1)
@@ -185,16 +185,22 @@ as $$
           then country_code
         else 'OTHER'
       end as country_code,
+      requests,
+      tokens,
+      workspace_count
+    from by_country
+  ),
+  privacy_buckets as (
+    select
+      country_code,
       sum(requests)::bigint as requests,
       sum(tokens) as tokens,
       case
-        when requests >= greatest(p_min_requests, 1)
-         and workspace_count >= greatest(p_min_workspaces, 2)
-          then max(workspace_count)
+        when country_code <> 'OTHER' then max(workspace_count)
         else 0
       end::bigint as workspace_count
-    from by_country
-    group by 1
+    from classified_countries
+    group by country_code
   )
   select
     b.country_code,

--- a/supabase/migrations/20260802173000_user_declared_country.sql
+++ b/supabase/migrations/20260802173000_user_declared_country.sql
@@ -19,7 +19,7 @@ alter table public.users
 alter table public.users
   validate constraint users_declared_country_code_check;
 
-create index concurrently if not exists users_declared_country_code_idx
+create index if not exists users_declared_country_code_idx
   on public.users (declared_country_code)
   where declared_country_code is not null;
 


### PR DESCRIPTION
## Summary

- restore the missing `20260802012339` response-healing migration from the linked project history
- make guarded function rewrites tolerate CRLF-backed PostgreSQL function definitions
- replace concurrent index operations with transaction-safe index operations supported by `supabase db push`
- correct the geography privacy-bucket aggregation so it is valid grouped SQL

## Why

A controlled deployment of the pending migration backlog exposed replay failures that prevented staging or fresh environments from reaching the production schema. Production is now fully migrated; this PR preserves the exact compatibility fixes needed to reproduce that state elsewhere.

## Validation

- `supabase db push --linked --include-all --yes` completed all pending migrations
- `supabase migration list --linked` reports matching local and remote versions through `20260803120000`
- live schema verification confirmed three provider-status columns, two geography columns, three new indexes, and the pricing/geography functions
- `git diff --check`

Created with Codex