### PR TITLE
Allow guarded manual production deploys

### DIFF
--- a/.github/PRODUCTION_DATABASE_MIGRATIONS.md
+++ b/.github/PRODUCTION_DATABASE_MIGRATIONS.md
@@ -4,6 +4,8 @@ Database migrations are validated on pull requests without production secrets. A
 
 CI-managed application deployment waits for the migration job. If migration validation, approval, dry-run, or application fails, the application deploy is skipped.
 
+The sole exception is an explicitly dispatched `deploy_production` run on `main`. Use it only after independently confirming that every migration on `main` has already been applied to the production database. Manual and push-triggered production releases share a concurrency lock, so this recovery path cannot overlap another production release.
+
 ## One-time GitHub setup
 
 Complete these steps before setting the opt-in variable:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,11 @@ on:
         types: [checks_requested]
     workflow_dispatch:
         inputs:
+            deploy_production:
+                description: "Deploy the selected ref to production without applying database migrations"
+                required: false
+                type: boolean
+                default: false
             importer_mode:
                 description: "Explicit production importer action"
                 required: false
@@ -836,11 +841,13 @@ jobs:
         if: >-
             always() &&
             github.ref == 'refs/heads/main' &&
-            github.event_name != 'workflow_dispatch' &&
             needs.apps.result == 'success' &&
             needs.check-paths.result == 'success' &&
+            ((github.event_name == 'push' &&
             (needs.check-paths.outputs.migrations-changed != 'true' ||
-            needs.migrate-production.result == 'success')
+            needs.migrate-production.result == 'success')) ||
+            (github.event_name == 'workflow_dispatch' &&
+            inputs.deploy_production == true))
         permissions:
             contents: read
         strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ on:
     workflow_dispatch:
         inputs:
             deploy_production:
-                description: "Deploy the selected ref to production without applying database migrations"
+                description: "Deploy main after confirming production migrations are already applied"
                 required: false
                 type: boolean
                 default: false
@@ -26,6 +26,10 @@ on:
 
 permissions:
     contents: read
+
+concurrency:
+    group: ${{ ((github.event_name == 'push' && github.ref == 'refs/heads/main') || (github.event_name == 'workflow_dispatch' && inputs.deploy_production == true)) && 'production-release' || format('ci-{0}-{1}', github.workflow, github.ref) }}
+    cancel-in-progress: false
 
 env:
     NODE_VERSION: 22


### PR DESCRIPTION
## Summary
- add an explicit `deploy_production` workflow-dispatch input
- permit production deployment from a manual run of `main` without rerunning database migrations
- preserve the existing migration-success requirement for ordinary pushes to `main`

## Why
The migrations in #1499 were applied directly with the Supabase CLI, but the production deploy remained blocked because the GitHub `production-database` environment does not yet contain the required Supabase secrets. This provides a guarded recovery path for already-applied migrations without weakening normal merge behavior.

## Validation
- `git diff --check`
- `pnpm run validate:ci-security`

Created with Codex

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional setting for manually triggered deployments to deploy the selected revision to production without running database migrations.
  * Automatic deployment behavior remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->