### PR TITLE
Refine model detail experience

### DIFF
--- a/apps/web-api/src/routes/public/models.test.ts
+++ b/apps/web-api/src/routes/public/models.test.ts
@@ -502,6 +502,11 @@ describe("public model routes", () => {
 	it("never exposes a synthetic unknown provider in performance data", async () => {
 		vi.stubGlobal("fetch", vi.fn(async (input: RequestInfo | URL) => {
 			const url = String(input);
+			if (url.includes("/v2_providers?")) {
+				return new Response(JSON.stringify([
+					{ provider_slug: "poolside", metadata: { colour: "#12AB78" } },
+				]), { status: 200 });
+			}
 			if (url.includes("/rpc/get_v2_model_cached_input_metrics")) {
 				return new Response(JSON.stringify({
 					hourly_24h: [],
@@ -541,6 +546,7 @@ describe("public model routes", () => {
 					phaseo_overhead_ms: percentile === 95 ? 45 : 20,
 					tpot_ms: percentile === 95 ? 65 : 110,
 					itl_ms: percentile === 95 ? 65 : 110,
+					cached_input_pct: percentile === 95 ? 88.5 : 62.5,
 				}))), { status: 200 });
 			}
 			return new Response(JSON.stringify([]), { status: 200 });
@@ -561,11 +567,12 @@ describe("public model routes", () => {
 			expect.objectContaining({ provider: "poolside" }),
 		]);
 		expect(payload.metrics.providerPerformance).toEqual([
-			expect.objectContaining({ provider: "poolside" }),
+			expect.objectContaining({ provider: "poolside", providerColor: "#12AB78" }),
 		]);
 		expect(payload.metrics.providerDaily7d).toEqual([
-			expect.objectContaining({
-				provider: "poolside",
+				expect.objectContaining({
+					provider: "poolside",
+					providerColor: "#12AB78",
 				cachedInputPct: 62.5,
 				cachedInputTokens: 625,
 				effectiveInputTokens: 1000,
@@ -576,10 +583,12 @@ describe("public model routes", () => {
 		expect(payload.metrics.providerPercentileDaily7d).toContainEqual(
 			expect.objectContaining({
 				provider: "poolside",
+				providerColor: "#12AB78",
 				percentile: 95,
 				avgLatencyMs: 900,
 				avgGenerationMs: 1200,
 				avgThroughput: 13.4,
+				cachedInputPct: 88.5,
 			}),
 		);
 		expect(JSON.stringify(payload)).not.toContain('"unknown"');

--- a/apps/web-api/src/routes/public/models.test.ts
+++ b/apps/web-api/src/routes/public/models.test.ts
@@ -429,7 +429,7 @@ describe("public model routes", () => {
 					{
 						model_id: "google/gemini-3.5-flash",
 						api_model_id: "google/gemini-3.5-flash",
-						provider_id: "openrouter",
+						provider_id: " OpenRouter ",
 						capability_id: "text.generate",
 						capability_status: "active",
 						is_active_gateway: false,

--- a/apps/web-api/src/routes/public/models.ts
+++ b/apps/web-api/src/routes/public/models.ts
@@ -1441,6 +1441,24 @@ publicModelsRouter.get("/:modelId/performance", async (c) => {
 			provider_uptime_24h: (performance.provider_uptime_24h ?? []).filter(isKnownProvider),
 			provider_daily_7d: (performance.provider_daily_7d ?? []).filter(isKnownProvider),
 		};
+		const providerSlugs = [...new Set([
+			...(performance.provider_uptime_24h ?? []).map((value: Record<string, unknown>) => String(value.provider ?? "")),
+			...(performance.provider_daily_7d ?? []).map((value: Record<string, unknown>) => String(value.provider ?? "")),
+		].map((provider) => provider.trim().toLowerCase()).filter(Boolean))];
+		const providerMetadata = providerSlugs.length > 0
+			? await client.from("v2_providers").select("provider_slug,metadata").in("provider_slug", providerSlugs)
+			: { data: [], error: null };
+		if (providerMetadata.error) throw providerMetadata.error;
+		const providerColors = new Map((providerMetadata.data ?? []).map((row) => {
+			const metadata = row.metadata && typeof row.metadata === "object" && !Array.isArray(row.metadata)
+				? row.metadata as Record<string, unknown>
+				: {};
+			const color = typeof metadata.colour === "string" && metadata.colour.trim()
+				? metadata.colour.trim()
+				: null;
+			return [String(row.provider_slug).trim().toLowerCase(), color] as const;
+		}));
+		const providerColor = (provider: unknown) => providerColors.get(String(provider ?? "").trim().toLowerCase()) ?? null;
 		const number = (value: unknown) => { const parsed = Number(value); return value == null || !Number.isFinite(parsed) ? null : parsed; };
 		const summary = (value: Record<string, unknown> | null | undefined) => ({ avgThroughput: number(value?.avg_throughput), avgOutputSpeed: number(value?.output_speed_tps), avgLatencyMs: number(value?.avg_latency_ms), avgGenerationMs: number(value?.avg_generation_ms), avgPhaseoOverheadMs: number(value?.phaseo_overhead_ms), avgTpotMs: number(value?.tpot_ms), avgItlMs: number(value?.itl_ms), uptimePct: number(value?.uptime_pct), totalRequests: Number(value?.total_requests ?? 0), successfulRequests: Number(value?.successful_requests ?? 0) });
 		const cachedInputMetrics = (cachedInput.data ?? {}) as Record<string, any>;
@@ -1450,10 +1468,10 @@ publicModelsRouter.get("/:modelId/performance", async (c) => {
 			const cache = cachedInputHourly.get(String(value.bucket ?? "")) as Record<string, unknown> | undefined;
 			return { bucket: value.bucket ?? "", avgThroughput: number(value.avg_throughput), avgOutputSpeed: number(value.output_speed_tps), avgLatencyMs: number(value.avg_latency_ms), avgGenerationMs: number(value.avg_generation_ms), avgPhaseoOverheadMs: number(value.phaseo_overhead_ms), avgTpotMs: number(value.tpot_ms), avgItlMs: number(value.itl_ms), cachedInputPct: number(cache?.cached_input_pct), cacheTelemetryRequests: Number(cache?.telemetry_requests ?? 0), requests: Number(value.requests ?? 0), successPct: number(value.success_pct) };
 		});
-		const providerPerformance = (performance.provider_uptime_24h ?? []).map((value: Record<string, any>) => ({ provider: value.provider ?? "", providerName: value.provider_name ?? value.provider ?? "", providerColor: null, avgThroughput: number(value.avg_throughput), avgLatencyMs: number(value.avg_latency_ms), avgGenerationMs: number(value.avg_generation_ms), requests: Number(value.requests ?? 0), uptimePct: number(value.uptime_pct), uptimeBuckets: (value.uptime_buckets ?? []).map((bucket: Record<string, unknown>) => ({ start: bucket.start ?? "", end: bucket.end ?? "", successPct: number(bucket.success_pct) })) }));
+		const providerPerformance = (performance.provider_uptime_24h ?? []).map((value: Record<string, any>) => ({ provider: value.provider ?? "", providerName: value.provider_name ?? value.provider ?? "", providerColor: providerColor(value.provider), avgThroughput: number(value.avg_throughput), avgLatencyMs: number(value.avg_latency_ms), avgGenerationMs: number(value.avg_generation_ms), requests: Number(value.requests ?? 0), uptimePct: number(value.uptime_pct), uptimeBuckets: (value.uptime_buckets ?? []).map((bucket: Record<string, unknown>) => ({ start: bucket.start ?? "", end: bucket.end ?? "", successPct: number(bucket.success_pct) })) }));
 		const providerDaily7d = (performance.provider_daily_7d ?? []).map((value: Record<string, unknown>) => {
 			const cache = cachedInputProviderDaily.get(`${String(value.day ?? "")}:${String(value.provider ?? "")}`) as Record<string, unknown> | undefined;
-			return { day: value.day ?? "", provider: value.provider ?? "", providerName: value.provider_name ?? value.provider ?? "", providerColor: null, avgThroughput: number(value.avg_throughput), avgOutputSpeed: number(value.output_speed_tps), avgLatencyMs: number(value.avg_latency_ms), avgGenerationMs: number(value.avg_generation_ms), avgPhaseoOverheadMs: number(value.phaseo_overhead_ms), avgTpotMs: number(value.tpot_ms), avgItlMs: number(value.itl_ms), cachedInputPct: number(cache?.cached_input_pct), cachedInputTokens: number(cache?.cached_input_tokens), effectiveInputTokens: number(cache?.effective_input_tokens), cacheTelemetryRequests: Number(cache?.telemetry_requests ?? 0), requests: Number(value.requests ?? 0) };
+			return { day: value.day ?? "", provider: value.provider ?? "", providerName: value.provider_name ?? value.provider ?? "", providerColor: providerColor(value.provider), avgThroughput: number(value.avg_throughput), avgOutputSpeed: number(value.output_speed_tps), avgLatencyMs: number(value.avg_latency_ms), avgGenerationMs: number(value.avg_generation_ms), avgPhaseoOverheadMs: number(value.phaseo_overhead_ms), avgTpotMs: number(value.tpot_ms), avgItlMs: number(value.itl_ms), cachedInputPct: number(cache?.cached_input_pct), cachedInputTokens: number(cache?.cached_input_tokens), effectiveInputTokens: number(cache?.effective_input_tokens), cacheTelemetryRequests: Number(cache?.telemetry_requests ?? 0), requests: Number(value.requests ?? 0) };
 		});
 		const providerCount = providerPerformance.filter((provider: Record<string, unknown>) => Number(provider.requests ?? 0) > 0).length;
 		const sevenDayProviderCount = new Set(
@@ -1480,7 +1498,7 @@ publicModelsRouter.get("/:modelId/performance", async (c) => {
 				day: value.usage_day ?? "",
 				provider: value.provider_id ?? "",
 				providerName: value.provider_name ?? value.provider_id ?? "",
-				providerColor: null,
+				providerColor: providerColor(value.provider_id),
 				percentile: seriesPercentile,
 				avgThroughput: number(value.effective_throughput_tps),
 				avgOutputSpeed: number(value.output_speed_tps),
@@ -1489,6 +1507,7 @@ publicModelsRouter.get("/:modelId/performance", async (c) => {
 				avgPhaseoOverheadMs: number(value.phaseo_overhead_ms),
 				avgTpotMs: number(value.tpot_ms),
 				avgItlMs: number(value.itl_ms),
+				cachedInputPct: number(value.cached_input_pct),
 				requests: Number(value.requests ?? 0),
 			};
 		}).filter((value) => String(value.provider).trim().length > 0);

--- a/apps/web-api/src/routes/public/models.ts
+++ b/apps/web-api/src/routes/public/models.ts
@@ -335,11 +335,18 @@ async function fetchProviderExecutionRegions(env: Env, providerIds: string[]) {
 
 async function fetchProviderStatuses(env: Env, providerIds: string[]) {
 	const statusesByProvider = new Map<string, string>();
-	if (providerIds.length === 0) return statusesByProvider;
+	const normalizedProviderIds = [
+		...new Set(
+			providerIds
+				.map((providerId) => providerId.trim().toLowerCase())
+				.filter(Boolean),
+		),
+	];
+	if (normalizedProviderIds.length === 0) return statusesByProvider;
 	const { data, error } = await getDataClient(env)
 		.from("v2_providers")
 		.select("provider_slug,status")
-		.in("provider_slug", providerIds);
+		.in("provider_slug", normalizedProviderIds);
 	if (error) throw error;
 	for (const row of data ?? []) {
 		const providerId = String(row.provider_slug ?? "").trim();
@@ -370,7 +377,7 @@ export async function fetchGatewayMonitorRows(
 	const providerIds = Array.from(
 		new Set(
 			rows
-				.map((row) => String(row.provider_id ?? "").trim())
+				.map((row) => String(row.provider_id ?? "").trim().toLowerCase())
 				.filter(Boolean),
 		),
 	);
@@ -388,10 +395,11 @@ export async function fetchGatewayMonitorRows(
 			? `${baseModelId}:free`
 			: baseModelId;
 		const providerId = String(row.provider_id ?? "").trim();
+		const normalizedProviderId = providerId.toLowerCase();
 		// The /models catalogue describes Phaseo availability. External catalogue
 		// providers remain available on model detail pages, but must not inflate
 		// this page's provider counts or hover lists.
-		if (providerStatusesById.get(providerId) === "external") continue;
+		if (providerStatusesById.get(normalizedProviderId) === "external") continue;
 		const apiModelId = String(row.api_model_id ?? "").trim();
 		const providerModelId = String(
 			row.provider_api_model_id ?? row.provider_model_slug ?? apiModelId,
@@ -425,7 +433,7 @@ export async function fetchGatewayMonitorRows(
 				fromPriceUnit: row.from_price_unit ?? null,
 				pricingDetailRows: [],
 				features: gatewayFeatures(params),
-				executionRegions: providerRegionsById.get(providerId) ?? [],
+				executionRegions: providerRegionsById.get(normalizedProviderId) ?? [],
 			},
 			endpoint: capabilityId,
 			gatewayStatus: normaliseGatewayStatus(row.capability_status, row.is_active_gateway),

--- a/apps/web/src/app/(dashboard)/models/[organisationId]/[modelId]/activity/page.tsx
+++ b/apps/web/src/app/(dashboard)/models/[organisationId]/[modelId]/activity/page.tsx
@@ -1,12 +1,17 @@
 import type { ModelRouteParams } from "@/components/(data)/model/model-route-helpers";
-import { redirectLegacyModelSection } from "../redirectLegacyModelSection";
+import {
+	redirectLegacyModelSection,
+	type LegacySearchParams,
+} from "../redirectLegacyModelSection";
 
 export const instant = false;
 
 export default async function Page({
 	params,
+	searchParams,
 }: {
 	params: Promise<ModelRouteParams>;
+	searchParams: Promise<LegacySearchParams>;
 }) {
-	return redirectLegacyModelSection(params, "activity");
+	return redirectLegacyModelSection(params, "activity", searchParams);
 }

--- a/apps/web/src/app/(dashboard)/models/[organisationId]/[modelId]/activity/page.tsx
+++ b/apps/web/src/app/(dashboard)/models/[organisationId]/[modelId]/activity/page.tsx
@@ -1,67 +1,12 @@
-import type { Metadata } from "next";
-import { permanentRedirect } from "next/navigation";
-import { buildMetadata } from "@/lib/seo";
-import ModelDetailShell from "@/components/(data)/model/ModelDetailShell";
-import { ModelActivitySection } from "@/components/(data)/model/overview/ModelOverviewSections";
-import {
-	getModelPath,
-	getModelMetadataIdentity,
-	resolveModelRouteIds,
-	type ModelRouteParams,
-} from "@/components/(data)/model/model-route-helpers";
-import { buildModelPageMetadataDescription } from "@/lib/models/modelDescription";
+import type { ModelRouteParams } from "@/components/(data)/model/model-route-helpers";
+import { redirectLegacyModelSection } from "../redirectLegacyModelSection";
 
-export async function generateMetadata(props: {
-	params: Promise<ModelRouteParams>;
-}): Promise<Metadata> {
-	const params = await props.params;
-	const { modelId, modelName, organisationName, modelDescription } = await getModelMetadataIdentity(
-		params,
-		false,
-	);
-	const path = getModelPath(modelId, "activity");
-	const imagePath = `/og/models/${modelId}`;
-
-	return buildMetadata({
-		title: `${modelName} Activity - Usage and Uptime`,
-		description: buildModelPageMetadataDescription({
-			modelDescription,
-			suffix:
-				"Track recent usage and uptime signals, including request volume, success rates, active providers, and token movement.",
-			fallback: `Track recent usage and uptime signals for ${modelName} on Phaseo, including request volume, success rates, active providers, and token movement.`,
-		}),
-		path,
-		keywords: [
-			modelName,
-			`${modelName} uptime`,
-			`${modelName} usage`,
-			organisationName ? `${organisationName} AI` : null,
-			"AI reliability metrics",
-			"Phaseo",
-		].filter(Boolean) as string[],
-		imagePath,
-	});
-}
+export const instant = false;
 
 export default async function Page({
 	params,
 }: {
 	params: Promise<ModelRouteParams>;
 }) {
-	const routeParams = await params;
-	const includeHidden = false;
-	const { requestedModelId, canonicalModelId } = await resolveModelRouteIds(
-		routeParams,
-		includeHidden,
-	);
-	if (canonicalModelId !== requestedModelId) {
-		permanentRedirect(getModelPath(canonicalModelId, "activity"));
-	}
-	const modelId = canonicalModelId;
-
-	return (
-		<ModelDetailShell modelId={modelId} tab="activity" includeHidden={includeHidden}>
-			<ModelActivitySection modelId={modelId} includeHidden={includeHidden} />
-		</ModelDetailShell>
-	);
+	return redirectLegacyModelSection(params, "activity");
 }

--- a/apps/web/src/app/(dashboard)/models/[organisationId]/[modelId]/apps/page.tsx
+++ b/apps/web/src/app/(dashboard)/models/[organisationId]/[modelId]/apps/page.tsx
@@ -1,12 +1,17 @@
 import type { ModelRouteParams } from "@/components/(data)/model/model-route-helpers";
-import { redirectLegacyModelSection } from "../redirectLegacyModelSection";
+import {
+	redirectLegacyModelSection,
+	type LegacySearchParams,
+} from "../redirectLegacyModelSection";
 
 export const instant = false;
 
 export default async function Page({
 	params,
+	searchParams,
 }: {
 	params: Promise<ModelRouteParams>;
+	searchParams: Promise<LegacySearchParams>;
 }) {
-	return redirectLegacyModelSection(params, "apps");
+	return redirectLegacyModelSection(params, "apps", searchParams);
 }

--- a/apps/web/src/app/(dashboard)/models/[organisationId]/[modelId]/apps/page.tsx
+++ b/apps/web/src/app/(dashboard)/models/[organisationId]/[modelId]/apps/page.tsx
@@ -1,67 +1,12 @@
-import type { Metadata } from "next";
-import { permanentRedirect } from "next/navigation";
-import { buildMetadata } from "@/lib/seo";
-import ModelDetailShell from "@/components/(data)/model/ModelDetailShell";
-import { ModelAppsSection } from "@/components/(data)/model/overview/ModelOverviewSections";
-import {
-	getModelPath,
-	getModelMetadataIdentity,
-	resolveModelRouteIds,
-	type ModelRouteParams,
-} from "@/components/(data)/model/model-route-helpers";
-import { buildModelPageMetadataDescription } from "@/lib/models/modelDescription";
+import type { ModelRouteParams } from "@/components/(data)/model/model-route-helpers";
+import { redirectLegacyModelSection } from "../redirectLegacyModelSection";
 
-export async function generateMetadata(props: {
-	params: Promise<ModelRouteParams>;
-}): Promise<Metadata> {
-	const params = await props.params;
-	const { modelId, modelName, organisationName, modelDescription } = await getModelMetadataIdentity(
-		params,
-		false,
-	);
-	const path = getModelPath(modelId, "apps");
-	const imagePath = `/og/models/${modelId}`;
-
-	return buildMetadata({
-		title: `${modelName} Apps - Product and Plan Availability`,
-		description: buildModelPageMetadataDescription({
-			modelDescription,
-			suffix:
-				"See which public apps are actively sending gateway requests to this model on Phaseo.",
-			fallback: `See which public apps are actively sending gateway requests to ${modelName} on Phaseo.`,
-		}),
-		path,
-		keywords: [
-			modelName,
-			`${modelName} apps`,
-			`${modelName} app usage`,
-			organisationName ? `${organisationName} AI` : null,
-			"gateway request usage",
-			"Phaseo",
-		].filter(Boolean) as string[],
-		imagePath,
-	});
-}
+export const instant = false;
 
 export default async function Page({
 	params,
 }: {
 	params: Promise<ModelRouteParams>;
 }) {
-	const routeParams = await params;
-	const includeHidden = false;
-	const { requestedModelId, canonicalModelId } = await resolveModelRouteIds(
-		routeParams,
-		includeHidden,
-	);
-	if (canonicalModelId !== requestedModelId) {
-		permanentRedirect(getModelPath(canonicalModelId, "apps"));
-	}
-	const modelId = canonicalModelId;
-
-	return (
-		<ModelDetailShell modelId={modelId} tab="apps" includeHidden={includeHidden}>
-			<ModelAppsSection modelId={modelId} includeHidden={includeHidden} />
-		</ModelDetailShell>
-	);
+	return redirectLegacyModelSection(params, "apps");
 }

--- a/apps/web/src/app/(dashboard)/models/[organisationId]/[modelId]/availability/page.tsx
+++ b/apps/web/src/app/(dashboard)/models/[organisationId]/[modelId]/availability/page.tsx
@@ -1,31 +1,12 @@
-import type { Metadata } from "next";
-import { permanentRedirect } from "next/navigation";
-import {
-	getModelPath,
-	resolveModelRouteIds,
-	type ModelRouteParams,
-} from "@/components/(data)/model/model-route-helpers";
+import type { ModelRouteParams } from "@/components/(data)/model/model-route-helpers";
+import { redirectLegacyModelSection } from "../redirectLegacyModelSection";
 
-export const metadata: Metadata = {
-	title: "Model availability redirect",
-	description:
-		"Redirect route to the model providers page on Phaseo for availability details.",
-	robots: {
-		index: false,
-		follow: false,
-	},
-};
+export const instant = false;
 
 export default async function Page({
 	params,
 }: {
 	params: Promise<ModelRouteParams>;
 }) {
-	const routeParams = await params;
-	const includeHidden = false;
-	const { canonicalModelId } = await resolveModelRouteIds(
-		routeParams,
-		includeHidden,
-	);
-	permanentRedirect(getModelPath(canonicalModelId, "providers"));
+	return redirectLegacyModelSection(params, "providers");
 }

--- a/apps/web/src/app/(dashboard)/models/[organisationId]/[modelId]/availability/page.tsx
+++ b/apps/web/src/app/(dashboard)/models/[organisationId]/[modelId]/availability/page.tsx
@@ -1,12 +1,17 @@
 import type { ModelRouteParams } from "@/components/(data)/model/model-route-helpers";
-import { redirectLegacyModelSection } from "../redirectLegacyModelSection";
+import {
+	redirectLegacyModelSection,
+	type LegacySearchParams,
+} from "../redirectLegacyModelSection";
 
 export const instant = false;
 
 export default async function Page({
 	params,
+	searchParams,
 }: {
 	params: Promise<ModelRouteParams>;
+	searchParams: Promise<LegacySearchParams>;
 }) {
-	return redirectLegacyModelSection(params, "providers");
+	return redirectLegacyModelSection(params, "uptime", searchParams);
 }

--- a/apps/web/src/app/(dashboard)/models/[organisationId]/[modelId]/benchmarks/page.tsx
+++ b/apps/web/src/app/(dashboard)/models/[organisationId]/[modelId]/benchmarks/page.tsx
@@ -1,12 +1,17 @@
 import type { ModelRouteParams } from "@/components/(data)/model/model-route-helpers";
-import { redirectLegacyModelSection } from "../redirectLegacyModelSection";
+import {
+	redirectLegacyModelSection,
+	type LegacySearchParams,
+} from "../redirectLegacyModelSection";
 
 export const instant = false;
 
 export default async function Page({
 	params,
+	searchParams,
 }: {
 	params: Promise<ModelRouteParams>;
+	searchParams: Promise<LegacySearchParams>;
 }) {
-	return redirectLegacyModelSection(params, "benchmarks");
+	return redirectLegacyModelSection(params, "benchmarks", searchParams);
 }

--- a/apps/web/src/app/(dashboard)/models/[organisationId]/[modelId]/benchmarks/page.tsx
+++ b/apps/web/src/app/(dashboard)/models/[organisationId]/[modelId]/benchmarks/page.tsx
@@ -1,67 +1,12 @@
-import { buildMetadata } from "@/lib/seo";
-import ModelDetailShell from "@/components/(data)/model/ModelDetailShell";
-import { ModelBenchmarksSection } from "@/components/(data)/model/overview/ModelOverviewSections";
-import type { Metadata } from "next";
-import {
-	getModelPath,
-	getModelMetadataIdentity,
-	resolveModelRouteIds,
-	type ModelRouteParams,
-} from "@/components/(data)/model/model-route-helpers";
-import { buildModelPageMetadataDescription } from "@/lib/models/modelDescription";
-import { permanentRedirect } from "next/navigation";
+import type { ModelRouteParams } from "@/components/(data)/model/model-route-helpers";
+import { redirectLegacyModelSection } from "../redirectLegacyModelSection";
 
-export async function generateMetadata(props: {
-	params: Promise<ModelRouteParams>;
-}): Promise<Metadata> {
-	const params = await props.params;
-	const { modelId, modelName, organisationName, modelDescription } = await getModelMetadataIdentity(
-		params,
-		false,
-	);
-	const path = getModelPath(modelId, "benchmarks");
-	const imagePath = `/og/models/${modelId}`;
-
-	return buildMetadata({
-		title: `${modelName} Benchmarks - Performance Highlights`,
-		description: buildModelPageMetadataDescription({
-			modelDescription,
-			suffix:
-				"Explore detailed benchmark scores, category breakdowns, and historical result updates across industry-standard evaluations.",
-			fallback: `Explore detailed benchmark scores for ${modelName} on Phaseo and compare performance across industry-standard evaluations, category breakdowns, and historical result updates.`,
-		}),
-		path,
-		keywords: [
-			modelName,
-			`${modelName} benchmarks`,
-			organisationName ? `${organisationName} AI` : null,
-			"AI model performance",
-			"AI model comparisons",
-			"Phaseo",
-		].filter(Boolean) as string[],
-		imagePath,
-	});
-}
+export const instant = false;
 
 export default async function Page({
 	params,
 }: {
 	params: Promise<ModelRouteParams>;
 }) {
-	const routeParams = await params;
-	const includeHidden = false;
-	const { requestedModelId, canonicalModelId } = await resolveModelRouteIds(
-		routeParams,
-		includeHidden,
-	);
-	if (canonicalModelId !== requestedModelId) {
-		permanentRedirect(getModelPath(canonicalModelId, "benchmarks"));
-	}
-	const modelId = canonicalModelId;
-
-	return (
-		<ModelDetailShell modelId={modelId} tab="benchmarks" includeHidden={includeHidden}>
-			<ModelBenchmarksSection modelId={modelId} includeHidden={includeHidden} />
-		</ModelDetailShell>
-	);
+	return redirectLegacyModelSection(params, "benchmarks");
 }

--- a/apps/web/src/app/(dashboard)/models/[organisationId]/[modelId]/layout.tsx
+++ b/apps/web/src/app/(dashboard)/models/[organisationId]/[modelId]/layout.tsx
@@ -1,4 +1,4 @@
-import type { ReactNode } from "react";
+import { Suspense, type ReactNode } from "react";
 import type { Metadata } from "next";
 import ShowFooterStyle from "@/components/layout/ShowFooterStyle";
 import type { ModelRouteParams } from "@/components/(data)/model/model-route-helpers";
@@ -13,20 +13,30 @@ export const metadata: Metadata = {
 	},
 };
 
-export default async function ModelDetailLayout({
+async function ModelRouteEffects({
+	params,
+}: {
+	params: Promise<ModelRouteParams>;
+}) {
+	const { organisationId, modelId } = await params;
+	return (
+		<ScrollToTopOnModelChange routeKey={`${organisationId}/${modelId}`} />
+	);
+}
+
+export default function ModelDetailLayout({
 	children,
 	params,
 }: {
 	children: ReactNode;
 	params: Promise<ModelRouteParams>;
 }) {
-	const { organisationId, modelId } = await params;
-	const routeKey = `${organisationId}/${modelId}`;
-
 	return (
 		<>
 			<ShowFooterStyle />
-			<ScrollToTopOnModelChange routeKey={routeKey} />
+			<Suspense fallback={null}>
+				<ModelRouteEffects params={params} />
+			</Suspense>
 			{children}
 		</>
 	);

--- a/apps/web/src/app/(dashboard)/models/[organisationId]/[modelId]/performance/page.tsx
+++ b/apps/web/src/app/(dashboard)/models/[organisationId]/[modelId]/performance/page.tsx
@@ -1,12 +1,17 @@
 import type { ModelRouteParams } from "@/components/(data)/model/model-route-helpers";
-import { redirectLegacyModelSection } from "../redirectLegacyModelSection";
+import {
+	redirectLegacyModelSection,
+	type LegacySearchParams,
+} from "../redirectLegacyModelSection";
 
 export const instant = false;
 
 export default async function Page({
 	params,
+	searchParams,
 }: {
 	params: Promise<ModelRouteParams>;
+	searchParams: Promise<LegacySearchParams>;
 }) {
-	return redirectLegacyModelSection(params, "performance");
+	return redirectLegacyModelSection(params, "performance", searchParams);
 }

--- a/apps/web/src/app/(dashboard)/models/[organisationId]/[modelId]/performance/page.tsx
+++ b/apps/web/src/app/(dashboard)/models/[organisationId]/[modelId]/performance/page.tsx
@@ -1,71 +1,12 @@
-import ModelDetailShell from "@/components/(data)/model/ModelDetailShell";
-import { ModelPerformanceSection } from "@/components/(data)/model/overview/ModelOverviewSections";
-import type { Metadata } from "next";
-import { buildMetadata } from "@/lib/seo";
-import {
-	getModelPath,
-	getModelMetadataIdentity,
-	resolveModelRouteIds,
-	type ModelRouteParams,
-} from "@/components/(data)/model/model-route-helpers";
-import { buildModelPageMetadataDescription } from "@/lib/models/modelDescription";
-import { permanentRedirect } from "next/navigation";
+import type { ModelRouteParams } from "@/components/(data)/model/model-route-helpers";
+import { redirectLegacyModelSection } from "../redirectLegacyModelSection";
 
-export async function generateMetadata(props: {
-	params: Promise<ModelRouteParams>;
-}): Promise<Metadata> {
-	const params = await props.params;
-	const { modelId, modelName, organisationName, modelDescription } = await getModelMetadataIdentity(
-		params,
-		false,
-	);
-	const path = getModelPath(modelId, "performance");
-	const imagePath = `/og/models/${modelId}`;
-
-	return buildMetadata({
-		title: `${modelName} Performance - Latency & Token Trajectory`,
-		description: buildModelPageMetadataDescription({
-			modelDescription,
-			suffix:
-				"Track latency trends, throughput signals, reliability movement, and historical usage metrics across recent gateway traffic.",
-			fallback: `Track ${modelName} performance on Phaseo with latency trends, throughput signals, reliability movement, and historical usage metrics across recent gateway traffic.`,
-		}),
-		path,
-		keywords: [
-			modelName,
-			`${modelName} performance`,
-			organisationName ? `${organisationName} AI` : null,
-			"latency metrics",
-			"token usage",
-			"Phaseo",
-		].filter(Boolean) as string[],
-		imagePath,
-	});
-}
+export const instant = false;
 
 export default async function Page({
 	params,
 }: {
 	params: Promise<ModelRouteParams>;
 }) {
-	const routeParams = await params;
-	const includeHidden = false;
-	const { requestedModelId, canonicalModelId } = await resolveModelRouteIds(
-		routeParams,
-		includeHidden,
-	);
-	if (canonicalModelId !== requestedModelId) {
-		permanentRedirect(getModelPath(canonicalModelId, "performance"));
-	}
-	const modelId = canonicalModelId;
-
-	return (
-		<ModelDetailShell modelId={modelId} tab="performance" includeHidden={includeHidden}>
-			<ModelPerformanceSection
-				modelId={modelId}
-				includeHidden={includeHidden}
-				surface="page"
-			/>
-		</ModelDetailShell>
-	);
+	return redirectLegacyModelSection(params, "performance");
 }

--- a/apps/web/src/app/(dashboard)/models/[organisationId]/[modelId]/pricing/page.tsx
+++ b/apps/web/src/app/(dashboard)/models/[organisationId]/[modelId]/pricing/page.tsx
@@ -1,12 +1,17 @@
 import type { ModelRouteParams } from "@/components/(data)/model/model-route-helpers";
-import { redirectLegacyModelSection } from "../redirectLegacyModelSection";
+import {
+	redirectLegacyModelSection,
+	type LegacySearchParams,
+} from "../redirectLegacyModelSection";
 
 export const instant = false;
 
 export default async function Page({
 	params,
+	searchParams,
 }: {
 	params: Promise<ModelRouteParams>;
+	searchParams: Promise<LegacySearchParams>;
 }) {
-	return redirectLegacyModelSection(params, "pricing");
+	return redirectLegacyModelSection(params, "pricing", searchParams);
 }

--- a/apps/web/src/app/(dashboard)/models/[organisationId]/[modelId]/pricing/page.tsx
+++ b/apps/web/src/app/(dashboard)/models/[organisationId]/[modelId]/pricing/page.tsx
@@ -1,103 +1,12 @@
-import type { Metadata } from "next";
-import { permanentRedirect } from "next/navigation";
-import { Suspense } from "react";
-import ModelDetailShell from "@/components/(data)/model/ModelDetailShell";
-import ModelPricingInsightsSection from "@/components/(data)/model/pricing/ModelPricingInsightsSection";
-import { Skeleton } from "@/components/ui/skeleton";
-import { buildMetadata } from "@/lib/seo";
-import {
-	getModelPath,
-	getModelMetadataIdentity,
-	resolveModelRouteIds,
-	type ModelRouteParams,
-} from "@/components/(data)/model/model-route-helpers";
-import { buildModelPageMetadataDescription } from "@/lib/models/modelDescription";
+import type { ModelRouteParams } from "@/components/(data)/model/model-route-helpers";
+import { redirectLegacyModelSection } from "../redirectLegacyModelSection";
 
-export async function generateMetadata(props: {
-	params: Promise<ModelRouteParams>;
-}): Promise<Metadata> {
-	const params = await props.params;
-	const { modelId, modelName, organisationName, modelDescription } = await getModelMetadataIdentity(
-		params,
-		false,
-	);
-	const path = getModelPath(modelId, "pricing");
-	const imagePath = `/og/models/${modelId}`;
-
-	return buildMetadata({
-		title: `${modelName} Pricing - Effective Cost & History`,
-		description: buildModelPageMetadataDescription({
-			modelDescription,
-			suffix:
-				"Track weighted effective input and output pricing plus 30-day pricing history by provider and meter.",
-			fallback: `${modelName} pricing on Phaseo. Track weighted effective input/output pricing and 30-day pricing history by provider and meter.`,
-		}),
-		path,
-		keywords: [
-			modelName,
-			`${modelName} pricing`,
-			`${modelName} effective pricing`,
-			`${modelName} pricing history`,
-			organisationName ? `${organisationName} AI` : null,
-			"token pricing",
-			"AI billing",
-			"Phaseo",
-		].filter(Boolean) as string[],
-		imagePath,
-	});
-}
-
-function PricingInsightsFallback() {
-	return (
-		<div className="space-y-8">
-			<section className="space-y-4">
-				<div className="space-y-2">
-					<Skeleton className="h-6 w-44" />
-					<Skeleton className="h-4 w-full max-w-2xl" />
-				</div>
-				<div className="grid grid-cols-1 gap-3 md:grid-cols-2">
-					<Skeleton className="h-[120px]" />
-					<Skeleton className="h-[120px]" />
-				</div>
-				<Skeleton className="h-[280px]" />
-			</section>
-			<section className="space-y-4">
-				<div className="space-y-2">
-					<Skeleton className="h-6 w-40" />
-					<Skeleton className="h-4 w-full max-w-xl" />
-				</div>
-				<Skeleton className="h-9 w-full max-w-md" />
-				<Skeleton className="h-[336px]" />
-			</section>
-		</div>
-	);
-}
+export const instant = false;
 
 export default async function Page({
 	params,
 }: {
 	params: Promise<ModelRouteParams>;
 }) {
-	const routeParams = await params;
-	const includeHidden = false;
-	const { requestedModelId, canonicalModelId } = await resolveModelRouteIds(
-		routeParams,
-		includeHidden,
-	);
-	if (canonicalModelId !== requestedModelId) {
-		permanentRedirect(getModelPath(canonicalModelId, "pricing"));
-	}
-	const modelId = canonicalModelId;
-
-	return (
-		<ModelDetailShell modelId={modelId} tab="pricing" includeHidden={includeHidden}>
-			<Suspense fallback={<PricingInsightsFallback />}>
-				<ModelPricingInsightsSection
-					modelId={modelId}
-					includeHidden={includeHidden}
-					showPageHeader
-				/>
-			</Suspense>
-		</ModelDetailShell>
-	);
+	return redirectLegacyModelSection(params, "pricing");
 }

--- a/apps/web/src/app/(dashboard)/models/[organisationId]/[modelId]/providers/page.tsx
+++ b/apps/web/src/app/(dashboard)/models/[organisationId]/[modelId]/providers/page.tsx
@@ -1,69 +1,12 @@
-import ModelDetailShell from "@/components/(data)/model/ModelDetailShell";
-import type { Metadata } from "next";
-import { buildMetadata } from "@/lib/seo";
-import { ModelProvidersSection } from "@/components/(data)/model/overview/ModelOverviewSections";
-import {
-	getModelPath,
-	getModelMetadataIdentity,
-	resolveModelRouteIds,
-	type ModelRouteParams,
-} from "@/components/(data)/model/model-route-helpers";
-import { buildModelPageMetadataDescription } from "@/lib/models/modelDescription";
-import { permanentRedirect } from "next/navigation";
+import type { ModelRouteParams } from "@/components/(data)/model/model-route-helpers";
+import { redirectLegacyModelSection } from "../redirectLegacyModelSection";
 
-export async function generateMetadata(props: {
-	params: Promise<ModelRouteParams>;
-}): Promise<Metadata> {
-	const params = await props.params;
-	const { modelId, modelName, organisationName, modelDescription } = await getModelMetadataIdentity(
-		params,
-		false,
-	);
-	const path = getModelPath(modelId, "providers");
-	const imagePath = `/og/models/${modelId}`;
-
-	return buildMetadata({
-		title: `${modelName} Providers - Availability & Pricing Details`,
-		description: buildModelPageMetadataDescription({
-			modelDescription,
-			suffix:
-				"View providers, availability, subscription coverage, and pricing details across supported API endpoints.",
-			fallback: `View providers for ${modelName} on Phaseo, including availability, subscription coverage, and pricing details across supported API endpoints.`,
-		}),
-		path,
-		keywords: [
-			modelName,
-			`${modelName} providers`,
-			`${modelName} pricing`,
-			`${modelName} subscriptions`,
-			organisationName ? `${organisationName} AI` : null,
-			"token pricing",
-			"AI billing",
-			"Phaseo",
-		].filter(Boolean) as string[],
-		imagePath,
-	});
-}
+export const instant = false;
 
 export default async function Page({
 	params,
 }: {
 	params: Promise<ModelRouteParams>;
 }) {
-	const routeParams = await params;
-	const includeHidden = false;
-	const { requestedModelId, canonicalModelId } = await resolveModelRouteIds(
-		routeParams,
-		includeHidden,
-	);
-	if (canonicalModelId !== requestedModelId) {
-		permanentRedirect(getModelPath(canonicalModelId, "providers"));
-	}
-	const modelId = canonicalModelId;
-
-	return (
-		<ModelDetailShell modelId={modelId} tab="providers" includeHidden={includeHidden}>
-			<ModelProvidersSection modelId={modelId} includeHidden={includeHidden} />
-		</ModelDetailShell>
-	);
+	return redirectLegacyModelSection(params, "providers");
 }

--- a/apps/web/src/app/(dashboard)/models/[organisationId]/[modelId]/providers/page.tsx
+++ b/apps/web/src/app/(dashboard)/models/[organisationId]/[modelId]/providers/page.tsx
@@ -1,12 +1,17 @@
 import type { ModelRouteParams } from "@/components/(data)/model/model-route-helpers";
-import { redirectLegacyModelSection } from "../redirectLegacyModelSection";
+import {
+	redirectLegacyModelSection,
+	type LegacySearchParams,
+} from "../redirectLegacyModelSection";
 
 export const instant = false;
 
 export default async function Page({
 	params,
+	searchParams,
 }: {
 	params: Promise<ModelRouteParams>;
+	searchParams: Promise<LegacySearchParams>;
 }) {
-	return redirectLegacyModelSection(params, "providers");
+	return redirectLegacyModelSection(params, "providers", searchParams);
 }

--- a/apps/web/src/app/(dashboard)/models/[organisationId]/[modelId]/quickstart/page.tsx
+++ b/apps/web/src/app/(dashboard)/models/[organisationId]/[modelId]/quickstart/page.tsx
@@ -1,7 +1,8 @@
 import type { ModelRouteParams } from "@/components/(data)/model/model-route-helpers";
-import { redirectLegacyModelSection } from "../redirectLegacyModelSection";
-
-type QuickstartSearchParams = Record<string, string | string[] | undefined>;
+import {
+	redirectLegacyModelSection,
+	type LegacySearchParams,
+} from "../redirectLegacyModelSection";
 
 export const instant = false;
 
@@ -10,7 +11,7 @@ export default async function Page({
 	searchParams,
 }: {
 	params: Promise<ModelRouteParams>;
-	searchParams: Promise<QuickstartSearchParams>;
+	searchParams: Promise<LegacySearchParams>;
 }) {
 	return redirectLegacyModelSection(params, "quickstart", searchParams);
 }

--- a/apps/web/src/app/(dashboard)/models/[organisationId]/[modelId]/quickstart/page.tsx
+++ b/apps/web/src/app/(dashboard)/models/[organisationId]/[modelId]/quickstart/page.tsx
@@ -1,53 +1,9 @@
-// src/app/(dashboard)/models/[modelId]/(data)/model/gateway/page.tsx
-import { buildMetadata } from "@/lib/seo";
-import { ModelQuickstartSection } from "@/components/(data)/model/overview/ModelOverviewSections";
-import ModelDetailShell from "@/components/(data)/model/ModelDetailShell";
-import type { Metadata } from "next";
-import {
-	getModelPath,
-	getModelMetadataIdentity,
-	resolveModelRouteIds,
-	type ModelRouteParams,
-} from "@/components/(data)/model/model-route-helpers";
-import { buildModelPageMetadataDescription } from "@/lib/models/modelDescription";
-import { permanentRedirect } from "next/navigation";
-import {
-	resolveQuickstartRequestContext,
-	type QuickstartSearchParams,
-} from "@/components/(data)/model/quickstart/requestContext";
+import type { ModelRouteParams } from "@/components/(data)/model/model-route-helpers";
+import { redirectLegacyModelSection } from "../redirectLegacyModelSection";
 
-export async function generateMetadata(props: {
-	params: Promise<ModelRouteParams>;
-}): Promise<Metadata> {
-	const params = await props.params;
-	const { modelId, modelName, organisationName, modelDescription } = await getModelMetadataIdentity(
-		params,
-		false,
-	);
-	const path = getModelPath(modelId, "quickstart");
-	const imagePath = `/og/models/${modelId}`;
+type QuickstartSearchParams = Record<string, string | string[] | undefined>;
 
-	const description = buildModelPageMetadataDescription({
-		modelDescription,
-		suffix:
-			"View providers, streaming support, request examples, and routing options for this model on Phaseo.",
-		fallback: `${modelName} Gateway support on Phaseo. View providers, streaming support, and routing options for this model.`,
-	});
-
-	return buildMetadata({
-		title: `${modelName} Gateway - Providers & Routing Options`,
-		description,
-		path,
-		imagePath,
-		keywords: [
-			modelName,
-			`${modelName} gateway`,
-			organisationName ? `${organisationName} AI` : null,
-			"AI gateway",
-			"Phaseo",
-		].filter(Boolean) as string[],
-	});
-}
+export const instant = false;
 
 export default async function Page({
 	params,
@@ -56,29 +12,5 @@ export default async function Page({
 	params: Promise<ModelRouteParams>;
 	searchParams: Promise<QuickstartSearchParams>;
 }) {
-	const [routeParams, routeSearchParams] = await Promise.all([
-		params,
-		searchParams,
-	]);
-	const includeHidden = false;
-	const quickstartRequestContext =
-		resolveQuickstartRequestContext(routeSearchParams);
-	const { requestedModelId, canonicalModelId } = await resolveModelRouteIds(
-		routeParams,
-		includeHidden,
-	);
-	if (canonicalModelId !== requestedModelId) {
-		permanentRedirect(getModelPath(canonicalModelId, "quickstart"));
-	}
-	const modelId = canonicalModelId;
-
-	return (
-		<ModelDetailShell modelId={modelId} tab="quickstart" includeHidden={includeHidden}>
-			<ModelQuickstartSection
-				modelId={modelId}
-				includeHidden={includeHidden}
-				quickstartRequestContext={quickstartRequestContext}
-			/>
-		</ModelDetailShell>
-	);
+	return redirectLegacyModelSection(params, "quickstart", searchParams);
 }

--- a/apps/web/src/app/(dashboard)/models/[organisationId]/[modelId]/redirectLegacyModelSection.ts
+++ b/apps/web/src/app/(dashboard)/models/[organisationId]/[modelId]/redirectLegacyModelSection.ts
@@ -1,0 +1,31 @@
+import { permanentRedirect } from "next/navigation";
+import {
+	getModelPath,
+	resolveModelRouteIds,
+	type ModelRouteParams,
+} from "@/components/(data)/model/model-route-helpers";
+
+type LegacySearchParams = Record<string, string | string[] | undefined>;
+
+export async function redirectLegacyModelSection(
+	params: Promise<ModelRouteParams>,
+	sectionId: string,
+	searchParams?: Promise<LegacySearchParams>,
+): Promise<never> {
+	const [{ canonicalModelId }, resolvedSearchParams] = await Promise.all([
+		params.then((routeParams) => resolveModelRouteIds(routeParams, false)),
+		searchParams ?? Promise.resolve<LegacySearchParams>({}),
+	]);
+	const query = new URLSearchParams();
+	for (const [key, value] of Object.entries(resolvedSearchParams)) {
+		if (Array.isArray(value)) {
+			for (const item of value) query.append(key, item);
+		} else if (value != null) {
+			query.set(key, value);
+		}
+	}
+	const queryString = query.toString();
+	permanentRedirect(
+		`${getModelPath(canonicalModelId)}${queryString ? `?${queryString}` : ""}#${sectionId}`,
+	);
+}

--- a/apps/web/src/app/(dashboard)/models/[organisationId]/[modelId]/redirectLegacyModelSection.ts
+++ b/apps/web/src/app/(dashboard)/models/[organisationId]/[modelId]/redirectLegacyModelSection.ts
@@ -5,7 +5,10 @@ import {
 	type ModelRouteParams,
 } from "@/components/(data)/model/model-route-helpers";
 
-type LegacySearchParams = Record<string, string | string[] | undefined>;
+export type LegacySearchParams = Record<
+	string,
+	string | string[] | undefined
+>;
 
 export async function redirectLegacyModelSection(
 	params: Promise<ModelRouteParams>,

--- a/apps/web/src/app/(dashboard)/models/[organisationId]/[modelId]/timeline/page.tsx
+++ b/apps/web/src/app/(dashboard)/models/[organisationId]/[modelId]/timeline/page.tsx
@@ -1,12 +1,17 @@
 import type { ModelRouteParams } from "@/components/(data)/model/model-route-helpers";
-import { redirectLegacyModelSection } from "../redirectLegacyModelSection";
+import {
+	redirectLegacyModelSection,
+	type LegacySearchParams,
+} from "../redirectLegacyModelSection";
 
 export const instant = false;
 
 export default async function Page({
 	params,
+	searchParams,
 }: {
 	params: Promise<ModelRouteParams>;
+	searchParams: Promise<LegacySearchParams>;
 }) {
-	return redirectLegacyModelSection(params, "about");
+	return redirectLegacyModelSection(params, "about", searchParams);
 }

--- a/apps/web/src/app/(dashboard)/models/[organisationId]/[modelId]/timeline/page.tsx
+++ b/apps/web/src/app/(dashboard)/models/[organisationId]/[modelId]/timeline/page.tsx
@@ -1,66 +1,12 @@
-import { buildMetadata } from "@/lib/seo";
-import ModelReleaseTimeline from "@/components/(data)/model/ModelReleaseTimeline";
-import ModelDetailShell from "@/components/(data)/model/ModelDetailShell";
-import type { Metadata } from "next";
-import {
-	getModelPath,
-	getModelMetadataIdentity,
-	resolveModelRouteIds,
-	type ModelRouteParams,
-} from "@/components/(data)/model/model-route-helpers";
-import { buildModelPageMetadataDescription } from "@/lib/models/modelDescription";
-import { permanentRedirect } from "next/navigation";
+import type { ModelRouteParams } from "@/components/(data)/model/model-route-helpers";
+import { redirectLegacyModelSection } from "../redirectLegacyModelSection";
 
-export async function generateMetadata(props: {
-	params: Promise<ModelRouteParams>;
-}): Promise<Metadata> {
-	const params = await props.params;
-	const { modelId, modelName, organisationName, modelDescription } = await getModelMetadataIdentity(
-		params,
-		false,
-	);
-	const path = getModelPath(modelId, "timeline");
-	const imagePath = `/og/models/${modelId}`;
-
-	return buildMetadata({
-		title: `${modelName} Timeline - Announcements & Release History`,
-		description: buildModelPageMetadataDescription({
-			modelDescription,
-			suffix:
-				"Explore announcements, launches, version changes, deprecations, and retirement milestones over time.",
-			fallback: `Explore the release timeline for ${modelName} on Phaseo, including announcements, launches, version changes, deprecations, and retirement milestones over time.`,
-		}),
-		path,
-		imagePath,
-		keywords: [
-			modelName,
-			`${modelName} timeline`,
-			organisationName ? `${organisationName} AI` : null,
-			"AI model releases",
-			"Phaseo",
-		].filter(Boolean) as string[],
-	});
-}
+export const instant = false;
 
 export default async function Page({
 	params,
 }: {
 	params: Promise<ModelRouteParams>;
 }) {
-	const routeParams = await params;
-	const includeHidden = false;
-	const { requestedModelId, canonicalModelId } = await resolveModelRouteIds(
-		routeParams,
-		includeHidden,
-	);
-	if (canonicalModelId !== requestedModelId) {
-		permanentRedirect(getModelPath(canonicalModelId, "timeline"));
-	}
-	const modelId = canonicalModelId;
-
-	return (
-		<ModelDetailShell modelId={modelId} tab="timeline" includeHidden={includeHidden}>
-			<ModelReleaseTimeline modelId={modelId} includeHidden={includeHidden} />
-		</ModelDetailShell>
-	);
+	return redirectLegacyModelSection(params, "about");
 }

--- a/apps/web/src/components/(data)/model/ModelPageToc.tsx
+++ b/apps/web/src/components/(data)/model/ModelPageToc.tsx
@@ -57,7 +57,33 @@ const activeSectionTopOffset = 212;
 const programmaticScrollLockMs = 3000;
 
 function useActiveSection(items: ModelPageTocItem[]) {
-	const [activeId, setActiveId] = useState(items[0]?.id ?? "");
+	const itemIndexById = useMemo(
+		() => new Map(items.map((item, index) => [item.id, index])),
+		[items],
+	);
+	const [{ activeId, activeDirection }, setActiveSection] = useState<{
+		activeId: string;
+		activeDirection: "up" | "down";
+	}>({
+		activeId: items[0]?.id ?? "",
+		activeDirection: "down",
+	});
+	const activateSection = useCallback(
+		(nextId: string) => {
+			setActiveSection((current) => {
+				if (current.activeId === nextId) return current;
+				return {
+					activeId: nextId,
+					activeDirection:
+						(itemIndexById.get(nextId) ?? 0) >=
+						(itemIndexById.get(current.activeId) ?? 0)
+							? "down"
+							: "up",
+				};
+			});
+		},
+		[itemIndexById],
+	);
 	const programmaticTargetRef = useRef<{
 		id: string;
 		expiresAt: number;
@@ -73,12 +99,15 @@ function useActiveSection(items: ModelPageTocItem[]) {
 				.split("#")
 				.filter(Boolean)
 				.pop() ?? "";
+		let hashFrameId = 0;
 
 		const handleHashChange = () => {
 			const nextHash = normalizeHash();
 			if (!nextHash || !itemIdSet.has(nextHash)) return;
-			setActiveId(nextHash);
-			window.requestAnimationFrame(() => {
+			activateSection(nextHash);
+			if (hashFrameId) window.cancelAnimationFrame(hashFrameId);
+			hashFrameId = window.requestAnimationFrame(() => {
+				hashFrameId = 0;
 				document.getElementById(nextHash)?.scrollIntoView({
 					behavior: "auto",
 					block: "start",
@@ -115,7 +144,7 @@ function useActiveSection(items: ModelPageTocItem[]) {
 			}
 
 			if (!nextId || !itemIdSet.has(nextId)) return;
-			setActiveId(nextId);
+			activateSection(nextId);
 		};
 
 		const requestScrollSync = () => {
@@ -145,6 +174,9 @@ function useActiveSection(items: ModelPageTocItem[]) {
 		});
 
 		return () => {
+			if (hashFrameId) {
+				window.cancelAnimationFrame(hashFrameId);
+			}
 			if (frameId) {
 				window.cancelAnimationFrame(frameId);
 			}
@@ -156,17 +188,17 @@ function useActiveSection(items: ModelPageTocItem[]) {
 			window.removeEventListener("hashchange", handleHashChange);
 			mutationObserver.disconnect();
 		};
-	}, [items]);
+	}, [activateSection, items]);
 
 	const setProgrammaticActiveId = useCallback((id: string) => {
 		programmaticTargetRef.current = {
 			id,
 			expiresAt: Date.now() + programmaticScrollLockMs,
 		};
-		setActiveId(id);
-	}, []);
+		activateSection(id);
+	}, [activateSection]);
 
-	return { activeId, setProgrammaticActiveId };
+	return { activeDirection, activeId, setProgrammaticActiveId };
 }
 
 function usePinnedMobileToc(anchorId: string) {
@@ -213,7 +245,8 @@ export default function ModelPageToc({
 		() => items.filter((item) => item.id && item.label),
 		[items],
 	);
-	const { activeId, setProgrammaticActiveId } = useActiveSection(filteredItems);
+	const { activeDirection, activeId, setProgrammaticActiveId } =
+		useActiveSection(filteredItems);
 	const mobileAnchorId = "model-page-toc-mobile-anchor";
 	const mobilePinned = usePinnedMobileToc(mobileAnchorId);
 	const activeItem =
@@ -222,17 +255,6 @@ export default function ModelPageToc({
 		filteredItems.findIndex((item) => item.id === activeItem?.id),
 		0,
 	);
-	const previousActiveIndexRef = useRef(activeIndex);
-	const [activeDirection, setActiveDirection] = useState<"up" | "down">("down");
-
-	useEffect(() => {
-		const previousIndex = previousActiveIndexRef.current;
-		if (activeIndex !== previousIndex) {
-			setActiveDirection(activeIndex > previousIndex ? "down" : "up");
-			previousActiveIndexRef.current = activeIndex;
-		}
-	}, [activeIndex]);
-
 	const scrollToSection = useCallback((id: string) => {
 		const section = document.getElementById(id);
 		if (!section) return;

--- a/apps/web/src/components/(data)/model/ModelPageToc.tsx
+++ b/apps/web/src/components/(data)/model/ModelPageToc.tsx
@@ -54,7 +54,7 @@ const sectionIcons: Record<string, LucideIcon> = {
 };
 
 const activeSectionTopOffset = 212;
-const programmaticScrollLockMs = 1400;
+const programmaticScrollLockMs = 3000;
 
 function useActiveSection(items: ModelPageTocItem[]) {
 	const [activeId, setActiveId] = useState(items[0]?.id ?? "");
@@ -98,15 +98,7 @@ function useActiveSection(items: ModelPageTocItem[]) {
 
 			const programmaticTarget = programmaticTargetRef.current;
 			if (programmaticTarget) {
-				const target = document.getElementById(programmaticTarget.id);
-				const targetTop = target?.getBoundingClientRect().top;
-				const targetReached =
-					typeof targetTop === "number" &&
-					Math.abs(targetTop - activeSectionTopOffset) <= 120;
-				if (
-					Date.now() < programmaticTarget.expiresAt &&
-					!targetReached
-				) {
+				if (Date.now() < programmaticTarget.expiresAt) {
 					return;
 				}
 				programmaticTargetRef.current = null;
@@ -130,6 +122,11 @@ function useActiveSection(items: ModelPageTocItem[]) {
 			if (frameId) return;
 			frameId = window.requestAnimationFrame(updateFromScroll);
 		};
+		const handleScrollEnd = () => {
+			if (!programmaticTargetRef.current) return;
+			programmaticTargetRef.current = null;
+			requestScrollSync();
+		};
 
 		requestScrollSync();
 		window.addEventListener("scroll", requestScrollSync, { passive: true });
@@ -137,6 +134,8 @@ function useActiveSection(items: ModelPageTocItem[]) {
 			capture: true,
 			passive: true,
 		});
+		window.addEventListener("scrollend", handleScrollEnd);
+		document.addEventListener("scrollend", handleScrollEnd, true);
 		window.addEventListener("resize", requestScrollSync);
 		window.addEventListener("hashchange", handleHashChange);
 		const mutationObserver = new MutationObserver(requestScrollSync);
@@ -151,6 +150,8 @@ function useActiveSection(items: ModelPageTocItem[]) {
 			}
 			window.removeEventListener("scroll", requestScrollSync);
 			document.removeEventListener("scroll", requestScrollSync, true);
+			window.removeEventListener("scrollend", handleScrollEnd);
+			document.removeEventListener("scrollend", handleScrollEnd, true);
 			window.removeEventListener("resize", requestScrollSync);
 			window.removeEventListener("hashchange", handleHashChange);
 			mutationObserver.disconnect();

--- a/apps/web/src/components/(data)/model/ModelPageToc.tsx
+++ b/apps/web/src/components/(data)/model/ModelPageToc.tsx
@@ -78,6 +78,12 @@ function useActiveSection(items: ModelPageTocItem[]) {
 			const nextHash = normalizeHash();
 			if (!nextHash || !itemIdSet.has(nextHash)) return;
 			setActiveId(nextHash);
+			window.requestAnimationFrame(() => {
+				document.getElementById(nextHash)?.scrollIntoView({
+					behavior: "auto",
+					block: "start",
+				});
+			});
 		};
 
 		handleHashChange();
@@ -215,6 +221,16 @@ export default function ModelPageToc({
 		filteredItems.findIndex((item) => item.id === activeItem?.id),
 		0,
 	);
+	const previousActiveIndexRef = useRef(activeIndex);
+	const [activeDirection, setActiveDirection] = useState<"up" | "down">("down");
+
+	useEffect(() => {
+		const previousIndex = previousActiveIndexRef.current;
+		if (activeIndex !== previousIndex) {
+			setActiveDirection(activeIndex > previousIndex ? "down" : "up");
+			previousActiveIndexRef.current = activeIndex;
+		}
+	}, [activeIndex]);
 
 	const scrollToSection = useCallback((id: string) => {
 		const section = document.getElementById(id);
@@ -232,14 +248,7 @@ export default function ModelPageToc({
 	if (!filteredItems.length) return null;
 
 	const renderMobileSelect = (variant: "inline" | "pinned") => (
-		<div
-			className={cn(
-				"w-full rounded-lg",
-				variant === "pinned"
-					? "border border-border/70 bg-background/95 shadow-sm backdrop-blur"
-					: null,
-			)}
-		>
+		<div className="w-full rounded-lg">
 			<Select
 				value={activeItem?.id}
 				onValueChange={scrollToSection}
@@ -249,10 +258,18 @@ export default function ModelPageToc({
 						"w-full justify-between text-left shadow-none",
 						variant === "inline"
 							? "h-9 rounded-lg border border-border/70 bg-background/90 px-3 hover:bg-muted/35"
-							: "h-10 rounded-lg border-0 bg-transparent px-3 hover:bg-muted/35 focus:ring-0",
+							: "h-9 rounded-lg border border-border/70 bg-muted/20 px-3 hover:bg-muted/45 focus:ring-0",
 					)}
 				>
-					<div className="flex min-w-0 items-center gap-2">
+					<div
+						key={activeItem?.id ?? "empty"}
+						className={cn(
+							"flex min-w-0 items-center gap-2 duration-200 motion-reduce:animate-none",
+							activeDirection === "down"
+								? "animate-in fade-in-0 slide-in-from-bottom-1"
+								: "animate-in fade-in-0 slide-in-from-top-1",
+						)}
+					>
 						{activeItem ? (
 							<>
 								{(() => {
@@ -275,8 +292,10 @@ export default function ModelPageToc({
 				</SelectTrigger>
 				<SelectContent
 					align="start"
+					alignItemWithTrigger={false}
+					side="bottom"
 					sideOffset={4}
-					className="max-h-[min(24rem,var(--available-height))] min-w-[14rem] rounded-lg"
+					className="max-h-[min(24rem,var(--available-height))] min-w-[14rem] rounded-lg border border-border/70"
 				>
 					{filteredItems.map((item) => {
 						const isActive = activeId === item.id;
@@ -286,7 +305,7 @@ export default function ModelPageToc({
 								key={item.id}
 								value={item.id}
 								className={cn(
-									"min-h-8 rounded-md pr-8",
+									"min-h-8 rounded-lg pr-8",
 									isActive
 										? "bg-muted text-foreground"
 										: "text-muted-foreground",
@@ -322,7 +341,7 @@ export default function ModelPageToc({
 				<div id={mobileAnchorId}>{renderMobileSelect("inline")}</div>
 				<div
 					className={cn(
-						"pointer-events-none fixed inset-x-0 top-[calc(var(--site-notice-height,0px)+var(--site-header-height,3.75rem)+3.25rem)] z-30 px-4 pt-2 transition-all duration-200",
+						"pointer-events-none fixed inset-x-0 top-[calc(var(--site-notice-height,0px)+var(--site-header-height,3.75rem)+3.25rem)] z-[39] border-b border-border/80 bg-background/95 py-2 shadow-sm backdrop-blur transition-all duration-200",
 						mobilePinned
 							? "translate-y-0 opacity-100"
 							: "-translate-y-2 opacity-0",
@@ -330,7 +349,7 @@ export default function ModelPageToc({
 				>
 					<div
 						className={cn(
-							"container mx-auto px-0",
+							"container mx-auto px-4 md:px-6 xl:px-8",
 							mobilePinned ? "pointer-events-auto" : "pointer-events-none",
 						)}
 					>
@@ -352,7 +371,7 @@ export default function ModelPageToc({
 						>
 							<span
 								aria-hidden="true"
-								className="pointer-events-none absolute inset-x-0 top-0 h-8 rounded-md bg-muted transition-transform duration-300 ease-[cubic-bezier(0.22,1,0.36,1)] motion-reduce:transition-none"
+								className="pointer-events-none absolute inset-x-0 top-0 h-8 rounded-lg bg-muted transition-transform duration-300 ease-[cubic-bezier(0.22,1,0.36,1)] motion-reduce:transition-none"
 								style={{
 									transform:
 										"translateY(calc(var(--toc-active-index) * 2.25rem))",
@@ -369,7 +388,7 @@ export default function ModelPageToc({
 										data-active={isActive ? "true" : undefined}
 										onClick={() => scrollToSection(item.id)}
 										className={cn(
-											"relative z-10 flex h-8 w-full min-w-0 items-center gap-1.5 rounded-md px-2.5 text-left text-[13px] transition-colors duration-200 motion-reduce:transition-none",
+											"relative z-10 flex h-8 w-full min-w-0 items-center gap-1.5 rounded-lg px-2.5 text-left text-[13px] transition-colors duration-200 motion-reduce:transition-none",
 											isActive
 												? "text-foreground"
 												: "text-muted-foreground hover:bg-muted/70 hover:text-foreground",

--- a/apps/web/src/components/(data)/model/overview/ModelFaqSection.test.tsx
+++ b/apps/web/src/components/(data)/model/overview/ModelFaqSection.test.tsx
@@ -155,17 +155,55 @@ describe("ModelFaqSection", () => {
 		expect(html).toContain("131,072 tokens");
 		expect(html).toContain("available through the Phaseo API");
 		expect(html).toContain("2 active providers");
+		expect(html).toContain('href="/api-providers/fast-cloud"');
+		expect(html).toContain("Fast Cloud");
 		expect(html).toContain("4 benchmark results");
 		expect(html).toContain("Input Text Tokens at $0.50 per 1M tokens");
 		expect(html).toContain("Output Text Tokens at $1.50 per 1M tokens");
 		expect(html).toContain("Output Image at $0.04 per image");
 		expect(html).toContain("Output Video Tokens at $2.00 per 1M tokens");
-		expect(html).not.toContain("Fast Cloud");
 		expect(html).toContain("lowest base rates currently recorded across providers");
 		expect(html).toContain('aria-expanded="false"');
 		expect(html).toContain("grid-rows-[0fr]");
 		expect(html).toContain('href="#pricing"');
 		expect(html).toContain('href="/organisations/acme"');
+	});
+
+	it("caps the provider-name summary and reports the remainder", () => {
+		const providerNames = [
+			"Alpha",
+			"Bravo",
+			"Charlie",
+			"Delta",
+			"Echo",
+			"Foxtrot",
+			"Golf",
+			"Hotel",
+			"India",
+			"Juliett",
+		];
+		const manyProviders: ProviderPricing[] = providerNames.map((name, index) => ({
+			provider: {
+				api_provider_id: `provider-${index + 1}`,
+				api_provider_name: name,
+			},
+			provider_models: [],
+			pricing_rules: [],
+		}));
+		const html = renderToStaticMarkup(
+			<ModelFaqSection
+				model={model}
+				benchmarkCount={0}
+				activeProviderCount={10}
+				isGatewayActive
+				pricing={manyProviders}
+			/>,
+		);
+
+		expect(html).toContain('href="/api-providers/provider-1"');
+		expect(html).toContain('href="/api-providers/provider-8"');
+		expect(html).toContain("and 2 more");
+		expect(html).not.toContain("India, Juliett");
 	});
 
 

--- a/apps/web/src/components/(data)/model/overview/ModelFaqSection.test.tsx
+++ b/apps/web/src/components/(data)/model/overview/ModelFaqSection.test.tsx
@@ -203,7 +203,8 @@ describe("ModelFaqSection", () => {
 		expect(html).toContain('href="/api-providers/provider-1"');
 		expect(html).toContain('href="/api-providers/provider-8"');
 		expect(html).toContain("and 2 more");
-		expect(html).not.toContain("India, Juliett");
+		expect(html).not.toContain("India");
+		expect(html).not.toContain("Juliett");
 	});
 
 

--- a/apps/web/src/components/(data)/model/overview/ModelFaqSection.tsx
+++ b/apps/web/src/components/(data)/model/overview/ModelFaqSection.tsx
@@ -30,6 +30,26 @@ function joinNaturalList(values: string[]): string {
 	return `${values.slice(0, -1).join(", ")}, and ${values.at(-1)}`;
 }
 
+const MAX_FAQ_PROVIDER_NAMES = 8;
+
+function getFaqProviders(pricing: ProviderPricing[]) {
+	const providersById = new Map<string, { id: string; name: string }>();
+	for (const entry of pricing) {
+		const id = entry.provider.api_provider_id.trim();
+		const name = entry.provider.api_provider_name.trim();
+		if (id && name && !providersById.has(id)) {
+			providersById.set(id, { id, name });
+		}
+	}
+	const providers = Array.from(providersById.values()).sort((left, right) =>
+		left.name.localeCompare(right.name),
+	);
+	return {
+		visible: providers.slice(0, MAX_FAQ_PROVIDER_NAMES),
+		remainingCount: Math.max(providers.length - MAX_FAQ_PROVIDER_NAMES, 0),
+	};
+}
+
 function getNumericDetail(
 	model: ModelOverviewPage,
 	...keys: string[]
@@ -284,6 +304,7 @@ export default function ModelFaqSection({
 		"max_output_tokens",
 	);
 	const pricingHighlights = isGatewayActive ? getPricingHighlights(pricing) : [];
+	const faqProviders = getFaqProviders(pricing);
 	// Native tool definitions are the minimum requirement for tool calling.
 	// tool_choice controls selection behaviour but cannot establish tool support alone.
 	const toolCallingSupport = getCapabilitySupport(gatewayMetadata, ["tools"]);
@@ -355,6 +376,38 @@ export default function ModelFaqSection({
 					{isGatewayActive && activeProviderCount > 0
 						? `${modelName} is available through the Phaseo API, with ${activeProviderCount} active ${activeProviderCount === 1 ? "provider" : "providers"} currently recorded. `
 						: `${modelName} is not currently marked as active in the Phaseo Gateway. `}
+					{faqProviders.visible.length > 0 ? (
+						<>
+							Recorded providers include{" "}
+							{faqProviders.visible.map((provider, index) => {
+								const isLast = index === faqProviders.visible.length - 1;
+								const separator =
+									index === 0
+										? ""
+										: faqProviders.remainingCount > 0
+											? ", "
+											: faqProviders.visible.length === 2
+												? " and "
+												: isLast
+													? ", and "
+													: ", ";
+								return (
+									<span key={provider.id}>
+										{separator}
+										<Link
+											href={`/api-providers/${provider.id}`}
+											className="font-medium underline underline-offset-4"
+										>
+											{provider.name}
+										</Link>
+									</span>
+								);
+							})}
+							{faqProviders.remainingCount > 0
+								? `, and ${faqProviders.remainingCount} more. `
+								: ". "}
+						</>
+					) : null}
 					The{" "}
 					<Link href="#providers" className="font-medium underline underline-offset-4">
 						providers section
@@ -474,7 +527,7 @@ export default function ModelFaqSection({
 
 	return (
 		<section id="faq" className="scroll-mt-28 space-y-4 border-t border-border/60 pt-5">
-			<h2 className="text-center text-lg font-medium tracking-tight">
+			<h2 className="text-xl font-semibold tracking-tight">
 				Frequently Asked Questions
 			</h2>
 			<ModelFaqAccordion items={items} />

--- a/apps/web/src/components/(data)/model/overview/ModelLinks.tsx
+++ b/apps/web/src/components/(data)/model/overview/ModelLinks.tsx
@@ -174,9 +174,9 @@ export default function ModelLinks({ model, showEmpty = false }: ModelLinksProps
 		if (!showEmpty) return null;
 
 		return (
-			<div className="inline-flex rounded-lg border border-border/70 bg-muted/10 px-3 py-2 text-sm text-muted-foreground">
+			<p className="text-sm text-muted-foreground">
 				No links listed.
-			</div>
+			</p>
 		);
 	}
 

--- a/apps/web/src/components/(data)/model/overview/ModelOverviewSections.tsx
+++ b/apps/web/src/components/(data)/model/overview/ModelOverviewSections.tsx
@@ -1495,6 +1495,7 @@ export default function ModelOverviewSections({
 						modelId={modelId}
 						includeHidden={includeHidden}
 						performancePromise={performancePromise}
+						surface="page"
 					/>
 				</Suspense>
 			</Section>

--- a/apps/web/src/components/(data)/model/overview/ModelOverviewSections.tsx
+++ b/apps/web/src/components/(data)/model/overview/ModelOverviewSections.tsx
@@ -1,4 +1,5 @@
 import Link from "next/link";
+import { connection } from "next/server";
 import { Suspense, type ReactNode } from "react";
 import {
 	Activity,
@@ -21,14 +22,14 @@ import ModelSubscriptions from "@/components/(data)/model/pricing/ModelSubscript
 import ModelPricingInsightsSection from "@/components/(data)/model/pricing/ModelPricingInsightsSection";
 import ModelPerformanceDashboard from "@/components/(data)/models/ModelPerformanceDashboard";
 import { fetchFrontendModelPerformanceColos } from "@/lib/fetchers/frontend/fetchPublicCatalog";
-import ModelSuccessChart from "@/components/(data)/models/ModelSuccessChart";
+import ModelUptimeDashboard from "@/components/(data)/models/ModelUptimeDashboard";
 import ModelActivityChart from "@/components/(data)/model/overview/ModelActivityChart";
 import Quickstart from "@/components/(data)/model/quickstart/Quickstart";
 import type { QuickstartRequestContext } from "@/components/(data)/model/quickstart/requestContext";
 import ModelBenchmarks from "@/components/(data)/model/benchmarks/ModelBenchmarks";
 import KeyDates from "@/components/(data)/model/overview/KeyDates";
 import OtherInfo from "@/components/(data)/model/overview/OtherInfo";
-import ModelLinks from "@/components/(data)/model/overview/ModelLinks";
+import ModelLinks, { hasModelLinks } from "@/components/(data)/model/overview/ModelLinks";
 import { isAdminViewer } from "@/lib/auth/getViewerRole";
 import type { ModelOverviewPage } from "@/lib/fetchers/models/getModel";
 import {
@@ -215,6 +216,7 @@ export async function ModelProvidersSection({
 	creatorOrganisationId,
 	description = "API providers, route pricing, availability, and recent reliability signals.",
 }: ModelSectionSharedProps & { modelStatus?: string | null; modelName?: string | null; creatorOrganisationId?: string | null; description?: string | null }) {
+	await connection();
 	return (
 		<ModelPricing
 			modelId={modelId}
@@ -408,17 +410,10 @@ export async function ModelUptimeSection({
 		null,
 		"uptime performance"
 	);
-	const showLeastStableProvider =
-		performanceMetrics?.successSeries.some(
-			(point) =>
-				(point.providerCount ?? 0) > 1 &&
-				point.worstProviderSuccessPct != null,
-		) ?? false;
-
 	return (
-		<ModelSuccessChart
-			successSeries={performanceMetrics?.successSeries ?? []}
-			showLeastStableProvider={showLeastStableProvider}
+		<ModelUptimeDashboard
+			modelId={modelId}
+			initialMetrics={performanceMetrics}
 		/>
 	);
 }
@@ -582,7 +577,16 @@ export async function ModelQuickstartSection({
 		);
 	}
 
-	const gatewayMetadata = prefetchedGatewayMetadata ?? await (async () => {
+	const gatewayMetadata = prefetchedGatewayMetadata !== undefined
+		? prefetchedGatewayMetadata
+		: await (async () => {
+			if (!includeHidden) {
+				return withOptionalSectionTimeout(
+					fetchFrontendModelGatewayMetadata(modelId),
+					null,
+					"quickstart metadata",
+				);
+			}
 		const includeInternalProviders = await withOptionalSectionTimeout(
 			isAdminViewer(),
 			false,
@@ -595,7 +599,7 @@ export async function ModelQuickstartSection({
 			null,
 			"quickstart metadata"
 		);
-	})();
+		})();
 
 	const quickstartEndpoint =
 		gatewayMetadata?.activeProviders.find((p) => p.endpoint)?.endpoint ??
@@ -864,15 +868,15 @@ export async function ModelAboutSection({
 
 	return (
 		<>
-			<KeyDates
-				announced={model.announcement_date ?? undefined}
-				released={model.release_date ?? undefined}
-				deprecated={model.deprecation_date ?? undefined}
-				retired={model.retirement_date ?? undefined}
-				showHeading={false}
-				showEmpty
-			/>
 			<div className="space-y-2">
+				<KeyDates
+					announced={model.announcement_date ?? undefined}
+					released={model.release_date ?? undefined}
+					deprecated={model.deprecation_date ?? undefined}
+					retired={model.retirement_date ?? undefined}
+					showHeading={false}
+					showEmpty
+				/>
 				<OtherInfo
 					details={model.model_details ?? undefined}
 					licenseUrl={getModelLicenseUrl(model)}
@@ -892,10 +896,12 @@ export async function ModelAboutSection({
 					]}
 				/>
 			</div>
-			<div className="space-y-2">
-				<h3 className="text-base font-semibold">Links</h3>
-				<ModelLinks model={model} showEmpty />
-			</div>
+			{hasModelLinks(model) ? (
+				<div className="space-y-2">
+					<h3 className="text-base font-semibold">Links</h3>
+					<ModelLinks model={model} />
+				</div>
+			) : null}
 			{hasLineage ? (
 				<div className="space-y-2">
 					<h3 className="text-base font-semibold">Related models</h3>

--- a/apps/web/src/components/(data)/model/pricing/ModelPricingClient.test.ts
+++ b/apps/web/src/components/(data)/model/pricing/ModelPricingClient.test.ts
@@ -1,0 +1,18 @@
+import {
+	isTerminalRuntimeStatsRetry,
+	resolveRuntimeStatsPercentileAfterError,
+} from "./ModelPricingClient";
+
+describe("runtime pricing percentile retries", () => {
+	it("keeps the attempted percentile selected through transient failures", () => {
+		expect(isTerminalRuntimeStatsRetry(1)).toBe(false);
+		expect(isTerminalRuntimeStatsRetry(2)).toBe(false);
+		expect(resolveRuntimeStatsPercentileAfterError(90, 50, 1)).toBe(90);
+		expect(resolveRuntimeStatsPercentileAfterError(90, 50, 2)).toBe(90);
+	});
+
+	it("restores the last successful percentile after retries are exhausted", () => {
+		expect(isTerminalRuntimeStatsRetry(3)).toBe(true);
+		expect(resolveRuntimeStatsPercentileAfterError(90, 50, 3)).toBe(50);
+	});
+});

--- a/apps/web/src/components/(data)/model/pricing/ModelPricingClient.tsx
+++ b/apps/web/src/components/(data)/model/pricing/ModelPricingClient.tsx
@@ -94,6 +94,21 @@ import ModelPercentileSelect, {
 } from "@/components/(data)/models/ModelPercentileSelect";
 const SORT_QUERY_KEY = "sort";
 const SORT_DIRECTION_QUERY_KEY = "dir";
+const RUNTIME_STATS_ERROR_RETRY_COUNT = 2;
+
+export function isTerminalRuntimeStatsRetry(retryCount: number) {
+	return retryCount > RUNTIME_STATS_ERROR_RETRY_COUNT;
+}
+
+export function resolveRuntimeStatsPercentileAfterError(
+	attemptedPercentile: ModelPercentile,
+	lastSuccessfulPercentile: ModelPercentile,
+	retryCount: number,
+) {
+	return isTerminalRuntimeStatsRetry(retryCount)
+		? lastSuccessfulPercentile
+		: attemptedPercentile;
+}
 
 type SortOption =
     | "default"
@@ -521,15 +536,29 @@ export default function ModelPricingClient({
 			}),
 		{
 			dedupingInterval: 30_000,
-			errorRetryCount: 2,
+			errorRetryCount: RUNTIME_STATS_ERROR_RETRY_COUNT,
 			fallbackData:
 				selectedPercentile === DEFAULT_MODEL_PERCENTILE
 					? runtimeStats
 					: undefined,
 			focusThrottleInterval: 60_000,
 			keepPreviousData: true,
-			onError: () => {
-				setSelectedPercentile(successfulPercentileRef.current);
+			onErrorRetry: (_error, _key, config, revalidate, retryOptions) => {
+				if (isTerminalRuntimeStatsRetry(retryOptions.retryCount)) {
+					setSelectedPercentile(
+						resolveRuntimeStatsPercentileAfterError(
+							selectedPercentile,
+							successfulPercentileRef.current,
+							retryOptions.retryCount,
+						),
+					);
+					return;
+				}
+				const retryDelay =
+					(Math.random() + 0.5) *
+					2 ** Math.min(retryOptions.retryCount, 8) *
+					(config.errorRetryInterval ?? 5_000);
+				window.setTimeout(() => revalidate(retryOptions), retryDelay);
 			},
 			onSuccess: () => {
 				successfulPercentileRef.current = selectedPercentile;

--- a/apps/web/src/components/(data)/model/pricing/ModelPricingClient.tsx
+++ b/apps/web/src/components/(data)/model/pricing/ModelPricingClient.tsx
@@ -8,6 +8,7 @@ import React, {
     useRef,
     useState,
 } from "react";
+import useSWR from "swr";
 import Link from "next/link";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import {
@@ -457,10 +458,6 @@ export default function ModelPricingClient({
     const [selectedPercentile, setSelectedPercentile] = useState<ModelPercentile>(
         DEFAULT_MODEL_PERCENTILE,
     );
-    const [liveRuntimeStats, setLiveRuntimeStats] = useState<ProviderRuntimeStatsMap>(
-        runtimeStats,
-    );
-    const [isLoadingPercentile, setIsLoadingPercentile] = useState(false);
     const displayProviders = useMemo(
         () => mergeProviderPricingOffers(providers),
         [providers]
@@ -496,25 +493,55 @@ export default function ModelPricingClient({
             ),
         [displayProviders],
     );
+	const runtimeStatsKey = useMemo(
+		() =>
+			[
+				"model-provider-runtime-stats",
+				modelId,
+				providerIds,
+				modelAliases,
+				selectedPercentile,
+			] as const,
+		[modelAliases, modelId, providerIds, selectedPercentile],
+	);
+	const successfulPercentileRef = useRef<ModelPercentile>(
+		DEFAULT_MODEL_PERCENTILE,
+	);
+	const {
+		data: liveRuntimeStats = runtimeStats,
+		isValidating: isLoadingPercentile,
+	} = useSWR<ProviderRuntimeStatsMap>(
+		runtimeStatsKey,
+		() =>
+			getModelProviderRuntimeStats({
+				modelId,
+				providerIds,
+				modelAliases,
+				percentile: selectedPercentile,
+			}),
+		{
+			dedupingInterval: 30_000,
+			errorRetryCount: 2,
+			fallbackData:
+				selectedPercentile === DEFAULT_MODEL_PERCENTILE
+					? runtimeStats
+					: undefined,
+			focusThrottleInterval: 60_000,
+			keepPreviousData: true,
+			onError: () => {
+				setSelectedPercentile(successfulPercentileRef.current);
+			},
+			onSuccess: () => {
+				successfulPercentileRef.current = selectedPercentile;
+			},
+			revalidateOnFocus: true,
+			revalidateOnReconnect: true,
+		},
+	);
 
-    const handlePercentileChange = async (nextPercentile: ModelPercentile) => {
+    const handlePercentileChange = (nextPercentile: ModelPercentile) => {
         if (nextPercentile === selectedPercentile || isLoadingPercentile) return;
-        const previousPercentile = selectedPercentile;
-        setIsLoadingPercentile(true);
-        try {
-            const nextStats = await getModelProviderRuntimeStats({
-                modelId,
-                providerIds,
-                modelAliases,
-                percentile: nextPercentile,
-            });
-            setLiveRuntimeStats(nextStats);
-            setSelectedPercentile(nextPercentile);
-        } catch {
-            setSelectedPercentile(previousPercentile);
-        } finally {
-            setIsLoadingPercentile(false);
-        }
+		setSelectedPercentile(nextPercentile);
     };
 
     const [sort, setSort] = useState<SortOption>(() => {
@@ -997,7 +1024,7 @@ export default function ModelPricingClient({
                         <DropdownMenu>
                             <DropdownMenuTrigger
                                 render={
-                                    <Button type="button" variant="outline" size="sm" className="gap-2 rounded-md" />
+                                    <Button type="button" variant="outline" size="sm" className="h-8 gap-2 rounded-md px-3 text-xs" />
                                 }
                             >
                                 <Filter className="size-3.5" />

--- a/apps/web/src/components/(data)/model/pricing/PricingInsights.tsx
+++ b/apps/web/src/components/(data)/model/pricing/PricingInsights.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo, useState } from "react";
+import { useLayoutEffect, useMemo, useRef, useState } from "react";
 import Link from "next/link";
 import {
 	CartesianGrid,
@@ -674,6 +674,28 @@ export default function PricingInsights({
 }: PricingInsightsProps) {
 	const [sortKey, setSortKey] = useState<SortKey | null>(null);
 	const [sortDirection, setSortDirection] = useState<SortDirection>("desc");
+	const effectivePricingViewportRef = useRef<HTMLDivElement>(null);
+	const [effectivePricingTableOverflows, setEffectivePricingTableOverflows] =
+		useState(false);
+
+	useLayoutEffect(() => {
+		const viewport = effectivePricingViewportRef.current;
+		if (!viewport) return;
+
+		const updateOverflow = () => {
+			setEffectivePricingTableOverflows(
+				viewport.scrollWidth > viewport.clientWidth + 1,
+			);
+		};
+		const observer = new ResizeObserver(updateOverflow);
+		observer.observe(viewport);
+		if (viewport.firstElementChild instanceof HTMLElement) {
+			observer.observe(viewport.firstElementChild);
+		}
+		updateOverflow();
+
+		return () => observer.disconnect();
+	}, []);
 
 	const routableProviders = useMemo(
 		() => providers.filter(isRoutableProvider),
@@ -961,8 +983,17 @@ export default function PricingInsights({
 				</div>
 
 				<ScrollArea
-					className="w-full border-b border-border/70"
+					className={cn(
+						"w-full border-b border-border/70",
+						effectivePricingTableOverflows
+							? "[&_[data-orientation=horizontal]]:h-2 [&_[data-orientation=horizontal]]:border-t-0 [&_[data-orientation=horizontal]_[data-slot=scroll-area-thumb]]:bg-zinc-400/70 [&_[data-orientation=horizontal]_[data-slot=scroll-area-thumb]]:transition-colors hover:[&_[data-orientation=horizontal]_[data-slot=scroll-area-thumb]]:bg-zinc-500/80 dark:[&_[data-orientation=horizontal]_[data-slot=scroll-area-thumb]]:bg-zinc-500/80 dark:hover:[&_[data-orientation=horizontal]_[data-slot=scroll-area-thumb]]:bg-zinc-400/90"
+							: "[&_[data-orientation=horizontal]]:hidden",
+					)}
 					scrollBarOrientation="horizontal"
+					viewportClassName={
+						effectivePricingTableOverflows ? "pb-1.5" : undefined
+					}
+					viewportRef={effectivePricingViewportRef}
 				>
 					<Table className="min-w-[760px]" wrapInContainer={false}>
 						<TableHeader>
@@ -1034,7 +1065,7 @@ export default function PricingInsights({
 													/>
 												</span>
 											</span>
-											<span className="font-medium text-foreground transition-colors group-hover/provider:text-primary">
+											<span className="font-medium text-foreground underline decoration-transparent underline-offset-4 transition-[text-decoration-color] group-hover/provider:decoration-current">
 												{row.providerName}
 											</span>
 										</Link>

--- a/apps/web/src/components/(data)/model/pricing/ProviderCard.tsx
+++ b/apps/web/src/components/(data)/model/pricing/ProviderCard.tsx
@@ -2692,7 +2692,7 @@ export default function ProviderCard({
 										/>
 									</div>
 								</div>
-								<span className="whitespace-nowrap font-semibold text-foreground transition-colors group-hover/provider:text-primary">
+								<span className="whitespace-nowrap font-semibold text-foreground underline decoration-transparent underline-offset-4 transition-[text-decoration-color] group-hover/provider:decoration-current">
 									{displayName}
 								</span>
 							</Link>

--- a/apps/web/src/components/(data)/model/quickstart/EndpointRoutesTable.tsx
+++ b/apps/web/src/components/(data)/model/quickstart/EndpointRoutesTable.tsx
@@ -40,35 +40,31 @@ function EndpointRouteRow({ route }: { route: EndpointRoute }) {
 	const docsHref = getEndpointDocsHref(route.value);
 
 	return (
-		<div
-			className="group grid w-full grid-cols-[72px_minmax(0,1fr)_auto] items-center gap-3 px-4 py-3 text-left transition-colors hover:bg-muted/35"
+		<Link
+			href={docsHref}
+			target="_blank"
+			rel="noopener noreferrer"
+			aria-label={`Open ${route.title} API reference`}
+			className="group grid w-full grid-cols-[72px_minmax(0,1fr)_auto] items-center gap-3 px-4 py-3 text-left transition-colors hover:bg-muted/35 focus-visible:bg-muted/35 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring"
 		>
 			<HttpMethodBadge method={route.method} />
 
 			<div className="min-w-0">
-				<Link
-					href={docsHref}
-					target="_blank"
-					rel="noopener noreferrer"
-					className="block min-w-0 truncate font-mono text-sm text-foreground underline decoration-transparent underline-offset-4 transition-colors hover:text-primary hover:decoration-current"
-				>
+				<div className="min-w-0 truncate font-mono text-sm text-foreground underline decoration-transparent underline-offset-4 transition-colors group-hover:decoration-muted-foreground">
 					{route.path}
-				</Link>
+				</div>
 				<div className="mt-0.5 truncate text-xs text-muted-foreground">
 					{route.title} API reference
 				</div>
 			</div>
 
-			<Link
-				href={docsHref}
-				target="_blank"
-				rel="noopener noreferrer"
-				aria-label={`Open ${route.title} API reference`}
-				className="rounded-md p-1 text-muted-foreground opacity-60 transition-all hover:bg-muted hover:text-foreground hover:opacity-100 group-hover:opacity-100"
+			<span
+				aria-hidden="true"
+				className="rounded-md p-1 text-muted-foreground opacity-60 transition-all group-hover:text-foreground group-hover:opacity-100"
 			>
 				<ExternalLink className="h-3.5 w-3.5" />
-			</Link>
-		</div>
+			</span>
+		</Link>
 	);
 }
 
@@ -94,7 +90,7 @@ export function EndpointRoutesTable({
 	);
 
 	return (
-		<div className="space-y-3">
+		<div className="space-y-2">
 			<div className="flex items-center justify-between gap-3">
 				<div>
 					<h3 className="text-base font-semibold">Supported endpoints</h3>

--- a/apps/web/src/components/(data)/model/quickstart/Quickstart.tsx
+++ b/apps/web/src/components/(data)/model/quickstart/Quickstart.tsx
@@ -1766,7 +1766,7 @@ console.log(response);`
 				: "Standard request";
 
 	return (
-		<section className="space-y-6">
+		<section className="space-y-4">
 			{showHeader ? (
 				<header className="space-y-1">
 					<h2 className="flex items-center gap-2 text-xl font-semibold tracking-tight">
@@ -1778,7 +1778,7 @@ console.log(response);`
 					</p>
 				</header>
 			) : null}
-			<div className="space-y-6">
+			<div className="space-y-4">
 				<div className="grid gap-3 md:grid-cols-[auto_minmax(0,1fr)]">
 					<Badge
 						variant="outline"
@@ -1809,7 +1809,7 @@ console.log(response);`
 								PHASEO_API_KEY
 							</code>
 						</div>
-						<Alert className="border-amber-200 bg-amber-50 py-2 text-amber-950 dark:border-amber-900/60 dark:bg-amber-900/20 dark:text-amber-50">
+						<Alert className="rounded-lg border-amber-200 bg-amber-50 py-2 text-amber-950 dark:border-amber-900/60 dark:bg-amber-900/20 dark:text-amber-50">
 							<Shield className="h-4 w-4 text-amber-700 dark:text-amber-300" />
 							<AlertTitle className="sr-only">Keep your API key secret</AlertTitle>
 							<AlertDescription className="text-sm text-amber-900/90 dark:text-amber-100/90">
@@ -1820,14 +1820,14 @@ console.log(response);`
 					</div>
 				</div>
 
-				<div className="space-y-5 border-t border-border/70 pt-6">
-					<div className="grid gap-3 md:grid-cols-[auto_minmax(0,1fr)]">
-						<Badge
-							variant="outline"
-							className="flex h-7 w-7 items-center justify-center rounded-full p-0 text-xs"
-						>
-							2
-						</Badge>
+				<div className="grid gap-3 border-t border-border/70 pt-4 md:grid-cols-[auto_minmax(0,1fr)]">
+					<Badge
+						variant="outline"
+						className="flex h-7 w-7 items-center justify-center rounded-full p-0 text-xs"
+					>
+						2
+					</Badge>
+					<div className="min-w-0 space-y-3">
 						<div className="space-y-1">
 							<h3 className="text-base font-semibold">
 								{isModelMetadataQuickstart
@@ -1840,23 +1840,22 @@ console.log(response);`
 									: "Choose a supported endpoint, pick a main language, then select the example style you want to copy."}
 							</p>
 						</div>
-					</div>
 
-					{isModelMetadataQuickstart ? null : (
-						<EndpointRoutesTable
-							endpointRoutes={endpointRoutes}
-							selectedEndpoint={selectedEndpoint}
-							showAllEndpointRoutes={showAllEndpointRoutes}
-							onToggleShowAllEndpointRoutes={() =>
-								setShowAllEndpointRoutes((current) => !current)
-							}
-						/>
-					)}
+						{isModelMetadataQuickstart ? null : (
+							<EndpointRoutesTable
+								endpointRoutes={endpointRoutes}
+								selectedEndpoint={selectedEndpoint}
+								showAllEndpointRoutes={showAllEndpointRoutes}
+								onToggleShowAllEndpointRoutes={() =>
+									setShowAllEndpointRoutes((current) => !current)
+								}
+							/>
+						)}
 
-					<QuickstartUsageSection
-						modelIdentifierInCode={modelIdentifierInCode}
-						acceptedIdentifiers={acceptedIdentifierList}
-						onSelectModelIdentifier={setSelectedModelIdentifier}
+						<QuickstartUsageSection
+							modelIdentifierInCode={modelIdentifierInCode}
+							acceptedIdentifiers={acceptedIdentifierList}
+							onSelectModelIdentifier={setSelectedModelIdentifier}
 						supportedParameters={supportedParameters}
 						selectedEndpointLabel={selectedEndpointLabel}
 						selectedEndpointValue={selectedEndpoint}
@@ -1865,7 +1864,6 @@ console.log(response);`
 							label: option.label,
 						}))}
 						showEndpointControl={!isModelMetadataQuickstart}
-						inlineCopy={isModelMetadataQuickstart}
 						selectedLanguage={selectedLanguage}
 						selectedLanguageLabel={`${selectedLanguageFamily?.label ?? selectedLanguageLabel} · ${selectedLanguageVariantLabel}`}
 						selectedLanguageFamilyId={selectedLanguageFamily?.id ?? "typescript"}
@@ -1914,7 +1912,8 @@ console.log(response);`
 						openaiNodeUsage={openaiNodeUsage}
 						anthropicPythonUsage={anthropicPythonUsage}
 						anthropicNodeUsage={anthropicNodeUsage}
-					/>
+						/>
+					</div>
 				</div>
 			</div>
 		</section>

--- a/apps/web/src/components/(data)/model/quickstart/QuickstartUsageSection.tsx
+++ b/apps/web/src/components/(data)/model/quickstart/QuickstartUsageSection.tsx
@@ -86,7 +86,6 @@ type QuickstartUsageSectionProps = {
 	selectedEndpointValue: string;
 	endpointOptions: Array<{ value: string; label: string }>;
 	showEndpointControl?: boolean;
-	inlineCopy?: boolean;
 	selectedLanguage: string;
 	selectedLanguageLabel?: string;
 	selectedLanguageFamilyId: string;
@@ -285,10 +284,8 @@ function sortSupportedParameters(
 
 function MiniCopyButton({
 	content,
-	label = "Copy",
 }: {
 	content: string;
-	label?: string;
 }) {
 	const [copied, setCopied] = useState(false);
 
@@ -301,16 +298,18 @@ function MiniCopyButton({
 	return (
 		<Button
 			type="button"
-			size="sm"
+			size="icon"
 			variant="outline"
-			className="h-8 rounded-lg gap-1.5 px-2.5 text-xs"
+			className="h-8 w-full gap-1.5 rounded-lg px-3 lg:size-8 lg:px-0"
+			aria-label={copied ? "Code copied" : "Copy code"}
+			title={copied ? "Copied" : "Copy code"}
 			onClick={async () => {
 				await navigator.clipboard.writeText(content);
 				setCopied(true);
 			}}
 		>
 			{copied ? <Check className="h-3.5 w-3.5" /> : <Copy className="h-3.5 w-3.5" />}
-			{copied ? "Copied" : label}
+			<span className="text-xs lg:sr-only">{copied ? "Copied" : "Copy"}</span>
 		</Button>
 	);
 }
@@ -389,7 +388,6 @@ export function QuickstartUsageSection({
 	selectedEndpointValue,
 	endpointOptions,
 	showEndpointControl = true,
-	inlineCopy = false,
 	selectedLanguage,
 	selectedLanguageFamilyId,
 	availableLanguageFamilies,
@@ -545,12 +543,12 @@ export function QuickstartUsageSection({
 	]);
 
 	return (
-		<div className="space-y-3">
-			<div className="overflow-hidden rounded-xl border border-border/70 bg-card">
-				<div className="flex flex-col gap-2 px-3 py-3">
-					<div className="flex flex-wrap items-center gap-2">
+		<div className="space-y-2">
+			<div className="overflow-hidden rounded-lg border border-border/70 bg-card">
+				<div className="relative px-2 py-2">
+					<div className="grid grid-cols-2 items-center gap-1.5 lg:flex lg:flex-wrap">
 						{showEndpointControl ? (
-							<div className="w-full sm:w-28">
+							<div className="w-full lg:w-28">
 								<Select
 									value={selectedEndpointValue}
 									onValueChange={onSelectEndpoint}
@@ -563,7 +561,7 @@ export function QuickstartUsageSection({
 									<SelectContent
 										align="start"
 										alignItemWithTrigger={false}
-										className="w-auto min-w-44 rounded-xl"
+										className="w-auto min-w-44 rounded-lg"
 									>
 										<SelectGroup>
 											<SelectLabel className="text-[11px] tracking-[0.04em] text-muted-foreground">
@@ -580,7 +578,7 @@ export function QuickstartUsageSection({
 								</Select>
 							</div>
 						) : null}
-						<div className="w-full sm:w-36">
+						<div className="w-full lg:w-36">
 							<Select
 								value={selectedLanguageFamilyId}
 								onValueChange={onSelectLanguageFamily}
@@ -596,7 +594,7 @@ export function QuickstartUsageSection({
 								<SelectContent
 									align="start"
 									alignItemWithTrigger={false}
-									className="w-auto min-w-40 rounded-xl"
+									className="w-auto min-w-40 rounded-lg"
 								>
 									<SelectGroup>
 										<SelectLabel className="text-[11px] tracking-[0.04em] text-muted-foreground">
@@ -615,7 +613,7 @@ export function QuickstartUsageSection({
 								</SelectContent>
 							</Select>
 						</div>
-						<div className="w-full sm:w-44">
+						<div className="w-full lg:w-44">
 							<Select value={selectedLanguage} onValueChange={onSelectLanguage}>
 								<SelectTrigger className="h-8 w-full rounded-lg bg-muted/60 text-xs">
 									<SelectValue placeholder="Example type">
@@ -628,7 +626,7 @@ export function QuickstartUsageSection({
 								<SelectContent
 									align="start"
 									alignItemWithTrigger={false}
-									className="w-auto min-w-56 rounded-xl"
+									className="w-auto min-w-56 rounded-lg"
 								>
 									<SelectGroup>
 										<SelectLabel className="text-[11px] tracking-[0.04em] text-muted-foreground">
@@ -647,16 +645,8 @@ export function QuickstartUsageSection({
 								</SelectContent>
 							</Select>
 						</div>
-						{inlineCopy ? (
-							<div className="ml-auto">
-								<MiniCopyButton content={requestExample.code} />
-							</div>
-						) : null}
-					</div>
-					{supportsServiceTier || showStreamingControl || !inlineCopy ? (
-						<div className="flex w-full flex-wrap items-center gap-2">
 						{supportsServiceTier ? (
-							<div className="w-full sm:w-32">
+							<div className="w-full lg:w-32">
 								<Select
 									value={selectedServiceTier}
 									onValueChange={(value) =>
@@ -674,7 +664,7 @@ export function QuickstartUsageSection({
 									<SelectContent
 										align="start"
 										alignItemWithTrigger={false}
-										className="w-auto min-w-48 rounded-xl"
+										className="w-auto min-w-48 rounded-lg"
 									>
 										<SelectGroup>
 											<SelectLabel className="text-[11px] tracking-[0.04em] text-muted-foreground">
@@ -707,30 +697,27 @@ export function QuickstartUsageSection({
 							</div>
 						) : null}
 						{showStreamingControl ? (
-							<div className="flex h-8 items-center gap-2 rounded-lg border border-border/70 bg-background px-3">
+							<div className="flex h-8 w-full items-center justify-between gap-2 rounded-lg bg-muted/60 px-3 lg:w-auto lg:justify-start">
+								<span className="text-xs font-medium">
+									{supportsStreaming ? "Streaming" : "No stream"}
+								</span>
 								<Switch
 									checked={streamingEnabled}
 									onCheckedChange={onToggleStreaming}
 									disabled={!supportsStreaming}
 									aria-label={supportsStreaming ? "Enable streaming" : "Streaming unavailable"}
 								/>
-								<span className="text-xs font-medium">
-									{supportsStreaming ? "Streaming" : "No stream"}
-								</span>
 							</div>
 						) : null}
-						{!inlineCopy ? (
-							<div className="ml-auto">
-								<MiniCopyButton content={requestExample.code} />
-							</div>
-						) : null}
+						<div className="w-full lg:absolute lg:right-2 lg:top-2 lg:w-auto">
+							<MiniCopyButton content={requestExample.code} />
 						</div>
-					) : null}
+					</div>
 				</div>
 				<Separator />
 				<RequestCodePane code={requestExample.code} lang={requestExample.lang} />
 				<Separator />
-				<div className="flex flex-col gap-2 px-3 py-3">
+				<div className="flex flex-col gap-2 px-3 py-2">
 					<div className="flex items-center justify-between gap-3">
 						<span className="text-xs font-medium text-muted-foreground">
 							Accepted IDs

--- a/apps/web/src/components/(data)/models/ModelPerformanceCards.test.ts
+++ b/apps/web/src/components/(data)/models/ModelPerformanceCards.test.ts
@@ -1,0 +1,58 @@
+import type { ModelProviderDailyPoint } from "@/lib/fetchers/models/getModelPerformance";
+import { selectMetricData } from "./ModelPerformanceCards";
+
+function point(
+	provider: string,
+	cachedInputPct: number | null,
+): ModelProviderDailyPoint {
+	return {
+		provider,
+		providerName: provider,
+		providerColor: null,
+		day: "2026-08-08",
+		avgThroughput: null,
+		avgOutputSpeed: null,
+		avgLatencyMs: null,
+		avgGenerationMs: null,
+		avgPhaseoOverheadMs: null,
+		avgTpotMs: null,
+		avgItlMs: null,
+		cachedInputPct,
+		cachedInputTokens: null,
+		effectiveInputTokens: null,
+		cacheTelemetryRequests: 0,
+		requests: 1,
+	};
+}
+
+describe("selectMetricData", () => {
+	it("falls back to detailed percentile data when the compact bands are empty", () => {
+		const detailData = [point("percentile-95", 42)];
+		const cardData = [point("percentile-50", null)];
+
+		expect(
+			selectMetricData(
+				"cachedInput",
+				false,
+				detailData,
+				cardData,
+				true,
+			),
+		).toBe(detailData);
+	});
+
+	it("keeps the compact percentile bands when they contain the metric", () => {
+		const detailData = [point("percentile-95", 42)];
+		const cardData = [point("percentile-50", 30)];
+
+		expect(
+			selectMetricData(
+				"cachedInput",
+				false,
+				detailData,
+				cardData,
+				true,
+			),
+		).toBe(cardData);
+	});
+});

--- a/apps/web/src/components/(data)/models/ModelPerformanceCards.tsx
+++ b/apps/web/src/components/(data)/models/ModelPerformanceCards.tsx
@@ -83,6 +83,26 @@ const METRICS: MetricDefinition[] = [
 	},
 ];
 
+const METRIC_DEFINITIONS = Object.fromEntries(
+	METRICS.map((definition) => [definition.metric, definition]),
+) as Record<MetricKey, MetricDefinition>;
+
+export function selectMetricData(
+	metric: MetricKey,
+	detailed: boolean,
+	detailData: ModelProviderDailyPoint[],
+	cardData: ModelProviderDailyPoint[],
+	hasPercentileSeries: boolean,
+) {
+	if (!hasPercentileSeries || detailed) return detailData;
+	const definition = METRIC_DEFINITIONS[metric];
+	return cardData.some((point) =>
+		isUsableMetricValue(metric, point[definition.valueKey]),
+	)
+		? cardData
+		: detailData;
+}
+
 interface ModelPerformanceCardsProps {
 	summary: ModelPerformanceSummary;
 	prevSummary?: ModelPerformanceSummary | null;
@@ -135,7 +155,7 @@ export default function ModelPerformanceCards({
 		? "All available percentile bands"
 		: `All ${providerCount.toLocaleString()} recorded provider${providerCount === 1 ? "" : "s"}`;
 	const preferredMetricData = (metric: MetricKey, detailed: boolean) => {
-		const definition = METRICS.find((item) => item.metric === metric)!;
+		const definition = METRIC_DEFINITIONS[metric];
 		const data = detailed ? detailData : cardData;
 		return data.some((point) =>
 			isUsableMetricValue(metric, point[definition.valueKey]),
@@ -143,12 +163,14 @@ export default function ModelPerformanceCards({
 			? data
 			: null;
 	};
-	const metricData = (metric: MetricKey, detailed: boolean) => {
-		if (chartProviderDaily7d) {
-			return preferredMetricData(metric, detailed) ?? (detailed ? detailData : cardData);
-		}
-		return providerDaily7d;
-	};
+	const metricData = (metric: MetricKey, detailed: boolean) =>
+		selectMetricData(
+			metric,
+			detailed,
+			detailData,
+			cardData,
+			chartProviderDaily7d != null,
+		);
 	const metricUsesPercentiles = (metric: MetricKey) =>
 		chartProviderDaily7d != null && preferredMetricData(metric, true) != null;
 	const availableMetrics = METRICS.filter(({ metric, valueKey }) =>

--- a/apps/web/src/components/(data)/models/ModelPerformanceCards.tsx
+++ b/apps/web/src/components/(data)/models/ModelPerformanceCards.tsx
@@ -134,12 +134,23 @@ export default function ModelPerformanceCards({
 	const detailSeriesLabel = chartProviderDaily7d
 		? "All available percentile bands"
 		: `All ${providerCount.toLocaleString()} recorded provider${providerCount === 1 ? "" : "s"}`;
-	const metricData = (metric: MetricKey, detailed: boolean) =>
-		metric === "cachedInput"
-			? providerDaily7d
-			: detailed
-				? detailData
-				: cardData;
+	const preferredMetricData = (metric: MetricKey, detailed: boolean) => {
+		const definition = METRICS.find((item) => item.metric === metric)!;
+		const data = detailed ? detailData : cardData;
+		return data.some((point) =>
+			isUsableMetricValue(metric, point[definition.valueKey]),
+		)
+			? data
+			: null;
+	};
+	const metricData = (metric: MetricKey, detailed: boolean) => {
+		if (chartProviderDaily7d) {
+			return preferredMetricData(metric, detailed) ?? (detailed ? detailData : cardData);
+		}
+		return providerDaily7d;
+	};
+	const metricUsesPercentiles = (metric: MetricKey) =>
+		chartProviderDaily7d != null && preferredMetricData(metric, true) != null;
 	const availableMetrics = METRICS.filter(({ metric, valueKey }) =>
 		metricData(metric, true).some(
 			(point) =>
@@ -176,7 +187,7 @@ export default function ModelPerformanceCards({
 								<DialogTitle className="text-xl">{definition.label}</DialogTitle>
 								<DialogDescription>
 									{definition.description}{" "}
-									{definition.metric === "cachedInput"
+									{definition.metric === "cachedInput" && !metricUsesPercentiles(definition.metric)
 										? `All ${cachedInputProviderCount.toLocaleString()} recorded provider${cachedInputProviderCount === 1 ? "" : "s"}`
 										: detailSeriesLabel}{" "}
 									are shown below.

--- a/apps/web/src/components/(data)/models/ModelPerformanceDashboard.tsx
+++ b/apps/web/src/components/(data)/models/ModelPerformanceDashboard.tsx
@@ -75,25 +75,26 @@ export default function ModelPerformanceDashboard({
 	headerDescription,
 	mode = "overview",
 }: ModelPerformanceDashboardProps) {
+	const [initialSelection] = useState<{
+		colo: string | null;
+		percentile: ModelPercentile;
+	}>(() => ({
+			colo: metrics.cloudflareColo ?? null,
+			percentile:
+				metrics.percentile != null && isModelPercentile(metrics.percentile)
+					? metrics.percentile
+					: DEFAULT_MODEL_PERCENTILE,
+		}));
 	const [selectedColo, setSelectedColo] = useState<string | null>(
-		metrics.cloudflareColo ?? null,
+		() => initialSelection.colo,
 	);
 	const [selectedPercentile, setSelectedPercentile] = useState<ModelPercentile>(
-		metrics.percentile != null && isModelPercentile(metrics.percentile)
-			? metrics.percentile
-			: DEFAULT_MODEL_PERCENTILE,
+		() => initialSelection.percentile,
 	);
-	const initialSelectionRef = useRef({
-		colo: metrics.cloudflareColo ?? null,
-		percentile:
-			metrics.percentile != null && isModelPercentile(metrics.percentile)
-				? metrics.percentile
-				: DEFAULT_MODEL_PERCENTILE,
-	});
-	const successfulSelectionRef = useRef(initialSelectionRef.current);
+	const successfulSelectionRef = useRef(initialSelection);
 	const isInitialSelection =
-		selectedColo === initialSelectionRef.current.colo &&
-		selectedPercentile === initialSelectionRef.current.percentile;
+		selectedColo === initialSelection.colo &&
+		selectedPercentile === initialSelection.percentile;
 	const {
 		data: selectedMetrics,
 		isValidating,
@@ -189,7 +190,7 @@ export default function ModelPerformanceDashboard({
 												variant="outline"
 												size="sm"
 												className="h-8 w-auto max-w-[calc(100vw-2rem)] justify-start gap-2 rounded-lg px-3 text-xs"
-												disabled={isLoadingRegion}
+												aria-busy={isLoadingRegion}
 												aria-label="Filter performance by API location"
 											>
 												{isLoadingRegion ? (

--- a/apps/web/src/components/(data)/models/ModelPerformanceDashboard.tsx
+++ b/apps/web/src/components/(data)/models/ModelPerformanceDashboard.tsx
@@ -4,11 +4,10 @@ import { useRef, useState } from "react";
 import ModelPerformanceCards from "./ModelPerformanceCards";
 import ModelSuccessChart from "./ModelSuccessChart";
 import ModelTokenTrajectoryChart from "./ModelTokenTrajectory";
-import { Activity, BarChart3, Filter, Globe2, Loader2 } from "lucide-react";
+import { Activity, Globe2, Loader2 } from "lucide-react";
 import type { ModelPerformanceMetrics } from "@/lib/fetchers/models/getModelPerformance";
 import type { ModelTokenTrajectory } from "@/lib/fetchers/models/getModelTokenTrajectory";
 import type { ModelPerformanceColo } from "@/lib/fetchers/frontend/fetchPublicCatalog";
-import { fetchOptionalPublicWebApi } from "@/lib/web-api/client";
 import {
 	CLOUDFLARE_COLOS,
 	CLOUDFLARE_CONTINENTS,
@@ -33,42 +32,13 @@ import {
 	DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { Button } from "@/components/ui/button";
-import {
-	Sheet,
-	SheetContent,
-	SheetDescription,
-	SheetHeader,
-	SheetTitle,
-	SheetTrigger,
-} from "@/components/ui/sheet";
-import {
-	Select,
-	SelectContent,
-	SelectItem,
-	SelectTrigger,
-	SelectValue,
-} from "@/components/ui/select";
 import { Card } from "@/components/ui/card";
-import {
-	Tooltip,
-	TooltipContent,
-	TooltipTrigger,
-} from "@/components/ui/tooltip";
 import { buildSingleProviderPercentileSeries } from "@/components/(data)/models/modelPerformancePercentiles";
+import {
+	MODEL_PERFORMANCE_REFRESH_INTERVAL_MS,
+	useModelPerformanceMetrics,
+} from "./useModelPerformanceMetrics";
 
-const STREAM_MODE_LABELS = {
-	all: "All responses",
-	stream: "Streaming",
-	non_stream: "Non-streaming",
-} as const;
-
-const CONTEXT_BUCKET_LABELS = {
-	all: "All contexts",
-	lte_4k: "≤ 4K input",
-	"4k_16k": "4K–16K input",
-	"16k_64k": "16K–64K input",
-	gt_64k: "> 64K input",
-} as const;
 import {
 	Empty,
 	EmptyDescription,
@@ -113,119 +83,56 @@ export default function ModelPerformanceDashboard({
 			? metrics.percentile
 			: DEFAULT_MODEL_PERCENTILE,
 	);
-	const [streamMode, setStreamMode] = useState<"all" | "stream" | "non_stream">(
-		metrics.streamMode ?? "all",
-	);
-	const [contextBucket, setContextBucket] = useState<
-		"all" | "lte_4k" | "4k_16k" | "16k_64k" | "gt_64k"
-	>(metrics.contextBucket ?? "all");
-	const [regionMetrics, setRegionMetrics] =
-		useState<ModelPerformanceMetrics | null>(null);
-	const [isLoadingRegion, setIsLoadingRegion] = useState(false);
-	const [isLoadingPercentile, setIsLoadingPercentile] = useState(false);
-	const requestGeneration = useRef(0);
-	const activeMetrics = regionMetrics ?? metrics;
+	const initialSelectionRef = useRef({
+		colo: metrics.cloudflareColo ?? null,
+		percentile:
+			metrics.percentile != null && isModelPercentile(metrics.percentile)
+				? metrics.percentile
+				: DEFAULT_MODEL_PERCENTILE,
+	});
+	const successfulSelectionRef = useRef(initialSelectionRef.current);
+	const isInitialSelection =
+		selectedColo === initialSelectionRef.current.colo &&
+		selectedPercentile === initialSelectionRef.current.percentile;
+	const {
+		data: selectedMetrics,
+		isValidating,
+	} = useModelPerformanceMetrics({
+		modelId,
+		cloudflareColo: selectedColo,
+		percentile: selectedPercentile,
+		fallbackData: isInitialSelection ? metrics : undefined,
+		refreshInterval: MODEL_PERFORMANCE_REFRESH_INTERVAL_MS,
+		onError: () => {
+				setSelectedColo(successfulSelectionRef.current.colo);
+				setSelectedPercentile(successfulSelectionRef.current.percentile);
+		},
+		onSuccess: (nextMetrics) => {
+				if (!nextMetrics) return;
+				successfulSelectionRef.current = {
+					colo: nextMetrics.cloudflareColo ?? null,
+					percentile:
+						nextMetrics.percentile != null &&
+						isModelPercentile(nextMetrics.percentile)
+							? nextMetrics.percentile
+							: selectedPercentile,
+				};
+		},
+	});
+	const activeMetrics = selectedMetrics ?? metrics;
+	const isLoadingRegion =
+		isValidating && selectedColo !== (activeMetrics.cloudflareColo ?? null);
+	const isLoadingPercentile =
+		isValidating && selectedPercentile !== activeMetrics.percentile;
 
-	const fetchSelectedMetrics = async (
-		colo: string | null,
-		percentile: number,
-		nextStreamMode = streamMode,
-		nextContextBucket = contextBucket,
-	) => {
-		const query = new URLSearchParams({ percentile: String(percentile) });
-		if (colo) query.set("colo", colo);
-		if (nextStreamMode !== "all") query.set("stream", nextStreamMode);
-		if (nextContextBucket !== "all") query.set("context", nextContextBucket);
-		const payload = await fetchOptionalPublicWebApi<{
-			metrics: ModelPerformanceMetrics | null;
-		}>(
-			`/api/_web/models/${encodeURIComponent(modelId)}/performance?${query.toString()}`,
-		);
-		return payload?.metrics ?? null;
-	};
-
-	const handleSegmentationChange = async (
-		nextStreamMode: "all" | "stream" | "non_stream",
-		nextContextBucket: "all" | "lte_4k" | "4k_16k" | "16k_64k" | "gt_64k",
-	) => {
-		const generation = ++requestGeneration.current;
-		const previousStreamMode = streamMode;
-		const previousContextBucket = contextBucket;
-		setStreamMode(nextStreamMode);
-		setContextBucket(nextContextBucket);
-		setIsLoadingPercentile(false);
-		setIsLoadingRegion(true);
-		try {
-			const nextMetrics = await fetchSelectedMetrics(
-				selectedColo,
-				selectedPercentile,
-				nextStreamMode,
-				nextContextBucket,
-			);
-			if (generation !== requestGeneration.current) return;
-			if (!nextMetrics) {
-				setStreamMode(previousStreamMode);
-				setContextBucket(previousContextBucket);
-				return;
-			}
-			setRegionMetrics(nextMetrics);
-		} catch {
-			if (generation === requestGeneration.current) {
-				setStreamMode(previousStreamMode);
-				setContextBucket(previousContextBucket);
-			}
-		} finally {
-			if (generation === requestGeneration.current) setIsLoadingRegion(false);
-		}
-	};
-
-	const handleColoChange = async (value: string) => {
+	const handleColoChange = (value: string) => {
 		const nextColo = value === "all" ? null : value;
-		const generation = ++requestGeneration.current;
-		const previousColo = selectedColo;
 		setSelectedColo(nextColo);
-		setIsLoadingPercentile(false);
-		setIsLoadingRegion(true);
-		try {
-			const nextMetrics = await fetchSelectedMetrics(
-				nextColo,
-				selectedPercentile,
-			);
-			if (generation !== requestGeneration.current) return;
-			if (!nextMetrics) {
-				setSelectedColo(previousColo);
-				return;
-			}
-			setRegionMetrics(nextMetrics);
-		} catch {
-			if (generation === requestGeneration.current)
-				setSelectedColo(previousColo);
-		} finally {
-			if (generation === requestGeneration.current) setIsLoadingRegion(false);
-		}
 	};
 
-	const handlePercentileChange = async (nextPercentile: ModelPercentile) => {
+	const handlePercentileChange = (nextPercentile: ModelPercentile) => {
 		if (nextPercentile === selectedPercentile) return;
-		const generation = ++requestGeneration.current;
-		const previousPercentile = selectedPercentile;
-		setIsLoadingRegion(false);
-		setIsLoadingPercentile(true);
-		try {
-			const nextMetrics = await fetchSelectedMetrics(
-				selectedColo,
-				nextPercentile,
-			);
-			if (generation !== requestGeneration.current || !nextMetrics) return;
-			setRegionMetrics(nextMetrics);
-			setSelectedPercentile(nextPercentile);
-		} catch {
-			if (generation === requestGeneration.current)
-				setSelectedPercentile(previousPercentile);
-		} finally {
-			if (generation === requestGeneration.current)
-				setIsLoadingPercentile(false);
-		}
+		setSelectedPercentile(nextPercentile);
 	};
 
 	const hasTelemetry =
@@ -237,9 +144,7 @@ export default function ModelPerformanceDashboard({
 			? Math.round(activeMetrics.cumulativeTokens).toLocaleString()
 			: "N/A";
 	const cumulativeSince = formatReleaseDate(activeMetrics.releaseDate);
-	const regionLabel = selectedColo
-		? formatCloudflareColo(selectedColo)
-		: "Select Location";
+	const regionLabel = selectedColo?.toUpperCase() ?? "All Locations";
 	const usageByColo = new Map(
 		availableColos
 			.filter((colo) => colo.requests > 0)
@@ -263,201 +168,29 @@ export default function ModelPerformanceDashboard({
 	);
 
 	return (
-		<section className="space-y-10">
+		<section className="space-y-6">
 			<div className="flex flex-wrap items-start justify-between gap-4">
 				<div className="space-y-1">
 					<h2 className="text-xl font-semibold tracking-tight">Performance</h2>
 					<p className="text-sm text-muted-foreground">{headerDescription}</p>
 				</div>
-				<div className="flex items-center gap-2">
-					<div className="hidden items-center gap-2 lg:flex">
-						<Select
-							value={streamMode}
-							disabled={isLoadingRegion}
-							onValueChange={(value) =>
-								void handleSegmentationChange(
-									value as "all" | "stream" | "non_stream",
-									contextBucket,
-								)
-							}
-						>
-							<SelectTrigger
-								size="sm"
-								className="h-8 w-36 rounded-md border-border bg-background text-xs"
-								aria-label="Streaming mode"
-							>
-								<SelectValue>{STREAM_MODE_LABELS[streamMode]}</SelectValue>
-							</SelectTrigger>
-							<SelectContent align="end" className="min-w-44">
-								<SelectItem value="all">All responses</SelectItem>
-								<SelectItem value="stream">Streaming</SelectItem>
-								<SelectItem value="non_stream">Non-streaming</SelectItem>
-							</SelectContent>
-						</Select>
-						<Select
-							value={contextBucket}
-							disabled={isLoadingRegion}
-							onValueChange={(value) =>
-								void handleSegmentationChange(
-									streamMode,
-									value as "all" | "lte_4k" | "4k_16k" | "16k_64k" | "gt_64k",
-								)
-							}
-						>
-							<SelectTrigger
-								size="sm"
-								className="h-8 w-36 rounded-md border-border bg-background text-xs"
-								aria-label="Context length"
-							>
-								<SelectValue>{CONTEXT_BUCKET_LABELS[contextBucket]}</SelectValue>
-							</SelectTrigger>
-							<SelectContent align="end" className="min-w-44">
-								<SelectItem value="all">All contexts</SelectItem>
-								<SelectItem value="lte_4k">≤ 4K input</SelectItem>
-								<SelectItem value="4k_16k">4K–16K input</SelectItem>
-								<SelectItem value="16k_64k">16K–64K input</SelectItem>
-								<SelectItem value="gt_64k">&gt; 64K input</SelectItem>
-							</SelectContent>
-						</Select>
-					</div>
-					<Sheet>
-						<SheetTrigger asChild>
-							<Button
-								variant="outline"
-								size="sm"
-								className="h-8 gap-2 rounded-lg px-3 text-xs lg:hidden"
-								aria-label="Performance filters"
-							>
-								{isLoadingRegion || isLoadingPercentile ? (
-									<Loader2 className="size-3.5 animate-spin" />
-								) : (
-									<Filter className="size-3.5" />
-								)}
-								Filters
-							</Button>
-						</SheetTrigger>
-						<SheetContent
-							side="bottom"
-							className="max-h-[85dvh] rounded-t-xl border-border/70 pb-[max(1rem,env(safe-area-inset-bottom))] lg:hidden"
-						>
-							<SheetHeader className="border-b border-border/70 px-5 py-4 text-left">
-								<SheetTitle>Performance filters</SheetTitle>
-								<SheetDescription>
-									Refine the requests included in these metrics.
-								</SheetDescription>
-							</SheetHeader>
-							<div className="overflow-y-auto px-5 py-4">
-								<div className="space-y-5">
-									<fieldset className="space-y-2">
-										<legend className="text-xs font-medium text-muted-foreground">
-											Response mode
-										</legend>
-										<div className="grid grid-cols-3 gap-2">
-											{Object.entries(STREAM_MODE_LABELS).map(([value, label]) => (
-												<Button
-													key={value}
-													type="button"
-													size="sm"
-													disabled={isLoadingRegion}
-													variant={streamMode === value ? "secondary" : "outline"}
-													className="rounded-lg px-2 text-xs"
-													aria-pressed={streamMode === value}
-													onClick={() =>
-														void handleSegmentationChange(
-															value as "all" | "stream" | "non_stream",
-															contextBucket,
-														)
-													}
-												>
-													{label}
-												</Button>
-											))}
-										</div>
-									</fieldset>
-									<fieldset className="space-y-2">
-										<legend className="text-xs font-medium text-muted-foreground">
-											Context length
-										</legend>
-										<div className="grid grid-cols-2 gap-2">
-											{Object.entries(CONTEXT_BUCKET_LABELS).map(([value, label]) => (
-												<Button
-													key={value}
-													type="button"
-													size="sm"
-													disabled={isLoadingRegion}
-													variant={contextBucket === value ? "secondary" : "outline"}
-													className="justify-start rounded-lg px-3 text-xs"
-													aria-pressed={contextBucket === value}
-													onClick={() =>
-														void handleSegmentationChange(
-															streamMode,
-															value as keyof typeof CONTEXT_BUCKET_LABELS,
-														)
-													}
-												>
-													{label}
-												</Button>
-											))}
-										</div>
-									</fieldset>
-									<div className="space-y-2">
-										<p className="text-xs font-medium text-muted-foreground">
-											API location
-										</p>
-										<Button
-											type="button"
-											variant="outline"
-											size="sm"
-											disabled
-											className="w-full justify-start rounded-lg text-xs"
-										>
-											<Globe2 className="size-3.5" />
-											All locations
-											<span className="ml-auto text-muted-foreground">Coming soon</span>
-										</Button>
-									</div>
-									{showPercentileSelector ? (
-										<fieldset className="space-y-2">
-											<legend className="flex items-center gap-1.5 text-xs font-medium text-muted-foreground">
-												<BarChart3 className="size-3.5" />
-												Percentile
-											</legend>
-											<div className="grid grid-cols-5 gap-2">
-												{[1, 5, 10, 25, 50, 75, 90, 95, 99].map((percentile) => (
-													<Button
-														key={percentile}
-														type="button"
-														size="sm"
-														variant={selectedPercentile === percentile ? "secondary" : "outline"}
-														className="rounded-lg px-2 text-xs tabular-nums"
-														aria-pressed={selectedPercentile === percentile}
-														onClick={() => {
-															if (isModelPercentile(percentile))
-																void handlePercentileChange(percentile);
-														}}
-													>
-														P{String(percentile).padStart(2, "0")}
-													</Button>
-												))}
-											</div>
-										</fieldset>
-									) : null}
-								</div>
-							</div>
-						</SheetContent>
-					</Sheet>
-					<div className="hidden items-center gap-2 lg:flex">
-						<Tooltip>
-							<TooltipTrigger asChild>
-								<span className="inline-flex" tabIndex={0}>
-									<DropdownMenu>
+				<div className="ml-auto flex items-center gap-2">
+					{showPercentileSelector ? (
+						<ModelPercentileSelect
+							value={selectedPercentile}
+							onChange={handlePercentileChange}
+							isLoading={isLoadingPercentile}
+							ariaLabel="Select performance percentile"
+						/>
+					) : null}
+					<DropdownMenu>
 										<DropdownMenuTrigger asChild>
 											<Button
 												variant="outline"
 												size="sm"
-												className="h-8 gap-2 rounded-md px-3 text-xs"
-												title="Coming Soon"
-												disabled
+												className="h-8 w-auto max-w-[calc(100vw-2rem)] justify-start gap-2 rounded-lg px-3 text-xs"
+												disabled={isLoadingRegion}
+												aria-label="Filter performance by API location"
 											>
 												{isLoadingRegion ? (
 													<Loader2 className="size-3.5 animate-spin" />
@@ -469,11 +202,20 @@ export default function ModelPerformanceDashboard({
 										</DropdownMenuTrigger>
 										<DropdownMenuContent
 											align="end"
-											className="min-w-56 rounded-md"
+											className="min-w-56 rounded-lg"
 										>
 											<div className="px-2 py-1.5 text-xs text-muted-foreground">
 												API Execution Location
 											</div>
+											<DropdownMenuSeparator />
+											<DropdownMenuRadioGroup
+												value={selectedColo ?? "all"}
+												onValueChange={handleColoChange}
+											>
+												<DropdownMenuRadioItem value="all">
+													All Locations
+												</DropdownMenuRadioItem>
+											</DropdownMenuRadioGroup>
 											<DropdownMenuSeparator />
 											{catalogColosByContinent.length === 0 ? (
 												<DropdownMenuItem disabled>
@@ -482,37 +224,27 @@ export default function ModelPerformanceDashboard({
 											) : (
 												catalogColosByContinent.map((group) => (
 													<DropdownMenuSub key={group.continent}>
-														<DropdownMenuSubTrigger>
-															<Globe2 className="size-3.5 text-muted-foreground" />
-															{group.continent}
-															<span className="ml-auto w-6 text-right text-[11px] tabular-nums text-muted-foreground">
-																{group.colos.length}
-															</span>
-														</DropdownMenuSubTrigger>
-														<DropdownMenuSubContent className="max-h-80 min-w-80 rounded-md">
+												<DropdownMenuSubTrigger>
+													<Globe2 className="size-3.5 text-muted-foreground" />
+													{group.continent}
+												</DropdownMenuSubTrigger>
+														<DropdownMenuSubContent className="max-h-80 min-w-80 rounded-lg">
 															<DropdownMenuRadioGroup
 																value={selectedColo ?? ""}
 																onValueChange={handleColoChange}
 															>
 																<DropdownMenuGroup>
-																	{group.colos.map((colo) => {
-																		const requests =
-																			usageByColo.get(colo.code) ?? 0;
-																		return (
-																			<DropdownMenuRadioItem
-																				key={colo.code}
+															{group.colos.map((colo) => (
+																	<DropdownMenuRadioItem
+																		key={colo.code}
 																				value={colo.code}
 																				className="gap-3"
 																			>
-																				<span className="min-w-0 flex-1 truncate">
-																					{formatCloudflareColo(colo.code)}
-																				</span>
-																				<span className="w-16 shrink-0 text-right text-[11px] tabular-nums text-muted-foreground">
-																					{requests.toLocaleString()}
-																				</span>
-																			</DropdownMenuRadioItem>
-																		);
-																	})}
+																		<span className="min-w-0 flex-1 truncate">
+																			{formatCloudflareColo(colo.code)}
+																		</span>
+																	</DropdownMenuRadioItem>
+															))}
 																</DropdownMenuGroup>
 															</DropdownMenuRadioGroup>
 														</DropdownMenuSubContent>
@@ -520,20 +252,7 @@ export default function ModelPerformanceDashboard({
 												))
 											)}
 										</DropdownMenuContent>
-									</DropdownMenu>
-								</span>
-							</TooltipTrigger>
-							<TooltipContent>Coming Soon</TooltipContent>
-						</Tooltip>
-						{showPercentileSelector ? (
-							<ModelPercentileSelect
-								value={selectedPercentile}
-								onChange={handlePercentileChange}
-								isLoading={isLoadingPercentile}
-								ariaLabel="Select performance percentile"
-							/>
-						) : null}
-					</div>
+					</DropdownMenu>
 				</div>
 			</div>
 			{hasTelemetry ? (

--- a/apps/web/src/components/(data)/models/ModelProviderTrendChart.test.ts
+++ b/apps/web/src/components/(data)/models/ModelProviderTrendChart.test.ts
@@ -14,6 +14,15 @@ describe("calculateCachedInputAverage", () => {
 
 		expect(calculateCachedInputAverage(points)).toBeCloseTo(89.2079, 4);
 	});
+
+	it("averages percentile percentages when raw token totals are unavailable", () => {
+		const points = [
+			{ cachedInputPct: 41.7 },
+			{ cachedInputPct: 42.1 },
+		] as Parameters<typeof calculateCachedInputAverage>[0];
+
+		expect(calculateCachedInputAverage(points)).toBeCloseTo(41.9, 4);
+	});
 });
 
 describe("getSeriesEmphasis", () => {

--- a/apps/web/src/components/(data)/models/ModelProviderTrendChart.tsx
+++ b/apps/web/src/components/(data)/models/ModelProviderTrendChart.tsx
@@ -1,19 +1,19 @@
 "use client";
 
-import { useState, type ReactNode } from "react";
-import { ArrowUpDown } from "lucide-react";
+import { useRef, useState, type ReactNode } from "react";
 import {
 	CartesianGrid,
 	Line,
 	LineChart,
 	ReferenceLine,
 	ResponsiveContainer,
+	Tooltip,
 	XAxis,
 	YAxis,
 } from "recharts";
 import type { ModelProviderDailyPoint } from "@/lib/fetchers/models/getModelPerformance";
-import { Button } from "@/components/ui/button";
 import { ScrollArea } from "@/components/ui/scroll-area";
+import { TableSortButton } from "@/components/ui/table-sort-button";
 import { formatProviderDuration } from "@/components/(data)/models/modelPerformanceFormatting";
 import { ModelMetricInfo } from "./ModelMetricInfo";
 
@@ -36,6 +36,12 @@ type ModelProviderTrendChartProps = {
 	showHeader?: boolean;
 	headerAction?: ReactNode;
 };
+
+type TableSortKey = "provider" | "minimum" | "maximum" | "average";
+type TableSort = {
+	key: TableSortKey;
+	direction: "asc" | "desc";
+} | null;
 
 export function getSeriesEmphasis(
 	activeSeriesKey: string | null,
@@ -74,8 +80,16 @@ export function calculateCachedInputAverage(
 		},
 		{ cached: 0, effective: 0 },
 	);
-	return totals.effective > 0
-		? Math.min(100, (totals.cached * 100) / totals.effective)
+	if (totals.effective > 0) {
+		return Math.min(100, (totals.cached * 100) / totals.effective);
+	}
+	const percentages = points
+		.map((point) => point.cachedInputPct)
+		.filter(
+			(value): value is number => value != null && Number.isFinite(value),
+		);
+	return percentages.length > 0
+		? percentages.reduce((sum, value) => sum + value, 0) / percentages.length
 		: null;
 }
 
@@ -203,6 +217,17 @@ function toSeriesKey(providerId: string): string {
 	return providerId.replace(/[^a-zA-Z0-9]+/g, "_");
 }
 
+function getPercentile(providerId: string): number | null {
+	const match = /^percentile-(\d+)$/.exec(providerId);
+	if (!match) return null;
+	const percentile = Number(match[1]);
+	return Number.isFinite(percentile) ? percentile : null;
+}
+
+function getPercentileDescription(percentile: number): string {
+	return `P${percentile} is the value at or below which ${percentile}% of recorded requests fall.`;
+}
+
 export default function ModelProviderTrendChart({
 	title,
 	data,
@@ -212,14 +237,20 @@ export default function ModelProviderTrendChart({
 	showHeader = true,
 	headerAction,
 }: ModelProviderTrendChartProps) {
+	const isPercentileData = data.some(
+		(point) => getPercentile(point.provider) != null,
+	);
 	const [activeDay, setActiveDay] = useState<string | null>(null);
+	const activeDayRef = useRef<string | null>(null);
 	const [hoveredSeriesKey, setHoveredSeriesKey] = useState<string | null>(null);
 	const [focusedSeriesKey, setFocusedSeriesKey] = useState<string | null>(null);
-	const [tableSort, setTableSort] = useState<{
-		key: "provider" | "minimum" | "maximum" | "average";
-		direction: "asc" | "desc";
-	}>({ key: "average", direction: "desc" });
+	const [tableSort, setTableSort] = useState<TableSort>(null);
 	const activeSeriesKey = hoveredSeriesKey ?? focusedSeriesKey;
+	const updateActiveDay = (day: string | null) => {
+		if (activeDayRef.current === day) return;
+		activeDayRef.current = day;
+		setActiveDay(day);
+	};
 	const metricConfig = METRICS[metric];
 	const observedData = data.filter(
 		(point) =>
@@ -336,9 +367,22 @@ export default function ModelProviderTrendChart({
 				};
 			});
 	const sortedProviderRows = (() => {
+		const defaultRows = isPercentileData
+			? [...providerRows].sort(
+					(left, right) =>
+						(getPercentile(left.provider) ?? 0) -
+						(getPercentile(right.provider) ?? 0),
+				)
+			: providerRows;
+		if (!tableSort) return defaultRows;
 		const multiplier = tableSort.direction === "asc" ? 1 : -1;
-		return [...providerRows].sort((left, right) => {
+		return [...defaultRows].sort((left, right) => {
 			if (tableSort.key === "provider") {
+				const leftPercentile = getPercentile(left.provider);
+				const rightPercentile = getPercentile(right.provider);
+				if (leftPercentile != null && rightPercentile != null) {
+					return (leftPercentile - rightPercentile) * multiplier;
+				}
 				return left.name.localeCompare(right.name) * multiplier;
 			}
 			const leftValue = left[tableSort.key] ?? Number.NEGATIVE_INFINITY;
@@ -346,14 +390,58 @@ export default function ModelProviderTrendChart({
 			return (leftValue - rightValue) * multiplier;
 		});
 	})();
-	const toggleTableSort = (
-		key: "provider" | "minimum" | "maximum" | "average",
-	) => {
-		setTableSort((current) => ({
-			key,
-			direction:
-				current.key === key && current.direction === "desc" ? "asc" : "desc",
-		}));
+	const cycleTableSort = (key: TableSortKey) => {
+		setTableSort((current) => {
+			if (!current || current.key !== key) return { key, direction: "desc" };
+			if (current.direction === "desc") return { key, direction: "asc" };
+			return null;
+		});
+	};
+	const renderDetailedTooltip = ({
+		active,
+		payload,
+	}: {
+		active?: boolean;
+		payload?: ReadonlyArray<{
+			payload?: Record<string, string | number | null>;
+		}>;
+	}) => {
+		const row = payload?.[0]?.payload;
+		if (!isHovering || !active || !row || typeof row.day !== "string") {
+			return null;
+		}
+		const tooltipRows = providers.flatMap((provider) => {
+			const value = row[provider.seriesKey];
+			return typeof value === "number" && Number.isFinite(value)
+				? [{ provider, value }]
+				: [];
+		});
+		if (tooltipRows.length === 0) return null;
+
+		return (
+			<div className="min-w-44 rounded-md border border-border/80 bg-popover/95 p-2 text-popover-foreground shadow-xl backdrop-blur-sm">
+				<p className="mb-1.5 text-[11px] font-medium text-muted-foreground">
+					{formatDayHeading(row.day)}
+				</p>
+				<div className="space-y-1">
+					{tooltipRows.map(({ provider, value }) => (
+						<div
+							key={provider.seriesKey}
+							className="grid grid-cols-[16px_minmax(0,1fr)_auto] items-center gap-2 text-xs"
+						>
+							<span
+								className="h-4 w-[3px] justify-self-center rounded-full"
+								style={{ backgroundColor: provider.color }}
+							/>
+							<span className="truncate font-medium">{provider.name}</span>
+							<span className="pl-3 text-right font-medium tabular-nums">
+								{metricConfig.formatValue(value)}
+							</span>
+						</div>
+					))}
+				</div>
+			</div>
+		);
 	};
 
 	if (providers.length === 0) {
@@ -387,7 +475,7 @@ export default function ModelProviderTrendChart({
 				</div>
 			</div> : null}
 			{chartData.length > 0 ? (
-				<div className={detailed ? "h-[300px] w-full shrink-0 pt-1" : "h-[148px] w-full pt-1"}>
+				<div className={detailed ? "h-[300px] w-full shrink-0 pt-1 [&_.recharts-surface]:outline-none" : "h-[148px] w-full pt-1 [&_.recharts-surface]:outline-none"}>
 				<ResponsiveContainer width="100%" height="100%">
 					<LineChart
 						data={chartData}
@@ -453,9 +541,9 @@ export default function ModelProviderTrendChart({
 								dayFromIndex ||
 								dayFromPayload ||
 								null;
-							setActiveDay(day);
+							updateActiveDay(day);
 						}}
-						onMouseLeave={() => setActiveDay(null)}
+						onMouseLeave={() => updateActiveDay(null)}
 					>
 						<CartesianGrid vertical={false} stroke="transparent" />
 						<XAxis
@@ -482,6 +570,14 @@ export default function ModelProviderTrendChart({
 							tickFormatter={metricConfig.formatAxisTick}
 							label={detailed ? { value: metricConfig.axisLabel, angle: -90, position: "insideLeft", offset: -10, fill: "var(--muted-foreground)", fontSize: 11 } : undefined}
 						/>
+						{detailed ? (
+							<Tooltip
+								content={renderDetailedTooltip}
+								cursor={false}
+								isAnimationActive={false}
+								wrapperStyle={{ pointerEvents: "none", zIndex: 20 }}
+							/>
+						) : null}
 						{isHovering && activeIndex != null ? (
 							<ReferenceLine
 								x={activeIndex}
@@ -514,11 +610,10 @@ export default function ModelProviderTrendChart({
 									strokeOpacity={isDimmed ? 0.18 : 1}
 									strokeLinecap="round"
 									strokeLinejoin="round"
-									dot={chartData.length === 1 ? { r: 3, strokeWidth: 2 } : false}
+									dot={chartData.length === 1 ? { r: 3, strokeWidth: 2, fill: provider.color, stroke: provider.color } : false}
+									activeDot={{ r: 4, strokeWidth: 1, fill: provider.color, stroke: "var(--background)" }}
 									connectNulls
 									isAnimationActive={false}
-									onMouseEnter={() => setHoveredSeriesKey(provider.seriesKey)}
-									onMouseLeave={() => setHoveredSeriesKey(null)}
 								/>
 							);
 						})}
@@ -533,33 +628,55 @@ export default function ModelProviderTrendChart({
 					keepScrollbarMounted
 				>
 					<div className="sticky top-0 z-10 grid grid-cols-[minmax(0,1fr)_repeat(3,minmax(5rem,0.35fr))] gap-3 border-b border-border/70 bg-background px-3 py-1.5 text-xs font-medium text-muted-foreground">
-						<Button variant="ghost" size="sm" className="-ml-2 h-7 w-fit px-2 text-xs" onClick={() => toggleTableSort("provider")}>
-							{seriesColumnLabel} <ArrowUpDown className="ml-1.5 size-3.5" />
-						</Button>
-						<Button variant="ghost" size="sm" className="ml-auto h-7 px-2 text-xs" onClick={() => toggleTableSort("minimum")}>
-							Min <ArrowUpDown className="ml-1.5 size-3.5" />
-						</Button>
-						<Button variant="ghost" size="sm" className="ml-auto h-7 px-2 text-xs" onClick={() => toggleTableSort("maximum")}>
-							Max <ArrowUpDown className="ml-1.5 size-3.5" />
-						</Button>
-						<Button variant="ghost" size="sm" className="ml-auto h-7 px-2 text-xs" onClick={() => toggleTableSort("average")}>
-							Avg <ArrowUpDown className="ml-1.5 size-3.5" />
-						</Button>
+						<TableSortButton className="-ml-2 w-fit" direction={tableSort?.key === "provider" ? tableSort.direction : null} onClick={() => cycleTableSort("provider")}>
+							{seriesColumnLabel}
+						</TableSortButton>
+						<TableSortButton align="end" direction={tableSort?.key === "minimum" ? tableSort.direction : null} onClick={() => cycleTableSort("minimum")}>
+							Min
+						</TableSortButton>
+						<TableSortButton align="end" direction={tableSort?.key === "maximum" ? tableSort.direction : null} onClick={() => cycleTableSort("maximum")}>
+							Max
+						</TableSortButton>
+						<TableSortButton align="end" direction={tableSort?.key === "average" ? tableSort.direction : null} onClick={() => cycleTableSort("average")}>
+							Avg
+						</TableSortButton>
 					</div>
-					{sortedProviderRows.map((provider) => (
-						<div
+					{sortedProviderRows.map((provider) => {
+						const { isActive, isDimmed } = getSeriesEmphasis(
+							activeSeriesKey,
+							provider.seriesKey,
+						);
+						return <div
 							key={provider.seriesKey}
-							className="grid grid-cols-[minmax(0,1fr)_repeat(3,minmax(5rem,0.35fr))] gap-3 border-b border-border/50 px-3 py-2.5 text-sm last:border-b-0"
+							className="grid grid-cols-[minmax(0,1fr)_repeat(3,minmax(5rem,0.35fr))] gap-3 border-b border-border/50 px-3 py-2.5 text-sm outline-none last:border-b-0 focus-visible:ring-1 focus-visible:ring-inset focus-visible:ring-ring"
+							style={{ opacity: isDimmed ? 0.35 : 1 }}
+							tabIndex={0}
+							onMouseEnter={() => setHoveredSeriesKey(provider.seriesKey)}
+							onMouseLeave={() => setHoveredSeriesKey(null)}
+							onFocus={() => setFocusedSeriesKey(provider.seriesKey)}
+							onBlur={(event) => {
+								if (!event.currentTarget.contains(event.relatedTarget)) {
+									setFocusedSeriesKey(null);
+								}
+							}}
 						>
 							<span className="inline-flex min-w-0 items-center gap-2">
 								<span className="size-2.5 shrink-0 rounded-full" style={{ backgroundColor: provider.color }} />
-								<span className="truncate font-medium">{provider.name}</span>
+								<span className={isActive ? "truncate font-semibold" : "truncate font-medium"}>{provider.name}</span>
+								{getPercentile(provider.provider) != null ? (
+									<ModelMetricInfo
+										label={provider.name}
+										description={getPercentileDescription(
+											getPercentile(provider.provider)!,
+										)}
+									/>
+								) : null}
 							</span>
 							<span className="text-right tabular-nums text-muted-foreground">{metricConfig.formatValue(provider.minimum)}</span>
 							<span className="text-right tabular-nums text-muted-foreground">{metricConfig.formatValue(provider.maximum)}</span>
 							<span className="text-right font-medium tabular-nums">{metricConfig.formatValue(provider.average)}</span>
-						</div>
-					))}
+						</div>;
+					})}
 				</ScrollArea>
 			) : (
 			<div className="space-y-1.5 pt-1">

--- a/apps/web/src/components/(data)/models/ModelProviderTrendChart.tsx
+++ b/apps/web/src/components/(data)/models/ModelProviderTrendChart.tsx
@@ -13,7 +13,10 @@ import {
 } from "recharts";
 import type { ModelProviderDailyPoint } from "@/lib/fetchers/models/getModelPerformance";
 import { ScrollArea } from "@/components/ui/scroll-area";
-import { TableSortButton } from "@/components/ui/table-sort-button";
+import {
+	TableSortButton,
+	type TableSortDirection,
+} from "@/components/ui/table-sort-button";
 import { formatProviderDuration } from "@/components/(data)/models/modelPerformanceFormatting";
 import { ModelMetricInfo } from "./ModelMetricInfo";
 
@@ -40,7 +43,7 @@ type ModelProviderTrendChartProps = {
 type TableSortKey = "provider" | "minimum" | "maximum" | "average";
 type TableSort = {
 	key: TableSortKey;
-	direction: "asc" | "desc";
+	direction: Exclude<TableSortDirection, null>;
 } | null;
 
 export function getSeriesEmphasis(
@@ -475,7 +478,13 @@ export default function ModelProviderTrendChart({
 				</div>
 			</div> : null}
 			{chartData.length > 0 ? (
-				<div className={detailed ? "h-[300px] w-full shrink-0 pt-1 [&_.recharts-surface]:outline-none" : "h-[148px] w-full pt-1 [&_.recharts-surface]:outline-none"}>
+				<div
+					className={
+						detailed
+							? "h-[300px] w-full shrink-0 pt-1"
+							: "h-[148px] w-full pt-1"
+					}
+				>
 				<ResponsiveContainer width="100%" height="100%">
 					<LineChart
 						data={chartData}
@@ -627,27 +636,56 @@ export default function ModelProviderTrendChart({
 					viewportClassName="min-h-0"
 					keepScrollbarMounted
 				>
-					<div className="sticky top-0 z-10 grid grid-cols-[minmax(0,1fr)_repeat(3,minmax(5rem,0.35fr))] gap-3 border-b border-border/70 bg-background px-3 py-1.5 text-xs font-medium text-muted-foreground">
-						<TableSortButton className="-ml-2 w-fit" direction={tableSort?.key === "provider" ? tableSort.direction : null} onClick={() => cycleTableSort("provider")}>
-							{seriesColumnLabel}
-						</TableSortButton>
-						<TableSortButton align="end" direction={tableSort?.key === "minimum" ? tableSort.direction : null} onClick={() => cycleTableSort("minimum")}>
-							Min
-						</TableSortButton>
-						<TableSortButton align="end" direction={tableSort?.key === "maximum" ? tableSort.direction : null} onClick={() => cycleTableSort("maximum")}>
-							Max
-						</TableSortButton>
-						<TableSortButton align="end" direction={tableSort?.key === "average" ? tableSort.direction : null} onClick={() => cycleTableSort("average")}>
-							Avg
-						</TableSortButton>
-					</div>
-					{sortedProviderRows.map((provider) => {
+					<div role="table" aria-label={`${title} details`}>
+						<div
+							role="row"
+							className="sticky top-0 z-10 grid grid-cols-[minmax(0,1fr)_repeat(3,minmax(5rem,0.35fr))] gap-3 border-b border-border/70 bg-background px-3 py-1.5 text-xs font-medium text-muted-foreground"
+						>
+							<div role="columnheader">
+								<TableSortButton
+									className="-ml-2 w-fit"
+									direction={tableSort?.key === "provider" ? tableSort.direction : null}
+									onClick={() => cycleTableSort("provider")}
+								>
+									{seriesColumnLabel}
+								</TableSortButton>
+							</div>
+							<div role="columnheader">
+								<TableSortButton
+									align="end"
+									direction={tableSort?.key === "minimum" ? tableSort.direction : null}
+									onClick={() => cycleTableSort("minimum")}
+								>
+									Min
+								</TableSortButton>
+							</div>
+							<div role="columnheader">
+								<TableSortButton
+									align="end"
+									direction={tableSort?.key === "maximum" ? tableSort.direction : null}
+									onClick={() => cycleTableSort("maximum")}
+								>
+									Max
+								</TableSortButton>
+							</div>
+							<div role="columnheader">
+								<TableSortButton
+									align="end"
+									direction={tableSort?.key === "average" ? tableSort.direction : null}
+									onClick={() => cycleTableSort("average")}
+								>
+									Avg
+								</TableSortButton>
+							</div>
+						</div>
+						{sortedProviderRows.map((provider) => {
 						const { isActive, isDimmed } = getSeriesEmphasis(
 							activeSeriesKey,
 							provider.seriesKey,
 						);
 						return <div
 							key={provider.seriesKey}
+							role="row"
 							className="grid grid-cols-[minmax(0,1fr)_repeat(3,minmax(5rem,0.35fr))] gap-3 border-b border-border/50 px-3 py-2.5 text-sm outline-none last:border-b-0 focus-visible:ring-1 focus-visible:ring-inset focus-visible:ring-ring"
 							style={{ opacity: isDimmed ? 0.35 : 1 }}
 							tabIndex={0}
@@ -660,7 +698,7 @@ export default function ModelProviderTrendChart({
 								}
 							}}
 						>
-							<span className="inline-flex min-w-0 items-center gap-2">
+							<span role="cell" className="inline-flex min-w-0 items-center gap-2">
 								<span className="size-2.5 shrink-0 rounded-full" style={{ backgroundColor: provider.color }} />
 								<span className={isActive ? "truncate font-semibold" : "truncate font-medium"}>{provider.name}</span>
 								{getPercentile(provider.provider) != null ? (
@@ -672,11 +710,12 @@ export default function ModelProviderTrendChart({
 									/>
 								) : null}
 							</span>
-							<span className="text-right tabular-nums text-muted-foreground">{metricConfig.formatValue(provider.minimum)}</span>
-							<span className="text-right tabular-nums text-muted-foreground">{metricConfig.formatValue(provider.maximum)}</span>
-							<span className="text-right font-medium tabular-nums">{metricConfig.formatValue(provider.average)}</span>
+							<span role="cell" className="text-right tabular-nums text-muted-foreground">{metricConfig.formatValue(provider.minimum)}</span>
+							<span role="cell" className="text-right tabular-nums text-muted-foreground">{metricConfig.formatValue(provider.maximum)}</span>
+							<span role="cell" className="text-right font-medium tabular-nums">{metricConfig.formatValue(provider.average)}</span>
 						</div>;
-					})}
+						})}
+					</div>
 				</ScrollArea>
 			) : (
 			<div className="space-y-1.5 pt-1">

--- a/apps/web/src/components/(data)/models/ModelUptimeDashboard.tsx
+++ b/apps/web/src/components/(data)/models/ModelUptimeDashboard.tsx
@@ -1,0 +1,35 @@
+"use client";
+
+import type { ModelPerformanceMetrics } from "@/lib/fetchers/models/getModelPerformance";
+import ModelSuccessChart from "./ModelSuccessChart";
+import { DEFAULT_MODEL_PERCENTILE } from "./ModelPercentileSelect";
+import { useModelPerformanceMetrics } from "./useModelPerformanceMetrics";
+
+export default function ModelUptimeDashboard({
+	modelId,
+	initialMetrics,
+}: {
+	modelId: string;
+	initialMetrics: ModelPerformanceMetrics | null;
+}) {
+	const { data } = useModelPerformanceMetrics({
+		modelId,
+		cloudflareColo: null,
+		percentile: DEFAULT_MODEL_PERCENTILE,
+		fallbackData: initialMetrics ?? undefined,
+	});
+	const metrics = data ?? initialMetrics;
+	const showLeastStableProvider =
+		metrics?.successSeries.some(
+			(point) =>
+				(point.providerCount ?? 0) > 1 &&
+				point.worstProviderSuccessPct != null,
+		) ?? false;
+
+	return (
+		<ModelSuccessChart
+			successSeries={metrics?.successSeries ?? []}
+			showLeastStableProvider={showLeastStableProvider}
+		/>
+	);
+}

--- a/apps/web/src/components/(data)/models/modelPerformancePercentiles.test.ts
+++ b/apps/web/src/components/(data)/models/modelPerformancePercentiles.test.ts
@@ -60,6 +60,30 @@ describe("buildSingleProviderPercentileSeries", () => {
 		expect(buildSingleProviderPercentileSeries(2, [])).toBeNull();
 	});
 
+	it("keeps cache-only percentile observations", () => {
+		const result = buildSingleProviderPercentileSeries(1, [
+			{
+				day: "2026-07-23",
+				provider: "poolside",
+				providerName: "Poolside",
+				providerColor: null,
+				percentile: 50,
+				avgThroughput: null,
+				avgLatencyMs: null,
+				avgGenerationMs: null,
+				cachedInputPct: 72.5,
+				requests: 100,
+			},
+		]);
+
+		expect(result).toEqual([
+			expect.objectContaining({
+				provider: "percentile-50",
+				cachedInputPct: 72.5,
+			}),
+		]);
+	});
+
 	it("assigns a distinct colour to every supported percentile", () => {
 		const result = buildSingleProviderPercentileSeries(
 			1,

--- a/apps/web/src/components/(data)/models/modelPerformancePercentiles.ts
+++ b/apps/web/src/components/(data)/models/modelPerformancePercentiles.ts
@@ -34,7 +34,8 @@ export function buildSingleProviderPercentileSeries(
 				point.requests > 0 &&
 				(point.avgThroughput != null ||
 					point.avgLatencyMs != null ||
-					point.avgGenerationMs != null),
+					point.avgGenerationMs != null ||
+					point.cachedInputPct != null),
 		)
 		.map((point) => {
 			const percentile = point.percentile as ModelPercentile;

--- a/apps/web/src/components/(data)/models/useModelPerformanceMetrics.ts
+++ b/apps/web/src/components/(data)/models/useModelPerformanceMetrics.ts
@@ -1,0 +1,68 @@
+"use client";
+
+import useSWR from "swr";
+
+import type { ModelPerformanceMetrics } from "@/lib/fetchers/models/getModelPerformance";
+import { fetchOptionalPublicWebApi } from "@/lib/web-api/client";
+import type { ModelPercentile } from "./ModelPercentileSelect";
+
+export const MODEL_PERFORMANCE_REFRESH_INTERVAL_MS = 15 * 60 * 1000;
+
+function getModelPerformanceKey({
+	modelId,
+	cloudflareColo,
+	percentile,
+}: {
+	modelId: string;
+	cloudflareColo: string | null;
+	percentile: ModelPercentile;
+}): `/api/_web/${string}` {
+	const query = new URLSearchParams({ percentile: String(percentile) });
+	if (cloudflareColo) query.set("colo", cloudflareColo);
+	return `/api/_web/models/${encodeURIComponent(modelId)}/performance?${query.toString()}`;
+}
+
+async function fetchModelPerformanceMetrics(key: `/api/_web/${string}`) {
+	const payload = await fetchOptionalPublicWebApi<{
+		metrics: ModelPerformanceMetrics | null;
+	}>(key);
+	return payload?.metrics ?? null;
+}
+
+export function useModelPerformanceMetrics({
+	modelId,
+	cloudflareColo,
+	percentile,
+	fallbackData,
+	refreshInterval = 0,
+	onError,
+	onSuccess,
+}: {
+	modelId: string;
+	cloudflareColo: string | null;
+	percentile: ModelPercentile;
+	fallbackData?: ModelPerformanceMetrics;
+	refreshInterval?: number;
+	onError?: () => void;
+	onSuccess?: (metrics: ModelPerformanceMetrics | null) => void;
+}) {
+	const key = getModelPerformanceKey({
+		modelId,
+		cloudflareColo,
+		percentile,
+	});
+	return useSWR<ModelPerformanceMetrics | null>(key, fetchModelPerformanceMetrics, {
+		dedupingInterval: 30_000,
+		errorRetryCount: 2,
+		fallbackData,
+		focusThrottleInterval: 60_000,
+		keepPreviousData: true,
+		onError,
+		onSuccess,
+		refreshInterval,
+		refreshWhenHidden: false,
+		refreshWhenOffline: false,
+		revalidateOnFocus: true,
+		revalidateOnReconnect: true,
+	});
+}

--- a/apps/web/src/components/ui/table-sort-button.tsx
+++ b/apps/web/src/components/ui/table-sort-button.tsx
@@ -1,0 +1,65 @@
+"use client";
+
+import { ChevronDown, ChevronUp, ChevronsUpDown } from "lucide-react";
+import type { ReactNode } from "react";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+
+type TableSortDirection = "asc" | "desc" | null;
+
+export function TableSortButton({
+	children,
+	direction,
+	onClick,
+	align = "start",
+	className,
+}: {
+	children: ReactNode;
+	direction: TableSortDirection;
+	onClick: () => void;
+	align?: "start" | "end";
+	className?: string;
+}) {
+	const Icon = direction == null
+		? ChevronsUpDown
+		: direction === "desc"
+			? ChevronDown
+			: ChevronUp;
+
+	return (
+		<Button
+			type="button"
+			variant="ghost"
+			size="sm"
+			className={cn(
+				"group h-7 rounded-sm px-2 text-xs hover:bg-transparent dark:hover:bg-transparent",
+				align === "end" ? "ml-auto justify-end" : "justify-start",
+				className,
+			)}
+			onClick={onClick}
+		>
+			{align === "end" ? <SortIcon Icon={Icon} direction={direction} /> : null}
+			{children}
+			{align === "start" ? <SortIcon Icon={Icon} direction={direction} /> : null}
+		</Button>
+	);
+}
+
+function SortIcon({
+	Icon,
+	direction,
+}: {
+	Icon: typeof ChevronsUpDown;
+	direction: TableSortDirection;
+}) {
+	return (
+		<Icon
+				className={cn(
+					"size-3.5 transition-opacity",
+					direction == null
+						? "opacity-0 group-hover:opacity-60 group-focus-visible:opacity-60"
+						: "opacity-100",
+				)}
+		/>
+	);
+}

--- a/apps/web/src/components/ui/table-sort-button.tsx
+++ b/apps/web/src/components/ui/table-sort-button.tsx
@@ -5,7 +5,7 @@ import type { ReactNode } from "react";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 
-type TableSortDirection = "asc" | "desc" | null;
+export type TableSortDirection = "asc" | "desc" | null;
 
 export function TableSortButton({
 	children,
@@ -40,6 +40,13 @@ export function TableSortButton({
 		>
 			{align === "end" ? <SortIcon Icon={Icon} direction={direction} /> : null}
 			{children}
+			<span className="sr-only">
+				{direction == null
+					? ", not sorted"
+					: direction === "asc"
+						? ", sorted ascending"
+						: ", sorted descending"}
+			</span>
 			{align === "start" ? <SortIcon Icon={Icon} direction={direction} /> : null}
 		</Button>
 	);

--- a/apps/web/src/lib/fetchers/frontend/fetchPublicCatalog.ts
+++ b/apps/web/src/lib/fetchers/frontend/fetchPublicCatalog.ts
@@ -3,6 +3,7 @@ import type {
 	AppUsageRow,
 	RangeKey,
 } from "@/lib/fetchers/apps/types";
+import { connection } from "next/server";
 import type { ProfileSnapshot } from "@/lib/fetchers/profile/types";
 import type {
 	OgEntity,
@@ -337,6 +338,7 @@ export async function fetchFrontendModelPendingApiReleaseState(
 			fetchFrontendModelHeader(modelId, false),
 			fetchFrontendModelPricing(modelId).catch(() => null),
 		]);
+		await connection();
 		const now = Date.now();
 		const hasActiveProvider = providers?.some((provider) => provider.provider_models.some((model) => {
 			if (!model.is_active_gateway || model.capability_status === "disabled" || !model.endpoint || model.endpoint === "unmapped") return false;

--- a/supabase/migrations/20260807170021_add_cached_input_performance_percentiles.sql
+++ b/supabase/migrations/20260807170021_add_cached_input_performance_percentiles.sql
@@ -1,0 +1,207 @@
+-- Add per-request cached-input percentage to the single-provider percentile
+-- series. The percentage follows the same subset/additive token semantics as
+-- get_v2_model_cached_input_metrics and remains null unless a daily cohort has
+-- at least 20 requests with explicit provider cache telemetry.
+begin;
+
+drop function if exists public.get_v2_model_provider_percentile_series_v2(text, text, text, text);
+drop function if exists public.get_v2_model_provider_percentile_series_v2_unsuppressed(text, text, text, text);
+
+create function public.get_v2_model_provider_percentile_series_v2_unsuppressed(
+  p_model_slug text,
+  p_cloudflare_colo text default null,
+  p_stream_mode text default 'all',
+  p_context_bucket text default 'all'
+)
+returns table (
+  usage_day date,
+  provider_id text,
+  provider_name text,
+  requests bigint,
+  percentile integer,
+  gateway_ttft_ms numeric,
+  provider_duration_ms numeric,
+  effective_throughput_tps numeric,
+  output_speed_tps numeric,
+  phaseo_overhead_ms numeric,
+  tpot_ms numeric,
+  itl_ms numeric,
+  cached_input_pct numeric
+)
+language sql
+stable
+security invoker
+set search_path = public
+as $$
+with percentile_values(percentile) as (
+  values (1), (5), (10), (25), (50), (75), (90), (95), (99)
+),
+scoped_facts as (
+  select fact.request_event_id
+  from public.v2_request_facts fact
+  where coalesce(fact.routed_model_slug, fact.requested_model_slug) = lower(trim(p_model_slug))
+    and fact.occurred_at >= now() - interval '7 days'
+),
+usage_tokens as (
+  select
+    usage.request_event_id,
+    sum(usage.quantity) filter (
+      where usage.meter_key in ('input_tokens', 'input_text_tokens', 'prompt_tokens')
+    )::numeric input_tokens,
+    sum(usage.quantity) filter (
+      where usage.meter_key = 'cached_input_tokens'
+    )::numeric cached_input_tokens,
+    bool_or(usage.meter_key = 'cached_input_tokens') cache_telemetry_observed
+  from public.v2_request_usage usage
+  join scoped_facts on scoped_facts.request_event_id = usage.request_event_id
+  where usage.meter_key in (
+    'input_tokens',
+    'input_text_tokens',
+    'prompt_tokens',
+    'cached_input_tokens'
+  )
+  group by usage.request_event_id
+),
+base as (
+  select
+    fact.occurred_at::date usage_day,
+    provider.provider_slug provider_id,
+    provider.name provider_name,
+    fact.success,
+    fact.stream,
+    tokens.input_tokens,
+    fact.gateway_ttft_ms,
+    fact.generation_ms provider_duration_ms,
+    fact.throughput effective_throughput_tps,
+    fact.output_speed_tps,
+    fact.phaseo_overhead_ms,
+    fact.tpot_ms,
+    fact.itl_ms,
+    case
+      when not coalesce(tokens.cache_telemetry_observed, false)
+        or tokens.input_tokens is null
+        or tokens.input_tokens <= 0
+        then null
+      else least(
+        100,
+        coalesce(tokens.cached_input_tokens, 0) * 100.0 /
+          case
+            when coalesce(
+              (fact.safe_metadata ->> 'cached_input_tokens_are_subset_of_input')::boolean,
+              true
+            ) then tokens.input_tokens
+            else tokens.input_tokens + coalesce(tokens.cached_input_tokens, 0)
+          end
+      )
+    end cached_input_pct
+  from public.v2_request_facts fact
+  join public.v2_model_provider_routes route
+    on route.provider_model_id = fact.provider_model_id
+  join public.v2_providers provider
+    on provider.provider_slug = route.provider_slug
+  left join usage_tokens tokens
+    on tokens.request_event_id = fact.request_event_id
+  where coalesce(fact.routed_model_slug, fact.requested_model_slug) = lower(trim(p_model_slug))
+    and fact.occurred_at >= now() - interval '7 days'
+    and (
+      nullif(upper(trim(p_cloudflare_colo)), '') is null
+      or upper(trim(fact.cloudflare_colo)) = upper(trim(p_cloudflare_colo))
+    )
+    and (
+      lower(p_stream_mode) not in ('stream', 'non_stream')
+      or fact.stream = (lower(p_stream_mode) = 'stream')
+    )
+    and (
+      lower(p_context_bucket) not in ('lte_4k', '4k_16k', '16k_64k', 'gt_64k')
+      or (lower(p_context_bucket) = 'lte_4k' and tokens.input_tokens <= 4096)
+      or (lower(p_context_bucket) = '4k_16k' and tokens.input_tokens > 4096 and tokens.input_tokens <= 16384)
+      or (lower(p_context_bucket) = '16k_64k' and tokens.input_tokens > 16384 and tokens.input_tokens <= 65536)
+      or (lower(p_context_bucket) = 'gt_64k' and tokens.input_tokens > 65536)
+    )
+)
+select
+  base.usage_day,
+  base.provider_id,
+  base.provider_name,
+  count(*)::bigint requests,
+  p.percentile,
+  percentile_cont(p.percentile / 100.0) within group (order by base.gateway_ttft_ms)
+    filter (where base.success and base.gateway_ttft_ms is not null)::numeric,
+  percentile_cont(p.percentile / 100.0) within group (order by base.provider_duration_ms)
+    filter (where base.success and base.provider_duration_ms is not null)::numeric,
+  percentile_cont(p.percentile / 100.0) within group (order by base.effective_throughput_tps)
+    filter (where base.success and base.effective_throughput_tps is not null)::numeric,
+  percentile_cont(p.percentile / 100.0) within group (order by base.output_speed_tps)
+    filter (where base.success and base.output_speed_tps is not null)::numeric,
+  percentile_cont(p.percentile / 100.0) within group (order by base.phaseo_overhead_ms)
+    filter (where base.success and base.phaseo_overhead_ms is not null)::numeric,
+  percentile_cont(p.percentile / 100.0) within group (order by base.tpot_ms)
+    filter (where base.success and base.tpot_ms is not null)::numeric,
+  percentile_cont(p.percentile / 100.0) within group (order by base.itl_ms)
+    filter (where base.success and base.itl_ms is not null)::numeric,
+  case
+    when count(base.cached_input_pct) >= 20 then
+      percentile_cont(p.percentile / 100.0) within group (order by base.cached_input_pct)
+        filter (where base.cached_input_pct is not null)::numeric
+    else null
+  end
+from base
+cross join percentile_values p
+group by base.usage_day, base.provider_id, base.provider_name, p.percentile
+order by base.usage_day, base.provider_id, p.percentile;
+$$;
+
+revoke execute on function public.get_v2_model_provider_percentile_series_v2_unsuppressed(text, text, text, text)
+  from public, anon, authenticated;
+grant execute on function public.get_v2_model_provider_percentile_series_v2_unsuppressed(text, text, text, text)
+  to service_role;
+
+create function public.get_v2_model_provider_percentile_series_v2(
+  p_model_slug text,
+  p_cloudflare_colo text default null,
+  p_stream_mode text default 'all',
+  p_context_bucket text default 'all'
+)
+returns table (
+  usage_day date,
+  provider_id text,
+  provider_name text,
+  requests bigint,
+  percentile integer,
+  gateway_ttft_ms numeric,
+  provider_duration_ms numeric,
+  effective_throughput_tps numeric,
+  output_speed_tps numeric,
+  phaseo_overhead_ms numeric,
+  tpot_ms numeric,
+  itl_ms numeric,
+  cached_input_pct numeric
+)
+language sql
+stable
+security definer
+set search_path = ''
+as $$
+select series.*
+from public.v2_models model
+cross join lateral public.get_v2_model_provider_percentile_series_v2_unsuppressed(
+  model.model_slug,
+  p_cloudflare_colo,
+  p_stream_mode,
+  p_context_bucket
+) series
+where model.model_slug = lower(trim(p_model_slug))
+  and model.hidden = false
+  and model.status <> 'disabled'
+  and series.requests >= 20;
+$$;
+
+revoke execute on function public.get_v2_model_provider_percentile_series_v2(text, text, text, text)
+  from public;
+grant execute on function public.get_v2_model_provider_percentile_series_v2(text, text, text, text)
+  to anon, authenticated, service_role;
+
+comment on function public.get_v2_model_provider_percentile_series_v2(text, text, text, text) is
+  'Returns daily single-provider performance percentiles, including cached-input share only for cohorts with at least 20 cache telemetry observations.';
+
+commit;


### PR DESCRIPTION
## Summary

Refines the consolidated model-detail experience across navigation, performance, providers, pricing, Quickstart, About, and FAQ surfaces.

The model page now has an attached mobile section navigator with directional active-section motion, denser and more consistent responsive controls, full-row endpoint links, neutral table hover states, improved provider FAQ context, and legacy model sub-routes that redirect to their equivalent consolidated sections.

Performance presentation now uses consistent charts and sortable detail tables for throughput, output speed, time to first token, provider duration, TPOT, ITL, and cached input. Cached-input percentiles are supplied by a new protected rollup migration. Performance and Uptime share an SSR-seeded SWR resource with focus/reconnect revalidation and a 15-minute refresh interval aligned with Cloudflare's edge cache, while the remaining model sections retain their Server Component and natural cache lifecycle.

## User impact

- Mobile model navigation remains visually attached to the sticky model identity header and opens below its trigger.
- Performance cards and dialogs present consistent axes, hover behaviour, percentile/provider tables, provider colours, and responsive filtering.
- Pricing and provider rows use neutral row highlighting without changing linked names to an accent colour.
- Quickstart controls remain usable across phone, tablet, and desktop widths, preserve composer state, and expose full-row documentation links.
- FAQ provider answers include linked provider names, capped at eight with a remaining-count summary.
- Old model-detail routes preserve compatibility by redirecting to the appropriate consolidated section.

## Validation

- `pnpm --filter @phaseo/web typecheck`
- `pnpm --filter @phaseo/web lint`
- `pnpm --filter @phaseo/web build`
- `pnpm --filter @phaseo/web-api typecheck`
- `pnpm --filter @phaseo/web-api lint` (no errors; existing max-file-length warnings only)
- `pnpm --filter @phaseo/web-api test -- src/routes/public/models.test.ts` (23 tests passed)
- `node scripts/validate-supabase-migrations.mjs`
- Browser verification at desktop, intermediate, and mobile widths for Providers, Performance, Pricing, Quickstart, About, FAQ, Uptime, and legacy redirects

The three targeted web Jest files currently cannot start because the repository's Jest 30 runtime throws `this._moduleMocker.clearMocksOnScope is not a function` during environment setup; no assertions execute. The production build and TypeScript validation pass.

Created with Codex


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added provider colors and cached-input percentages to performance metrics and percentile charts.
  * Added provider links and “and more” summaries to model FAQs.
  * Added responsive performance filtering, refreshed uptime dashboards, and improved metric fallbacks.
  * Legacy model sections now redirect to their canonical locations while preserving relevant links and filters.

* **Improvements**
  * Enhanced table sorting, chart accessibility, navigation scrolling, quickstart layouts, and pricing-table responsiveness.
  * Refined styling across model pages, controls, links, and empty states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->