### PR TITLE
Bound BYOK credential fanout

### DIFF
--- a/.changeset/bright-keys-rest.md
+++ b/.changeset/bright-keys-rest.md
@@ -1,0 +1,5 @@
+---
+"@phaseo/gateway-api": patch
+---
+
+Bound BYOK key hydration and upstream credential attempts for each gateway request.

--- a/apps/api/src/pipeline/before/context.ts
+++ b/apps/api/src/pipeline/before/context.ts
@@ -142,17 +142,9 @@ async function hydrateByokKeys(
 		(context.providers ?? []).map((provider) => provider.providerId).filter(Boolean),
 	));
 	if (!providerIds.length) return context;
-	const maxKeysPerModePerProvider = 8;
 	const keyIds = Array.from(new Set(
 		(context.providers ?? []).flatMap((provider) =>
-			(["priority", "fallback"] as const).flatMap((mode) =>
-				(provider.byokMeta ?? [])
-					.filter((key) => (key.routingMode ?? (key.alwaysUse ? "priority" : "fallback")) === mode)
-					.sort((a, b) => (a.sortOrder ?? 0) - (b.sortOrder ?? 0) || a.id.localeCompare(b.id))
-					.slice(0, maxKeysPerModePerProvider)
-					.map((key) => key.id)
-					.filter(Boolean)
-			),
+			(provider.byokMeta ?? []).map((key) => key.id).filter(Boolean),
 		),
 	));
 	// The cached/RPC context contains only metadata. Avoid a Supabase read entirely
@@ -179,7 +171,27 @@ async function hydrateByokKeys(
 		};
 	}
 
