### PR TITLE
Protect daily game answers

### DIFF
--- a/apps/web-api/src/games/results.test.ts
+++ b/apps/web-api/src/games/results.test.ts
@@ -24,6 +24,27 @@ describe("game results", () => {
     ).toEqual({ won: false, score: 1, maxScore: 2, attempts: 1 });
   });
 
+  it("records reveal actions as losses for every game", () => {
+    expect(gameCompletion(
+      "timeline",
+      { action: "reveal" },
+      { answer: [] },
+      { order: ["a", "b", "c", "d", "e"] }
+    )).toEqual({ won: false, score: 0, maxScore: 5, attempts: 1 });
+    expect(gameCompletion(
+      "head-to-head",
+      { action: "reveal" },
+      { answer: {} },
+      { answers: { latency: "a", throughput: "b" } }
+    )).toEqual({ won: false, score: 0, maxScore: 2, attempts: 1 });
+    expect(gameCompletion(
+      "sprint",
+      { action: "reveal" },
+      { answer: [] },
+      { candidates: [{ id: "a" }, { id: "b" }] }
+    )).toEqual({ won: false, score: 0, maxScore: 2, attempts: 1 });
+  });
+
   it("builds per-game totals and a daily streak", () => {
     const summary = buildGameProfileSummary([
       { game_key: "modele", puzzle_date: "2026-07-31", won: true, score: 1, max_score: 1, completed_at: "2026-07-31T10:00:00Z" },

--- a/apps/web-api/src/games/results.ts
+++ b/apps/web-api/src/games/results.ts
@@ -23,17 +23,24 @@ export function gameCompletion(
   result: Record<string, unknown>,
   answerPayload: Record<string, unknown>
 ): GameCompletion | null {
-  if (body.action === "reveal" && game !== "modele" && game !== "pricele")
-    return null;
+  if (body.action === "reveal") {
+    const maxScore = game === "timeline"
+      ? 5
+      : game === "head-to-head"
+        ? Object.keys((answerPayload.answers as object | undefined) ?? {}).length
+        : game === "sprint"
+          ? ((answerPayload.candidates as Array<unknown> | undefined) ?? []).length
+          : 1;
+    return {
+      won: false,
+      score: 0,
+      maxScore,
+      attempts: game === "modele" || game === "pricele"
+        ? boundedInteger(body.attempts, 0)
+        : 1,
+    };
+  }
   if (game === "modele" || game === "pricele") {
-    if (body.action === "reveal") {
-      return {
-        won: false,
-        score: 0,
-        maxScore: 1,
-        attempts: boundedInteger(body.attempts, 0),
-      };
-    }
     if (result.correct !== true) return null;
     return {
       won: true,

--- a/apps/web-api/src/routes/public/games.test.ts
+++ b/apps/web-api/src/routes/public/games.test.ts
@@ -28,4 +28,20 @@ describe("catalogue games preview boundary", () => {
     );
     expect(response.status).toBe(404);
   });
+
+  it("requires authentication before evaluating a reveal", async () => {
+    const response = await app.request(
+      "https://phaseo.app/games/timeline/check",
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ puzzleId: "puzzle-1", action: "reveal" }),
+      },
+      {
+        ENV: "development",
+      }
+    );
+    expect(response.status).toBe(401);
+    await expect(response.json()).resolves.toEqual({ error: "unauthorized" });
+  });
 });

--- a/apps/web-api/src/routes/public/games.ts
+++ b/apps/web-api/src/routes/public/games.ts
@@ -73,6 +73,11 @@ publicGamesRouter.post("/:game/check", async (c) => {
           userId: user.id,
           error,
         });
+        if (body.action === "reveal") {
+          return c.json({ error: "result_persistence_failed" }, 503, {
+            "Cache-Control": "private, no-store",
+          });
+        }
       }
     }
     return c.json(evaluation, 200, {

--- a/apps/web-api/src/routes/public/games.ts
+++ b/apps/web-api/src/routes/public/games.ts
@@ -44,6 +44,12 @@ publicGamesRouter.post("/:game/check", async (c) => {
   } catch {
     return c.json({ error: "invalid_request" }, 400);
   }
+  const revealUser = body.action === "reveal"
+    ? await requireUser(c.req.raw, c.env)
+    : null;
+  if (body.action === "reveal" && !revealUser) {
+    return c.json({ error: "unauthorized" }, 401);
+  }
   try {
     const puzzle = await resolveDailyPuzzle(c.env, game);
     if (body.puzzleId !== puzzle.puzzle_id) {
@@ -57,7 +63,7 @@ publicGamesRouter.post("/:game/check", async (c) => {
       puzzle.answer_payload
     );
     if (completion) {
-      const user = await requireUser(c.req.raw, c.env);
+      const user = revealUser ?? await requireUser(c.req.raw, c.env);
       if (!user) return c.json({ error: "unauthorized" }, 401);
       try {
         await persistGameCompletion(c.env, user, puzzle, completion);


### PR DESCRIPTION
## Summary
- require authentication before evaluating daily puzzle reveal requests
- persist reveals as losses for every catalogue game
- cover unauthenticated reveal rejection and multi-game reveal scoring

## Security impact
Public callers can no longer retrieve server-only daily answers, and authenticated players cannot reveal an answer and later submit a perfect synced result for the same puzzle.

## Validation
- `pnpm --filter @phaseo/web-api test -- src/games/results.test.ts src/routes/public/games.test.ts` (7 tests)
- `pnpm --filter @phaseo/web-api typecheck`
- `git diff --check`

Created with Codex