### PR TITLE
Bound profile usage aggregation

### DIFF
--- a/apps/web-api/src/routes/account/settings-profile.test.ts
+++ b/apps/web-api/src/routes/account/settings-profile.test.ts
@@ -54,8 +54,10 @@ describe("account profile settings route", () => {
 
 	it("aggregates profile usage across every workspace membership", async () => {
 		let requestCalls = 0;
+		const requestedUrls: string[] = [];
 		vi.stubGlobal("fetch", vi.fn(async (input: RequestInfo | URL) => {
 			const url = input instanceof Request ? input.url : String(input);
+			requestedUrls.push(url);
 			if (url.includes("/auth/v1/user")) return new Response(JSON.stringify({
 				id: "user-1",
 				email: "person@example.com",
@@ -102,5 +104,9 @@ describe("account profile settings route", () => {
 				],
 			},
 		});
+		expect(requestedUrls.find((url) => url.includes("workspace_members"))).toContain("limit=100");
+		expect(requestedUrls.filter((url) => url.includes("v2_web_gateway_requests"))).toEqual(
+			expect.arrayContaining([expect.stringContaining("created_at=gte.")]),
+		);
 	});
 });

--- a/apps/web-api/src/routes/account/settings-profile.ts
+++ b/apps/web-api/src/routes/account/settings-profile.ts
@@ -112,9 +112,11 @@ async function usageAggregateRows(client: ReturnType<typeof getDataClient>, work
 	if (!workspaceIds.length) return [];
 	const rows: UsageAggregateRow[] = [];
 	const since = new Date(Date.now() - PROFILE_USAGE_WINDOW_DAYS * 24 * 60 * 60 * 1000).toISOString();
+	const perWorkspaceLimit = Math.max(1, Math.floor(PROFILE_USAGE_MAX_ROWS / workspaceIds.length));
 	for (const workspaceId of workspaceIds) {
-		for (let offset = 0; rows.length < PROFILE_USAGE_MAX_ROWS; offset += PAGE_SIZE) {
-			const remaining = PROFILE_USAGE_MAX_ROWS - rows.length;
+		let workspaceRows = 0;
+		for (let offset = 0; workspaceRows < perWorkspaceLimit; offset += PAGE_SIZE) {
+			const remaining = perWorkspaceLimit - workspaceRows;
 			const pageLimit = Math.min(PAGE_SIZE, remaining);
 			const result = await client.from("v2_web_gateway_requests")
 				.select("created_at,model_id,usage,cost_nanos")
@@ -131,9 +133,9 @@ async function usageAggregateRows(client: ReturnType<typeof getDataClient>, work
 				tokens: tokenCount(row.usage),
 				cost: (Number(row.cost_nanos) || 0) / 1_000_000_000,
 			})));
+			workspaceRows += page.length;
 			if (page.length < pageLimit) break;
 		}
-		if (rows.length >= PROFILE_USAGE_MAX_ROWS) break;
 	}
 	return rows;
 }

--- a/apps/web-api/src/routes/account/settings-profile.ts
+++ b/apps/web-api/src/routes/account/settings-profile.ts
@@ -19,6 +19,9 @@ type UsageAggregateRow = {
 };
 
 const PAGE_SIZE = 1000;
+const PROFILE_USAGE_MAX_ROWS = 50_000;
+const PROFILE_USAGE_WINDOW_DAYS = 365;
+const PROFILE_USAGE_MAX_WORKSPACES = 100;
 
 function dateKey(value: Date | string): string {
 	const date = typeof value === "string" ? new Date(value) : value;
@@ -108,13 +111,17 @@ function normalizePublicProfileSlug(value: unknown): string {
 async function usageAggregateRows(client: ReturnType<typeof getDataClient>, workspaceIds: string[]): Promise<UsageAggregateRow[]> {
 	if (!workspaceIds.length) return [];
 	const rows: UsageAggregateRow[] = [];
+	const since = new Date(Date.now() - PROFILE_USAGE_WINDOW_DAYS * 24 * 60 * 60 * 1000).toISOString();
 	for (const workspaceId of workspaceIds) {
-		for (let offset = 0; ; offset += PAGE_SIZE) {
+		for (let offset = 0; rows.length < PROFILE_USAGE_MAX_ROWS; offset += PAGE_SIZE) {
+			const remaining = PROFILE_USAGE_MAX_ROWS - rows.length;
+			const pageLimit = Math.min(PAGE_SIZE, remaining);
 			const result = await client.from("v2_web_gateway_requests")
 				.select("created_at,model_id,usage,cost_nanos")
 				.eq("workspace_id", workspaceId)
-				.order("created_at", { ascending: true })
-				.range(offset, offset + PAGE_SIZE - 1);
+				.gte("created_at", since)
+				.order("created_at", { ascending: false })
+				.range(offset, offset + pageLimit - 1);
 			if (result.error) throw new Error(result.error.message || "profile_usage_unavailable");
 			const page = (result.data ?? []) as RequestRow[];
 			rows.push(...page.map((row) => ({
@@ -124,8 +131,9 @@ async function usageAggregateRows(client: ReturnType<typeof getDataClient>, work
 				tokens: tokenCount(row.usage),
 				cost: (Number(row.cost_nanos) || 0) / 1_000_000_000,
 			})));
-			if (page.length < PAGE_SIZE) break;
+			if (page.length < pageLimit) break;
 		}
+		if (rows.length >= PROFILE_USAGE_MAX_ROWS) break;
 	}
 	return rows;
 }
@@ -362,7 +370,8 @@ accountSettingsProfileRouter.get("/profile/usage", async (c) => {
 	const membershipsResult = await client
 		.from("workspace_members")
 		.select("workspace_id")
-		.eq("user_id", user.id);
+		.eq("user_id", user.id)
+		.limit(PROFILE_USAGE_MAX_WORKSPACES);
 	if (membershipsResult.error) return c.json({ error: "profile_usage_unavailable" }, 503, PRIVATE_NO_STORE_HEADERS);
 	const workspaceIds = Array.from(new Set(
 		(membershipsResult.data ?? [])


### PR DESCRIPTION
## Summary
- restrict profile usage scans to the trailing 365 days
- cap aggregation at 50,000 newest request rows across at most 100 workspaces
- verify the bounded query contract in route tests

## Security impact
Authenticated users can no longer trigger an unbounded full-history scan across every workspace membership through the profile usage endpoint.

## Validation
- `pnpm --filter @phaseo/web-api test -- src/routes/account/settings-profile.test.ts` (2 tests)
- `pnpm --filter @phaseo/web-api typecheck`
- `git diff --check`

Created with Codex