### PR TITLE
fix(pricing): apply CrofAI GLM 5.2 discount

### DIFF
--- a/.changeset/crofai-glm52-discount.md
+++ b/.changeset/crofai-glm52-discount.md
@@ -1,0 +1,5 @@
+---
+"@phaseo/gateway-api": patch
+---
+
+Apply CrofAI's current open-ended 80% discounted GLM 5.2 token pricing while preserving the existing base rules for historical billing.

--- a/packages/data/catalog/src/data/pricing/crofai/z-ai-glm-5.2/text.generate/pricing.json
+++ b/packages/data/catalog/src/data/pricing/crofai/z-ai-glm-5.2/text.generate/pricing.json
@@ -52,16 +52,87 @@
       "cache_duration_seconds": null,
       "conditions": [],
       "source": null
+    },
+    {
+      "meter": "input_text_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 0.06,
+      "currency": "USD",
+      "pricing_plan": "standard",
+      "note": "CrofAI /v1/models effective price with an 80% discount versus the public pricing table; no expiry published.",
+      "match": [],
+      "priority": 110,
+      "effective_from": "2026-08-09T00:00:00Z",
+      "region": null,
+      "cache_duration_seconds": null,
+      "conditions": [],
+      "source": {
+        "kind": "api",
+        "url": "https://crof.ai/v1/models",
+        "accessed_at": "2026-08-09T00:00:00Z"
+      }
+    },
+    {
+      "meter": "cached_read_text_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 0.01,
+      "currency": "USD",
+      "pricing_plan": "standard",
+      "note": "CrofAI /v1/models effective price with an 80% discount versus the public pricing table; no expiry published.",
+      "match": [],
+      "priority": 110,
+      "effective_from": "2026-08-09T00:00:00Z",
+      "region": null,
+      "cache_duration_seconds": null,
+      "conditions": [],
+      "source": {
+        "kind": "api",
+        "url": "https://crof.ai/v1/models",
+        "accessed_at": "2026-08-09T00:00:00Z"
+      }
+    },
+    {
+      "meter": "output_text_tokens",
+      "unit": "token",
+      "unit_size": 1000000,
+      "price_per_unit": 0.21,
+      "currency": "USD",
+      "pricing_plan": "standard",
+      "note": "CrofAI /v1/models effective price with an 80% discount versus the public pricing table; no expiry published.",
+      "match": [],
+      "priority": 110,
+      "effective_from": "2026-08-09T00:00:00Z",
+      "region": null,
+      "cache_duration_seconds": null,
+      "conditions": [],
+      "source": {
+        "kind": "api",
+        "url": "https://crof.ai/v1/models",
+        "accessed_at": "2026-08-09T00:00:00Z"
+      }
     }
   ],
   "regions": [],
   "service_tiers": [
     "standard"
   ],
-  "sources": [],
+  "sources": [
+    {
+      "kind": "api",
+      "url": "https://crof.ai/v1/models",
+      "accessed_at": "2026-08-09T00:00:00Z"
+    },
+    {
+      "kind": "pricing",
+      "url": "https://crof.ai/pricing",
+      "accessed_at": "2026-08-09T00:00:00Z"
+    }
+  ],
   "verification": {
-    "status": "unverified",
-    "checked_at": null,
-    "notes": null
+    "status": "verified",
+    "checked_at": "2026-08-09T00:00:00Z",
+    "notes": "CrofAI's live models API reports $0.06/$0.010/$0.21 per 1M tokens with an 80% discount; the public pricing table lists $0.30/$0.05/$1.05. The discounted rules are open-ended until CrofAI publishes an expiry."
   }
 }


### PR DESCRIPTION
## Summary

- Add CrofAI GLM 5.2's current effective rates from the live [models API](https://crof.ai/v1/models): $0.06 input, $0.010 cached input, and $0.21 output per 1M tokens.
- Keep the existing $0.30 / $0.05 / $1.05 base rules unchanged for historical billing.
- Use priority 110 for the new open-ended rules so they override the existing priority-100 rules without adding an expiry.
- Record the live [CrofAI pricing table](https://crof.ai/pricing) and API as provenance.

## Validation

- `pnpm validate:pricing`
- `pnpm validate:data` (passes with existing non-blocking warnings)
- `pnpm validate:gateway`
- `pnpm --filter @phaseo/gateway-api test -- src/pipeline/pricing/engine.discount.test.ts`
- `pnpm exec changeset status --since origin/main`

When CrofAI publishes an end date for the discount, the priority-110 rules can be given an `effective_to` without deleting the historical rules.

Created with Codex

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added discounted pricing for CrofAI’s GLM 5.2 token usage, effective August 9, 2026.
  - Rates are $0.06 per million input tokens, $0.01 per million cached input tokens, and $0.21 per million output tokens.
  - Pricing applies without an end date.

- **Bug Fixes**
  - Existing pricing rules remain available for accurate historical billing.

- **Documentation**
  - Updated pricing details and verification records with supporting source information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->