### PR TITLE
Split Muse Spark 1.2 model variants

### DIFF
--- a/apps/api/src/providers/openai-compatible/__tests__/meta-config.test.ts
+++ b/apps/api/src/providers/openai-compatible/__tests__/meta-config.test.ts
@@ -27,6 +27,7 @@ describe("Meta OpenAI-compatible config", () => {
 		const contributorRoute = readCatalogJson("api_providers/meta-contributor/models.json")[0];
 		const standardProvider = readCatalogJson("api_providers/meta/api_provider.json");
 		const contributorProvider = readCatalogJson("api_providers/meta-contributor/api_provider.json");
+		const manifest = readCatalogJson("manifest.json");
 
 		expect(standard.model_id).toBe("meta/muse-spark-1.2");
 		expect(contributor.model_id).toBe("meta/muse-spark-1.2-contributor");
@@ -34,8 +35,13 @@ describe("Meta OpenAI-compatible config", () => {
 		expect(contributor.family_id).toBe(standard.family_id);
 		expect(contributorRoute.canonical_model_id).toBe(contributor.model_id);
 		expect(contributorRoute.internal_model_id).toBe(contributor.model_id);
+		expect(contributorRoute.provider_api_model_id).toBe(
+			"meta-contributor:meta/muse-spark-1.2-contributor",
+		);
+		expect(contributorRoute.provider_model_slug).toBe("muse-spark-1.2-contributor");
 		expect(standardProvider.prompt_training_policy).toBe("no_train");
 		expect(contributorProvider.prompt_training_policy).toBe("may_train");
+		expect(manifest.families).toContain("meta-muse-spark-1.2");
 	});
 
 	it("routes Muse Spark models through Responses", () => {

--- a/apps/api/src/providers/openai-compatible/__tests__/meta-config.test.ts
+++ b/apps/api/src/providers/openai-compatible/__tests__/meta-config.test.ts
@@ -2,6 +2,8 @@
 // Why: Muse Spark uses the Responses API and the Meta Model API key only.
 // How: Tests route, URL, and gateway key resolution in isolation from provider-wide fixtures.
 
+import { readFileSync } from "node:fs";
+import path from "node:path";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { setupRuntimeFromEnv, setupTestRuntime, teardownTestRuntime } from "../../../../tests/helpers/runtime";
 import { openAICompatUrl, resolveOpenAICompatKey, resolveOpenAICompatRoute } from "../config";
@@ -15,6 +17,27 @@ afterAll(() => {
 });
 
 describe("Meta OpenAI-compatible config", () => {
+	it("keeps standard and contributor editions as separate models in one family", () => {
+		const catalogRoot = path.resolve(process.cwd(), "../../packages/data/catalog/src/data");
+		const readCatalogJson = (relativePath: string) => JSON.parse(
+			readFileSync(path.join(catalogRoot, relativePath), "utf8"),
+		);
+		const standard = readCatalogJson("models/meta/muse-spark-1.2/model.json");
+		const contributor = readCatalogJson("models/meta/muse-spark-1.2-contributor/model.json");
+		const contributorRoute = readCatalogJson("api_providers/meta-contributor/models.json")[0];
+		const standardProvider = readCatalogJson("api_providers/meta/api_provider.json");
+		const contributorProvider = readCatalogJson("api_providers/meta-contributor/api_provider.json");
+
+		expect(standard.model_id).toBe("meta/muse-spark-1.2");
+		expect(contributor.model_id).toBe("meta/muse-spark-1.2-contributor");
+		expect(standard.family_id).toBe("meta/muse-spark-1.2");
+		expect(contributor.family_id).toBe(standard.family_id);
+		expect(contributorRoute.canonical_model_id).toBe(contributor.model_id);
+		expect(contributorRoute.internal_model_id).toBe(contributor.model_id);
+		expect(standardProvider.prompt_training_policy).toBe("no_train");
+		expect(contributorProvider.prompt_training_policy).toBe("may_train");
+	});
+
 	it("routes Muse Spark models through Responses", () => {
 		expect(resolveOpenAICompatRoute("meta", "muse-spark-1.1")).toBe("responses");
 		expect(resolveOpenAICompatRoute("meta", "muse-spark-1.2")).toBe("responses");

--- a/packages/data/catalog/src/data/api_providers/meta/api_provider.json
+++ b/packages/data/catalog/src/data/api_providers/meta/api_provider.json
@@ -9,7 +9,7 @@
   "privacy_policy_url": "https://www.facebook.com/privacy/policy/",
   "terms_of_service_url": "https://llama.developer.meta.com/legal/terms-of-service",
   "prompt_training_policy": "no_train",
-  "prompt_training_notes": "Meta Model API standard-tier prompts and completions are not used to train Meta models. Individual contributor-tier model routes override this policy because they permit training in exchange for discounted pricing.",
+  "prompt_training_notes": "Meta Model API standard-tier prompts and completions are not used to train Meta models. The training-enabled contributor edition is exposed as a separate canonical model and provider offer.",
   "prompt_training_source_url": "https://dev.meta.ai/docs/pricing-rate-limits",
   "gateway_kind": null,
   "routable": null,

--- a/packages/data/catalog/src/data/families/meta-muse-spark-1.2/family.json
+++ b/packages/data/catalog/src/data/families/meta-muse-spark-1.2/family.json
@@ -1,0 +1,5 @@
+{
+  "family_id": "meta/muse-spark-1.2",
+  "family_name": "Muse Spark 1.2",
+  "organisation_id": "meta"
+}

--- a/packages/data/catalog/src/data/manifest.json
+++ b/packages/data/catalog/src/data/manifest.json
@@ -2110,6 +2110,7 @@
     "meta-llama-2.0",
     "meta-llama-3.0",
     "meta-llama-4.0",
+    "meta-muse-spark-1.2",
     "microsoft-phi-4.0",
     "moonshotai-kimi-k2",
     "openai-gpt-1",

--- a/packages/data/catalog/src/data/models/meta/muse-spark-1.2-contributor/model.json
+++ b/packages/data/catalog/src/data/models/meta/muse-spark-1.2-contributor/model.json
@@ -99,7 +99,7 @@
   "verification": {
     "status": "unverified",
     "checked_at": null,
-    "notes": "Contributor model metadata and pricing were verified against the Meta Model API dashboard on 2026-08-05."
+    "notes": "Contributor model metadata and pricing are based on the Meta Model API dashboard captured on 2026-08-05; live model availability remains unverified."
   },
   "last_updated": "2026-08-06T00:00:00",
   "removal_date": null,

--- a/packages/data/catalog/src/data/models/meta/muse-spark-1.2-contributor/model.json
+++ b/packages/data/catalog/src/data/models/meta/muse-spark-1.2-contributor/model.json
@@ -4,7 +4,7 @@
   "name": "Muse Spark 1.2 Contributor",
   "status": "Available",
   "previous_model_id": null,
-  "description": "Muse Spark 1.2 Contributor is the explicit opt-in variant that discounts inference in exchange for allowing Meta to use prompts and completions for model training.",
+  "description": "Muse Spark 1.2 Contributor is the lower-cost, training-enabled edition of Meta's coding-optimized model for agentic workflows. It shares the capabilities and 1 million token context window of Muse Spark 1.2, while allowing Meta to use prompts and completions to train future models.",
   "announced_date": "2026-08-05T00:00:00",
   "release_date": "2026-08-05T00:00:00",
   "deprecation_date": null,
@@ -31,18 +31,25 @@
       "value": "1048576",
       "unit": "tokens",
       "source_link": "https://dev.meta.ai/docs/models",
-      "other_info": "Meta lists a 1,048,576 token context window for Muse Spark 1.2."
+      "other_info": "Meta lists a 1,048,576 token context window for Muse Spark 1.2 Contributor."
+    },
+    {
+      "name": "api_status",
+      "value": "public_preview",
+      "unit": null,
+      "source_link": "https://dev.meta.ai/docs/models",
+      "other_info": "Available through the training-enabled Meta Model API contributor route."
     },
     {
       "name": "data_use",
-      "value": "may_train",
+      "value": "training_enabled",
       "unit": null,
       "source_link": "https://dev.meta.ai/docs/pricing-rate-limits",
-      "other_info": "This explicit contributor variant permits Meta to use prompts and completions for training."
+      "other_info": "Meta may use prompts and completions to train future models in exchange for discounted pricing."
     }
   ],
   "benchmarks": [],
-  "family_id": null,
+  "family_id": "meta/muse-spark-1.2",
   "model_type": null,
   "knowledge_cutoff": null,
   "limits": {
@@ -86,13 +93,13 @@
       "kind": "pricing",
       "url": "https://dev.meta.ai/docs/pricing-rate-limits",
       "accessed_at": "2026-08-05",
-      "notes": "Contributor tier pricing and data-use policy."
+      "notes": "Contributor pricing, data-use policy, and rate limits."
     }
   ],
   "verification": {
     "status": "unverified",
     "checked_at": null,
-    "notes": "Contributor tier metadata was verified against the Meta Model API dashboard on 2026-08-05."
+    "notes": "Contributor model metadata and pricing were verified against the Meta Model API dashboard on 2026-08-05."
   },
   "last_updated": "2026-08-06T00:00:00",
   "removal_date": null,

--- a/packages/data/catalog/src/data/models/meta/muse-spark-1.2/model.json
+++ b/packages/data/catalog/src/data/models/meta/muse-spark-1.2/model.json
@@ -38,11 +38,11 @@
       "value": "public_preview",
       "unit": null,
       "source_link": "https://dev.meta.ai/docs/models",
-      "other_info": "Available through the Meta Model API in standard and contributor routes."
+      "other_info": "Available through the Meta Model API standard route, where prompts and completions are not used for training."
     }
   ],
   "benchmarks": [],
-  "family_id": null,
+  "family_id": "meta/muse-spark-1.2",
   "model_type": null,
   "knowledge_cutoff": null,
   "limits": {
@@ -86,7 +86,7 @@
       "kind": "pricing",
       "url": "https://dev.meta.ai/docs/pricing-rate-limits",
       "accessed_at": "2026-08-05",
-      "notes": "Standard and contributor tier pricing, data-use policy, and rate limits."
+      "notes": "Standard tier pricing, data-use policy, and rate limits."
     }
   ],
   "verification": {


### PR DESCRIPTION
## Summary

- add separate canonical models for Muse Spark 1.2 standard and contributor editions
- group both models under the Muse Spark 1.2 family
- keep contributor routing and pricing isolated behind the training-enabled provider policy
- add regression coverage for canonical IDs, family membership, and privacy policies

## Validation

- pnpm validate:data
- pnpm validate:pricing
- pnpm validate:gateway
- pnpm validate:docs
- pnpm --filter @phaseo/gateway-api typecheck
- pnpm --filter @phaseo/gateway-api test -- src/providers/openai-compatible/__tests__/meta-config.test.ts
- pnpm --filter @phaseo/gateway-api test:aimock -- --provider meta-contributor

Created with Codex

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added catalog support for Meta’s Muse Spark 1.2 Contributor model.
  * Added family metadata linking standard and Contributor editions.
  * Documented model capabilities, availability, pricing, API access, and data-use policies.

* **Updates**
  * Clarified that standard and Contributor editions are separate offerings with distinct training policies.
  * Updated model identifiers and catalog listings for accurate routing and discovery.

* **Tests**
  * Added coverage verifying correct separation, family grouping, routing, and policy handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->