### PR TITLE
Enforce preset visibility in feedback APIs

### DIFF
--- a/apps/api/src/routes/v1/control/feedback.test.ts
+++ b/apps/api/src/routes/v1/control/feedback.test.ts
@@ -55,6 +55,7 @@ const state = {
 		preset_id: "55555555-5555-4555-8555-555555555555",
 		baseline_preset_id: null,
 	} as Record<string, unknown> | null,
+	visiblePresetRows: [{ id: "55555555-5555-4555-8555-555555555555" }] as Array<Record<string, unknown>>,
 };
 
 function buildSelectChain(
@@ -64,6 +65,18 @@ function buildSelectChain(
 	const chain: any = {
 		eq: vi.fn((...args: unknown[]) => {
 			state.queryCalls.push({ table, method: "eq", args });
+			return chain;
+		}),
+		is: vi.fn((...args: unknown[]) => {
+			state.queryCalls.push({ table, method: "is", args });
+			return chain;
+		}),
+		neq: vi.fn((...args: unknown[]) => {
+			state.queryCalls.push({ table, method: "neq", args });
+			return chain;
+		}),
+		or: vi.fn((...args: unknown[]) => {
+			state.queryCalls.push({ table, method: "or", args });
 			return chain;
 		}),
 		contains: vi.fn((...args: unknown[]) => {
@@ -147,7 +160,7 @@ function buildSupabaseMock() {
 			if (table === "presets") {
 				return {
 					select: () => buildSelectChain(table, {
-						data: { id: "55555555-5555-4555-8555-555555555555" },
+						data: state.visiblePresetRows,
 						error: null,
 					}),
 				};
@@ -197,6 +210,7 @@ describe("feedback control routes", () => {
 			preset_id: "55555555-5555-4555-8555-555555555555",
 			baseline_preset_id: null,
 		};
+		state.visiblePresetRows = [{ id: "55555555-5555-4555-8555-555555555555" }];
 		guardManagementAuthMock.mockReset();
 		getSupabaseAdminMock.mockReset();
 		guardManagementAuthMock.mockResolvedValue({
@@ -282,6 +296,21 @@ describe("feedback control routes", () => {
 			method: "eq",
 			args: ["workspace_id", "33333333-3333-4333-8333-333333333333"],
 		});
+	});
+
+	it("hides another user's private preset from feedback writes", async () => {
+		state.visiblePresetRows = [];
+		const response = await feedbackRoutes.request("https://api.example.com/", {
+			method: "POST",
+			headers: { "content-type": "application/json" },
+			body: JSON.stringify({
+				presetId: "55555555-5555-4555-8555-555555555555",
+				rating: "correct",
+			}),
+		});
+
+		expect(response.status).toBe(404);
+		expect(state.insertCalls).toHaveLength(0);
 	});
 
 	it("rejects unsupported feedback ratings before database insertion", async () => {
@@ -378,6 +407,7 @@ describe("feedback control routes", () => {
 	});
 
 	it("rejects feedback when preset and test run do not match", async () => {
+		state.visiblePresetRows.push({ id: "77777777-7777-4777-8777-777777777777" });
 		const response = await feedbackRoutes.request("https://api.example.com/", {
 			method: "POST",
 			headers: { "content-type": "application/json" },
@@ -432,12 +462,13 @@ describe("feedback control routes", () => {
 				name: "gateway_feedback_summary",
 				args: expect.objectContaining({
 					p_workspace_id: "33333333-3333-4333-8333-333333333333",
+					p_visible_preset_ids: ["55555555-5555-4555-8555-555555555555"],
 					p_group_by: "preset_id",
 					p_limit: 5000,
 				}),
 			}),
 		]);
-		expect(state.queryCalls).toHaveLength(0);
+		expect(state.queryCalls.some((call) => call.table === "presets" && call.method === "or")).toBe(true);
 	});
 	it("passes date and target filters to the summary RPC", async () => {
 		const response = await feedbackRoutes.request(

--- a/apps/api/src/routes/v1/control/feedback.ts
+++ b/apps/api/src/routes/v1/control/feedback.ts
@@ -305,16 +305,35 @@ async function authorize(req: Request, capability: string, roles: string[]) {
 	return { auth: auth.value as AuthValue };
 }
 
-async function ensurePresetAccess(workspaceId: string, presetId: string | null): Promise<Response | null> {
-	if (!presetId) return null;
-	const { data, error } = await getSupabaseAdmin()
+async function visiblePresetIds(auth: AuthValue): Promise<string[] | Response> {
+	let query = getSupabaseAdmin()
 		.from("presets")
 		.select("id")
-		.eq("workspace_id", workspaceId)
-		.eq("id", presetId)
-		.maybeSingle();
+		.eq("workspace_id", auth.workspaceId)
+		.is("archived_at", null);
+	const userId = normalizeUuid(auth.userId);
+	query = userId
+		? query.or(`visibility.neq.private,created_by.eq.${userId}`)
+		: query.neq("visibility", "private");
+	const { data, error } = await query;
 	if (error) return json({ error: "failed", message: error.message }, 500, { "Cache-Control": "no-store" });
-	if (!data) return json({ error: "not_found", message: "Preset not found" }, 404, { "Cache-Control": "no-store" });
+	return (data ?? []).map((row) => String(row.id));
+}
+
+function applyPresetVisibility(query: any, presetIds: string[], ...columns: string[]) {
+	for (const column of columns) {
+		query = presetIds.length
+			? query.or(`${column}.is.null,${column}.in.(${presetIds.join(",")})`)
+			: query.is(column, null);
+	}
+	return query;
+}
+
+async function ensurePresetAccess(auth: AuthValue, presetId: string | null): Promise<Response | null> {
+	if (!presetId) return null;
+	const visible = await visiblePresetIds(auth);
+	if (isResponse(visible)) return visible;
+	if (!visible.includes(presetId)) return json({ error: "not_found", message: "Preset not found" }, 404, { "Cache-Control": "no-store" });
 	return null;
 }
 
@@ -331,16 +350,20 @@ async function ensureRequestAccess(workspaceId: string, requestId: string | null
 	return null;
 }
 
-async function ensureTestRunAccess(workspaceId: string, testRunId: string | null): Promise<TestRunAccessRow | Response | null> {
+async function ensureTestRunAccess(auth: AuthValue, testRunId: string | null): Promise<TestRunAccessRow | Response | null> {
 	if (!testRunId) return null;
 	const { data, error } = await getSupabaseAdmin()
 		.from("gateway_preset_test_runs")
 		.select("id,preset_id,baseline_preset_id")
-		.eq("workspace_id", workspaceId)
+		.eq("workspace_id", auth.workspaceId)
 		.eq("id", testRunId)
 		.maybeSingle();
 	if (error) return json({ error: "failed", message: error.message }, 500, { "Cache-Control": "no-store" });
 	if (!data) return json({ error: "not_found", message: "Preset test run not found" }, 404, { "Cache-Control": "no-store" });
+	for (const presetId of [data.preset_id, data.baseline_preset_id]) {
+		const presetError = await ensurePresetAccess(auth, presetId);
+		if (presetError) return presetError;
+	}
 	return data as TestRunAccessRow;
 }
 
@@ -440,11 +463,11 @@ async function handleCreateFeedback(req: Request) {
 	if (!requestId && !sessionId && !presetId && !testRunId) {
 		return json({ error: "bad_request", message: "Feedback must target a request, session, preset, or test run" }, 400, { "Cache-Control": "no-store" });
 	}
-	const presetError = await ensurePresetAccess(auth.workspaceId, presetId);
+	const presetError = await ensurePresetAccess(auth, presetId);
 	if (presetError) return presetError;
 	const requestError = await ensureRequestAccess(auth.workspaceId, requestId);
 	if (requestError) return requestError;
-	const testRun = await ensureTestRunAccess(auth.workspaceId, testRunId);
+	const testRun = await ensureTestRunAccess(auth, testRunId);
 	if (isResponse(testRun)) return testRun;
 	const presetMismatchError = validatePresetMatchesTestRun(presetId, testRun);
 	if (presetMismatchError) return presetMismatchError;
@@ -495,6 +518,8 @@ async function handleListFeedback(req: Request) {
 	const authorized = await authorize(req, CAPABILITIES.FEEDBACK_READ, ["owner", "admin", "member"]);
 	if (authorized.response) return authorized.response;
 	const auth = authorized.auth;
+	const visible = await visiblePresetIds(auth);
+	if (isResponse(visible)) return visible;
 	const url = new URL(req.url);
 	const limit = parsePositiveInt(url.searchParams.get("limit"), 100, 500);
 	const offset = parseOffset(url.searchParams.get("offset"));
@@ -510,6 +535,7 @@ async function handleListFeedback(req: Request) {
 		.order("id", { ascending: false })
 		.range(offset, offset + limit - 1);
 	query = applyTargetFilters(query, url);
+	query = applyPresetVisibility(query, visible, "preset_id");
 	query = applyMetadataFilters(query, url);
 	query = applyDateFilters(query, dateFilters);
 	const rating = url.searchParams.get("rating")?.trim();
@@ -524,6 +550,8 @@ async function handleFeedbackSummary(req: Request) {
 	const authorized = await authorize(req, CAPABILITIES.FEEDBACK_READ, ["owner", "admin", "member"]);
 	if (authorized.response) return authorized.response;
 	const auth = authorized.auth;
+	const visible = await visiblePresetIds(auth);
+	if (isResponse(visible)) return visible;
 	const url = new URL(req.url);
 	const rawGroupBy = url.searchParams.get("group_by") ?? "preset";
 	if (!new Set(["preset", "preset_id", "test_run", "test_run_id", "metadata"]).has(rawGroupBy)) {
@@ -558,6 +586,7 @@ async function handleFeedbackSummary(req: Request) {
 		p_created_until: dateFilters.until,
 		p_metadata_filters: collectMetadataFilters(url),
 		p_limit: limit,
+		p_visible_preset_ids: visible,
 	});
 	if (error) return json({ error: "failed", message: error.message }, 500, { "Cache-Control": "no-store" });
 
@@ -596,11 +625,11 @@ async function handleCreateEvent(req: Request) {
 	if (!requestId && !sessionId && !presetId && !testRunId) {
 		return json({ error: "bad_request", message: "Event must target a request, session, preset, or test run" }, 400, { "Cache-Control": "no-store" });
 	}
-	const presetError = await ensurePresetAccess(auth.workspaceId, presetId);
+	const presetError = await ensurePresetAccess(auth, presetId);
 	if (presetError) return presetError;
 	const requestError = await ensureRequestAccess(auth.workspaceId, requestId);
 	if (requestError) return requestError;
-	const testRun = await ensureTestRunAccess(auth.workspaceId, testRunId);
+	const testRun = await ensureTestRunAccess(auth, testRunId);
 	if (isResponse(testRun)) return testRun;
 	const presetMismatchError = validatePresetMatchesTestRun(presetId, testRun);
 	if (presetMismatchError) return presetMismatchError;
@@ -651,6 +680,8 @@ async function handleListEvents(req: Request) {
 	const authorized = await authorize(req, CAPABILITIES.FEEDBACK_READ, ["owner", "admin", "member"]);
 	if (authorized.response) return authorized.response;
 	const auth = authorized.auth;
+	const visible = await visiblePresetIds(auth);
+	if (isResponse(visible)) return visible;
 	const url = new URL(req.url);
 	const limit = parsePositiveInt(url.searchParams.get("limit"), 100, 500);
 	const offset = parseOffset(url.searchParams.get("offset"));
@@ -666,6 +697,7 @@ async function handleListEvents(req: Request) {
 		.order("id", { ascending: false })
 		.range(offset, offset + limit - 1);
 	query = applyTargetFilters(query, url);
+	query = applyPresetVisibility(query, visible, "preset_id");
 	query = applyMetadataFilters(query, url);
 	query = applyDateFilters(query, dateFilters, "occurred_at");
 	const category = url.searchParams.get("category")?.trim();
@@ -686,9 +718,9 @@ async function handleCreateTestRun(req: Request) {
 	if (isResponse(body)) return body;
 	const presetId = normalizeUuid(body.presetId ?? body.preset_id);
 	const baselinePresetId = normalizeUuid(body.baselinePresetId ?? body.baseline_preset_id);
-	const presetError = await ensurePresetAccess(auth.workspaceId, presetId);
+	const presetError = await ensurePresetAccess(auth, presetId);
 	if (presetError) return presetError;
-	const baselineError = await ensurePresetAccess(auth.workspaceId, baselinePresetId);
+	const baselineError = await ensurePresetAccess(auth, baselinePresetId);
 	if (baselineError) return baselineError;
 	const status = normalizeAllowedText(body.status, TEST_RUN_STATUSES) ?? "pending";
 	if (body.status != null && !normalizeAllowedText(body.status, TEST_RUN_STATUSES)) {
@@ -729,6 +761,8 @@ async function handleListTestRuns(req: Request) {
 	const authorized = await authorize(req, CAPABILITIES.FEEDBACK_READ, ["owner", "admin", "member"]);
 	if (authorized.response) return authorized.response;
 	const auth = authorized.auth;
+	const visible = await visiblePresetIds(auth);
+	if (isResponse(visible)) return visible;
 	const url = new URL(req.url);
 	const limit = parsePositiveInt(url.searchParams.get("limit"), 100, 250);
 	const offset = parseOffset(url.searchParams.get("offset"));
@@ -739,6 +773,7 @@ async function handleListTestRuns(req: Request) {
 		.order("created_at", { ascending: false })
 		.order("id", { ascending: false })
 		.range(offset, offset + limit - 1);
+	query = applyPresetVisibility(query, visible, "preset_id", "baseline_preset_id");
 	const presetId = url.searchParams.get("preset_id")?.trim();
 	if (presetId && !normalizeUuid(presetId)) return json({ error: "bad_request", message: "Invalid preset id" }, 400, { "Cache-Control": "no-store" });
 	if (presetId) query = query.eq("preset_id", presetId);
@@ -755,12 +790,15 @@ async function handleGetOrUpdateTestRun(req: Request) {
 	const authorized = await authorize(req, CAPABILITIES.FEEDBACK_READ, ["owner", "admin", "member"]);
 	if (authorized.response) return authorized.response;
 	const auth = authorized.auth;
-	const { data, error } = await getSupabaseAdmin()
+	const visible = await visiblePresetIds(auth);
+	if (isResponse(visible)) return visible;
+	let query: any = getSupabaseAdmin()
 		.from("gateway_preset_test_runs")
 		.select(TEST_RUN_SELECT)
 		.eq("workspace_id", auth.workspaceId)
-		.eq("id", id)
-		.maybeSingle();
+		.eq("id", id);
+	query = applyPresetVisibility(query, visible, "preset_id", "baseline_preset_id");
+	const { data, error } = await query.maybeSingle();
 	if (error) return json({ error: "failed", message: error.message }, 500, { "Cache-Control": "no-store" });
 	if (!data) return json({ error: "not_found", message: "Preset test run not found" }, 404, { "Cache-Control": "no-store" });
 
@@ -776,6 +814,8 @@ async function handleUpdateTestRun(req: Request, id: string) {
 	const authorized = await authorize(req, CAPABILITIES.FEEDBACK_WRITE, ["owner", "admin"]);
 	if (authorized.response) return authorized.response;
 	const auth = authorized.auth;
+	const existing = await ensureTestRunAccess(auth, id);
+	if (isResponse(existing)) return existing;
 	const body = await requireJsonBody(req);
 	if (isResponse(body)) return body;
 	const update: Record<string, unknown> = { updated_at: new Date().toISOString() };

--- a/apps/api/src/routes/v1/control/feedback.ts
+++ b/apps/api/src/routes/v1/control/feedback.ts
@@ -306,18 +306,27 @@ async function authorize(req: Request, capability: string, roles: string[]) {
 }
 
 async function visiblePresetIds(auth: AuthValue): Promise<string[] | Response> {
-	let query = getSupabaseAdmin()
-		.from("presets")
-		.select("id")
-		.eq("workspace_id", auth.workspaceId)
-		.is("archived_at", null);
 	const userId = normalizeUuid(auth.userId);
-	query = userId
-		? query.or(`visibility.neq.private,created_by.eq.${userId}`)
-		: query.neq("visibility", "private");
-	const { data, error } = await query;
-	if (error) return json({ error: "failed", message: error.message }, 500, { "Cache-Control": "no-store" });
-	return (data ?? []).map((row) => String(row.id));
+	const pageSize = 1_000;
+	const presetIds: string[] = [];
+	for (let offset = 0; ; offset += pageSize) {
+		let query = getSupabaseAdmin()
+			.from("presets")
+			.select("id")
+			.eq("workspace_id", auth.workspaceId)
+			.is("archived_at", null);
+		query = userId
+			? query.or(`visibility.neq.private,created_by.eq.${userId}`)
+			: query.neq("visibility", "private");
+		const { data, error } = await query
+			.order("id", { ascending: true })
+			.range(offset, offset + pageSize - 1);
+		if (error) return json({ error: "failed", message: error.message }, 500, { "Cache-Control": "no-store" });
+		const rows = data ?? [];
+		presetIds.push(...rows.map((row) => String(row.id)));
+		if (rows.length < pageSize) break;
+	}
+	return presetIds;
 }
 
 function applyPresetVisibility(query: any, presetIds: string[], ...columns: string[]) {

--- a/supabase/migrations/20260805184000_feedback_preset_visibility.sql
+++ b/supabase/migrations/20260805184000_feedback_preset_visibility.sql
@@ -1,0 +1,109 @@
+-- Keep service-role feedback summaries within the caller's preset visibility boundary.
+drop function if exists public.gateway_feedback_summary(
+  uuid, text, text, text, text, uuid, uuid, timestamptz, timestamptz, jsonb, integer
+);
+
+create function public.gateway_feedback_summary(
+  p_workspace_id uuid,
+  p_visible_preset_ids uuid[],
+  p_group_by text default 'preset_id',
+  p_metadata_key text default null,
+  p_request_id text default null,
+  p_session_id text default null,
+  p_preset_id uuid default null,
+  p_test_run_id uuid default null,
+  p_created_since timestamptz default null,
+  p_created_until timestamptz default null,
+  p_metadata_filters jsonb default '{}'::jsonb,
+  p_limit integer default 5000
+)
+returns table (
+  group_value text,
+  count bigint,
+  positive bigint,
+  negative bigint,
+  partial bigint,
+  average_score numeric,
+  ratings jsonb,
+  last_feedback_at timestamptz
+)
+language plpgsql
+stable
+security definer
+set search_path = ''
+as $$
+begin
+  if p_group_by not in ('preset_id', 'test_run_id', 'metadata') then
+    raise exception 'invalid feedback summary grouping' using errcode = '22023';
+  end if;
+  if p_group_by = 'metadata'
+     and (p_metadata_key is null or p_metadata_key !~ '^[a-zA-Z0-9_.:-]{1,64}$') then
+    raise exception 'valid metadata key required for metadata grouping' using errcode = '22023';
+  end if;
+  if jsonb_typeof(coalesce(p_metadata_filters, '{}'::jsonb)) <> 'object' then
+    raise exception 'metadata filters must be a JSON object' using errcode = '22023';
+  end if;
+
+  return query
+  with filtered as (
+    select
+      case p_group_by
+        when 'preset_id' then feedback.preset_id::text
+        when 'test_run_id' then feedback.test_run_id::text
+        when 'metadata' then feedback.metadata_dimensions ->> p_metadata_key
+      end as summary_group,
+      feedback.rating,
+      feedback.score,
+      feedback.created_at
+    from public.gateway_feedback as feedback
+    where feedback.workspace_id = p_workspace_id
+      and (feedback.preset_id is null or feedback.preset_id = any(coalesce(p_visible_preset_ids, '{}'::uuid[])))
+      and (p_request_id is null or feedback.request_id = p_request_id)
+      and (p_session_id is null or feedback.session_id = p_session_id)
+      and (p_preset_id is null or feedback.preset_id = p_preset_id)
+      and (p_test_run_id is null or feedback.test_run_id = p_test_run_id)
+      and (p_created_since is null or feedback.created_at >= p_created_since)
+      and (p_created_until is null or feedback.created_at <= p_created_until)
+      and feedback.metadata_dimensions @> coalesce(p_metadata_filters, '{}'::jsonb)
+  ),
+  grouped as (
+    select summary_group,
+      count(*) as feedback_count,
+      count(*) filter (where rating in ('thumbs_up', 'correct')) as positive_count,
+      count(*) filter (where rating in ('thumbs_down', 'incorrect', 'unsafe')) as negative_count,
+      count(*) filter (where rating = 'partly_correct') as partial_count,
+      avg(score) filter (where score is not null) as mean_score,
+      max(created_at) as latest_feedback_at
+    from filtered
+    where summary_group is not null and summary_group <> ''
+    group by summary_group
+  ),
+  rating_counts as (
+    select summary_group, coalesce(rating, 'unrated') as rating_key, count(*) as rating_count
+    from filtered
+    where summary_group is not null and summary_group <> ''
+    group by summary_group, coalesce(rating, 'unrated')
+  ),
+  rating_totals as (
+    select summary_group, jsonb_object_agg(rating_key, rating_count) as rating_map
+    from rating_counts group by summary_group
+  )
+  select grouped.summary_group, grouped.feedback_count, grouped.positive_count,
+    grouped.negative_count, grouped.partial_count, grouped.mean_score,
+    coalesce(rating_totals.rating_map, '{}'::jsonb), grouped.latest_feedback_at
+  from grouped left join rating_totals using (summary_group)
+  order by grouped.latest_feedback_at desc, grouped.summary_group asc
+  limit greatest(1, least(coalesce(p_limit, 5000), 10000));
+end;
+$$;
+
+revoke all on function public.gateway_feedback_summary(
+  uuid, uuid[], text, text, text, text, uuid, uuid, timestamptz, timestamptz, jsonb, integer
+) from public, anon, authenticated;
+grant execute on function public.gateway_feedback_summary(
+  uuid, uuid[], text, text, text, text, uuid, uuid, timestamptz, timestamptz, jsonb, integer
+) to service_role;
+
+comment on function public.gateway_feedback_summary(
+  uuid, uuid[], text, text, text, text, uuid, uuid, timestamptz, timestamptz, jsonb, integer
+) is 'Service-role-only feedback aggregation constrained to caller-visible presets.';


### PR DESCRIPTION
## Summary
- enforce preset visibility on feedback, feedback-event, and feedback test-run reads
- fail closed when writes reference presets the caller cannot access
- scope feedback summary aggregation to caller-visible presets

## Security impact
Private preset feedback, event metadata, and evaluation test data are no longer exposed to other workspace actors or management-key callers.

## Validation
- `pnpm --filter @phaseo/gateway-api test -- src/routes/v1/control/feedback.test.ts`
- `pnpm --filter @phaseo/gateway-api typecheck`
- targeted ESLint on changed TypeScript files
- `git diff --check`

Created with Codex