### PR TITLE
Add AdSense ads.txt record

### DIFF
--- a/apps/web/public/ads.txt
+++ b/apps/web/public/ads.txt
@@ -1,0 +1,1 @@
+google.com, pub-5904826500425921, DIRECT, f08c47fec0942fa0


### PR DESCRIPTION
## What changed

- Added `apps/web/public/ads.txt` with Phaseo's Google AdSense authorised-seller record.
- Next.js will serve the file from the site root at `/ads.txt`.

## Why

PR #1374 added the `google-adsense-account` metadata used to verify site ownership, but it did not create an `ads.txt` file. AdSense therefore verifies ownership while continuing to report the site's ads.txt status as **Not found**.

## Impact

After deployment, Google can discover Phaseo's publisher authorisation at `https://phaseo.app/ads.txt`.

## Validation

- Confirmed no `ads.txt` file currently exists on `main`.
- Confirmed the branch is one commit ahead of `main` and changes only `apps/web/public/ads.txt`.
- Confirmed the record uses publisher ID `pub-5904826500425921` and Google's authorised-seller identifier.