### PR TITLE
Add PWA foundation

### DIFF
--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -53,6 +53,23 @@ const nextConfig = {
   async headers() {
     return [
       {
+        source: "/sw.js",
+        headers: [
+          {
+            key: "Content-Type",
+            value: "application/javascript; charset=utf-8",
+          },
+          {
+            key: "Cache-Control",
+            value: "no-cache, no-store, must-revalidate",
+          },
+          {
+            key: "Content-Security-Policy",
+            value: "default-src 'self'; script-src 'self'",
+          },
+        ],
+      },
+      {
         source: "/:path*",
         headers: [
           { key: "X-Content-Type-Options", value: "nosniff" },

--- a/apps/web/public/offline.html
+++ b/apps/web/public/offline.html
@@ -1,0 +1,82 @@
+<!doctype html>
+<html lang="en">
+	<head>
+		<meta charset="utf-8" />
+		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta name="theme-color" content="#0a0a0a" />
+		<title>Phaseo is offline</title>
+		<style>
+			:root {
+				color-scheme: light dark;
+				font-family: Montserrat, ui-sans-serif, system-ui, sans-serif;
+				background: #fff;
+				color: #171717;
+			}
+
+			body {
+				display: grid;
+				min-height: 100dvh;
+				margin: 0;
+				place-items: center;
+			}
+
+			main {
+				width: min(28rem, calc(100% - 3rem));
+				text-align: center;
+			}
+
+			img {
+				width: 4rem;
+				height: 4rem;
+				margin-bottom: 1.5rem;
+				border-radius: 1rem;
+			}
+
+			h1 {
+				margin: 0;
+				font-size: 1.5rem;
+			}
+
+			p {
+				margin: 0.75rem 0 1.5rem;
+				color: #666;
+				line-height: 1.6;
+			}
+
+			button {
+				border: 0;
+				border-radius: 0.625rem;
+				background: #171717;
+				color: #fff;
+				font: inherit;
+				font-weight: 600;
+				padding: 0.75rem 1rem;
+				cursor: pointer;
+			}
+
+			@media (prefers-color-scheme: dark) {
+				:root {
+					background: #171717;
+					color: #fafafa;
+				}
+
+				p {
+					color: #a3a3a3;
+				}
+
+				button {
+					background: #fafafa;
+					color: #171717;
+				}
+			}
+		</style>
+	</head>
+	<body>
+		<main>
+			<img src="/png_logo_dark.png" alt="" />
+			<h1>You’re offline</h1>
+			<p>Reconnect to continue using Phaseo and load the latest model and gateway data.</p>
+			<button type="button" onclick="window.location.reload()">Try again</button>
+		</main>
+	</body>
+</html>

--- a/apps/web/public/sw.js
+++ b/apps/web/public/sw.js
@@ -1,0 +1,44 @@
+const CACHE_NAME = "phaseo-offline-v1";
+const OFFLINE_URL = "/offline.html";
+const OFFLINE_ASSETS = [OFFLINE_URL, "/png_logo_dark.png"];
+
+self.addEventListener("install", (event) => {
+	event.waitUntil(
+		caches.open(CACHE_NAME).then((cache) => cache.addAll(OFFLINE_ASSETS)),
+	);
+	self.skipWaiting();
+});
+
+self.addEventListener("activate", (event) => {
+	event.waitUntil(
+		caches
+			.keys()
+			.then((keys) =>
+				Promise.all(
+					keys
+						.filter(
+							(key) => key.startsWith("phaseo-offline-") && key !== CACHE_NAME,
+						)
+						.map((key) => caches.delete(key)),
+				),
+		)
+		.then(() => self.clients.claim()),
+	);
+});
+
+self.addEventListener("fetch", (event) => {
+	const { request } = event;
+
+	// Keep API, authenticated, RSC, and asset requests on their existing network and
+	// browser-cache paths. Only replace failed document navigations with the offline page.
+	if (request.method !== "GET" || request.mode !== "navigate") {
+		return;
+	}
+
+	event.respondWith(
+		fetch(request).catch(async () => {
+			const offlineResponse = await caches.match(OFFLINE_URL);
+			return offlineResponse ?? Response.error();
+		}),
+	);
+});

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -7,7 +7,7 @@ import { TooltipProvider } from "@/components/ui/tooltip";
 import { Montserrat } from "next/font/google";
 import { cn } from "@/lib/utils";
 import { TailwindIndicator } from "@/components/tailwind-indicator";
-import { Metadata } from "next";
+import type { Metadata, Viewport } from "next";
 import {
 	METADATA_BASE,
 	PREFERRED_SITE_NAME,
@@ -23,6 +23,7 @@ import ThemeAwareFavicon from "@/components/ThemeAwareFavicon";
 import { Suspense } from "react";
 import { PublicSWRProvider } from "@/components/providers/PublicSWRProvider";
 import AdminDeveloperMenuLauncher from "@/components/developer-menu/AdminDeveloperMenuLauncher";
+import { ServiceWorkerRegistration } from "@/components/pwa/ServiceWorkerRegistration";
 
 const montserrat = Montserrat({ subsets: ["latin"] });
 
@@ -34,7 +35,21 @@ export const metadata: Metadata = {
 	description:
 		"Discover and compare the world's most comprehensive AI model database and gateway. Browse benchmarks, features, pricing, and access state-of-the-art AI models.",
 	applicationName: PREFERRED_SITE_NAME,
+	appleWebApp: {
+		capable: true,
+		statusBarStyle: "default",
+		title: PREFERRED_SITE_NAME,
+	},
 	authors: [{ name: SITE_NAME }],
+	icons: {
+		apple: [
+			{
+				url: "/png_logo_dark.png",
+				sizes: "1024x1024",
+				type: "image/png",
+			},
+		],
+	},
 	other: {
 		"google-adsense-account": "ca-pub-5904826500425921",
 	},
@@ -67,6 +82,13 @@ export const metadata: Metadata = {
 	},
 };
 
+export const viewport: Viewport = {
+	themeColor: [
+		{ media: "(prefers-color-scheme: light)", color: "#ffffff" },
+		{ media: "(prefers-color-scheme: dark)", color: "#171717" },
+	],
+};
+
 export default function RootLayout({
 	children,
 }: {
@@ -90,6 +112,7 @@ export default function RootLayout({
 					"min-h-screen h-full bg-background antialiased"
 				)}
 			>
+				<ServiceWorkerRegistration />
 				<CookieConsentManager gaMeasurementId={GA_MEASUREMENT_ID} />
 				<ConsoleEasterEgg />
 				<ThemeProvider

--- a/apps/web/src/app/manifest.ts
+++ b/apps/web/src/app/manifest.ts
@@ -1,0 +1,29 @@
+import type { MetadataRoute } from "next";
+
+export default function manifest(): MetadataRoute.Manifest {
+	return {
+		name: "Phaseo",
+		short_name: "Phaseo",
+		description:
+			"Compare AI models and access them through a unified AI gateway.",
+		start_url: "/",
+		scope: "/",
+		display: "standalone",
+		background_color: "#ffffff",
+		theme_color: "#0a0a0a",
+		icons: [
+			{
+				src: "/png_logo_dark.png",
+				sizes: "1024x1024",
+				type: "image/png",
+				purpose: "any",
+			},
+			{
+				src: "/png_logo_dark.png",
+				sizes: "1024x1024",
+				type: "image/png",
+				purpose: "maskable",
+			},
+		],
+	};
+}

--- a/apps/web/src/components/pwa/ServiceWorkerRegistration.tsx
+++ b/apps/web/src/components/pwa/ServiceWorkerRegistration.tsx
@@ -1,0 +1,20 @@
+"use client";
+
+import { useEffect } from "react";
+
+export function ServiceWorkerRegistration() {
+	useEffect(() => {
+		if (process.env.NODE_ENV !== "production" || !("serviceWorker" in navigator)) {
+			return;
+		}
+
+		void navigator.serviceWorker
+			.register("/sw.js", {
+				scope: "/",
+				updateViaCache: "none",
+			})
+			.catch(() => undefined);
+	}, []);
+
+	return null;
+}


### PR DESCRIPTION
## Summary

Phaseo did not expose install metadata or register a service worker, so browsers could not offer a complete standalone PWA experience and offline navigations fell back to the browser error page.

This change adds the smallest safe PWA foundation for the web app:

- a Next.js App Router web manifest with Phaseo branding and standalone display mode
- Apple web-app metadata and light/dark theme colours
- production-only service-worker registration with update caching disabled
- a branded offline fallback for failed document navigations
- explicit no-store and content-security headers for the service-worker script

The service worker deliberately leaves API requests, authenticated data, RSC payloads, assets, and successful navigations on their existing network and browser-cache paths. Existing Next.js, CDN, and application caching behaviour is unchanged.

## User impact

Supported browsers can install Phaseo to a home screen or desktop and launch it in a standalone window. If a document navigation fails while offline, users see a Phaseo recovery screen rather than a generic browser failure.

This PR does not add push notifications, background sync, or offline persistence of account and gateway data.

## Validation

- `node --check apps/web/public/sw.js`
- targeted ESLint for the manifest, root layout, and service-worker registration component
- `git diff --check`
- local Next.js HTTP verification for `/manifest.webmanifest`, `/sw.js`, `/offline.html`, manifest linkage, install metadata, and service-worker response headers
- production compilation completed; the wider source worktree later stopped on an unrelated pre-existing TypeScript error outside this PR

Created with Codex