-	const decrypted = await Promise.all((data as any[]).map(async (row) => {
+	const maxKeysPerModePerProvider = 8;
+	const rowsByProvider = new Map<string, any[]>();
+	for (const row of data as any[]) {
+		const providerRows = rowsByProvider.get(String(row.provider_id)) ?? [];
+		providerRows.push(row);
+		rowsByProvider.set(String(row.provider_id), providerRows);
+	}
+	const selectedRows = Array.from(rowsByProvider.values())
+		.flatMap((providerRows) => (["priority", "fallback"] as const).flatMap((mode) =>
+			providerRows
+				.filter((row) => {
+					const rowMode = row.routing_mode === "priority" || row.routing_mode === "fallback"
+						? row.routing_mode
+						: row.always_use ? "priority" : "fallback";
+					return rowMode === mode;
+				})
+				.sort((a, b) => Number(a.sort_order ?? 0) - Number(b.sort_order ?? 0) || String(a.id).localeCompare(String(b.id)))
+				.slice(0, maxKeysPerModePerProvider)
+		));
+
+	const decrypted = await Promise.all(selectedRows.map(async (row) => {
 		try {
 			const decryptedBytes = await decryptBYOK(row);
 			let key: string;

--- a/apps/api/src/pipeline/before/context.ts
+++ b/apps/api/src/pipeline/before/context.ts
@@ -142,9 +142,17 @@ async function hydrateByokKeys(
 		(context.providers ?? []).map((provider) => provider.providerId).filter(Boolean),
 	));
 	if (!providerIds.length) return context;
+	const maxKeysPerModePerProvider = 8;
 	const keyIds = Array.from(new Set(
 		(context.providers ?? []).flatMap((provider) =>
-			(provider.byokMeta ?? []).map((key) => key.id).filter(Boolean),
+			(["priority", "fallback"] as const).flatMap((mode) =>
+				(provider.byokMeta ?? [])
+					.filter((key) => (key.routingMode ?? (key.alwaysUse ? "priority" : "fallback")) === mode)
+					.sort((a, b) => (a.sortOrder ?? 0) - (b.sortOrder ?? 0) || a.id.localeCompare(b.id))
+					.slice(0, maxKeysPerModePerProvider)
+					.map((key) => key.id)
+					.filter(Boolean)
+			),
 		),
 	));
 	// The cached/RPC context contains only metadata. Avoid a Supabase read entirely

--- a/apps/api/src/pipeline/execute/credential-plan.test.ts
+++ b/apps/api/src/pipeline/execute/credential-plan.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { buildCredentialAttemptPlan } from "./index";
+import { buildCredentialAttemptPlan, MAX_BYOK_CREDENTIAL_ATTEMPTS } from "./index";
 
 function key(id: string, routingMode: "priority" | "fallback", sortOrder: number) {
 	return {
@@ -62,5 +62,41 @@ describe("credential attempt plan", () => {
 
 		const plan = buildCredentialAttemptPlan([provider], { includeFallbackByok: false });
 		expect(plan.map((attempt) => attempt.phase)).toEqual(["priority_byok", "gateway"]);
+	});
+
+	it("caps total BYOK attempts without removing the managed provider attempt", () => {
+		const provider = {
+			candidate: {
+				providerId: "provider-a",
+				byokMeta: Array.from({ length: 2_400 }, (_, index) =>
+					key(`key-${String(index).padStart(4, "0")}`, index < 1_200 ? "priority" : "fallback", index)
+				),
+			},
+		};
+
+		const plan = buildCredentialAttemptPlan([provider]);
+
+		expect(plan).toHaveLength(MAX_BYOK_CREDENTIAL_ATTEMPTS + 1);
+		expect(plan.filter((attempt) => attempt.credential.kind === "byok")).toHaveLength(
+			MAX_BYOK_CREDENTIAL_ATTEMPTS,
+		);
+		expect(plan.filter((attempt) => attempt.credential.kind === "gateway")).toHaveLength(1);
+	});
+
+	it("uses remaining BYOK budget for fallback keys", () => {
+		const provider = {
+			candidate: {
+				providerId: "provider-a",
+				byokMeta: [
+					...Array.from({ length: 3 }, (_, index) => key(`priority-${index}`, "priority", index)),
+					...Array.from({ length: 20 }, (_, index) => key(`fallback-${index}`, "fallback", index)),
+				],
+			},
+		};
+
+		const plan = buildCredentialAttemptPlan([provider]);
+
+		expect(plan.filter((attempt) => attempt.phase === "priority_byok")).toHaveLength(3);
+		expect(plan.filter((attempt) => attempt.phase === "fallback_byok")).toHaveLength(5);
 	});
 });

--- a/apps/api/src/pipeline/execute/index.ts
+++ b/apps/api/src/pipeline/execute/index.ts
@@ -100,6 +100,7 @@ const ATTEMPT_PREVIEW_LIMIT = 320;
 const MAX_UPSTREAM_ERROR_BODY_BYTES = 32 * 1024;
 const MAX_RETRYABLE_EXECUTOR_RETRIES = 0;
 const SINGLE_PROVIDER_FAILURE_RETRIES = 0;
+export const MAX_BYOK_CREDENTIAL_ATTEMPTS = 8;
 
 export type CredentialAttemptPhase = "priority_byok" | "gateway" | "fallback_byok";
 
@@ -125,16 +126,23 @@ export function buildCredentialAttemptPlan(
 				credential: { kind: "byok" as const, key },
 			}));
 
+	const priorityAttempts = rankedProviders.flatMap((routed) => keysForMode(routed, "priority"));
+	const limitedPriorityAttempts = priorityAttempts.slice(0, MAX_BYOK_CREDENTIAL_ATTEMPTS);
+	const remainingByokAttempts = MAX_BYOK_CREDENTIAL_ATTEMPTS - limitedPriorityAttempts.length;
+	const fallbackAttempts = options.includeFallbackByok === false
+		? []
+		: rankedProviders
+			.flatMap((routed) => keysForMode(routed, "fallback"))
+			.slice(0, remainingByokAttempts);
+
 	return [
-		...rankedProviders.flatMap((routed) => keysForMode(routed, "priority")),
+		...limitedPriorityAttempts,
 		...rankedProviders.map((routed) => ({
 			routed,
 			phase: "gateway" as const,
 			credential: { kind: "gateway" as const },
 		})),
-		...(options.includeFallbackByok === false
-			? []
-			: rankedProviders.flatMap((routed) => keysForMode(routed, "fallback"))),
+		...fallbackAttempts,
 	];
 }
 

--- a/supabase/migrations/20260805204556_limit_byok_keys_per_provider.sql
+++ b/supabase/migrations/20260805204556_limit_byok_keys_per_provider.sql
@@ -1,0 +1,48 @@
+create or replace function public.enforce_byok_key_provider_limit()
+returns trigger
+language plpgsql
+set search_path = ''
+as $$
+declare
+  existing_key_count integer;
+  excluded_key_id uuid;
+begin
+  if tg_op = 'UPDATE'
+    and new.workspace_id is not distinct from old.workspace_id
+    and new.provider_id is not distinct from old.provider_id then
+    return new;
+  end if;
+
+  if tg_op = 'UPDATE' then
+    excluded_key_id := old.id;
+  end if;
+
+  perform pg_catalog.pg_advisory_xact_lock(
+    pg_catalog.hashtextextended(new.workspace_id::text || ':' || new.provider_id, 0)
+  );
+
+  select count(*)
+  into existing_key_count
+  from public.byok_keys
+  where workspace_id = new.workspace_id
+    and provider_id = new.provider_id
+    and (excluded_key_id is null or id <> excluded_key_id);
+
+  if existing_key_count >= 32 then
+    raise exception 'BYOK key limit reached for workspace provider'
+      using errcode = '23514';
+  end if;
+
+  return new;
+end;
+$$;
+
+revoke all on function public.enforce_byok_key_provider_limit() from public, anon, authenticated;
+
+drop trigger if exists enforce_byok_key_provider_limit on public.byok_keys;
+create trigger enforce_byok_key_provider_limit
+before insert or update of workspace_id, provider_id on public.byok_keys
+for each row execute function public.enforce_byok_key_provider_limit();
+
+comment on function public.enforce_byok_key_provider_limit() is
+  'Caps stored BYOK credentials at 32 per workspace/provider using a transaction-scoped advisory lock.';


### PR DESCRIPTION
## Summary
- cap BYOK upstream attempts at eight per gateway request while preserving managed-provider attempts
- limit secret hydration to the first eight priority and fallback credentials per provider
- add a concurrency-safe database trigger capping stored keys at 32 per workspace/provider
- add regression coverage for thousands of attacker-controlled credentials

## Validation
- pnpm --filter @phaseo/gateway-api exec vitest run src/pipeline/execute/credential-plan.test.ts
- pnpm --filter @phaseo/gateway-api typecheck
- node scripts/validate-supabase-migrations.mjs origin/main
- git diff --check
- local migration replay was unavailable because the local Supabase database is not running

Created with Codex