### PR TITLE
Harden OTLP collector endpoints

### DIFF
--- a/apps/api/src/observability/otlp-export.test.ts
+++ b/apps/api/src/observability/otlp-export.test.ts
@@ -1,6 +1,22 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { deliverGatewayOtlpPayload } from "./otlp-export";
 
+vi.mock("@core/webhook-endpoints", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("@core/webhook-endpoints")>();
+	return {
+		...actual,
+		validateWebhookEndpointUrlForDelivery: vi.fn(async (value: unknown) => {
+			const validated = actual.validateWebhookEndpointUrl(value);
+			if (!validated.ok) return validated;
+			const hostname = new URL(validated.url).hostname;
+			if (hostname === "private-dns.example.com") {
+				return { ok: false as const, reason: "webhook_url_private_network_not_allowed" as const };
+			}
+			return validated;
+		}),
+	};
+});
+
 afterEach(() => {
 	vi.unstubAllGlobals();
 });
@@ -19,7 +35,7 @@ describe("deliverGatewayOtlpPayload", () => {
 		expect(result).toMatchObject({ delivered: true, retryable: false, status: 200 });
 		const [url, init] = fetchMock.mock.calls[0] as [URL, RequestInit];
 		expect(url.toString()).toBe("https://collector.example.com/v1/traces");
-		expect(init).toMatchObject({ method: "POST", body: JSON.stringify(payload) });
+		expect(init).toMatchObject({ method: "POST", body: JSON.stringify(payload), redirect: "manual" });
 		const sentHeaders = new Headers(init.headers);
 		expect(sentHeaders.get("content-type")).toBe("application/json");
 		expect(sentHeaders.get("x-tenant")).toBe("phaseo");
@@ -69,12 +85,30 @@ describe("deliverGatewayOtlpPayload", () => {
 		"http://[::1]:4318",
 		"http://[fd00::1]:4318",
 		"http://[fe80::1]:4318",
+		"https://[::ffff:127.0.0.1]:4318",
 	])("rejects bracketed private IPv6 collector endpoint %s", async (endpoint) => {
 		const fetchMock = vi.fn();
 		vi.stubGlobal("fetch", fetchMock);
 		const result = await deliverGatewayOtlpPayload({ resourceSpans: [] }, { endpoint });
 
 		expect(result).toMatchObject({ delivered: false, retryable: false, status: null });
+		expect(fetchMock).not.toHaveBeenCalled();
+	});
+
+	it("rejects collector hostnames that resolve to private addresses", async () => {
+		const fetchMock = vi.fn();
+		vi.stubGlobal("fetch", fetchMock);
+		const result = await deliverGatewayOtlpPayload(
+			{ resourceSpans: [] },
+			{ endpoint: "https://private-dns.example.com" },
+		);
+
+		expect(result).toMatchObject({
+			delivered: false,
+			retryable: false,
+			status: null,
+			error: "Invalid OTLP endpoint: webhook_url_private_network_not_allowed",
+		});
 		expect(fetchMock).not.toHaveBeenCalled();
 	});
 });

--- a/apps/api/src/observability/otlp-export.test.ts
+++ b/apps/api/src/observability/otlp-export.test.ts
@@ -95,6 +95,20 @@ describe("deliverGatewayOtlpPayload", () => {
 		expect(fetchMock).not.toHaveBeenCalled();
 	});
 
+	it("continues to support public HTTP collectors", async () => {
+		const fetchMock = vi.fn().mockResolvedValue(
+			new Response(JSON.stringify({ partialSuccess: {} }), { status: 200 }),
+		);
+		vi.stubGlobal("fetch", fetchMock);
+		const result = await deliverGatewayOtlpPayload(
+			{ resourceSpans: [] },
+			{ endpoint: "http://collector.example.com" },
+		);
+
+		expect(result).toMatchObject({ delivered: true, status: 200 });
+		expect((fetchMock.mock.calls[0] as [URL])[0].toString()).toBe("http://collector.example.com/v1/traces");
+	});
+
 	it("rejects collector hostnames that resolve to private addresses", async () => {
 		const fetchMock = vi.fn();
 		vi.stubGlobal("fetch", fetchMock);

--- a/apps/api/src/observability/otlp-export.ts
+++ b/apps/api/src/observability/otlp-export.ts
@@ -1,4 +1,5 @@
 import { getBindings, getSupabaseAdmin } from "@/runtime/env";
+import { validateWebhookEndpointUrlForDelivery } from "@core/webhook-endpoints";
 import {
 	buildAsyncGenAiOtlpPayload,
 	buildGatewayGenAiOtlpPayload,
@@ -321,6 +322,12 @@ export async function deliverGatewayOtlpPayload(
 	try {
 		collectorEndpoint = endpoint(config);
 		collectorHeaders = headers(config);
+		// Reuse the hardened outbound-webhook boundary so mapped IPv6 literals
+		// and DNS records resolving to private networks are rejected immediately
+		// before the collector request.
+		const validated = await validateWebhookEndpointUrlForDelivery(collectorEndpoint.toString());
+		if (validated.ok === false) throw new Error(`Invalid OTLP endpoint: ${validated.reason}`);
+		collectorEndpoint = new URL(validated.url);
 	} catch (error) {
 		return {
 			delivered: false,
@@ -336,6 +343,7 @@ export async function deliverGatewayOtlpPayload(
 			method: "POST",
 			headers: collectorHeaders,
 			body: JSON.stringify(payload),
+			redirect: "manual",
 			signal: AbortSignal.timeout(15_000),
 		});
 	} catch (error) {

--- a/apps/api/src/observability/otlp-export.ts
+++ b/apps/api/src/observability/otlp-export.ts
@@ -325,9 +325,13 @@ export async function deliverGatewayOtlpPayload(
 		// Reuse the hardened outbound-webhook boundary so mapped IPv6 literals
 		// and DNS records resolving to private networks are rejected immediately
 		// before the collector request.
-		const validated = await validateWebhookEndpointUrlForDelivery(collectorEndpoint.toString());
+		const validationUrl = new URL(collectorEndpoint);
+		// The shared boundary requires TLS for webhooks. OTLP explicitly supports
+		// public HTTP collectors, so validate the identical host/path through the
+		// hardened DNS boundary without changing the actual collector scheme.
+		if (validationUrl.protocol === "http:") validationUrl.protocol = "https:";
+		const validated = await validateWebhookEndpointUrlForDelivery(validationUrl.toString());
 		if (validated.ok === false) throw new Error(`Invalid OTLP endpoint: ${validated.reason}`);
-		collectorEndpoint = new URL(validated.url);
 	} catch (error) {
 		return {
 			delivered: false,


### PR DESCRIPTION
## Summary
- validate OTLP collector URLs through the hardened outbound webhook boundary immediately before delivery
- reject mapped IPv6 literals and hostnames resolving to private, loopback, link-local, or metadata ranges
- disable redirect following on collector POSTs
- cover private DNS and mapped IPv6 rejection while preserving public collector delivery

## Security impact
Prevents workspace-configured OTLP destinations from reaching internal network services through literal, DNS, or redirect-based SSRF paths.

## Validation
- `pnpm --filter @phaseo/gateway-api exec vitest run src/observability/otlp-export.test.ts` (9 passed)
- `pnpm --filter @phaseo/gateway-api typecheck`
- `pnpm --dir apps/api exec eslint src/observability/otlp-export.ts src/observability/otlp-export.test.ts`
- `git diff --check`

Created with Codex