### PR TITLE
Close final validation gaps

### DIFF
--- a/.changeset/clean-final-findings.md
+++ b/.changeset/clean-final-findings.md
@@ -1,0 +1,6 @@
+---
+"@phaseo/ai-sdk-provider": patch
+"@phaseo/web": patch
+---
+
+Align the AI SDK provider Node requirement with AI SDK 7, harden malformed catalogue 404 paths, and correct catalogue manifest and importer-state validation gaps.

--- a/apps/web/src/components/(data)/CatalogNotFoundState.tsx
+++ b/apps/web/src/components/(data)/CatalogNotFoundState.tsx
@@ -5,6 +5,7 @@ import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { ArrowLeft } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import { safelyDecodePathSegments } from "./safePathname";
 
 export type CatalogResourceType = "model" | "organisation" | "country" | "provider";
 
@@ -73,7 +74,7 @@ function getResourceIdFromPathname(
 	if (resourceIndex === -1) return null;
 	const resourceId = segments.slice(resourceIndex + 1, resourceIndex + 1 + config.pathSegments);
 	if (resourceId.length !== config.pathSegments) return null;
-	return resourceId.map((segment) => decodeURIComponent(segment)).join("/");
+	return safelyDecodePathSegments(resourceId);
 }
 
 export default function CatalogNotFoundState({

--- a/apps/web/src/components/(data)/safePathname.test.ts
+++ b/apps/web/src/components/(data)/safePathname.test.ts
@@ -1,0 +1,14 @@
+import { safelyDecodePathSegments } from "./safePathname";
+
+describe("safelyDecodePathSegments", () => {
+	it("decodes valid catalogue path segments", () => {
+		expect(safelyDecodePathSegments(["openai", "gpt-5.6-sol"])).toBe("openai/gpt-5.6-sol");
+	});
+
+	it.each([["%ZZ", "missing"], ["%E0%A4%A", "missing"]])(
+		"returns a safe fallback for malformed encoding",
+		(...segments) => {
+			expect(safelyDecodePathSegments(segments)).toBeNull();
+		},
+	);
+});

--- a/apps/web/src/components/(data)/safePathname.ts
+++ b/apps/web/src/components/(data)/safePathname.ts
@@ -1,0 +1,8 @@
+export function safelyDecodePathSegments(segments: string[]): string | null {
+	try {
+		return segments.map((segment) => decodeURIComponent(segment)).join("/");
+	} catch (error) {
+		if (error instanceof URIError) return null;
+		throw error;
+	}
+}

--- a/packages/data/catalog/src/data/.import-state.json
+++ b/packages/data/catalog/src/data/.import-state.json
@@ -29549,7 +29549,7 @@
       }
     },
     "../../packages/data/catalog/src/data/models/moonshotai/kimi-k3/model.json": {
-      "hash": "7c775c38f0bfdaa66524b280f1625513",
+      "hash": "9e820b8e30bffc527b57317a935c04ae",
       "meta": {
         "model_id": "moonshotai/kimi-k3",
         "organisation_id": "moonshotai",

--- a/packages/integrations/ai-sdk-phaseo/package.json
+++ b/packages/integrations/ai-sdk-phaseo/package.json
@@ -57,7 +57,7 @@
     "ai": "^7.0.0"
   },
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=22.0.0"
   },
   "repository": {
     "type": "git",

--- a/scripts/sync-catalog-manifest.ts
+++ b/scripts/sync-catalog-manifest.ts
@@ -141,7 +141,7 @@ function getDrift(manifest: JsonObject, models: Map<string, ModelRecord>): Manif
         .filter((modelId) => !indexedModels.has(modelId))
         .sort((a, b) => a.localeCompare(b));
     const missingOrganisationIds = [...new Set(
-        missingModelIds
+        [...active.modelIds]
             .map((modelId) => models.get(modelId)?.organisationId)
             .filter((value): value is string => Boolean(value))
     )]


### PR DESCRIPTION
## Summary
- align the AI SDK provider engine declaration with its AI SDK 7 dependencies
- detect missing organisations independently of missing model IDs in the catalogue manifest check
- correct the Kimi K3 importer-state hash to match the current model file
- safely fall back when catalogue not-found routes contain malformed percent encoding

The remaining informational reports were already fixed on current main (LongCat rule-level expiry and zero-code discovery envelopes) or were not actionable (OpenAI GPT-5.6 base slugs intentionally support Pro mode at the same token rates).

## Validation
- catalogue manifest check passed
- `pnpm validate:data` passed all 9 enforced checks
- malformed pathname tests passed (3)
- model-discovery response error tests passed
- importer-state hash was compared against the current model file
- `git diff --check`
- AI SDK provider tests could not be meaningfully run against the shared local dependency junction because it contains AI SDK 6; required CI installs the branch's AI SDK 7 lockfile dependencies

Created with Codex