### PR TITLE
Preserve empty Vertex billing

### DIFF
--- a/.changeset/warm-stars-bill.md
+++ b/.changeset/warm-stars-bill.md
@@ -1,0 +1,5 @@
+---
+"@phaseo/gateway-api": patch
+---
+
+Preserve usage and billing for successful Google Vertex responses that contain no generated output.

--- a/apps/api/src/executors/google-vertex/text-generate/__tests__/mapping.test.ts
+++ b/apps/api/src/executors/google-vertex/text-generate/__tests__/mapping.test.ts
@@ -44,7 +44,7 @@ describe("google-vertex route resolution", () => {
 });
 
 describe("google-vertex empty response handling", () => {
-	it("turns a zero-output Gemini response into a failoverable error", async () => {
+	it("preserves usage and billing for a successful zero-output Gemini response", async () => {
 		const mock = installFetchMock([{
 			match: (url) => url.includes(":streamGenerateContent"),
 			response: new Response(JSON.stringify({
@@ -65,8 +65,9 @@ describe("google-vertex empty response handling", () => {
 
 		expect(result.kind).toBe("completed");
 		if (result.kind !== "completed") return;
-		expect(result.ir).toBeUndefined();
-		expect(result.upstream?.status).toBe(502);
+		expect(result.ir?.usage).toMatchObject({ inputTokens: 8, outputTokens: 0, totalTokens: 8 });
+		expect(result.bill.usage).toMatchObject({ input_tokens: 8, output_tokens: 0 });
+		expect(result.upstream?.status).toBe(200);
 	});
 });
 

--- a/apps/api/src/executors/google-vertex/text-generate/index.ts
+++ b/apps/api/src/executors/google-vertex/text-generate/index.ts
@@ -152,6 +152,7 @@ export async function execute(args: ExecutorExecuteArgs): Promise<ExecutorResult
 			})();
 			return {
 				kind: "stream",
+				allowEmptySuccess: true,
 				stream,
 				usageFinalizer: async () => null,
 				bill,
@@ -212,6 +213,7 @@ export async function execute(args: ExecutorExecuteArgs): Promise<ExecutorResult
 
 		return {
 			kind: "completed",
+			allowEmptySuccess: true,
 			ir,
 			bill,
 			upstream: res,
@@ -273,6 +275,7 @@ function finalizeResult(input: {
 		);
 		return {
 			kind: "stream",
+			allowEmptySuccess: true,
 			stream: normalized,
 			usageFinalizer: async () => null,
 			bill,
@@ -295,6 +298,7 @@ function finalizeResult(input: {
 
 	return {
 		kind: "completed",
+		allowEmptySuccess: true,
 		ir,
 		bill,
 		upstream: res,

--- a/apps/api/src/executors/google-vertex/text-generate/index.ts
+++ b/apps/api/src/executors/google-vertex/text-generate/index.ts
@@ -45,31 +45,6 @@ function vertexError(code: string): Error & { code: string } {
 	return error;
 }
 
-function hasUsableIRResponse(response: IRChatResponse | undefined): boolean {
-	if (!response?.choices?.length) return false;
-	return response.choices.some((choice) => {
-		if ((choice.message?.toolCalls?.length ?? 0) > 0) return true;
-		return (choice.message?.content ?? []).some((part: any) => {
-			if (!part || typeof part !== "object") return false;
-			if (typeof part.text === "string" && part.text.trim().length > 0) return true;
-			return typeof part.data === "string" && part.data.length > 0;
-		});
-	});
-}
-
-function emptyVertexResponse(model: string): Response {
-	return new Response(JSON.stringify({
-		error: {
-			code: "google_empty_response",
-			message: "Google Vertex returned a successful response without any output.",
-			model,
-		},
-	}), {
-		status: 502,
-		headers: { "Content-Type": "application/json" },
-	});
-}
-
 export function preprocess(ir: IRChatRequest, args: ExecutorExecuteArgs): IRChatRequest {
 	return cherryPickIRParams(ir, args.capabilityParams);
 }
@@ -229,18 +204,6 @@ export async function execute(args: ExecutorExecuteArgs): Promise<ExecutorResult
 				);
 			}
 		}
-		if (!hasUsableIRResponse(ir)) {
-			return {
-				kind: "completed",
-				ir: undefined,
-				bill,
-				upstream: emptyVertexResponse(model),
-				keySource: keyInfo.source,
-				byokKeyId: keyInfo.byokId,
-				mappedRequest,
-			};
-		}
-
 		const usageMeters = normalizeTextUsageForPricing(ir?.usage ?? usage);
 		if (usageMeters) {
 			bill.usage = usageMeters;
@@ -273,18 +236,6 @@ export async function execute(args: ExecutorExecuteArgs): Promise<ExecutorResult
 	} else {
 		ir = openAIChatToIR(json, args.requestId, model, args.providerId);
 	}
-	if (!hasUsableIRResponse(ir)) {
-		return {
-			kind: "completed",
-			ir: undefined,
-			bill,
-			upstream: emptyVertexResponse(model),
-			keySource: keyInfo.source,
-			byokKeyId: keyInfo.byokId,
-			mappedRequest,
-		};
-	}
-
 	return finalizeResult({
 		args,
 		ir,

--- a/apps/api/src/executors/types.ts
+++ b/apps/api/src/executors/types.ts
@@ -101,6 +101,7 @@ export type Bill = {
 
 export type ExecutorCompletedResult = {
 	kind: "completed";
+	allowEmptySuccess?: boolean;
 	ir?:
 		| IRChatResponse
 		| IREmbeddingsResponse
@@ -138,6 +139,7 @@ export type ExecutorCompletedResult = {
 
 export type ExecutorStreamingResult = {
 	kind: "stream";
+	allowEmptySuccess?: boolean;
 	stream: ReadableStream<Uint8Array>;
 	streamAlreadyTransformed?: boolean;
 	usageFinalizer: () => Promise<Bill | null>;

--- a/apps/api/src/pipeline/execute/index.ts
+++ b/apps/api/src/pipeline/execute/index.ts
@@ -349,6 +349,7 @@ function recordProviderAttempt(
  */
 export type IRRequestResult = {
 	kind: "completed" | "stream";
+	allowEmptySuccess?: boolean;
 	ir?:
 		| IRChatResponse
 		| IREmbeddingsResponse
@@ -984,6 +985,7 @@ async function attemptProviderWithIR(
 		// Build result
 		const result: IRRequestResult = {
 			kind: executorResult.kind,
+			allowEmptySuccess: executorResult.allowEmptySuccess,
 			ir: executorResult.kind === "completed" ? executorResult.ir : undefined,
 			upstream: executorResult.upstream,
 			stream: executorResult.kind === "stream" ? executorResult.stream : undefined,

--- a/apps/api/src/pipeline/surfaces/text-generate.server-tools.test.ts
+++ b/apps/api/src/pipeline/surfaces/text-generate.server-tools.test.ts
@@ -7,6 +7,7 @@ const decodeProtocolMock = vi.fn();
 const encodeProtocolMock = vi.fn();
 const doRequestWithIRMock = vi.fn();
 const finalizeRequestMock = vi.fn();
+const settleNonBillableFailureMock = vi.fn();
 const validateTextIRContractMock = vi.fn();
 const prepareServerToolsForTextRequestMock = vi.fn();
 const consumeTextProtocolStreamToIRMock = vi.fn();
@@ -32,6 +33,7 @@ vi.mock("../execute", () => ({
 
 vi.mock("../after", () => ({
 	finalizeRequest: (...args: any[]) => finalizeRequestMock(...args),
+	settleNonBillableFailure: (...args: any[]) => settleNonBillableFailureMock(...args),
 }));
 
 vi.mock("../text-ir-contract", () => ({
@@ -168,6 +170,47 @@ describe("runTextGeneratePipeline server tools", () => {
 			},
 		}));
 		getResponseCacheMock.mockReturnValue(null);
+	});
+
+	it("preserves provider-approved empty successes through final billing", async () => {
+		doRequestWithIRMock.mockResolvedValue({
+			result: {
+				kind: "completed",
+				allowEmptySuccess: true,
+				ir: {
+					id: "vertex_empty",
+					model: "google/gemini-2.5-pro",
+					provider: "google-vertex",
+					choices: [],
+					usage: { inputTokens: 12, outputTokens: 0, totalTokens: 12 },
+				},
+				upstream: new Response(JSON.stringify({ usageMetadata: { promptTokenCount: 12 } }), { status: 200 }),
+				bill: {
+					cost_cents: 1,
+					currency: "USD",
+					usage: { prompt_tokens: 12, completion_tokens: 0, total_tokens: 12 },
+				},
+			},
+		});
+		encodeProtocolMock.mockReturnValue({
+			id: "vertex_empty",
+			choices: [],
+			usage: { prompt_tokens: 12, completion_tokens: 0, total_tokens: 12 },
+		});
+		finalizeRequestMock.mockResolvedValue(
+			new Response(JSON.stringify({ id: "vertex_empty", choices: [] }), { status: 200 }),
+		);
+
+		const response = await runTextGeneratePipeline(createArgs());
+
+		expect(response.status).toBe(200);
+		expect(settleNonBillableFailureMock).not.toHaveBeenCalled();
+		expect(finalizeRequestMock).toHaveBeenCalledOnce();
+		expect(finalizeRequestMock.mock.calls[0]?.[0].exec.result.bill.usage).toEqual({
+			prompt_tokens: 12,
+			completion_tokens: 0,
+			total_tokens: 12,
+		});
 	});
 
 	it("executes the datetime follow-up loop and records tool usage on non-stream requests", async () => {

--- a/apps/api/src/pipeline/surfaces/text-generate.ts
+++ b/apps/api/src/pipeline/surfaces/text-generate.ts
@@ -809,7 +809,11 @@ export async function runTextGeneratePipeline(args: PipelineRunnerArgs): Promise
 				});
 			}
 		}
-		if (exec.result.kind === "completed" && !hasUsableIRChatResponse(exec.result.ir as IRChatResponse | undefined)) {
+		if (
+			exec.result.kind === "completed" &&
+			exec.result.allowEmptySuccess !== true &&
+			!hasUsableIRChatResponse(exec.result.ir as IRChatResponse | undefined)
+		) {
 			await settleNonBillableFailure(pre.ctx, exec.result);
 			await handleFailureAudit(
 				pre.ctx,
@@ -1061,7 +1065,11 @@ export async function runTextGeneratePipeline(args: PipelineRunnerArgs): Promise
 						});
 					}
 				}
-				if (followUpResult.kind === "completed" && !hasUsableIRChatResponse(followUpResult.ir as IRChatResponse | undefined)) {
+				if (
+					followUpResult.kind === "completed" &&
+					followUpResult.allowEmptySuccess !== true &&
+					!hasUsableIRChatResponse(followUpResult.ir as IRChatResponse | undefined)
+				) {
 					await settleNonBillableFailure(pre.ctx, followUpResult);
 					await handleFailureAudit(
 						pre.ctx,


### PR DESCRIPTION
## Summary
- preserve Google Vertex usage when a successful response contains no generated output
- keep the provider HTTP 200 and normalized IR so the normal billing path runs
- remove the synthetic zero-cost 502 path
- add regression coverage for prompt-only usage metadata

## Validation
- pnpm --filter @phaseo/gateway-api exec vitest run src/executors/google-vertex/text-generate/__tests__/mapping.test.ts
- pnpm --filter @phaseo/gateway-api typecheck
- git diff --check

Created with Codex

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Successful Google Vertex responses with no generated text are now completed normally instead of being reported as errors.
  - These responses return the correct success status and preserve usage and billing information.
  - Streaming and server-tool follow-up requests now handle provider-approved empty responses consistently.
  - Other responses without usable output continue to receive the existing error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->