### PR TITLE
Fix private preset version exposure

### DIFF
--- a/apps/web-api/src/routes/account/settings-policy.test.ts
+++ b/apps/web-api/src/routes/account/settings-policy.test.ts
@@ -11,6 +11,78 @@ const env = {
 afterEach(() => vi.unstubAllGlobals());
 
 describe("account policy settings routes", () => {
+	it("does not expose upstream versions when the source preset is no longer public", async () => {
+		const requestedUrls: string[] = [];
+		vi.stubGlobal("fetch", vi.fn(async (input: RequestInfo | URL) => {
+			const url = input instanceof Request ? input.url : String(input);
+			requestedUrls.push(url);
+			if (url.includes("/auth/v1/user")) return new Response(JSON.stringify({ id: "user-1", email: "user@example.com", created_at: "2025-01-01" }), { status: 200 });
+			if (url.includes("workspace_members")) return new Response(JSON.stringify([{ role: "member" }]), { status: 200 });
+			if (url.includes("/presets") && url.includes("workspace_id=eq.workspace-1")) {
+				return new Response(JSON.stringify([{ id: "fork-1", workspace_id: "workspace-1", created_by: "user-1", source_preset_id: "source-1", upstream_version_id: "version-1", name: "Fork", visibility: "private" }]), { status: 200 });
+			}
+			if (url.includes("/presets") && url.includes("id=in.%28source-1%29")) return new Response(JSON.stringify([]), { status: 200 });
+			return new Response(JSON.stringify([]), { status: 200 });
+		}));
+
+		const response = await app.request("https://phaseo.app/api/account/settings/presets/list?workspaceId=workspace-1", {
+			headers: { authorization: "Bearer session-token" },
+		}, env);
+
+		expect(response.status).toBe(200);
+		await expect(response.json()).resolves.toMatchObject({
+			presets: [{ id: "fork-1", latestUpstreamVersion: null, hasUpstreamUpdate: false }],
+		});
+		expect(requestedUrls.some((url) => url.includes("visibility=eq.public") && url.includes("archived_at=is.null"))).toBe(true);
+		expect(requestedUrls.some((url) => url.includes("/preset_versions"))).toBe(false);
+	});
+
+	it("continues to advertise public versions from a public source preset", async () => {
+		vi.stubGlobal("fetch", vi.fn(async (input: RequestInfo | URL) => {
+			const url = input instanceof Request ? input.url : String(input);
+			if (url.includes("/auth/v1/user")) return new Response(JSON.stringify({ id: "user-1", email: "user@example.com", created_at: "2025-01-01" }), { status: 200 });
+			if (url.includes("workspace_members")) return new Response(JSON.stringify([{ role: "member" }]), { status: 200 });
+			if (url.includes("/presets") && url.includes("workspace_id=eq.workspace-1")) {
+				return new Response(JSON.stringify([{ id: "fork-1", workspace_id: "workspace-1", created_by: "user-1", source_preset_id: "source-1", upstream_version_id: "version-1", name: "Fork", visibility: "private" }]), { status: 200 });
+			}
+			if (url.includes("/presets") && url.includes("id=in.%28source-1%29")) return new Response(JSON.stringify([{ id: "source-1" }]), { status: 200 });
+			if (url.includes("/preset_versions")) return new Response(JSON.stringify([{ id: "version-2", preset_id: "source-1", version_number: 2 }]), { status: 200 });
+			return new Response(JSON.stringify([]), { status: 200 });
+		}));
+
+		const response = await app.request("https://phaseo.app/api/account/settings/presets/list?workspaceId=workspace-1", {
+			headers: { authorization: "Bearer session-token" },
+		}, env);
+
+		expect(response.status).toBe(200);
+		await expect(response.json()).resolves.toMatchObject({
+			presets: [{ id: "fork-1", latestUpstreamVersion: { id: "version-2", version_number: 2 }, hasUpstreamUpdate: true }],
+		});
+	});
+
+	it("rejects a non-public source version when creating a fork", async () => {
+		const requestedUrls: string[] = [];
+		vi.stubGlobal("fetch", vi.fn(async (input: RequestInfo | URL) => {
+			const url = input instanceof Request ? input.url : String(input);
+			requestedUrls.push(url);
+			if (url.includes("/auth/v1/user")) return new Response(JSON.stringify({ id: "user-1", email: "user@example.com", created_at: "2025-01-01" }), { status: 200 });
+			if (url.includes("workspace_members")) return new Response(JSON.stringify([{ role: "member" }]), { status: 200 });
+			if (url.includes("/presets") && url.includes("id=eq.source-1")) return new Response(JSON.stringify([{ id: "source-1", name: "Source", slug: "source", description: null, config: { safe: true }, visibility: "public", active_version_id: "version-1" }]), { status: 200 });
+			if (url.includes("/preset_versions")) return new Response(JSON.stringify([]), { status: 200 });
+			return new Response(JSON.stringify([]), { status: 200 });
+		}));
+
+		const response = await app.request("https://phaseo.app/api/account/settings/presets/source-1/fork", {
+			method: "POST",
+			headers: { authorization: "Bearer session-token", "content-type": "application/json" },
+			body: JSON.stringify({ workspaceId: "workspace-1", sourceVersionId: "private-version" }),
+		}, env, { waitUntil: vi.fn(), passThroughOnException: vi.fn() } as any);
+
+		expect(response.status).toBe(400);
+		await expect(response.json()).resolves.toEqual({ error: "invalid_source_version" });
+		expect(requestedUrls.some((url) => url.includes("/preset_versions") && url.includes("visibility=eq.public"))).toBe(true);
+	});
+
 	it("returns private routing, preset, and guardrail payloads", async () => {
 		vi.stubGlobal("fetch", vi.fn(async (input: RequestInfo | URL) => {
 			const url = input instanceof Request ? input.url : String(input);

--- a/apps/web-api/src/routes/account/settings-policy.ts
+++ b/apps/web-api/src/routes/account/settings-policy.ts
@@ -121,7 +121,11 @@ async function withPresetLifecycle(client: ReturnType<typeof getDataClient>, row
 	const sourceIds = [...new Set(rows.map((row) => String(row.source_preset_id ?? "")).filter(Boolean))];
 	const latestBySource = new Map<string, { id: string; version_number: number }>();
 	if (sourceIds.length) {
-		const versions = await client.from("preset_versions").select("id,preset_id,version_number").in("preset_id", sourceIds).order("version_number", { ascending: false });
+		const publicSources = await client.from("presets").select("id").in("id", sourceIds).eq("visibility", "public").is("archived_at", null);
+		if (publicSources.error) throw publicSources.error;
+		const publicSourceIds = (publicSources.data ?? []).map((source) => String(source.id));
+		if (!publicSourceIds.length) return presetLifecycleFallback(rows);
+		const versions = await client.from("preset_versions").select("id,preset_id,version_number").in("preset_id", publicSourceIds).eq("visibility", "public").order("version_number", { ascending: false });
 		if (versions.error) throw versions.error;
 		for (const version of versions.data ?? []) if (!latestBySource.has(String(version.preset_id))) latestBySource.set(String(version.preset_id), { id: String(version.id), version_number: Number(version.version_number) });
 	}
@@ -189,7 +193,7 @@ accountSettingsPolicyRouter.post("/presets/:presetId/fork", async (c) => {
 	if (source.error) return c.json({ error: "settings_unavailable" }, 503, PRIVATE_NO_STORE_HEADERS); if (!source.data || source.data.visibility !== "public") return c.json({ error: "not_public" }, 404, PRIVATE_NO_STORE_HEADERS);
 	let sourceSnapshot = { id: source.data.active_version_id, name: source.data.name, slug: source.data.slug, description: source.data.description, config: source.data.config };
 	if (body.sourceVersionId) {
-		const version = await context.client.from("preset_versions").select("id,name,slug,description,config").eq("id", body.sourceVersionId).eq("preset_id", source.data.id).maybeSingle();
+		const version = await context.client.from("preset_versions").select("id,name,slug,description,config").eq("id", body.sourceVersionId).eq("preset_id", source.data.id).eq("visibility", "public").maybeSingle();
 		if (version.error) return c.json({ error: "settings_unavailable" }, 503, PRIVATE_NO_STORE_HEADERS);
 		if (!version.data) return c.json({ error: "invalid_source_version" }, 400, PRIVATE_NO_STORE_HEADERS);
 		sourceSnapshot = version.data;

--- a/supabase/migrations/20260805183000_secure_preset_upstream_versions.sql
+++ b/supabase/migrations/20260805183000_secure_preset_upstream_versions.sql
@@ -1,0 +1,36 @@
+-- Fork owners may only apply public versions from a currently public source preset.
+create or replace function public.apply_preset_upstream_version(target_preset_id uuid, target_version_id uuid, actor_user_id uuid)
+returns public.presets language plpgsql security definer set search_path = public as $function$
+declare
+  p public.presets%rowtype;
+  source public.presets%rowtype;
+  upstream public.preset_versions%rowtype;
+  updated public.presets%rowtype;
+begin
+  select * into p from public.presets where id = target_preset_id and archived_at is null for update;
+  if not found or p.created_by <> actor_user_id then raise exception 'preset_update_forbidden'; end if;
+  if p.source_preset_id is null then raise exception 'preset_has_no_upstream'; end if;
+  if p.draft_name is distinct from p.name
+    or p.draft_slug is distinct from p.slug
+    or p.draft_description is distinct from p.description
+    or p.draft_config is distinct from p.config
+    or p.draft_visibility is distinct from p.visibility
+  then raise exception 'preset_has_local_draft_changes'; end if;
+
+  select * into source from public.presets
+  where id = p.source_preset_id and visibility = 'public' and archived_at is null;
+  if not found then raise exception 'upstream_preset_not_public'; end if;
+
+  select * into upstream from public.preset_versions
+  where id = target_version_id and preset_id = source.id and visibility = 'public';
+  if not found then raise exception 'upstream_version_not_public'; end if;
+
+  update public.presets set draft_name = upstream.name, draft_slug = upstream.slug,
+    draft_description = upstream.description, draft_config = upstream.config,
+    upstream_version_id = upstream.id, updated_at = now()
+  where id = p.id returning * into updated;
+  return updated;
+end $function$;
+
+revoke all on function public.apply_preset_upstream_version(uuid, uuid, uuid) from public, anon, authenticated;
+grant execute on function public.apply_preset_upstream_version(uuid, uuid, uuid) to service_role;


### PR DESCRIPTION
## Summary
- restrict upstream update discovery to public versions of currently public, non-archived presets
- reject non-public source versions during fork creation
- enforce the same tenant-isolation invariant inside the `SECURITY DEFINER` upstream-apply RPC
- add regression coverage for private-source denial and legitimate public updates

## Security impact
Prevents fork owners from discovering or applying later private/team-only versions from an upstream preset. Authorization is enforced in both the API queries and the privileged database function.

## Validation
- `pnpm --filter @phaseo/web-api exec vitest run src/routes/account/settings-policy.test.ts` (5 passed)
- `pnpm --filter @phaseo/web-api typecheck`
- `pnpm --dir apps/web-api exec eslint src/routes/account/settings-policy.ts src/routes/account/settings-policy.test.ts`
- `git diff --check`

Created with Codex