### PR TITLE
Improve model performance filters and charts

### DIFF
--- a/.changeset/tidy-model-performance-filters.md
+++ b/.changeset/tidy-model-performance-filters.md
@@ -1,0 +1,5 @@
+---
+"@phaseo/web": patch
+---
+
+Improve model performance filters on smaller screens, clarify empty chart states, add detailed chart tooltips, and give every percentile series a distinct colour.

--- a/apps/web/src/components/(data)/models/ModelPerformanceDashboard.tsx
+++ b/apps/web/src/components/(data)/models/ModelPerformanceDashboard.tsx
@@ -249,7 +249,7 @@ export default function ModelPerformanceDashboard({
 					<p className="text-sm text-muted-foreground">{headerDescription}</p>
 				</div>
 				<div className="flex items-center gap-2">
-					<div className="hidden items-center gap-2 md:flex">
+					<div className="hidden items-center gap-2 lg:flex">
 						<Select
 							value={streamMode}
 							disabled={isLoadingRegion}
@@ -304,7 +304,7 @@ export default function ModelPerformanceDashboard({
 							<Button
 								variant="outline"
 								size="sm"
-								className="h-8 gap-2 rounded-md px-3 text-xs md:hidden"
+								className="h-8 gap-2 rounded-md px-3 text-xs lg:hidden"
 							>
 								{isLoadingRegion || isLoadingPercentile ? (
 									<Loader2 className="size-3.5 animate-spin" />
@@ -409,7 +409,7 @@ export default function ModelPerformanceDashboard({
 							) : null}
 						</DropdownMenuContent>
 					</DropdownMenu>
-					<div className="hidden items-center gap-2 md:flex">
+					<div className="hidden items-center gap-2 lg:flex">
 						<Tooltip>
 							<TooltipTrigger asChild>
 								<span className="inline-flex" tabIndex={0}>

--- a/apps/web/src/components/(data)/models/ModelPerformanceDashboard.tsx
+++ b/apps/web/src/components/(data)/models/ModelPerformanceDashboard.tsx
@@ -4,7 +4,7 @@ import { useRef, useState } from "react";
 import ModelPerformanceCards from "./ModelPerformanceCards";
 import ModelSuccessChart from "./ModelSuccessChart";
 import ModelTokenTrajectoryChart from "./ModelTokenTrajectory";
-import { Activity, Globe2, Loader2 } from "lucide-react";
+import { Activity, BarChart3, Filter, Globe2, Loader2 } from "lucide-react";
 import type { ModelPerformanceMetrics } from "@/lib/fetchers/models/getModelPerformance";
 import type { ModelTokenTrajectory } from "@/lib/fetchers/models/getModelTokenTrajectory";
 import type { ModelPerformanceColo } from "@/lib/fetchers/frontend/fetchPublicCatalog";
@@ -26,6 +26,7 @@ import {
 	DropdownMenuItem,
 	DropdownMenuRadioGroup,
 	DropdownMenuRadioItem,
+	DropdownMenuLabel,
 	DropdownMenuSeparator,
 	DropdownMenuSub,
 	DropdownMenuSubContent,
@@ -33,8 +34,19 @@ import {
 	DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { Button } from "@/components/ui/button";
+import {
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue,
+} from "@/components/ui/select";
 import { Card } from "@/components/ui/card";
-import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import {
+	Tooltip,
+	TooltipContent,
+	TooltipTrigger,
+} from "@/components/ui/tooltip";
 import { buildSingleProviderPercentileSeries } from "@/components/(data)/models/modelPerformancePercentiles";
 import {
 	Empty,
@@ -86,7 +98,8 @@ export default function ModelPerformanceDashboard({
 	const [contextBucket, setContextBucket] = useState<
 		"all" | "lte_4k" | "4k_16k" | "16k_64k" | "gt_64k"
 	>(metrics.contextBucket ?? "all");
-	const [regionMetrics, setRegionMetrics] = useState<ModelPerformanceMetrics | null>(null);
+	const [regionMetrics, setRegionMetrics] =
+		useState<ModelPerformanceMetrics | null>(null);
 	const [isLoadingRegion, setIsLoadingRegion] = useState(false);
 	const [isLoadingPercentile, setIsLoadingPercentile] = useState(false);
 	const requestGeneration = useRef(0);
@@ -153,7 +166,10 @@ export default function ModelPerformanceDashboard({
 		setIsLoadingPercentile(false);
 		setIsLoadingRegion(true);
 		try {
-			const nextMetrics = await fetchSelectedMetrics(nextColo, selectedPercentile);
+			const nextMetrics = await fetchSelectedMetrics(
+				nextColo,
+				selectedPercentile,
+			);
 			if (generation !== requestGeneration.current) return;
 			if (!nextMetrics) {
 				setSelectedColo(previousColo);
@@ -161,7 +177,8 @@ export default function ModelPerformanceDashboard({
 			}
 			setRegionMetrics(nextMetrics);
 		} catch {
-			if (generation === requestGeneration.current) setSelectedColo(previousColo);
+			if (generation === requestGeneration.current)
+				setSelectedColo(previousColo);
 		} finally {
 			if (generation === requestGeneration.current) setIsLoadingRegion(false);
 		}
@@ -174,14 +191,19 @@ export default function ModelPerformanceDashboard({
 		setIsLoadingRegion(false);
 		setIsLoadingPercentile(true);
 		try {
-			const nextMetrics = await fetchSelectedMetrics(selectedColo, nextPercentile);
+			const nextMetrics = await fetchSelectedMetrics(
+				selectedColo,
+				nextPercentile,
+			);
 			if (generation !== requestGeneration.current || !nextMetrics) return;
 			setRegionMetrics(nextMetrics);
 			setSelectedPercentile(nextPercentile);
 		} catch {
-			if (generation === requestGeneration.current) setSelectedPercentile(previousPercentile);
+			if (generation === requestGeneration.current)
+				setSelectedPercentile(previousPercentile);
 		} finally {
-			if (generation === requestGeneration.current) setIsLoadingPercentile(false);
+			if (generation === requestGeneration.current)
+				setIsLoadingPercentile(false);
 		}
 	};
 
@@ -194,7 +216,9 @@ export default function ModelPerformanceDashboard({
 			? Math.round(activeMetrics.cumulativeTokens).toLocaleString()
 			: "N/A";
 	const cumulativeSince = formatReleaseDate(activeMetrics.releaseDate);
-	const regionLabel = selectedColo ? formatCloudflareColo(selectedColo) : "Select Location";
+	const regionLabel = selectedColo
+		? formatCloudflareColo(selectedColo)
+		: "Select Location";
 	const usageByColo = new Map(
 		availableColos
 			.filter((colo) => colo.requests > 0)
@@ -225,95 +249,254 @@ export default function ModelPerformanceDashboard({
 					<p className="text-sm text-muted-foreground">{headerDescription}</p>
 				</div>
 				<div className="flex items-center gap-2">
-				<label className="sr-only" htmlFor="performance-stream-mode">Streaming mode</label>
-				<select
-					id="performance-stream-mode"
-					className="h-8 rounded-md border bg-background px-2 text-xs"
-					value={streamMode}
-					disabled={isLoadingRegion}
-					onChange={(event) => void handleSegmentationChange(
-						event.target.value as "all" | "stream" | "non_stream",
-						contextBucket,
-					)}
-				>
-					<option value="all">All responses</option>
-					<option value="stream">Streaming</option>
-					<option value="non_stream">Non-streaming</option>
-				</select>
-				<label className="sr-only" htmlFor="performance-context-bucket">Context length</label>
-				<select
-					id="performance-context-bucket"
-					className="h-8 rounded-md border bg-background px-2 text-xs"
-					value={contextBucket}
-					disabled={isLoadingRegion}
-					onChange={(event) => void handleSegmentationChange(
-						streamMode,
-						event.target.value as "all" | "lte_4k" | "4k_16k" | "16k_64k" | "gt_64k",
-					)}
-				>
-					<option value="all">All contexts</option>
-					<option value="lte_4k">≤ 4K input</option>
-					<option value="4k_16k">4K–16K input</option>
-					<option value="16k_64k">16K–64K input</option>
-					<option value="gt_64k">&gt; 64K input</option>
-				</select>
-				<Tooltip>
-					<TooltipTrigger asChild>
-						<span className="inline-flex" tabIndex={0}>
-				<DropdownMenu>
-					<DropdownMenuTrigger asChild>
-						<Button variant="outline" size="sm" className="h-8 gap-2 rounded-md px-3 text-xs" title="Coming Soon" disabled>
-							{isLoadingRegion ? <Loader2 className="size-3.5 animate-spin" /> : <Globe2 className="size-3.5" />}
-							{regionLabel}
-						</Button>
-					</DropdownMenuTrigger>
-					<DropdownMenuContent align="end" className="min-w-56 rounded-md">
-						<div className="px-2 py-1.5 text-xs text-muted-foreground">API Execution Location</div>
-						<DropdownMenuSeparator />
-						{catalogColosByContinent.length === 0 ? (
-							<DropdownMenuItem disabled>No location data available</DropdownMenuItem>
-						) : catalogColosByContinent.map((group) => (
-							<DropdownMenuSub key={group.continent}>
-								<DropdownMenuSubTrigger>
-									<Globe2 className="size-3.5 text-muted-foreground" />
-									{group.continent}
-									<span className="ml-auto w-6 text-right text-[11px] tabular-nums text-muted-foreground">
-										{group.colos.length}
-									</span>
-								</DropdownMenuSubTrigger>
-								<DropdownMenuSubContent className="max-h-80 min-w-80 rounded-md">
-									<DropdownMenuRadioGroup value={selectedColo ?? ""} onValueChange={handleColoChange}>
-										<DropdownMenuGroup>
-											{group.colos.map((colo) => {
-												const requests = usageByColo.get(colo.code) ?? 0;
-												return (
-													<DropdownMenuRadioItem key={colo.code} value={colo.code} className="gap-3">
-														<span className="min-w-0 flex-1 truncate">{formatCloudflareColo(colo.code)}</span>
-														<span className="w-16 shrink-0 text-right text-[11px] tabular-nums text-muted-foreground">
-															{requests.toLocaleString()}
-														</span>
-													</DropdownMenuRadioItem>
-												);
-											})}
-										</DropdownMenuGroup>
+					<div className="hidden items-center gap-2 md:flex">
+						<Select
+							value={streamMode}
+							disabled={isLoadingRegion}
+							onValueChange={(value) =>
+								void handleSegmentationChange(
+									value as "all" | "stream" | "non_stream",
+									contextBucket,
+								)
+							}
+						>
+							<SelectTrigger
+								size="sm"
+								className="h-8 rounded-md border-border bg-background text-xs"
+								aria-label="Streaming mode"
+							>
+								<SelectValue />
+							</SelectTrigger>
+							<SelectContent align="end">
+								<SelectItem value="all">All responses</SelectItem>
+								<SelectItem value="stream">Streaming</SelectItem>
+								<SelectItem value="non_stream">Non-streaming</SelectItem>
+							</SelectContent>
+						</Select>
+						<Select
+							value={contextBucket}
+							disabled={isLoadingRegion}
+							onValueChange={(value) =>
+								void handleSegmentationChange(
+									streamMode,
+									value as "all" | "lte_4k" | "4k_16k" | "16k_64k" | "gt_64k",
+								)
+							}
+						>
+							<SelectTrigger
+								size="sm"
+								className="h-8 rounded-md border-border bg-background text-xs"
+								aria-label="Context length"
+							>
+								<SelectValue />
+							</SelectTrigger>
+							<SelectContent align="end">
+								<SelectItem value="all">All contexts</SelectItem>
+								<SelectItem value="lte_4k">≤ 4K input</SelectItem>
+								<SelectItem value="4k_16k">4K–16K input</SelectItem>
+								<SelectItem value="16k_64k">16K–64K input</SelectItem>
+								<SelectItem value="gt_64k">&gt; 64K input</SelectItem>
+							</SelectContent>
+						</Select>
+					</div>
+					<DropdownMenu>
+						<DropdownMenuTrigger asChild>
+							<Button
+								variant="outline"
+								size="sm"
+								className="h-8 gap-2 rounded-md px-3 text-xs md:hidden"
+							>
+								{isLoadingRegion || isLoadingPercentile ? (
+									<Loader2 className="size-3.5 animate-spin" />
+								) : (
+									<Filter className="size-3.5" />
+								)}
+								Filters
+							</Button>
+						</DropdownMenuTrigger>
+						<DropdownMenuContent align="end" className="min-w-64">
+							<DropdownMenuLabel>Performance filters</DropdownMenuLabel>
+							<DropdownMenuSeparator />
+							<DropdownMenuSub>
+								<DropdownMenuSubTrigger>Response mode</DropdownMenuSubTrigger>
+								<DropdownMenuSubContent>
+									<DropdownMenuRadioGroup
+										value={streamMode}
+										onValueChange={(value) =>
+											void handleSegmentationChange(
+												value as "all" | "stream" | "non_stream",
+												contextBucket,
+											)
+										}
+									>
+										<DropdownMenuRadioItem value="all">
+											All responses
+										</DropdownMenuRadioItem>
+										<DropdownMenuRadioItem value="stream">
+											Streaming
+										</DropdownMenuRadioItem>
+										<DropdownMenuRadioItem value="non_stream">
+											Non-streaming
+										</DropdownMenuRadioItem>
 									</DropdownMenuRadioGroup>
 								</DropdownMenuSubContent>
 							</DropdownMenuSub>
-						))}
-					</DropdownMenuContent>
-				</DropdownMenu>
-						</span>
-					</TooltipTrigger>
-					<TooltipContent>Coming Soon</TooltipContent>
-				</Tooltip>
-				{showPercentileSelector ? (
-					<ModelPercentileSelect
-						value={selectedPercentile}
-						onChange={handlePercentileChange}
-						isLoading={isLoadingPercentile}
-						ariaLabel="Select performance percentile"
-					/>
-				) : null}
+							<DropdownMenuSub>
+								<DropdownMenuSubTrigger>Context length</DropdownMenuSubTrigger>
+								<DropdownMenuSubContent>
+									<DropdownMenuRadioGroup
+										value={contextBucket}
+										onValueChange={(value) =>
+											void handleSegmentationChange(
+												streamMode,
+												value as
+													| "all"
+													| "lte_4k"
+													| "4k_16k"
+													| "16k_64k"
+													| "gt_64k",
+											)
+										}
+									>
+										<DropdownMenuRadioItem value="all">
+											All contexts
+										</DropdownMenuRadioItem>
+										<DropdownMenuRadioItem value="lte_4k">
+											≤ 4K input
+										</DropdownMenuRadioItem>
+										<DropdownMenuRadioItem value="4k_16k">
+											4K–16K input
+										</DropdownMenuRadioItem>
+										<DropdownMenuRadioItem value="16k_64k">
+											16K–64K input
+										</DropdownMenuRadioItem>
+										<DropdownMenuRadioItem value="gt_64k">
+											&gt; 64K input
+										</DropdownMenuRadioItem>
+									</DropdownMenuRadioGroup>
+								</DropdownMenuSubContent>
+							</DropdownMenuSub>
+							<DropdownMenuItem disabled>
+								<Globe2 />
+								API location (coming soon)
+							</DropdownMenuItem>
+							{showPercentileSelector ? (
+								<DropdownMenuSub>
+									<DropdownMenuSubTrigger>
+										<BarChart3 />
+										Percentile
+									</DropdownMenuSubTrigger>
+									<DropdownMenuSubContent>
+										<DropdownMenuRadioGroup
+											value={String(selectedPercentile)}
+											onValueChange={(value) => {
+												const parsed = Number(value);
+												if (isModelPercentile(parsed))
+													void handlePercentileChange(parsed);
+											}}
+										>
+											{[1, 5, 10, 25, 50, 75, 90, 95, 99].map((percentile) => (
+												<DropdownMenuRadioItem
+													key={percentile}
+													value={String(percentile)}
+												>
+													P{String(percentile).padStart(2, "0")}
+												</DropdownMenuRadioItem>
+											))}
+										</DropdownMenuRadioGroup>
+									</DropdownMenuSubContent>
+								</DropdownMenuSub>
+							) : null}
+						</DropdownMenuContent>
+					</DropdownMenu>
+					<div className="hidden items-center gap-2 md:flex">
+						<Tooltip>
+							<TooltipTrigger asChild>
+								<span className="inline-flex" tabIndex={0}>
+									<DropdownMenu>
+										<DropdownMenuTrigger asChild>
+											<Button
+												variant="outline"
+												size="sm"
+												className="h-8 gap-2 rounded-md px-3 text-xs"
+												title="Coming Soon"
+												disabled
+											>
+												{isLoadingRegion ? (
+													<Loader2 className="size-3.5 animate-spin" />
+												) : (
+													<Globe2 className="size-3.5" />
+												)}
+												{regionLabel}
+											</Button>
+										</DropdownMenuTrigger>
+										<DropdownMenuContent
+											align="end"
+											className="min-w-56 rounded-md"
+										>
+											<div className="px-2 py-1.5 text-xs text-muted-foreground">
+												API Execution Location
+											</div>
+											<DropdownMenuSeparator />
+											{catalogColosByContinent.length === 0 ? (
+												<DropdownMenuItem disabled>
+													No location data available
+												</DropdownMenuItem>
+											) : (
+												catalogColosByContinent.map((group) => (
+													<DropdownMenuSub key={group.continent}>
+														<DropdownMenuSubTrigger>
+															<Globe2 className="size-3.5 text-muted-foreground" />
+															{group.continent}
+															<span className="ml-auto w-6 text-right text-[11px] tabular-nums text-muted-foreground">
+																{group.colos.length}
+															</span>
+														</DropdownMenuSubTrigger>
+														<DropdownMenuSubContent className="max-h-80 min-w-80 rounded-md">
+															<DropdownMenuRadioGroup
+																value={selectedColo ?? ""}
+																onValueChange={handleColoChange}
+															>
+																<DropdownMenuGroup>
+																	{group.colos.map((colo) => {
+																		const requests =
+																			usageByColo.get(colo.code) ?? 0;
+																		return (
+																			<DropdownMenuRadioItem
+																				key={colo.code}
+																				value={colo.code}
+																				className="gap-3"
+																			>
+																				<span className="min-w-0 flex-1 truncate">
+																					{formatCloudflareColo(colo.code)}
+																				</span>
+																				<span className="w-16 shrink-0 text-right text-[11px] tabular-nums text-muted-foreground">
+																					{requests.toLocaleString()}
+																				</span>
+																			</DropdownMenuRadioItem>
+																		);
+																	})}
+																</DropdownMenuGroup>
+															</DropdownMenuRadioGroup>
+														</DropdownMenuSubContent>
+													</DropdownMenuSub>
+												))
+											)}
+										</DropdownMenuContent>
+									</DropdownMenu>
+								</span>
+							</TooltipTrigger>
+							<TooltipContent>Coming Soon</TooltipContent>
+						</Tooltip>
+						{showPercentileSelector ? (
+							<ModelPercentileSelect
+								value={selectedPercentile}
+								onChange={handlePercentileChange}
+								isLoading={isLoadingPercentile}
+								ariaLabel="Select performance percentile"
+							/>
+						) : null}
+					</div>
 				</div>
 			</div>
 			{hasTelemetry ? (
@@ -358,8 +541,9 @@ export default function ModelPerformanceDashboard({
 						</EmptyMedia>
 						<EmptyTitle>No gateway telemetry yet</EmptyTitle>
 						<EmptyDescription>
-							This model hasn&apos;t processed any gateway traffic in the selected
-							window. Live charts will appear as soon as requests arrive.
+							This model hasn&apos;t processed any gateway traffic in the
+							selected window. Live charts will appear as soon as requests
+							arrive.
 						</EmptyDescription>
 					</EmptyHeader>
 				</Empty>

--- a/apps/web/src/components/(data)/models/ModelProviderTrendChart.tsx
+++ b/apps/web/src/components/(data)/models/ModelProviderTrendChart.tsx
@@ -31,7 +31,10 @@ type ModelProviderTrendChartProps = {
 	onActiveDayChange: (day: string | null) => void;
 };
 
-export function getSeriesEmphasis(activeSeriesKey: string | null, seriesKey: string) {
+export function getSeriesEmphasis(
+	activeSeriesKey: string | null,
+	seriesKey: string,
+) {
 	const isActive = activeSeriesKey === seriesKey;
 	return {
 		isActive,
@@ -136,8 +139,8 @@ export default function ModelProviderTrendChart({
 		(point) => point.requests > 0 && point[metricConfig.valueKey] != null,
 	);
 	const providers = Array.from(
-		observedData.reduce(
-			(map, point) => {
+		observedData
+			.reduce((map, point) => {
 				const existing = map.get(point.provider) ?? {
 					provider: point.provider,
 					name: point.providerName || point.provider,
@@ -150,26 +153,27 @@ export default function ModelProviderTrendChart({
 				}
 				map.set(point.provider, existing);
 				return map;
-			},
-			new Map<
-				string,
-				{ provider: string; name: string; color: string | null; requests: number }
-			>(),
-		).values(),
+			}, new Map<string, { provider: string; name: string; color: string | null; requests: number }>())
+			.values(),
 	)
 		.sort((a, b) => b.requests - a.requests)
 		.slice(0, maxSeries)
 		.map((provider, index) => ({
 			...provider,
 			seriesKey: toSeriesKey(provider.provider),
-			color: provider.color ?? FALLBACK_PROVIDER_COLORS[index] ?? FALLBACK_PROVIDER_COLORS[0],
+			color:
+				provider.color ??
+				FALLBACK_PROVIDER_COLORS[index] ??
+				FALLBACK_PROVIDER_COLORS[0],
 		}));
 
 	const providerIdSet = new Set(providers.map((provider) => provider.provider));
-	const filtered = observedData.filter((point) => providerIdSet.has(point.provider));
-	const sortedDays = Array.from(new Set(filtered.map((point) => point.day))).sort(
-		(a, b) => new Date(a).getTime() - new Date(b).getTime(),
+	const filtered = observedData.filter((point) =>
+		providerIdSet.has(point.provider),
 	);
+	const sortedDays = Array.from(
+		new Set(filtered.map((point) => point.day)),
+	).sort((a, b) => new Date(a).getTime() - new Date(b).getTime());
 	const byDay = new Map<string, Record<string, number | null>>();
 	for (const day of sortedDays) {
 		byDay.set(day, {});
@@ -177,7 +181,9 @@ export default function ModelProviderTrendChart({
 	for (const point of filtered) {
 		const row = byDay.get(point.day);
 		if (!row) continue;
-		const provider = providers.find((providerItem) => providerItem.provider === point.provider);
+		const provider = providers.find(
+			(providerItem) => providerItem.provider === point.provider,
+		);
 		if (!provider) continue;
 		row[provider.seriesKey] = point[metricConfig.valueKey] ?? null;
 	}
@@ -194,7 +200,7 @@ export default function ModelProviderTrendChart({
 	});
 	const latestRow = chartData[chartData.length - 1] ?? null;
 	const hoveredRow = activeDay
-		? chartData.find((row) => row.day === activeDay) ?? null
+		? (chartData.find((row) => row.day === activeDay) ?? null)
 		: null;
 	const activeRow = hoveredRow ?? latestRow;
 	const activeHeadingDate =
@@ -211,8 +217,7 @@ export default function ModelProviderTrendChart({
 					.filter((point) => point.provider === provider.provider)
 					.map((point) => point[metricConfig.valueKey])
 					.filter(
-						(value): value is number =>
-							value != null && Number.isFinite(value),
+						(value): value is number => value != null && Number.isFinite(value),
 					);
 				const average =
 					metricValues.length > 0
@@ -235,8 +240,13 @@ export default function ModelProviderTrendChart({
 
 	if (providers.length === 0) {
 		return (
-			<div className="flex h-full items-center justify-center rounded-md border border-dashed border-border text-xs text-muted-foreground">
-				No provider trend data available.
+			<div className="flex h-full flex-col gap-3">
+				<p className="text-lg font-medium leading-none text-foreground">
+					{title}
+				</p>
+				<div className="flex flex-1 items-center justify-center rounded-md border border-dashed border-border px-4 text-center text-xs text-muted-foreground">
+					No data is available for this metric and filter combination.
+				</div>
 			</div>
 		);
 	}
@@ -244,7 +254,9 @@ export default function ModelProviderTrendChart({
 	return (
 		<div className="space-y-3">
 			<div className="flex items-start justify-between gap-3">
-				<p className="text-lg font-medium leading-none text-foreground">{title}</p>
+				<p className="text-lg font-medium leading-none text-foreground">
+					{title}
+				</p>
 				<span className="shrink-0 whitespace-nowrap text-[11px] text-muted-foreground">
 					{activeHeadingDate}
 				</span>
@@ -283,8 +295,7 @@ export default function ModelProviderTrendChart({
 									? state.activeLabel
 									: null;
 							const dayFromNumericLabel =
-								typeof state?.activeLabel === "number" &&
-								chartData.length > 0
+								typeof state?.activeLabel === "number" && chartData.length > 0
 									? String(
 											chartData[
 												Math.max(
@@ -328,8 +339,47 @@ export default function ModelProviderTrendChart({
 						/>
 						<YAxis hide />
 						<Tooltip
-							content={() => null}
 							cursor={false}
+							content={({ active, payload }) => {
+								if (!active || !payload?.length) return null;
+								const day = payload[0]?.payload?.day;
+								return (
+									<div className="min-w-44 rounded-md border border-border bg-popover p-2.5 text-xs text-popover-foreground shadow-md">
+										<p className="mb-2 font-medium">
+											{typeof day === "string" ? formatDayHeading(day) : title}
+										</p>
+										<div className="space-y-1.5">
+											{payload
+												.filter((entry) => typeof entry.value === "number")
+												.map((entry) => {
+													const provider = providers.find(
+														(item) => item.seriesKey === entry.dataKey,
+													);
+													if (!provider) return null;
+													return (
+														<div
+															key={provider.seriesKey}
+															className="flex items-center justify-between gap-4"
+														>
+															<span className="inline-flex min-w-0 items-center gap-1.5">
+																<span
+																	className="size-2 shrink-0 rounded-full"
+																	style={{ backgroundColor: provider.color }}
+																/>
+																<span className="truncate text-muted-foreground">
+																	{provider.name}
+																</span>
+															</span>
+															<span className="shrink-0 font-medium tabular-nums">
+																{metricConfig.formatValue(Number(entry.value))}
+															</span>
+														</div>
+													);
+												})}
+										</div>
+									</div>
+								);
+							}}
 						/>
 						{isHovering && activeIndex != null ? (
 							<ReferenceLine
@@ -345,22 +395,24 @@ export default function ModelProviderTrendChart({
 								provider.seriesKey,
 							);
 							return (
-							<Line
-								key={provider.seriesKey}
-								type="monotone"
-								dataKey={provider.seriesKey}
-								stroke={provider.color}
-								strokeWidth={isActive ? 3.5 : 2}
-								strokeOpacity={isDimmed ? 0.18 : 1}
-								style={{ transition: "stroke-opacity 150ms, stroke-width 150ms" }}
-								strokeLinecap="round"
-								strokeLinejoin="round"
-								dot={false}
-								connectNulls
-								isAnimationActive={false}
-								onMouseEnter={() => setHoveredSeriesKey(provider.seriesKey)}
-								onMouseLeave={() => setHoveredSeriesKey(null)}
-							/>
+								<Line
+									key={provider.seriesKey}
+									type="monotone"
+									dataKey={provider.seriesKey}
+									stroke={provider.color}
+									strokeWidth={isActive ? 3.5 : 2}
+									strokeOpacity={isDimmed ? 0.18 : 1}
+									style={{
+										transition: "stroke-opacity 150ms, stroke-width 150ms",
+									}}
+									strokeLinecap="round"
+									strokeLinejoin="round"
+									dot={false}
+									connectNulls
+									isAnimationActive={false}
+									onMouseEnter={() => setHoveredSeriesKey(provider.seriesKey)}
+									onMouseLeave={() => setHoveredSeriesKey(null)}
+								/>
 							);
 						})}
 					</LineChart>
@@ -373,37 +425,45 @@ export default function ModelProviderTrendChart({
 						provider.seriesKey,
 					);
 					return (
-					<div
-						key={provider.seriesKey}
-						className="flex items-center justify-between gap-3 rounded-sm text-xs outline-none transition-[opacity,transform] duration-150 focus-visible:ring-1 focus-visible:ring-ring"
-						style={{
-							opacity: isDimmed ? 0.35 : 1,
-							transform: isActive ? "translateX(2px)" : "translateX(0)",
-						}}
-						tabIndex={0}
-						onMouseEnter={() => setHoveredSeriesKey(provider.seriesKey)}
-						onMouseLeave={() => setHoveredSeriesKey(null)}
-						onFocus={() => setFocusedSeriesKey(provider.seriesKey)}
-						onBlur={() => setFocusedSeriesKey(null)}
-					>
-						<span className="inline-flex min-w-0 items-center gap-2">
-							<span
-								className="inline-block h-2.5 w-2.5 shrink-0 rounded-full"
-								style={{ backgroundColor: provider.color }}
-							/>
-							<span className={isActive ? "truncate font-medium text-foreground" : "truncate text-foreground"}>{provider.name}</span>
-						</span>
-						<span className="shrink-0 tabular-nums text-foreground">
-							{isHovering ? (
-								metricConfig.formatValue(provider.hoveredValue)
-							) : (
-								<>
-									<span className="text-muted-foreground">Avg </span>
-									{metricConfig.formatValue(provider.average)}
-								</>
-							)}
-						</span>
-					</div>
+						<div
+							key={provider.seriesKey}
+							className="flex items-center justify-between gap-3 rounded-sm text-xs outline-none transition-[opacity,transform] duration-150 focus-visible:ring-1 focus-visible:ring-ring"
+							style={{
+								opacity: isDimmed ? 0.35 : 1,
+								transform: isActive ? "translateX(2px)" : "translateX(0)",
+							}}
+							tabIndex={0}
+							onMouseEnter={() => setHoveredSeriesKey(provider.seriesKey)}
+							onMouseLeave={() => setHoveredSeriesKey(null)}
+							onFocus={() => setFocusedSeriesKey(provider.seriesKey)}
+							onBlur={() => setFocusedSeriesKey(null)}
+						>
+							<span className="inline-flex min-w-0 items-center gap-2">
+								<span
+									className="inline-block h-2.5 w-2.5 shrink-0 rounded-full"
+									style={{ backgroundColor: provider.color }}
+								/>
+								<span
+									className={
+										isActive
+											? "truncate font-medium text-foreground"
+											: "truncate text-foreground"
+									}
+								>
+									{provider.name}
+								</span>
+							</span>
+							<span className="shrink-0 tabular-nums text-foreground">
+								{isHovering ? (
+									metricConfig.formatValue(provider.hoveredValue)
+								) : (
+									<>
+										<span className="text-muted-foreground">Avg </span>
+										{metricConfig.formatValue(provider.average)}
+									</>
+								)}
+							</span>
+						</div>
 					);
 				})}
 			</div>

--- a/apps/web/src/components/(data)/models/ModelProviderTrendChart.tsx
+++ b/apps/web/src/components/(data)/models/ModelProviderTrendChart.tsx
@@ -350,7 +350,11 @@ export default function ModelProviderTrendChart({
 										</p>
 										<div className="space-y-1.5">
 											{payload
-												.filter((entry) => typeof entry.value === "number")
+												.filter(
+													(entry) =>
+														typeof entry.value === "number" &&
+														Number.isFinite(entry.value),
+												)
 												.map((entry) => {
 													const provider = providers.find(
 														(item) => item.seriesKey === entry.dataKey,

--- a/apps/web/src/components/(data)/models/modelPerformancePercentiles.test.ts
+++ b/apps/web/src/components/(data)/models/modelPerformancePercentiles.test.ts
@@ -39,10 +39,20 @@ describe("buildSingleProviderPercentileSeries", () => {
 		]);
 
 		expect(result).toEqual([
-			expect.objectContaining({ provider: "percentile-1", providerName: "P01" }),
-			expect.objectContaining({ provider: "percentile-50", providerName: "P50" }),
-			expect.objectContaining({ provider: "percentile-95", providerName: "P95" }),
+			expect.objectContaining({
+				provider: "percentile-1",
+				providerName: "P01",
+			}),
+			expect.objectContaining({
+				provider: "percentile-50",
+				providerName: "P50",
+			}),
+			expect.objectContaining({
+				provider: "percentile-95",
+				providerName: "P95",
+			}),
 		]);
+		expect(new Set(result?.map((point) => point.providerColor)).size).toBe(3);
 	});
 
 	it("does not replace provider comparison for multiple providers", () => {
@@ -51,40 +61,42 @@ describe("buildSingleProviderPercentileSeries", () => {
 
 	it("rejects empty or unsupported single-provider points", () => {
 		expect(buildSingleProviderPercentileSeries(1, [])).toBeNull();
-		expect(buildSingleProviderPercentileSeries(1, [
-			{
-				day: "2026-07-23",
-				provider: "poolside",
-				providerName: "Poolside",
-				providerColor: null,
-				percentile: 42,
-				avgThroughput: 8.5,
-				avgLatencyMs: 230,
-				avgGenerationMs: 520,
-				requests: 100,
-			},
-			{
-				day: "2026-07-23",
-				provider: "poolside",
-				providerName: "Poolside",
-				providerColor: null,
-				percentile: 50,
-				avgThroughput: 8.5,
-				avgLatencyMs: 230,
-				avgGenerationMs: 520,
-				requests: 0,
-			},
-			{
-				day: "2026-07-23",
-				provider: "poolside",
-				providerName: "Poolside",
-				providerColor: null,
-				percentile: 95,
-				avgThroughput: null,
-				avgLatencyMs: null,
-				avgGenerationMs: null,
-				requests: 100,
-			},
-		])).toBeNull();
+		expect(
+			buildSingleProviderPercentileSeries(1, [
+				{
+					day: "2026-07-23",
+					provider: "poolside",
+					providerName: "Poolside",
+					providerColor: null,
+					percentile: 42,
+					avgThroughput: 8.5,
+					avgLatencyMs: 230,
+					avgGenerationMs: 520,
+					requests: 100,
+				},
+				{
+					day: "2026-07-23",
+					provider: "poolside",
+					providerName: "Poolside",
+					providerColor: null,
+					percentile: 50,
+					avgThroughput: 8.5,
+					avgLatencyMs: 230,
+					avgGenerationMs: 520,
+					requests: 0,
+				},
+				{
+					day: "2026-07-23",
+					provider: "poolside",
+					providerName: "Poolside",
+					providerColor: null,
+					percentile: 95,
+					avgThroughput: null,
+					avgLatencyMs: null,
+					avgGenerationMs: null,
+					requests: 100,
+				},
+			]),
+		).toBeNull();
 	});
 });

--- a/apps/web/src/components/(data)/models/modelPerformancePercentiles.test.ts
+++ b/apps/web/src/components/(data)/models/modelPerformancePercentiles.test.ts
@@ -1,4 +1,5 @@
 import { buildSingleProviderPercentileSeries } from "@/components/(data)/models/modelPerformancePercentiles";
+import { MODEL_PERCENTILES } from "@/components/(data)/models/ModelPercentileSelect";
 
 describe("buildSingleProviderPercentileSeries", () => {
 	it("turns one provider into percentile chart series", () => {
@@ -57,6 +58,28 @@ describe("buildSingleProviderPercentileSeries", () => {
 
 	it("does not replace provider comparison for multiple providers", () => {
 		expect(buildSingleProviderPercentileSeries(2, [])).toBeNull();
+	});
+
+	it("assigns a distinct colour to every supported percentile", () => {
+		const result = buildSingleProviderPercentileSeries(
+			1,
+			MODEL_PERCENTILES.map((percentile) => ({
+				day: "2026-07-23",
+				provider: "poolside",
+				providerName: "Poolside",
+				providerColor: null,
+				percentile,
+				avgThroughput: 8.5,
+				avgLatencyMs: 230,
+				avgGenerationMs: 520,
+				requests: 100,
+			})),
+		);
+
+		expect(result).toHaveLength(MODEL_PERCENTILES.length);
+		expect(new Set(result?.map((point) => point.providerColor)).size).toBe(
+			MODEL_PERCENTILES.length,
+		);
 	});
 
 	it("rejects empty or unsupported single-provider points", () => {

--- a/apps/web/src/components/(data)/models/modelPerformancePercentiles.ts
+++ b/apps/web/src/components/(data)/models/modelPerformancePercentiles.ts
@@ -9,15 +9,15 @@ import {
 } from "@/components/(data)/models/ModelPercentileSelect";
 
 const PERCENTILE_COLORS: Record<ModelPercentile, string> = {
-	1: "var(--chart-1)",
-	5: "var(--chart-2)",
-	10: "var(--chart-3)",
-	25: "var(--chart-4)",
-	50: "var(--chart-1)",
-	75: "var(--chart-2)",
-	90: "var(--chart-3)",
-	95: "var(--chart-4)",
-	99: "var(--chart-5)",
+	1: "oklch(0.78 0.14 205)",
+	5: "oklch(0.74 0.15 220)",
+	10: "oklch(0.70 0.16 235)",
+	25: "oklch(0.66 0.17 250)",
+	50: "oklch(0.62 0.18 265)",
+	75: "oklch(0.59 0.19 280)",
+	90: "oklch(0.56 0.20 295)",
+	95: "oklch(0.53 0.21 310)",
+	99: "oklch(0.50 0.22 325)",
 };
 
 export function buildSingleProviderPercentileSeries(


### PR DESCRIPTION
## Summary

- replace native performance controls with the shared Base UI select components on desktop
- collapse performance controls into one responsive Filters menu on mobile and tablet widths
- preserve chart titles when a selected metric has no data
- add detailed chart tooltips with dates, series labels, and formatted values
- use a distinct nine-step colour progression from P01 through P99
- add regression coverage for distinct percentile-series colours

## Root cause

The performance header mixed native selects with shared dropdown components and allowed the full control row to compete for limited width. Trend charts rendered a generic untitled empty box, their Recharts tooltip was intentionally suppressed, and the percentile palette reused four colours across nine series.

## Validation

- `git diff --check`
- targeted esbuild syntax compilation for the changed TS/TSX files
- full web type-check/test execution was attempted, but pnpm stopped during dependency installation because the repository supply-chain policy rejects Electron Forge's transitive Git dependency `@electron/node-gyp` while `blockExoticSubdeps` is enabled; this policy was not bypassed

## Impact

Model performance controls now remain compact across viewport sizes, empty charts retain context, hover details are readable, and percentile lines can be distinguished reliably.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added responsive model performance filters for desktop and mobile.
  * Added detailed provider values to chart tooltips.
  * Improved empty chart states with clearer messaging and titles.
  * Added distinct colors for percentile chart series.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->