### PR TITLE
Disable mismatched MiniMax region

### DIFF
--- a/packages/data/catalog/src/data/api_providers/nebius-token-factory/models.json
+++ b/packages/data/catalog/src/data/api_providers/nebius-token-factory/models.json
@@ -628,7 +628,7 @@
     "provider_api_model_id": "nebius-token-factory:minimax/minimax-m3",
     "provider_model_slug": "MiniMaxAI/MiniMax-M3",
     "internal_model_id": "minimax/minimax-m3",
-    "is_active_gateway": true,
+    "is_active_gateway": false,
     "quantization_scheme": "FP4",
     "input_modalities": "text",
     "output_modalities": "text",


### PR DESCRIPTION
## Summary
- disable the MiniMax M3 route owned by the global Nebius Token Factory provider
- preserve other active MiniMax providers while preventing the regional metadata mismatch

## Security impact
Requests requiring `us-central1` can no longer pass residency checks on this route and then be sent through Nebius's global endpoint. The route can be re-enabled after it is represented by a complete regional catalogue provider.

## Validation
- `pnpm validate:data`
- `pnpm validate:gateway`
- `git diff --check`

Created with Codex