### PR TITLE
Use analytics request key

### DIFF
--- a/apps/api/src/routes/v1/control/analytics.test.ts
+++ b/apps/api/src/routes/v1/control/analytics.test.ts
@@ -22,9 +22,16 @@ vi.mock("../../utils", () => ({
 
 import { analyticsRoutes } from "./analytics";
 
-function queryResult(result: { data: unknown[]; error: unknown; count?: number | null }) {
+function queryResult(
+	result: { data: unknown[]; error: unknown; count?: number | null },
+	onSelect?: (columns: string) => void,
+) {
 	const query: Record<string, unknown> = {};
-	for (const method of ["select", "eq", "gte", "lt", "in", "order", "range"]) {
+	query.select = vi.fn((columns: string) => {
+		onSelect?.(columns);
+		return query;
+	});
+	for (const method of ["eq", "gte", "lt", "in", "order", "range"]) {
 		query[method] = vi.fn(() => query);
 	}
 	query.then = (resolve: (value: unknown) => unknown) => Promise.resolve(result).then(resolve);
@@ -48,11 +55,17 @@ describe("analyticsRoutes", () => {
 	it("loads the current v2 daily rollup and aggregates meter totals", async () => {
 		const yesterday = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString().slice(0, 10);
 		let factQueries = 0;
+		let countSelection = "";
 		getSupabaseAdminMock.mockReturnValue({
 			from: vi.fn((table: string) => {
 				if (table === "v2_request_facts") {
 					factQueries += 1;
-					if (factQueries === 1) return queryResult({ data: [], error: null, count: 1 });
+					if (factQueries === 1) {
+						return queryResult(
+							{ data: [], error: null, count: 1 },
+							(columns) => { countSelection = columns; },
+						);
+					}
 					return queryResult({ data: [{
 					occurred_at: `${yesterday}T12:00:00.000Z`,
 					endpoint: "chat/completions",
@@ -80,6 +93,7 @@ describe("analyticsRoutes", () => {
 		const body = await response.json() as { data: Array<Record<string, unknown>> };
 
 		expect(response.status).toBe(200);
+		expect(countSelection).toBe("request_event_id");
 		expect(body.data).toEqual([
 			expect.objectContaining({
 				date: yesterday,

--- a/apps/api/src/routes/v1/control/analytics.ts
+++ b/apps/api/src/routes/v1/control/analytics.ts
@@ -182,7 +182,7 @@ async function loadAnalyticsFactRows(args: {
     const rows: AnalyticsFactRow[] = [];
 	const countResult = await supabase
 		.from("v2_request_facts")
-		.select("id", { count: "exact", head: true })
+		.select("request_event_id", { count: "exact", head: true })
 		.eq("workspace_id", args.workspaceId)
 		.gte("occurred_at", args.startIso)
 		.lt("occurred_at", args.endIso);


### PR DESCRIPTION
## Summary

- select `request_event_id` for the analytics HEAD/count query
- add a regression assertion for the count-column contract
- preserve successful aggregation and the existing row-cap failure behavior

## Validation

- `pnpm --filter @phaseo/gateway-api exec vitest run src/routes/v1/control/analytics.test.ts`
- `pnpm --filter @phaseo/gateway-api typecheck`
- `git diff --check origin/main...HEAD`

Created with Codex
