### PR TITLE
Correct SDK registry installation documentation

### DIFF
--- a/apps/docs/v1/sdk-reference/csharp/agent-sdk-installation.mdx
+++ b/apps/docs/v1/sdk-reference/csharp/agent-sdk-installation.mdx
@@ -1,25 +1,23 @@
 ---
 icon: "package"
 title: "Installation"
-description: "Evaluate the C# Agent SDK from source while its NuGet package is prepared."
+description: "Install and configure the Phaseo C# Agent SDK."
 ---
+
+The Agent SDK is published as [`Phaseo.AgentSdk`](https://www.nuget.org/packages/Phaseo.AgentSdk) on NuGet.
 
 ## Requirements
 
 - .NET 8 or newer
 - a Phaseo API key
 
-## Install
-
-<Note type="warning">
-  The C# Agent SDK is implemented, but `Phaseo.AgentSdk` is not yet published to NuGet. Use the repository source for evaluation; the core [`Phaseo.Sdk`](https://www.nuget.org/packages/Phaseo.Sdk) package is public.
-</Note>
+## Installation
 
 ```bash
-git clone https://github.com/phaseoteam/Phaseo.git
-cd Phaseo/packages/sdk/agent-sdk-csharp
-dotnet test
+dotnet add package Phaseo.AgentSdk
 ```
+
+The core `Phaseo.Sdk` package is installed automatically as a dependency.
 
 ## Environment
 

--- a/apps/docs/v1/sdk-reference/go/agent-sdk-installation.mdx
+++ b/apps/docs/v1/sdk-reference/go/agent-sdk-installation.mdx
@@ -1,25 +1,23 @@
 ---
 icon: "package"
 title: "Installation"
-description: "Evaluate the Go Agent SDK from source while its module release is prepared."
+description: "Install and configure the Phaseo Go Agent SDK."
 ---
+
+The Agent SDK is published as [`agent-sdk-go`](https://pkg.go.dev/github.com/phaseoteam/Phaseo/packages/sdk/agent-sdk-go) through Go modules.
 
 ## Requirements
 
 - Go 1.24 or newer
 - a Phaseo API key
 
-## Install
-
-<Note type="warning">
-  The Go Agent SDK is implemented, but it does not yet have a public module version. Use the repository source for evaluation; the core [`sdk-go/v2`](https://pkg.go.dev/github.com/phaseoteam/Phaseo/packages/sdk/sdk-go/v2) module is public.
-</Note>
+## Installation
 
 ```bash
-git clone https://github.com/phaseoteam/Phaseo.git
-cd Phaseo/packages/sdk/agent-sdk-go
-go test ./...
+go get github.com/phaseoteam/Phaseo/packages/sdk/agent-sdk-go@latest
 ```
+
+The core `sdk-go/v2` module is installed automatically as a dependency.
 
 ## Environment
 

--- a/apps/docs/v1/sdk-reference/php/agent-sdk-installation.mdx
+++ b/apps/docs/v1/sdk-reference/php/agent-sdk-installation.mdx
@@ -1,8 +1,10 @@
 ---
 icon: "package"
 title: "Installation"
-description: "Evaluate the PHP Agent SDK from source while its Packagist package is prepared."
+description: "Install and configure the Phaseo PHP Agent SDK."
 ---
+
+The Agent SDK is published as [`phaseo/agent-sdk`](https://packagist.org/packages/phaseo/agent-sdk) on Packagist.
 
 ## Requirements
 
@@ -10,17 +12,13 @@ description: "Evaluate the PHP Agent SDK from source while its Packagist package
 - Composer
 - a Phaseo API key
 
-## Install
-
-<Note type="warning">
-  The PHP Agent SDK is implemented, but `phaseo/agent-sdk` is not yet published to Packagist. Use the repository source for evaluation; the core [`phaseo/sdk`](https://packagist.org/packages/phaseo/sdk) package is public.
-</Note>
+## Installation
 
 ```bash
-git clone https://github.com/phaseoteam/Phaseo.git
-cd Phaseo/packages/sdk/agent-sdk-php
-composer install
+composer require phaseo/agent-sdk
 ```
+
+The core `phaseo/sdk` package is installed automatically as a dependency.
 
 ## Environment
 

--- a/apps/docs/v1/sdk-reference/python/agent-sdk-installation.mdx
+++ b/apps/docs/v1/sdk-reference/python/agent-sdk-installation.mdx
@@ -1,38 +1,33 @@
 ---
 icon: "package"
 title: "Installation"
-description: "Evaluate the Python Agent SDK from source while its registry package is prepared."
+description: "Install and configure the Phaseo Python Agent SDK."
 ---
+
+The Agent SDK is published as [`phaseo-agent-sdk`](https://pypi.org/project/phaseo-agent-sdk/) on PyPI.
 
 ## Requirements
 
 - Python 3.10 or newer
 - a Phaseo API key
 
-## Install
+## Installation
 
-<Note type="warning">
-  The Python Agent SDK is implemented, but `phaseo-agent-sdk` is not yet published to PyPI. Use the repository source for evaluation; the core [`phaseo`](https://pypi.org/project/phaseo/) client is public.
-</Note>
-
-Clone the repository, then install both editable Python packages using your preferred package manager:
-
-```bash
-git clone https://github.com/phaseoteam/Phaseo.git
-cd Phaseo
-```
+Install the Agent SDK using your preferred Python package manager:
 
 <CodeGroup>
 
     ```bash title="pip"
-    python -m pip install -e packages/sdk/sdk-py -e packages/sdk/agent-sdk-py
+    pip install phaseo-agent-sdk
     ```
 
     ```bash title="uv"
-    uv pip install -e packages/sdk/sdk-py -e packages/sdk/agent-sdk-py
+    uv add phaseo-agent-sdk
     ```
 
 </CodeGroup>
+
+The core `phaseo` client is installed automatically as a dependency.
 
 ## Environment
 

--- a/apps/docs/v1/sdk-reference/python/agent-sdk-installation.mdx
+++ b/apps/docs/v1/sdk-reference/python/agent-sdk-installation.mdx
@@ -15,11 +15,24 @@ description: "Evaluate the Python Agent SDK from source while its registry packa
   The Python Agent SDK is implemented, but `phaseo-agent-sdk` is not yet published to PyPI. Use the repository source for evaluation; the core [`phaseo`](https://pypi.org/project/phaseo/) client is public.
 </Note>
 
+Clone the repository, then install both editable Python packages using your preferred package manager:
+
 ```bash
 git clone https://github.com/phaseoteam/Phaseo.git
 cd Phaseo
-python -m pip install -e packages/sdk/sdk-py -e packages/sdk/agent-sdk-py
 ```
+
+<CodeGroup>
+
+    ```bash title="pip"
+    python -m pip install -e packages/sdk/sdk-py -e packages/sdk/agent-sdk-py
+    ```
+
+    ```bash title="uv"
+    uv pip install -e packages/sdk/sdk-py -e packages/sdk/agent-sdk-py
+    ```
+
+</CodeGroup>
 
 ## Environment
 

--- a/apps/docs/v1/sdk-reference/python/installation.mdx
+++ b/apps/docs/v1/sdk-reference/python/installation.mdx
@@ -8,9 +8,19 @@ The SDK is published as [`phaseo`](https://pypi.org/project/phaseo/) on PyPI.
 
 ## Installation
 
-```bash
-pip install phaseo
-```
+Install the SDK using your preferred Python package manager:
+
+<CodeGroup>
+
+    ```bash title="pip"
+    pip install phaseo
+    ```
+
+    ```bash title="uv"
+    uv add phaseo
+    ```
+
+</CodeGroup>
 
 ## Requirements
 

--- a/apps/docs/v1/sdk-reference/ruby/agent-sdk-installation.mdx
+++ b/apps/docs/v1/sdk-reference/ruby/agent-sdk-installation.mdx
@@ -1,8 +1,10 @@
 ---
 icon: "package"
 title: "Installation"
-description: "Evaluate the Ruby Agent SDK from source while its RubyGems package is prepared."
+description: "Install and configure the Phaseo Ruby Agent SDK."
 ---
+
+The Agent SDK is published as [`phaseo_agent_sdk`](https://rubygems.org/gems/phaseo_agent_sdk) on RubyGems.
 
 ## Requirements
 
@@ -10,17 +12,19 @@ description: "Evaluate the Ruby Agent SDK from source while its RubyGems package
 - RubyGems or Bundler
 - a Phaseo API key
 
-## Install
-
-<Note type="warning">
-  The Ruby Agent SDK is implemented, but `phaseo_agent_sdk` is not yet published to RubyGems. Use the repository source for evaluation; the core [`phaseo_sdk`](https://rubygems.org/gems/phaseo_sdk) gem is public.
-</Note>
+## Installation
 
 ```bash
-git clone https://github.com/phaseoteam/Phaseo.git
-cd Phaseo/packages/sdk/agent-sdk-ruby
-bundle install
+gem install phaseo_agent_sdk
 ```
+
+Or add it to your `Gemfile`:
+
+```ruby
+gem "phaseo_agent_sdk"
+```
+
+The core `phaseo_sdk` gem is installed automatically as a dependency.
 
 ## Environment
 

--- a/apps/docs/v1/sdk-reference/typescript/agent-sdk-installation.mdx
+++ b/apps/docs/v1/sdk-reference/typescript/agent-sdk-installation.mdx
@@ -1,25 +1,41 @@
 ---
 icon: "package"
 title: "Installation"
-description: "Install the TypeScript Agent SDK and its core dependency."
+description: "Install and configure the Phaseo TypeScript Agent SDK."
 ---
+
+The Agent SDK is published as [`@phaseo/agent-sdk`](https://www.npmjs.com/package/@phaseo/agent-sdk) on npm.
 
 ## Requirements
 
 - a TypeScript or JavaScript project using npm, pnpm, Yarn, or Bun
 - a Phaseo API key
 
-## Install
+## Installation
 
-```bash
-pnpm add @phaseo/sdk @phaseo/agent-sdk
-```
+Install the Agent SDK using your preferred package manager:
 
-You can also use `npm` or `yarn` if that matches your app:
+<CodeGroup>
 
-```bash
-npm install @phaseo/sdk @phaseo/agent-sdk
-```
+    ```bash title="npm"
+    npm install @phaseo/agent-sdk
+    ```
+
+    ```bash title="pnpm"
+    pnpm add @phaseo/agent-sdk
+    ```
+
+    ```bash title="yarn"
+    yarn add @phaseo/agent-sdk
+    ```
+
+    ```bash title="bun"
+    bun add @phaseo/agent-sdk
+    ```
+
+</CodeGroup>
+
+The core `@phaseo/sdk` package is installed automatically as a dependency.
 
 ## Environment
 


### PR DESCRIPTION
## Summary
- document both pip and uv installation for the core Python SDK and Python Agent SDK
- replace stale source-only warnings for the published Go, PHP, Ruby, and C# Agent SDKs with their registry installation commands
- make TypeScript Agent SDK installation consistent across npm, pnpm, Yarn, and Bun
- clarify where each Agent SDK installs its core Phaseo SDK automatically

## Audit scope
- reviewed core and Agent SDK installation pages for TypeScript, Python, Go, PHP, Ruby, Rust, and C#
- checked documentation against package manifests, package READMEs, canonical distribution targets, and release workflows
- Rust and the non-Python core SDK pages already matched their release model
- Java remains explicitly work-in-progress and is not exposed in the SDK reference installation section

## Validation
- verified all seven updated MDX files on the branch
- reused the existing `<CodeGroup>` documentation pattern where an ecosystem has multiple package managers