### PR TITLE
Polish Chat Settings shortcut layout

### DIFF
--- a/apps/web/src/components/(chat)/ChatHeader.tsx
+++ b/apps/web/src/components/(chat)/ChatHeader.tsx
@@ -1630,7 +1630,7 @@ export function ChatHeader({
 				<Dialog open={settingsOpen} onOpenChange={onSettingsOpenChange}>
 					<DialogContent
 						showCloseButton={false}
-						className="max-h-[calc(100dvh-1rem)] w-[calc(100vw-1rem)] max-w-[calc(100vw-1rem)] overflow-hidden p-0 md:max-h-[520px] md:w-auto md:max-w-[760px] lg:max-w-[820px]"
+						className="max-h-[calc(100dvh-1rem)] w-[calc(100vw-1rem)] max-w-[calc(100vw-1rem)] overflow-hidden p-0 md:max-h-[520px] md:w-[760px] md:max-w-[760px] lg:w-[820px] lg:max-w-[820px]"
 					>
 						<DialogTitle className="sr-only">Settings</DialogTitle>
 						<DialogDescription className="sr-only">
@@ -2204,9 +2204,7 @@ export function ChatHeader({
 													models, and the composer.
 												</p>
 											</div>
-											<div className="rounded-2xl border border-border bg-card p-3">
-												<ChatShortcutReference />
-											</div>
+											<ChatShortcutReference />
 										</div>
 									)}
 									{settingsTab === "admin" && isAdmin && (

--- a/apps/web/src/components/(chat)/ChatShortcutReference.tsx
+++ b/apps/web/src/components/(chat)/ChatShortcutReference.tsx
@@ -103,7 +103,7 @@ export function ChatShortcutReference() {
 							return (
 								<div
 									key={item.title}
-									className="grid grid-cols-[auto_minmax(0,1fr)] items-start gap-x-3 gap-y-1 rounded-lg px-2 py-2 hover:bg-muted/70"
+									className="grid grid-cols-[auto_minmax(0,1fr)] items-start gap-x-3 gap-y-1 rounded-lg px-2 py-2 hover:bg-muted/70 sm:grid-cols-[auto_minmax(0,1fr)_auto]"
 								>
 									<div className="row-span-2 flex size-8 shrink-0 items-center justify-center rounded-md bg-muted text-muted-foreground">
 											<Icon className="h-4 w-4" />
@@ -116,7 +116,7 @@ export function ChatShortcutReference() {
 											{item.description}
 										</div>
 									</div>
-									<div className="hidden flex-wrap items-center gap-1 sm:flex">
+									<div className="flex flex-wrap items-center gap-1 sm:justify-self-end">
 										{item.keys.map((key, keyIndex) => (
 											<Fragment key={`${item.title}-${key}`}>
 												{keyIndex > 0 ? (


### PR DESCRIPTION
## Summary

Polish the Chat Route Settings dialog so its layout is stable and the Keyboard Shortcuts section uses the available space more effectively across desktop and mobile.

## Cause

The dialog width was content-driven at desktop breakpoints, so switching Settings sections could change the outer dialog size. The shortcut reference also wrapped keycaps below each description on desktop, and hid the keycaps entirely on mobile.

## Changes

- Set explicit responsive dialog widths: 760px at medium breakpoints and 820px at large breakpoints.
- Remove the bordered card wrapper around the Keyboard Shortcuts reference.
- Place desktop keycaps in a right-hand grid column.
- Keep keycaps visible on mobile beneath each shortcut description.

## Validation

- `pnpm exec eslint "src/components/(chat)/ChatHeader.tsx" "src/components/(chat)/ChatShortcutReference.tsx"` — passes with existing warnings.
- `git diff --check` — passes.
- `pnpm --filter @phaseo/web typecheck` — currently reports pre-existing `LayoutProps` errors in unrelated dashboard layouts on `origin/main`.

Created with Codex
