### PR TITLE
Bound public pricing fanout

### DIFF
--- a/.changeset/calm-plums-listen.md
+++ b/.changeset/calm-plums-listen.md
@@ -1,0 +1,5 @@
+---
+"@phaseo/web-api": patch
+---
+
+Reject unsupported public pricing query parameters and fail closed when provider routes exceed the bounded catalogue scan.

--- a/apps/web-api/src/routes/public/pricing.test.ts
+++ b/apps/web-api/src/routes/public/pricing.test.ts
@@ -168,7 +168,7 @@ describe("public pricing routes", () => {
 		expect(fetchMock).not.toHaveBeenCalled();
 	});
 
-	it("caps unfiltered provider-route pagination", async () => {
+	it("fails closed instead of caching a truncated provider-route catalogue", async () => {
 		const fullPage = Array.from({ length: 1_000 }, (_, index) => ({
 			provider_model_id: `provider:model-${index}`,
 			provider_slug: "provider",
@@ -180,7 +180,12 @@ describe("public pricing routes", () => {
 		const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
 			const url = String(input);
 			if (url.includes("v2_model_provider_routes")) {
-				return new Response(JSON.stringify(fullPage), { status: 200 });
+				const providerCalls = fetchMock.mock.calls.filter(([input]) =>
+					String(input).includes("v2_model_provider_routes")
+				).length;
+				return new Response(JSON.stringify(
+					providerCalls === 5 ? [...fullPage, { ...fullPage[0], provider_model_id: "provider:overflow" }] : fullPage,
+				), { status: 200 });
 			}
 			return new Response("[]", { status: 200 });
 		});
@@ -188,7 +193,8 @@ describe("public pricing routes", () => {
 
 		const response = await app.request("https://phaseo.app/api/_web/pricing/models", {}, env);
 
-		expect(response.status).toBe(200);
+		expect(response.status).toBe(503);
+		await expect(response.json()).resolves.toEqual({ error: "pricing_models_unavailable" });
 		const providerRequests = fetchMock.mock.calls.filter(([input]) =>
 			String(input).includes("v2_model_provider_routes")
 		);

--- a/apps/web-api/src/routes/public/pricing.test.ts
+++ b/apps/web-api/src/routes/public/pricing.test.ts
@@ -152,4 +152,46 @@ describe("public pricing routes", () => {
 		)?.[0]);
 		expect(decodeURIComponent(providerUrl)).toContain("model_slug=in.(openai/gpt-5.6-sol)");
 	});
+
+	it("rejects cache-busting parameters before accessing the database", async () => {
+		const fetchMock = vi.fn();
+		vi.stubGlobal("fetch", fetchMock);
+
+		const response = await app.request(
+			"https://phaseo.app/api/_web/pricing/models?cb=random",
+			{},
+			env,
+		);
+
+		expect(response.status).toBe(400);
+		await expect(response.json()).resolves.toEqual({ error: "unsupported_query_parameter" });
+		expect(fetchMock).not.toHaveBeenCalled();
+	});
+
+	it("caps unfiltered provider-route pagination", async () => {
+		const fullPage = Array.from({ length: 1_000 }, (_, index) => ({
+			provider_model_id: `provider:model-${index}`,
+			provider_slug: "provider",
+			provider_model_slug: `model-${index}`,
+			model_slug: `organisation/model-${index}`,
+			routing_enabled: true,
+			status: "active",
+		}));
+		const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+			const url = String(input);
+			if (url.includes("v2_model_provider_routes")) {
+				return new Response(JSON.stringify(fullPage), { status: 200 });
+			}
+			return new Response("[]", { status: 200 });
+		});
+		vi.stubGlobal("fetch", fetchMock);
+
+		const response = await app.request("https://phaseo.app/api/_web/pricing/models", {}, env);
+
+		expect(response.status).toBe(200);
+		const providerRequests = fetchMock.mock.calls.filter(([input]) =>
+			String(input).includes("v2_model_provider_routes")
+		);
+		expect(providerRequests).toHaveLength(5);
+	});
 });

--- a/apps/web-api/src/routes/public/pricing.ts
+++ b/apps/web-api/src/routes/public/pricing.ts
@@ -6,6 +6,8 @@ import { withPublicCache } from "@/http/cache";
 export const publicPricingRouter = new Hono<{ Bindings: Env }>();
 
 const POSTGREST_IN_CHUNK_SIZE = 100;
+const PROVIDER_ROUTE_PAGE_SIZE = 1_000;
+const PROVIDER_ROUTE_MAX_ROWS = 5_000;
 
 function chunks<T>(values: T[]): T[][] {
 	const result: T[][] = [];
@@ -25,6 +27,10 @@ function rowsOrThrow<T extends Record<string, unknown>>(
 
 publicPricingRouter.get("/pricing/models", async (c) => {
 	try {
+		const queryKeys = [...new URL(c.req.url).searchParams.keys()];
+		if (queryKeys.some((key) => key !== "model_ids")) {
+			return c.json({ error: "unsupported_query_parameter" }, 400);
+		}
 		const client = getDataClient(c.env); const now = Date.now();
 		const requestedModelIds = [...new Set(
 			(c.req.query("model_ids") ?? "")
@@ -34,7 +40,7 @@ publicPricingRouter.get("/pricing/models", async (c) => {
 		)].slice(0, 100);
 		const active = (row: Record<string, unknown>) => { const from = row.effective_from ? Date.parse(String(row.effective_from)) : Number.NEGATIVE_INFINITY; const to = row.effective_to ? Date.parse(String(row.effective_to)) : Number.POSITIVE_INFINITY; return now >= from && now < to; };
 		const providerRows: Array<Record<string, unknown>> = [];
-		for (let offset = 0; ; offset += 1_000) {
+		for (let offset = 0; offset < PROVIDER_ROUTE_MAX_ROWS; offset += PROVIDER_ROUTE_PAGE_SIZE) {
 			let query = client
 				.from("v2_model_provider_routes")
 				.select("provider_model_id,provider_slug,provider_model_slug,model_slug,routing_enabled,status,effective_from,effective_to")
@@ -43,11 +49,11 @@ publicPricingRouter.get("/pricing/models", async (c) => {
 			if (requestedModelIds.length > 0) query = query.in("model_slug", requestedModelIds);
 			const providerResult = await query
 				.order("provider_model_id", { ascending: true })
-				.range(offset, offset + 999);
+				.range(offset, Math.min(offset + PROVIDER_ROUTE_PAGE_SIZE - 1, PROVIDER_ROUTE_MAX_ROWS - 1));
 			if (providerResult.error) throw providerResult.error;
 			const page = (providerResult.data ?? []) as Array<Record<string, unknown>>;
 			providerRows.push(...page.filter(active));
-			if (page.length < 1_000) break;
+			if (page.length < PROVIDER_ROUTE_PAGE_SIZE) break;
 		}
 		const routeIds = providerRows.map((row) => String(row.provider_model_id ?? "")).filter(Boolean);
 		const modelIds = [...new Set(providerRows.map((row) => String(row.model_slug ?? "")).filter(Boolean))];

--- a/apps/web-api/src/routes/public/pricing.ts
+++ b/apps/web-api/src/routes/public/pricing.ts
@@ -41,6 +41,7 @@ publicPricingRouter.get("/pricing/models", async (c) => {
 		const active = (row: Record<string, unknown>) => { const from = row.effective_from ? Date.parse(String(row.effective_from)) : Number.NEGATIVE_INFINITY; const to = row.effective_to ? Date.parse(String(row.effective_to)) : Number.POSITIVE_INFINITY; return now >= from && now < to; };
 		const providerRows: Array<Record<string, unknown>> = [];
 		for (let offset = 0; offset < PROVIDER_ROUTE_MAX_ROWS; offset += PROVIDER_ROUTE_PAGE_SIZE) {
+			const isFinalAllowedPage = offset + PROVIDER_ROUTE_PAGE_SIZE >= PROVIDER_ROUTE_MAX_ROWS;
 			let query = client
 				.from("v2_model_provider_routes")
 				.select("provider_model_id,provider_slug,provider_model_slug,model_slug,routing_enabled,status,effective_from,effective_to")
@@ -49,10 +50,13 @@ publicPricingRouter.get("/pricing/models", async (c) => {
 			if (requestedModelIds.length > 0) query = query.in("model_slug", requestedModelIds);
 			const providerResult = await query
 				.order("provider_model_id", { ascending: true })
-				.range(offset, Math.min(offset + PROVIDER_ROUTE_PAGE_SIZE - 1, PROVIDER_ROUTE_MAX_ROWS - 1));
+				.range(offset, isFinalAllowedPage ? PROVIDER_ROUTE_MAX_ROWS : offset + PROVIDER_ROUTE_PAGE_SIZE - 1);
 			if (providerResult.error) throw providerResult.error;
 			const page = (providerResult.data ?? []) as Array<Record<string, unknown>>;
-			providerRows.push(...page.filter(active));
+			if (isFinalAllowedPage && page.length > PROVIDER_ROUTE_PAGE_SIZE) {
+				throw new Error("provider_route_catalogue_limit_exceeded");
+			}
+			providerRows.push(...page.slice(0, PROVIDER_ROUTE_PAGE_SIZE).filter(active));
 			if (page.length < PROVIDER_ROUTE_PAGE_SIZE) break;
 		}
 		const routeIds = providerRows.map((row) => String(row.provider_model_id ?? "")).filter(Boolean);


### PR DESCRIPTION
## Summary
- cap public pricing provider-route scans at 5,000 rows
- reject unsupported query parameters before creating the Supabase client
- add coverage for cache-busting rejection and pagination bounds

## Security impact
Unauthenticated callers can no longer force unbounded service-role database pagination or use ignored query parameters to manufacture cache keys for equivalent expensive requests.

## Validation
- `pnpm --filter @phaseo/web-api test -- src/routes/public/pricing.test.ts` (5 tests)
- `pnpm --filter @phaseo/web-api typecheck`
- `git diff --check`

Created with Codex

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Pricing requests with unsupported query parameters now return a clear 400 error.
  - Provider pricing pagination is capped at 5,000 records per request.
  - Pagination now stops correctly when fewer results are available, improving request efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->