### PR TITLE
Redact diarization telemetry

### DIFF
--- a/apps/api/src/observability/__tests__/privacy.test.ts
+++ b/apps/api/src/observability/__tests__/privacy.test.ts
@@ -102,4 +102,16 @@ describe("observability privacy sanitization", () => {
 		expect(String(sanitized.api_key)).toContain("[redacted");
 		expect(String(sanitized.token)).toContain("[redacted");
 	});
+
+	it("redacts diarization speaker identities and reference audio", () => {
+		const sanitized = sanitizeForAxiom({
+			known_speaker_names: ["Alice Example", "Bob Example"],
+			known_speaker_references: ["data:audio/wav;base64,U0VOU0lUSVZF"],
+			language: "en",
+		}) as any;
+
+		expect(String(sanitized.known_speaker_names)).toContain("[redacted");
+		expect(String(sanitized.known_speaker_references)).toContain("[redacted");
+		expect(sanitized.language).toBe("en");
+	});
 });

--- a/apps/api/src/observability/__tests__/privacy.test.ts
+++ b/apps/api/src/observability/__tests__/privacy.test.ts
@@ -107,11 +107,15 @@ describe("observability privacy sanitization", () => {
 		const sanitized = sanitizeForAxiom({
 			known_speaker_names: ["Alice Example", "Bob Example"],
 			known_speaker_references: ["data:audio/wav;base64,U0VOU0lUSVZF"],
+			"known_speaker_names[]": "Carol Example",
+			"known_speaker_references[]": "data:audio/wav;base64,QlJBQ0tFVEVE",
 			language: "en",
 		}) as any;
 
 		expect(String(sanitized.known_speaker_names)).toContain("[redacted");
 		expect(String(sanitized.known_speaker_references)).toContain("[redacted");
+		expect(String(sanitized["known_speaker_names[]"])).toContain("[redacted");
+		expect(String(sanitized["known_speaker_references[]"])).toContain("[redacted");
 		expect(sanitized.language).toBe("en");
 	});
 });

--- a/apps/api/src/observability/privacy.ts
+++ b/apps/api/src/observability/privacy.ts
@@ -19,6 +19,8 @@ const PROMPT_COMPLETION_KEYS = new Set([
 	"completion",
 	"completions",
 	"generated_text",
+	"known_speaker_names",
+	"known_speaker_references",
 ]);
 
 const TEXT_CONTENT_TYPES = new Set([

--- a/apps/api/src/observability/privacy.ts
+++ b/apps/api/src/observability/privacy.ts
@@ -134,7 +134,7 @@ function shouldRedactByKey(
 	value: unknown,
 	parent: Record<string, unknown>,
 ): boolean {
-	const normalized = key.toLowerCase();
+	const normalized = key.toLowerCase().replace(/\[\]$/, "");
 
 	// Keep usage/cost stats queryable.
 	if (


### PR DESCRIPTION
## Summary
- classify diarization speaker names as sensitive telemetry content
- redact speaker reference audio before detailed Axiom serialization
- retain non-sensitive transcription metadata and add regression coverage

## Security impact
Detailed operational telemetry no longer records caller-supplied speaker identities or reference audio from diarization requests.

## Validation
- `pnpm --filter @phaseo/gateway-api test -- src/observability/__tests__/privacy.test.ts` (7 tests)
- `pnpm --filter @phaseo/gateway-api typecheck`
- `git diff --check`

Created with Codex