### PR TITLE
Keep workspace search pins private

### DIFF
--- a/.changeset/quiet-pins-clean.md
+++ b/.changeset/quiet-pins-clean.md
@@ -1,0 +1,5 @@
+---
+"@phaseo/web": patch
+---
+
+Keep private workspace search results out of persistent command-palette pins and remove legacy workspace pins from browser storage.

--- a/apps/web/src/components/header/Search/Search.storage.test.ts
+++ b/apps/web/src/components/header/Search/Search.storage.test.ts
@@ -1,0 +1,56 @@
+import type { PaletteItem } from "./Search.types";
+import {
+	invalidatePinnedItemsCache,
+	PINNED_STORAGE_KEY,
+	readPinnedItems,
+	togglePinnedItem,
+	writePinnedItems,
+} from "./Search.storage";
+
+function installStorage(initial: PaletteItem[] = []) {
+	const values = new Map([[PINNED_STORAGE_KEY, JSON.stringify(initial)]]);
+	Object.defineProperty(globalThis, "window", {
+		configurable: true,
+		value: {
+			localStorage: {
+				getItem: (key: string) => values.get(key) ?? null,
+				setItem: (key: string, value: string) => values.set(key, value),
+			},
+		},
+	});
+	return values;
+}
+
+afterEach(() => {
+	invalidatePinnedItemsCache();
+	Reflect.deleteProperty(globalThis, "window");
+});
+
+describe("command palette pinned storage", () => {
+	it("removes legacy workspace metadata when reading stored pins", () => {
+		const values = installStorage([
+			{ id: "workspace:private-id", title: "Private workspace", workspaceId: "private-id" },
+			{ id: "models", title: "Models", href: "/models" },
+		]);
+
+		expect(readPinnedItems()).toEqual([{ id: "models", title: "Models", href: "/models" }]);
+		expect(JSON.parse(values.get(PINNED_STORAGE_KEY) ?? "[]")).toEqual([
+			{ id: "models", title: "Models", href: "/models" },
+		]);
+	});
+
+	it("never writes or toggles session-only workspace items", () => {
+		const values = installStorage();
+		const workspace = {
+			id: "workspace:private-id",
+			title: "Private workspace",
+			workspaceId: "private-id",
+			persistable: false,
+		};
+		const publicItem = { id: "models", title: "Models", href: "/models" };
+
+		expect(writePinnedItems([workspace, publicItem])).toEqual([publicItem]);
+		expect(togglePinnedItem([publicItem], workspace)).toEqual([publicItem]);
+		expect(JSON.parse(values.get(PINNED_STORAGE_KEY) ?? "[]")).toEqual([publicItem]);
+	});
+});

--- a/apps/web/src/components/header/Search/Search.storage.ts
+++ b/apps/web/src/components/header/Search/Search.storage.ts
@@ -10,13 +10,21 @@ function isPaletteItem(value: unknown): value is PaletteItem {
 	return typeof item.id === "string" && typeof item.title === "string";
 }
 
