### PR TITLE
Protect cookie-backed API proxy auth

### DIFF
--- a/.changeset/calm-dogs-protect.md
+++ b/.changeset/calm-dogs-protect.md
@@ -1,0 +1,6 @@
+---
+"@phaseo/web": patch
+"@phaseo/web-api": patch
+---
+
+Prevent cross-site cookie sessions from being upgraded to bearer credentials by the web proxy, and require explicit persistence for workspace selection.

--- a/apps/web-api/src/routes/account/auth.ts
+++ b/apps/web-api/src/routes/account/auth.ts
@@ -98,7 +98,7 @@ accountAuthRouter.get("/workspace", async (c) => {
 	].filter(Boolean));
 	const defaultWorkspaceId = String(userResult.data?.default_workspace_id ?? "").trim();
 	const workspaceId = (requested && accessible.has(requested) ? requested : null) ?? (defaultWorkspaceId && accessible.has(defaultWorkspaceId) ? defaultWorkspaceId : null) ?? [...accessible].sort()[0] ?? null;
-	if (workspaceId && workspaceId !== defaultWorkspaceId && c.req.query("persist") !== "0") {
+	if (workspaceId && workspaceId !== defaultWorkspaceId && c.req.query("persist") === "1") {
 		const update = await client.from("users").update({ default_workspace_id: workspaceId }).eq("user_id", user.id);
 		if (update.error) return c.json({ error: "workspace_unavailable" }, 503, PRIVATE_NO_STORE_HEADERS);
 	}

--- a/apps/web/src/utils/supabase/cookieAuthRequest.test.ts
+++ b/apps/web/src/utils/supabase/cookieAuthRequest.test.ts
@@ -1,0 +1,41 @@
+import { canUpgradeCookieAuth } from "./cookieAuthRequest"
+
+const APP_ORIGIN = "https://phaseo.app"
+
+describe("canUpgradeCookieAuth", () => {
+    it("allows same-origin browser requests", () => {
+        const headers = new Headers({
+            origin: APP_ORIGIN,
+            referer: `${APP_ORIGIN}/chat`,
+            "sec-fetch-site": "same-origin",
+        })
+
+        expect(canUpgradeCookieAuth(headers, APP_ORIGIN)).toBe(true)
+    })
+
+    it("allows trusted server requests without browser metadata", () => {
+        expect(canUpgradeCookieAuth(new Headers(), APP_ORIGIN)).toBe(true)
+    })
+
+    it.each([
+        ["cross-site", "https://attacker.example"],
+        ["same-site", "https://evil.phaseo.app"],
+    ])("rejects %s cookie-auth upgrades", (fetchSite, origin) => {
+        const headers = new Headers({
+            origin,
+            referer: `${origin}/redirect`,
+            "sec-fetch-site": fetchSite,
+        })
+
+        expect(canUpgradeCookieAuth(headers, APP_ORIGIN)).toBe(false)
+    })
+
+    it("rejects a mismatched Origin even without Fetch Metadata", () => {
+        expect(
+            canUpgradeCookieAuth(
+                new Headers({ origin: "https://attacker.example" }),
+                APP_ORIGIN
+            )
+        ).toBe(false)
+    })
+})

--- a/apps/web/src/utils/supabase/cookieAuthRequest.ts
+++ b/apps/web/src/utils/supabase/cookieAuthRequest.ts
@@ -1,0 +1,26 @@
+const TRUSTED_FETCH_SITES = new Set(["same-origin", "none"])
+
+function headerOrigin(value: string | null): string | null {
+    if (!value) return null
+    try {
+        return new URL(value).origin
+    } catch {
+        return null
+    }
+}
+
+export function canUpgradeCookieAuth(
+    headers: Headers,
+    requestOrigin: string
+): boolean {
+    const fetchSite = headers.get("sec-fetch-site")?.toLowerCase()
+    if (fetchSite && !TRUSTED_FETCH_SITES.has(fetchSite)) return false
+
+    const origin = headerOrigin(headers.get("origin"))
+    if (headers.has("origin") && origin !== requestOrigin) return false
+
+    const referer = headerOrigin(headers.get("referer"))
+    if (headers.has("referer") && referer !== requestOrigin) return false
+
+    return true
+}

--- a/apps/web/src/utils/supabase/middleware.ts
+++ b/apps/web/src/utils/supabase/middleware.ts
@@ -1,5 +1,6 @@
 import { createServerClient, type CookieOptions } from '@supabase/ssr'
 import { NextResponse, type NextRequest } from 'next/server'
+import { canUpgradeCookieAuth } from './cookieAuthRequest'
 
 export async function updateSession(request: NextRequest) {
     const forwardedHeaders = new Headers(request.headers)
@@ -52,6 +53,7 @@ export async function updateSession(request: NextRequest) {
     if (
         isPrivateWebApiRequest &&
         session?.access_token &&
+        canUpgradeCookieAuth(request.headers, request.nextUrl.origin) &&
         !forwardedHeaders.has('authorization')
     ) {
         const responseCookies = supabaseResponse.cookies.getAll()

--- a/apps/web/src/utils/workspaceCookie.ts
+++ b/apps/web/src/utils/workspaceCookie.ts
@@ -75,7 +75,7 @@ export async function resolveAccessibleWorkspaceIdFromCookie(): Promise<string |
 		const rawCookieWorkspaceId = await getActiveWorkspaceIdFromCookieRaw();
 		const context = await getServerAccountContext();
 		if (!context.accessToken) { await clearActiveWorkspaceCookie(); return undefined; }
-		const query = rawCookieWorkspaceId ? `?requested=${encodeURIComponent(rawCookieWorkspaceId)}` : "";
+		const query = rawCookieWorkspaceId ? `?requested=${encodeURIComponent(rawCookieWorkspaceId)}&persist=1` : "";
 		const result = await fetchAccountWebApi<{ signedIn: boolean; workspaceId: string | null }>(`/api/account/auth/workspace${query}`, context.accessToken);
 		if (!result.workspaceId) { await clearActiveWorkspaceCookie(); return undefined; }
 		if (result.workspaceId !== rawCookieWorkspaceId) await setActiveWorkspaceCookie(result.workspaceId);


### PR DESCRIPTION
## Summary
- reject cross-site and sibling-site browser requests before converting a Supabase cookie session into a bearer credential
- retain support for same-origin browser traffic and server-originated requests without browser fetch metadata
- make workspace preference persistence opt-in and update the trusted server-side caller accordingly
- cover trusted and hostile request metadata combinations

## Validation
- `pnpm --filter @phaseo/web-api typecheck`
- `pnpm --filter @phaseo/web-api test -- src/routes/account/auth.test.ts` (6 passed)
- `git diff --check`
- Web typecheck reached unrelated existing generated `LayoutProps` errors in dashboard layouts
- Focused web Jest execution was blocked by the shared local dependency junction loading incompatible Jest internals; CI will run with the branch lockfile installation

Created with Codex