### PR TITLE
Reject malformed model endpoint paths

### DIFF
--- a/apps/api/src/routes/v1/control/models.test.ts
+++ b/apps/api/src/routes/v1/control/models.test.ts
@@ -642,6 +642,18 @@ describe("handleModels", () => {
         );
     });
 
+    it("returns a controlled 400 for malformed endpoint path encoding", async () => {
+        const response = await handleModelEndpoints(
+            new Request("https://api.example.com/v1/models/%E0%A4%A/example/endpoints"),
+        );
+
+        expect(response.status).toBe(400);
+        await expect(response.json()).resolves.toEqual(expect.objectContaining({
+            error: "invalid_request",
+        }));
+        expect(guardAuthMock).not.toHaveBeenCalled();
+    });
+
     it("returns provider-specific endpoint capability rows across modalities", async () => {
         const endpointDefinitions = [
             { endpoint: "responses", input: ["text"], output: ["text"], params: ["temperature"] },

--- a/apps/api/src/routes/v1/control/models.ts
+++ b/apps/api/src/routes/v1/control/models.ts
@@ -114,15 +114,21 @@ function parseMultiValueAliases(params: URLSearchParams, names: string[]): strin
     return Array.from(new Set(names.flatMap((name) => parseMultiValue(params, name))));
 }
 
-function parsePathSegments(req: Request): string[] {
-    return new URL(req.url).pathname
-        .split("/")
-        .map((segment) => decodeURIComponent(segment))
-        .filter(Boolean);
+function parsePathSegments(req: Request): string[] | null {
+    try {
+        return new URL(req.url).pathname
+            .split("/")
+            .map((segment) => decodeURIComponent(segment))
+            .filter(Boolean);
+    } catch (error) {
+        if (error instanceof URIError) return null;
+        throw error;
+    }
 }
 
 function parseEndpointRouteModelId(req: Request): string | null {
     const segments = parsePathSegments(req);
+    if (!segments) return null;
     const endpointsIndex = segments.lastIndexOf("endpoints");
     if (endpointsIndex < 2) return null;
     const author = segments[endpointsIndex - 2];


### PR DESCRIPTION
## Summary
- safely reject malformed percent-encoding in model endpoint paths
- return the existing controlled `invalid_request` 400 instead of allowing `URIError` to escape
- add a regression test for malformed unauthenticated route input

## Validation
- `pnpm --filter @phaseo/gateway-api exec vitest run src/routes/v1/control/models.test.ts` (21 passed)
- `pnpm --filter @phaseo/gateway-api typecheck`
- `git diff --check`

Created with Codex