### PR TITLE
Hide private app rollups

### DIFF
--- a/.changeset/safe-apps-filter.md
+++ b/.changeset/safe-apps-filter.md
@@ -1,0 +1,5 @@
+---
+"@phaseo/web-api": patch
+---
+
+Filter provider app telemetry against authoritative public-app visibility before returning it.

--- a/apps/web-api/src/routes/public/providers.test.ts
+++ b/apps/web-api/src/routes/public/providers.test.ts
@@ -25,7 +25,7 @@ describe("public provider routes", () => {
 		vi.stubGlobal("fetch", vi.fn(async (input: RequestInfo | URL) => {
 			const url = input instanceof Request ? input.url : String(input);
 			if (url.includes("get_top_models_stats_tokens")) return new Response(JSON.stringify([{ model_id: "openai/gpt-test", model_name: "GPT Test", request_count: "4", total_tokens: "120", median_latency_ms: "12.6", median_throughput: "3.456" }]), { status: 200 });
-			if (url.includes("get_top_apps_stats")) return new Response(JSON.stringify([{ app_id: "app-1", title: "Example", url: "https://example.com", total_tokens: "99" }, { app_id: "unknown", title: "Unknown", total_tokens: 1000 }]), { status: 200 });
+			if (url.includes("get_top_apps_stats")) return new Response(JSON.stringify([{ app_id: "app-1", title: "Example", url: "https://example.com", total_tokens: "99" }, { app_id: "app-private", title: "Private", url: "https://private.example", total_tokens: "500" }, { app_id: "unknown", title: "Unknown", total_tokens: 1000 }]), { status: 200 });
 			if (url.includes("v2_models")) return new Response(JSON.stringify([{ model_slug: "openai/gpt-test", hidden: false }]), { status: 200 });
 			if (url.includes("api_apps")) return new Response(JSON.stringify([{ id: "app-1", image_url: "https://example.com/app.png" }]), { status: 200 });
 			return new Response(JSON.stringify([]), { status: 200 });

--- a/apps/web-api/src/routes/public/providers.ts
+++ b/apps/web-api/src/routes/public/providers.ts
@@ -247,10 +247,10 @@ async function appTokenSeries(env: Env, providerId: string, days: number, topLim
 		totals.set(id, (totals.get(id) ?? 0) + tokens); const values = daily.get(day) ?? new Map<string, number>(); values.set(id, (values.get(id) ?? 0) + tokens); daily.set(day, values);
 	}
 	const ids = Array.from(totals.entries()).sort((left, right) => right[1] - left[1]).slice(0, topLimit).map(([id]) => id);
-	const metaResult = ids.length ? await getDataClient(env).from("api_apps").select("id,title,url,image_url").in("id", ids) : { data: [], error: null };
+	const metaResult = ids.length ? await getDataClient(env).from("api_apps").select("id,title,url,image_url").in("id", ids).eq("is_public", true) : { data: [], error: null };
 	if (metaResult.error) throw metaResult.error;
 	const meta = new Map((metaResult.data ?? []).map((row) => [String(row.id), row])); const topMeta = new Map(topRows.map((row) => [String(row.app_id), row]));
-	const apps = ids.map((appId) => {
+	const apps = ids.filter((appId) => meta.has(appId)).map((appId) => {
 		const primary = topMeta.get(appId) as Record<string, unknown> | undefined; const fallback = meta.get(appId); const title = String(primary?.title ?? fallback?.title ?? appId).trim() || appId;
 		const primaryUrl = typeof primary?.url === "string" ? primary.url : null;
 		return unknownApp(appId, title) ? null : { appId, title, url: primaryUrl ?? fallback?.url ?? null, imageUrl: fallback?.image_url ?? null, totalTokens: Math.round(totals.get(appId) ?? 0) };
@@ -368,10 +368,13 @@ publicProvidersRouter.get("/:providerId/top-apps", async (c) => {
 		}
 		const rows = (result.data ?? []).filter((row) => !unknownApp(String(row.app_id ?? ""), row.title));
 		const ids = rows.map((row) => String(row.app_id ?? "")).filter(Boolean);
-		const appResult = ids.length ? await client.from("api_apps").select("id,image_url").in("id", ids) : { data: [], error: null };
+		const appResult = ids.length ? await client.from("api_apps").select("id,title,url,image_url").in("id", ids).eq("is_public", true) : { data: [], error: null };
 		if (appResult.error) throw appResult.error;
-		const images = new Map((appResult.data ?? []).map((row) => [row.id, row.image_url ?? null]));
-		const apps = rows.map((row) => ({ app_id: row.app_id, title: row.title || row.app_id, url: row.url || null, image_url: images.get(row.app_id) ?? null, total_tokens: Number(row.total_tokens) }));
+		const publicApps = new Map((appResult.data ?? []).map((row) => [row.id, row]));
+		const apps = rows.flatMap((row) => {
+			const app = publicApps.get(row.app_id);
+			return app ? [{ app_id: row.app_id, title: app.title || row.title || row.app_id, url: app.url || row.url || null, image_url: app.image_url ?? null, total_tokens: Number(row.total_tokens) }] : [];
+		});
 		return withPublicCache(c.json({ apps }), providerPolicy(TELEMETRY_CACHE, providerId));
 	} catch (error) {
 		console.error("[web-api/providers] top apps failed", { providerId, error });

--- a/supabase/migrations/20260805205056_protect_private_app_rollups.sql
+++ b/supabase/migrations/20260805205056_protect_private_app_rollups.sql
@@ -5,12 +5,7 @@ create policy v2_public_usage_daily_public_select
   for select to anon, authenticated
   using (
     app_id is null
-    or exists (
-      select 1
-      from public.api_apps app
-      where app.id = v2_public_usage_daily.app_id
-        and coalesce(app.is_public, false)
-    )
+    or (select public.is_public_api_app(app_id))
   );
 
 drop policy if exists v2_public_usage_hourly_public_select
@@ -20,12 +15,7 @@ create policy v2_public_usage_hourly_public_select
   for select to anon, authenticated
   using (
     app_id is null
-    or exists (
-      select 1
-      from public.api_apps app
-      where app.id = v2_public_usage_hourly.app_id
-        and coalesce(app.is_public, false)
-    )
+    or (select public.is_public_api_app(app_id))
   );
 
 drop policy if exists v2_public_usage_daily_meters_public_select
@@ -58,3 +48,21 @@ comment on policy v2_public_usage_daily_public_select on public.v2_public_usage_
   'Exposes anonymous usage and usage attributed to explicitly public apps only.';
 comment on policy v2_public_usage_hourly_public_select on public.v2_public_usage_hourly is
   'Exposes anonymous usage and usage attributed to explicitly public apps only.';
+comment on function public.is_public_api_app(uuid) is
+  'RLS-safe public-app visibility lookup that exposes only a boolean classification.';
+create or replace function public.is_public_api_app(p_app_id uuid)
+returns boolean
+language sql
+stable
+security definer
+set search_path = ''
+as $$
+  select coalesce((
+    select app.is_public
+    from public.api_apps app
+    where app.id = p_app_id
+  ), false);
+$$;
+
+revoke all on function public.is_public_api_app(uuid) from public;
+grant execute on function public.is_public_api_app(uuid) to anon, authenticated, service_role;

--- a/supabase/migrations/20260805205056_protect_private_app_rollups.sql
+++ b/supabase/migrations/20260805205056_protect_private_app_rollups.sql
@@ -1,0 +1,60 @@
+drop policy if exists v2_public_usage_daily_public_select
+  on public.v2_public_usage_daily;
+create policy v2_public_usage_daily_public_select
+  on public.v2_public_usage_daily
+  for select to anon, authenticated
+  using (
+    app_id is null
+    or exists (
+      select 1
+      from public.api_apps app
+      where app.id = v2_public_usage_daily.app_id
+        and coalesce(app.is_public, false)
+    )
+  );
+
+drop policy if exists v2_public_usage_hourly_public_select
+  on public.v2_public_usage_hourly;
+create policy v2_public_usage_hourly_public_select
+  on public.v2_public_usage_hourly
+  for select to anon, authenticated
+  using (
+    app_id is null
+    or exists (
+      select 1
+      from public.api_apps app
+      where app.id = v2_public_usage_hourly.app_id
+        and coalesce(app.is_public, false)
+    )
+  );
+
+drop policy if exists v2_public_usage_daily_meters_public_select
+  on public.v2_public_usage_daily_meters;
+create policy v2_public_usage_daily_meters_public_select
+  on public.v2_public_usage_daily_meters
+  for select to anon, authenticated
+  using (
+    exists (
+      select 1
+      from public.v2_public_usage_daily rollup
+      where rollup.rollup_id = v2_public_usage_daily_meters.rollup_id
+    )
+  );
+
+drop policy if exists v2_public_usage_hourly_meters_public_select
+  on public.v2_public_usage_hourly_meters;
+create policy v2_public_usage_hourly_meters_public_select
+  on public.v2_public_usage_hourly_meters
+  for select to anon, authenticated
+  using (
+    exists (
+      select 1
+      from public.v2_public_usage_hourly rollup
+      where rollup.rollup_id = v2_public_usage_hourly_meters.rollup_id
+    )
+  );
+
+comment on policy v2_public_usage_daily_public_select on public.v2_public_usage_daily is
+  'Exposes anonymous usage and usage attributed to explicitly public apps only.';
+comment on policy v2_public_usage_hourly_public_select on public.v2_public_usage_hourly is
+  'Exposes anonymous usage and usage attributed to explicitly public apps only.';


### PR DESCRIPTION
## Summary
- restrict public daily and hourly rollup rows to anonymous usage or explicitly public apps
- make meter-table visibility inherit from the corresponding permitted parent rollup
- preserve vetted public RPC access over the privacy-filtered projection

## Validation
- node scripts/validate-supabase-migrations.mjs origin/main
- git diff --check
- local migration replay was unavailable because the local Supabase database is not running

Created with Codex