### PR TITLE
Reject pricing tier coverage gaps

### DIFF
--- a/apps/api/src/pipeline/pricing/engine.plan-fallback.test.ts
+++ b/apps/api/src/pipeline/pricing/engine.plan-fallback.test.ts
@@ -53,7 +53,7 @@ describe("pricing engine non-standard plan fallback", () => {
 		expect(result.lines.find((line) => line.dimension === "output_text_tokens")?.rule_id).toBe("standard-output");
 	});
 
-	it("falls back to standard for long-context holes in non-standard plans", () => {
+	it("rejects condition holes in requested non-standard plans", () => {
 		const card = makeCard([
 			{
 				id: "priority-input-lt-272k",
@@ -101,7 +101,7 @@ describe("pricing engine non-standard plan fallback", () => {
 			},
 		]);
 
-		const result = computeBillSummary(
+		expect(() => computeBillSummary(
 			{
 				input_tokens: 300_000,
 				input_text_tokens: 300_000,
@@ -110,12 +110,7 @@ describe("pricing engine non-standard plan fallback", () => {
 			card,
 			{},
 			"priority",
-		);
-
-		expect(result.lines).toHaveLength(2);
-		expect(result.cost_usd_str).toBe("9.900000000");
-		expect(result.lines.find((line) => line.dimension === "input_text_tokens")?.rule_id).toBe("standard-input-gte-272k");
-		expect(result.lines.find((line) => line.dimension === "output_text_tokens")?.rule_id).toBe("standard-output-gte-272k");
+		)).toThrow("pricing_plan_coverage_missing:priority:input_text_tokens");
 	});
 });
 

--- a/apps/api/src/pipeline/pricing/engine.ts
+++ b/apps/api/src/pipeline/pricing/engine.ts
@@ -664,6 +664,12 @@ export function computeBillSummary(
         let candidates = findCandidatesForPlanAndMeter(pricingPlan, dim);
         let resolvedPlan = pricingPlan;
         if (!candidates.length && pricingPlan !== "standard") {
+            const requestedPlanDefinesMeter = card.rules.some(
+                (rule) => rule.pricing_plan === pricingPlan && rule.meter === dim,
+            );
+            if (requestedPlanDefinesMeter) {
+                throw new Error(`pricing_plan_coverage_missing:${pricingPlan}:${dim}`);
+            }
             const fallbackCandidates = findCandidatesForPlanAndMeter("standard", dim);
             if (fallbackCandidates.length) {
                 candidates = fallbackCandidates;

--- a/packages/data/catalog/src/data/pricing/openai/openai-gpt-5.4/text.generate/pricing.json
+++ b/packages/data/catalog/src/data/pricing/openai/openai-gpt-5.4/text.generate/pricing.json
@@ -519,8 +519,8 @@
           "value": 272000
         }
       ],
-      "source": "https://developers.openai.com/api/docs/pricing",
-      "effective_to": null
+      "source": null,
+      "effective_to": "2026-07-30T00:00:00Z"
     },
     {
       "meter": "cached_read_text_tokens",
@@ -552,8 +552,8 @@
           "value": 272000
         }
       ],
-      "source": "https://developers.openai.com/api/docs/pricing",
-      "effective_to": null
+      "source": null,
+      "effective_to": "2026-07-30T00:00:00Z"
     },
     {
       "meter": "output_text_tokens",
@@ -585,8 +585,8 @@
           "value": 272000
         }
       ],
-      "source": "https://developers.openai.com/api/docs/pricing",
-      "effective_to": null
+      "source": null,
+      "effective_to": "2026-07-30T00:00:00Z"
     },
     {
       "meter": "input_text_tokens",

--- a/packages/data/catalog/src/data/pricing/openai/openai-gpt-5.4/text.generate/pricing.json
+++ b/packages/data/catalog/src/data/pricing/openai/openai-gpt-5.4/text.generate/pricing.json
@@ -519,8 +519,8 @@
           "value": 272000
         }
       ],
-      "source": null,
-      "effective_to": "2026-07-30T00:00:00Z"
+      "source": "https://developers.openai.com/api/docs/pricing",
+      "effective_to": null
     },
     {
       "meter": "cached_read_text_tokens",
@@ -552,8 +552,8 @@
           "value": 272000
         }
       ],
-      "source": null,
-      "effective_to": "2026-07-30T00:00:00Z"
+      "source": "https://developers.openai.com/api/docs/pricing",
+      "effective_to": null
     },
     {
       "meter": "output_text_tokens",
@@ -585,8 +585,8 @@
           "value": 272000
         }
       ],
-      "source": null,
-      "effective_to": "2026-07-30T00:00:00Z"
+      "source": "https://developers.openai.com/api/docs/pricing",
+      "effective_to": null
     },
     {
       "meter": "input_text_tokens",


### PR DESCRIPTION
## Summary
- fail closed when a requested non-standard pricing tier defines a meter but its conditions do not cover the request
- preserve standard-tier fallback when the requested tier does not define that meter at all
- prevent unsupported GPT-5.4 long-context priority requests from being billed at standard rates

## Validation
- pnpm --filter @phaseo/gateway-api exec vitest run src/pipeline/pricing/engine.plan-fallback.test.ts
- pnpm --filter @phaseo/gateway-api typecheck
- pnpm validate:pricing

Created with Codex