+function isPersistablePinnedItem(item: PaletteItem): boolean {
+	return item.persistable !== false && !item.id.startsWith("workspace:");
+}
+
 export function readPinnedItems(): PaletteItem[] {
 	if (pinnedCache) return pinnedCache;
 	if (typeof window === "undefined") return [];
 	try {
 		const rawValue = window.localStorage.getItem(PINNED_STORAGE_KEY);
 		const parsed = rawValue ? (JSON.parse(rawValue) as unknown) : [];
-		pinnedCache = Array.isArray(parsed) ? parsed.filter(isPaletteItem).slice(0, MAX_PINNED_ITEMS) : [];
+		const storedItems = Array.isArray(parsed) ? parsed.filter(isPaletteItem) : [];
+		pinnedCache = storedItems.filter(isPersistablePinnedItem).slice(0, MAX_PINNED_ITEMS);
+		if (pinnedCache.length !== storedItems.length) {
+			window.localStorage.setItem(PINNED_STORAGE_KEY, JSON.stringify(pinnedCache));
+		}
 	} catch {
 		pinnedCache = [];
 	}
@@ -24,7 +32,10 @@ export function readPinnedItems(): PaletteItem[] {
 }
 
 export function writePinnedItems(items: readonly PaletteItem[]): PaletteItem[] {
-	const normalized = items.slice(0, MAX_PINNED_ITEMS).map((item) => ({ ...item }));
+	const normalized = items
+		.filter(isPersistablePinnedItem)
+		.slice(0, MAX_PINNED_ITEMS)
+		.map((item) => ({ ...item }));
 	pinnedCache = normalized;
 	if (typeof window !== "undefined") {
 		try {
@@ -37,6 +48,7 @@ export function writePinnedItems(items: readonly PaletteItem[]): PaletteItem[] {
 }
 
 export function togglePinnedItem(items: readonly PaletteItem[], item: PaletteItem): PaletteItem[] {
+	if (!isPersistablePinnedItem(item)) return items.filter(isPersistablePinnedItem);
 	if (items.some((candidate) => candidate.id === item.id)) {
 		return items.filter((candidate) => candidate.id !== item.id);
 	}

--- a/apps/web/src/components/header/Search/Search.tsx
+++ b/apps/web/src/components/header/Search/Search.tsx
@@ -1329,7 +1329,7 @@ export default function Search({ className, mobileGhost = false }: Props) {
 															}}
 															onSelect={handleSelect}
 															isPinned={pinnedItemIds.has(item.id)}
-															onTogglePin={handleTogglePin}
+													onTogglePin={item.persistable === false ? undefined : handleTogglePin}
 														/>
 													))}
 												</div>
@@ -1377,7 +1377,7 @@ export default function Search({ className, mobileGhost = false }: Props) {
 														}}
 														onSelect={handleSelect}
 														isPinned={pinnedItemIds.has(row.item.id)}
-														onTogglePin={handleTogglePin}
+													onTogglePin={row.item.persistable === false ? undefined : handleTogglePin}
 													/>
 												)}
 											</div>

--- a/apps/web/src/components/header/Search/Search.types.ts
+++ b/apps/web/src/components/header/Search/Search.types.ts
@@ -19,6 +19,7 @@ export type PaletteItem = {
 	actionValue?: string;
 	shortcut?: readonly [string, string];
 	workspaceId?: string;
+	persistable?: boolean;
 };
 
 // Types for curated/featured search items.

--- a/apps/web/src/components/header/Search/Search.workspaces.test.ts
+++ b/apps/web/src/components/header/Search/Search.workspaces.test.ts
@@ -16,6 +16,7 @@ describe("workspace search", () => {
 			subtitle: "Workspace settings",
 			href: "/settings/workspaces/settings",
 			workspaceId: "workspace/id",
+			persistable: false,
 			keywords: ["workspace", "team", "Production"],
 		});
 	});

--- a/apps/web/src/components/header/Search/Search.workspaces.ts
+++ b/apps/web/src/components/header/Search/Search.workspaces.ts
@@ -18,6 +18,7 @@ export function createWorkspaceSearchItem(
 		subtitle: "Workspace settings",
 		href: "/settings/workspaces/settings",
 		workspaceId: workspace.id,
+		persistable: false,
 		keywords: ["workspace", "team", workspace.name],
 	};
 }


### PR DESCRIPTION
## Summary
- mark private workspace search results as session-only command-palette items
- remove pin controls from workspace rows
- reject workspace items at the persistent storage boundary
- scrub legacy workspace pins from localStorage when pinned items are read

## Validation
- focused command-palette storage and workspace tests (4 passed)
- `git diff --check`
- The full web typecheck could not run against the isolated worktree because its shared local dependency junction lacks the current Next.js package; required CI installs dependencies from the lockfile

Created with Codex