### PR TITLE
Verify Aion Labs registered seat

### DIFF
--- a/packages/data/catalog/src/data/organisations/aion-labs/organisation.json
+++ b/packages/data/catalog/src/data/organisations/aion-labs/organisation.json
@@ -2,7 +2,7 @@
   "organisation_id": "aion-labs",
   "name": "Aion Labs",
   "country_code": "PL",
-  "description": "Aion Labs is an AI model lab behind the Aion model family. They publish models via Hugging Face and provide access/community via their website, Discord, and subreddit.",
+  "description": "Aion Labs is an AI model lab operated by Deep Forge sp. z o.o., a Polish company with its registered seat in Konstancin-Jeziorna, Poland. They publish models via Hugging Face and provide access/community via their website, Discord, and subreddit.",
   "colour": "#0f172a",
   "organisation_links": [
     {
@@ -28,10 +28,23 @@
   ],
   "status": "active",
   "routable": null,
-  "sources": [],
+  "sources": [
+    {
+      "kind": "official_legal_terms",
+      "url": "https://www.aionlabs.ai/terms/",
+      "accessed_at": "2026-08-09T00:00:00Z",
+      "notes": "Aion Labs identifies Deep Forge sp. z o.o. (NIP: 1231533694) as the company operating the platform and states that Polish law governs the terms."
+    },
+    {
+      "kind": "official_company_registry",
+      "url": "https://api-krs.ms.gov.pl/api/krs/OdpisAktualny/0001036658?rejestr=P&format=json",
+      "accessed_at": "2026-08-09T00:00:00Z",
+      "notes": "The current KRS record for Deep Forge sp. z o.o. (KRS: 0001036658) lists its registered seat at ul. Uzdrowiskowa 7, 05-510 Konstancin-Jeziorna, Poland."
+    }
+  ],
   "verification": {
-    "status": "unverified",
-    "checked_at": null,
-    "notes": null
+    "status": "verified",
+    "checked_at": "2026-08-09T00:00:00Z",
+    "notes": "Verified as Poland-based through Aion Labs' official legal terms and the current Polish KRS record for its legal operator. The supported location wording is registered seat in Konstancin-Jeziorna, Poland; no separate public source was found for a Warsaw headquarters."
   }
 }


### PR DESCRIPTION
## Summary

The Aion Labs organisation record already identified Poland (`country_code: PL`) but had no source provenance and remained unverified. That left the catalogue without precise, source-backed location wording and made it easier to confuse this AI model lab with the unrelated AION Labs venture studio.

## Changes

- Clarify that Aion Labs is operated by Deep Forge sp. z o.o., a Polish company with its registered seat in Konstancin-Jeziorna, Poland.
- Preserve the existing `PL` country code.
- Record Aion Labs' official legal terms and the current Polish KRS record for Deep Forge sp. z o.o. (KRS 0001036658) as sources.
- Mark the organisation record verified while explicitly limiting the location claim to the registered seat; no unsupported Warsaw headquarters claim is added.

## Evidence

- Aion Labs' official terms identify Deep Forge sp. z o.o. (NIP 1231533694) as the company operating the platform and state that Polish law governs the terms: https://www.aionlabs.ai/terms/
- The current Polish KRS record lists the registered seat at ul. Uzdrowiskowa 7, 05-510 Konstancin-Jeziorna, Poland: https://api-krs.ms.gov.pl/api/krs/OdpisAktualny/0001036658?rejestr=P&format=json

## Validation

- `pnpm.cmd validate:data` — passed all 9 enforced checks; existing non-blocking warnings remain.
- `git diff --check` — passed.

Created with Codex


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Aion Labs’ profile to identify its Polish operator and registered location.
  * Added official legal-terms and company-registry sources.
  * Marked the profile as verified with supporting details and a verification timestamp.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->