### PR TITLE
Require TLS for remote Curie endpoints

### DIFF
--- a/packages/cli/phaseo/src/curie.ts
+++ b/packages/cli/phaseo/src/curie.ts
@@ -155,9 +155,10 @@ export async function runCurie(configPath: string | undefined, flags: Flags): Pr
 		const model = modelDetails(modelValue);
 		const started = performance.now();
 		try {
-			const response = await fetch(`${baseUrl}/chat/completions`, {
-				method: "POST",
-				headers: { authorization: `Bearer ${apiKey}`, "content-type": "application/json" },
+		const response = await fetch(`${baseUrl}/chat/completions`, {
+			method: "POST",
+			redirect: "error",
+			headers: { authorization: `Bearer ${apiKey}`, "content-type": "application/json" },
 				body: JSON.stringify({ model: model.id, messages: item.messages ?? [{ role: "user", content: item.input }], ...config.params, ...item.params, stream: false }),
 			});
 			const body: any = await response.json();

--- a/packages/cli/phaseo/src/curie.ts
+++ b/packages/cli/phaseo/src/curie.ts
@@ -109,6 +109,11 @@ export function validateCurieEndpoint(
 	if (apiKeyEnv !== "PHASEO_CURIE_API_KEY") {
 		throw new Error("Custom Curie endpoints require the isolated PHASEO_CURIE_API_KEY variable");
 	}
+	const hostname = parsed.hostname.toLowerCase().replace(/^\[|\]$/g, "");
+	const loopback = hostname === "localhost" || hostname === "::1" || /^127(?:\.\d{1,3}){3}$/.test(hostname);
+	if (parsed.protocol !== "https:" && !loopback) {
+		throw new Error("Remote custom Curie endpoints must use HTTPS; HTTP is only allowed for loopback development endpoints");
+	}
 	return normalized;
 }
 

--- a/packages/cli/phaseo/tests/curie.test.ts
+++ b/packages/cli/phaseo/tests/curie.test.ts
@@ -1,6 +1,9 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { evaluateCurieOutput, outputCost, summariseCurieResults, validateCurieConfig, validateCurieEndpoint, type CurieResult } from "../src/curie.ts";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { evaluateCurieOutput, outputCost, runCurie, summariseCurieResults, validateCurieConfig, validateCurieEndpoint, type CurieResult } from "../src/curie.ts";
 
 test("validates a minimal local run", () => {
 	const config = validateCurieConfig({ models: ["phaseo/test"], cases: [{ id: "hello", input: "Say hello" }] });
@@ -50,6 +53,29 @@ test("prevents configs from redirecting arbitrary environment secrets", () => {
 		"http://[::1]:8787/v1",
 	);
 	assert.equal(validateCurieEndpoint("https://api.phaseo.app/v1", "PHASEO_API_KEY", false), "https://api.phaseo.app/v1");
+});
+
+test("disables redirects on authenticated Curie requests", async () => {
+	const directory = await mkdtemp(join(tmpdir(), "phaseo-curie-"));
+	const configPath = join(directory, "config.json");
+	const originalFetch = globalThis.fetch;
+	const originalKey = process.env.PHASEO_CURIE_API_KEY;
+	let requestInit: RequestInit | undefined;
+	try {
+		await writeFile(configPath, JSON.stringify({ models: ["phaseo/test"], cases: [{ id: "case", input: "hello", expect: { equals: "ok" } }] }));
+		process.env.PHASEO_CURIE_API_KEY = "test-key";
+		globalThis.fetch = (async (_input, init) => {
+			requestInit = init;
+			return Response.json({ choices: [{ message: { content: "ok" } }] });
+		}) as typeof fetch;
+		await runCurie(configPath, { "base-url": "https://collector.example/v1", "allow-custom-base-url": true, "api-key-env": "PHASEO_CURIE_API_KEY" });
+		assert.equal(requestInit?.redirect, "error");
+	} finally {
+		globalThis.fetch = originalFetch;
+		if (originalKey === undefined) delete process.env.PHASEO_CURIE_API_KEY;
+		else process.env.PHASEO_CURIE_API_KEY = originalKey;
+		await rm(directory, { recursive: true, force: true });
+	}
 });
 
 test("summarises pass rate, latency, tokens, and reported cost", () => {

--- a/packages/cli/phaseo/tests/curie.test.ts
+++ b/packages/cli/phaseo/tests/curie.test.ts
@@ -37,6 +37,18 @@ test("prevents configs from redirecting arbitrary environment secrets", () => {
 		validateCurieEndpoint("https://collector.example/v1/", "PHASEO_CURIE_API_KEY", true),
 		"https://collector.example/v1",
 	);
+	assert.throws(
+		() => validateCurieEndpoint("http://collector.example/v1", "PHASEO_CURIE_API_KEY", true),
+		/Remote custom Curie endpoints must use HTTPS/,
+	);
+	assert.equal(
+		validateCurieEndpoint("http://127.0.0.1:8787/v1/", "PHASEO_CURIE_API_KEY", true),
+		"http://127.0.0.1:8787/v1",
+	);
+	assert.equal(
+		validateCurieEndpoint("http://[::1]:8787/v1", "PHASEO_CURIE_API_KEY", true),
+		"http://[::1]:8787/v1",
+	);
 	assert.equal(validateCurieEndpoint("https://api.phaseo.app/v1", "PHASEO_API_KEY", false), "https://api.phaseo.app/v1");
 });
 


### PR DESCRIPTION
## Summary
- require HTTPS for remote custom Curie endpoints
- retain HTTP support for explicit loopback development endpoints
- cover remote cleartext rejection and IPv4/IPv6 loopback compatibility

## Security impact
Prevents the isolated Curie bearer credential and prompt data from being transmitted to remote endpoints over cleartext HTTP.

## Validation
- `pnpm --filter @phaseo/cli test` (34 passed)
- `pnpm --filter @phaseo/cli build`
- `git diff --check`

Created with Codex

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved custom endpoint security by requiring HTTPS for remote endpoints.
  * Continued support for local development endpoints using HTTP, including localhost and loopback IPv4/IPv6 addresses.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->