### PR TITLE
Synchronize performance chart hover

### DIFF
--- a/apps/web/src/components/(data)/models/ModelPerformanceCards.tsx
+++ b/apps/web/src/components/(data)/models/ModelPerformanceCards.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { useState } from "react";
 import { Maximize2 } from "lucide-react";
 import type {
 	ModelPerformancePoint,
@@ -101,7 +100,6 @@ export default function ModelPerformanceCards({
 	chartProviderDaily7d,
 	qualitySeries = [],
 }: ModelPerformanceCardsProps) {
-	const [activeDay, setActiveDay] = useState<string | null>(null);
 	void summary;
 	void prevSummary;
 	const hasHourly = hourly.some((point) => point.requests > 0);
@@ -160,8 +158,6 @@ export default function ModelPerformanceCards({
 								data={metricData(definition.metric, false)}
 								metric={definition.metric}
 								maxSeries={3}
-								activeDay={activeDay}
-								onActiveDayChange={setActiveDay}
 								headerAction={
 									<DialogTrigger asChild>
 										<button
@@ -194,8 +190,6 @@ export default function ModelPerformanceCards({
 									maxSeries={Number.MAX_SAFE_INTEGER}
 									detailed
 									showHeader={false}
-									activeDay={activeDay}
-									onActiveDayChange={setActiveDay}
 								/>
 							</div>
 						</DialogContent>

--- a/apps/web/src/components/(data)/models/ModelProviderTrendChart.tsx
+++ b/apps/web/src/components/(data)/models/ModelProviderTrendChart.tsx
@@ -302,7 +302,7 @@ export default function ModelProviderTrendChart({
 			: "-";
 	const activeIndex =
 		activeRow && typeof activeRow.index === "number" ? activeRow.index : null;
-	const isHovering = activeDay != null;
+	const isHovering = hoveredRow != null;
 	const providerRows = providers.map((provider) => {
 				const providerPoints = filtered.filter(
 					(point) => point.provider === provider.provider,

--- a/apps/web/src/components/(data)/models/ModelProviderTrendChart.tsx
+++ b/apps/web/src/components/(data)/models/ModelProviderTrendChart.tsx
@@ -35,8 +35,6 @@ type ModelProviderTrendChartProps = {
 	detailed?: boolean;
 	showHeader?: boolean;
 	headerAction?: ReactNode;
-	activeDay: string | null;
-	onActiveDayChange: (day: string | null) => void;
 };
 
 export function getSeriesEmphasis(
@@ -213,9 +211,8 @@ export default function ModelProviderTrendChart({
 	detailed = false,
 	showHeader = true,
 	headerAction,
-	activeDay,
-	onActiveDayChange,
 }: ModelProviderTrendChartProps) {
+	const [activeDay, setActiveDay] = useState<string | null>(null);
 	const [hoveredSeriesKey, setHoveredSeriesKey] = useState<string | null>(null);
 	const [focusedSeriesKey, setFocusedSeriesKey] = useState<string | null>(null);
 	const [tableSort, setTableSort] = useState<{
@@ -456,9 +453,9 @@ export default function ModelProviderTrendChart({
 								dayFromIndex ||
 								dayFromPayload ||
 								null;
-							onActiveDayChange(day);
+							setActiveDay(day);
 						}}
-						onMouseLeave={() => onActiveDayChange(null)}
+						onMouseLeave={() => setActiveDay(null)}
 					>
 						<CartesianGrid vertical={false} stroke="transparent" />
 						<XAxis
@@ -515,9 +512,6 @@ export default function ModelProviderTrendChart({
 								stroke={provider.color}
 									strokeWidth={isActive ? 3.5 : 2}
 									strokeOpacity={isDimmed ? 0.18 : 1}
-									style={{
-										transition: "stroke-opacity 150ms, stroke-width 150ms",
-									}}
 									strokeLinecap="round"
 									strokeLinejoin="round"
 									dot={chartData.length === 1 ? { r: 3, strokeWidth: 2 } : false}
@@ -577,7 +571,7 @@ export default function ModelProviderTrendChart({
 					return (
 						<div
 							key={provider.seriesKey}
-							className="flex items-center justify-between gap-3 rounded-sm text-xs outline-none transition-[opacity,transform] duration-150 focus-visible:ring-1 focus-visible:ring-ring"
+							className="flex items-center justify-between gap-3 rounded-sm text-xs outline-none focus-visible:ring-1 focus-visible:ring-ring"
 							style={{
 								opacity: isDimmed ? 0.35 : 1,
 								transform: isActive ? "translateX(2px)" : "translateX(0)",


### PR DESCRIPTION
## Summary

Performance chart hover feedback could appear delayed and out of sync: moving across one chart updated shared state for the entire performance-card grid, while chart series and legend rows used separate 150 ms transitions.

This change keeps the transient hover date local to each chart and removes the staggered hover transitions. The active date, reference line, series emphasis, and displayed values now update in the same render without forcing unrelated charts to redraw.

Cached Input colour behaviour is unchanged and verified to use each provider's configured `providerColor` for both chart strokes and provider markers.

## Validation

- `pnpm --filter @phaseo/web exec eslint 'src/components/(data)/models/ModelProviderTrendChart.tsx' 'src/components/(data)/models/ModelPerformanceCards.tsx'`
- `git diff --check`
- Manual localhost interaction review on the Macaron V1 Venti performance charts

Created with Codex


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved day selection behavior in model provider trend charts.
  * Ensured each trend chart manages its selected day independently.
* **Style**
  * Simplified chart interactions by removing unnecessary visual transition effects.
  * Non-detailed provider rows now display without transitional opacity or movement effects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->