### PR TITLE
Audit organisation and provider location metadata

### DIFF
--- a/packages/data/catalog/src/data/api_providers/anthropic/api_provider.json
+++ b/packages/data/catalog/src/data/api_providers/anthropic/api_provider.json
@@ -3,7 +3,7 @@
   "api_provider_name": "Anthropic",
   "provider_family_id": "anthropic",
   "offer_scope": "global",
-  "description": null,
+  "description": "Anthropic's API is provided by an AI research and deployment company with its corporate address in San Francisco, California.",
   "link": "https://docs.anthropic.com/en/home",
   "residency_mode": "customer_selectable",
   "default_execution_regions": [
@@ -38,10 +38,17 @@
   "auth_env": null,
   "api_formats": [],
   "service_tiers": [],
-  "sources": [],
+  "sources": [
+    {
+      "kind": "official_privacy_notice",
+      "url": "https://www-cdn.anthropic.com/8fd65f023a39d74220c5ebff85c788875c05533f.pdf",
+      "accessed_at": "2026-08-09T00:00:00Z",
+      "notes": "Anthropic's official employee/candidate privacy notice lists Anthropic, PBC at 548 Market Street, PMB 90375, San Francisco, CA 94104."
+    }
+  ],
   "verification": {
-    "status": "unverified",
-    "checked_at": null,
-    "notes": null
+    "status": "partial",
+    "checked_at": "2026-08-09T00:00:00Z",
+    "notes": "Location metadata verified; other provider policy and catalogue fields were not re-audited."
   }
 }

--- a/packages/data/catalog/src/data/api_providers/cloudflare-ai-gateway/api_provider.json
+++ b/packages/data/catalog/src/data/api_providers/cloudflare-ai-gateway/api_provider.json
@@ -4,7 +4,7 @@
   "provider_family_id": null,
   "offer_label": null,
   "offer_scope": "specialized",
-  "description": null,
+  "description": "Cloudflare AI Gateway is Cloudflare's AI gateway service; Cloudflare is headquartered in San Francisco, California.",
   "link": "https://developers.cloudflare.com/ai-gateway/",
   "residency_mode": null,
   "default_execution_regions": null,
@@ -22,7 +22,7 @@
   "regional_pricing_uplift_percent": null,
   "pricing_source_url": null,
   "regional_pricing_notes": null,
-  "country_code": null,
+  "country_code": "US",
   "status": "Active",
   "colour": null,
   "gateway_kind": "gateway",
@@ -44,11 +44,17 @@
       "url": "https://models.dev/api.json",
       "accessed_at": "2026-07-22T11:23:04.646Z",
       "notes": "Gateway metadata seed; verify provider policy and regional semantics before enabling routing."
+    },
+    {
+      "kind": "official_company_page",
+      "url": "https://www.cloudflare.com/about/",
+      "accessed_at": "2026-08-09T00:00:00Z",
+      "notes": "Cloudflare's official About page identifies San Francisco as its headquarters and lists 101 Townsend St., San Francisco, CA 94107."
     }
   ],
   "verification": {
     "status": "partial",
-    "checked_at": "2026-07-22T11:23:04.646Z",
-    "notes": "Imported from the public models.dev provider registry; not a Phaseo-routable offer."
+    "checked_at": "2026-08-09T00:00:00Z",
+    "notes": "Location metadata verified; other provider policy and catalogue fields were not re-audited. Existing provider verification note: Gateway metadata seed; verify provider policy and regional semantics before enabling routing."
   }
 }

--- a/packages/data/catalog/src/data/api_providers/cloudflare/api_provider.json
+++ b/packages/data/catalog/src/data/api_providers/cloudflare/api_provider.json
@@ -1,7 +1,7 @@
 {
   "api_provider_id": "cloudflare",
   "api_provider_name": "Cloudflare",
-  "description": null,
+  "description": "Cloudflare's AI services are provided by a web-infrastructure company headquartered in San Francisco, California.",
   "link": "https://developers.cloudflare.com/workers-ai/platform/pricing/",
   "country_code": "US",
   "status": "Active",
@@ -20,10 +20,17 @@
   "auth_env": null,
   "api_formats": [],
   "service_tiers": [],
-  "sources": [],
+  "sources": [
+    {
+      "kind": "official_company_page",
+      "url": "https://www.cloudflare.com/about/",
+      "accessed_at": "2026-08-09T00:00:00Z",
+      "notes": "Cloudflare's official About page identifies San Francisco as its headquarters and lists 101 Townsend St., San Francisco, CA 94107."
+    }
+  ],
   "verification": {
-    "status": "unverified",
-    "checked_at": null,
-    "notes": null
+    "status": "partial",
+    "checked_at": "2026-08-09T00:00:00Z",
+    "notes": "Location metadata verified; other provider policy and catalogue fields were not re-audited."
   }
 }

--- a/packages/data/catalog/src/data/api_providers/github-models/api_provider.json
+++ b/packages/data/catalog/src/data/api_providers/github-models/api_provider.json
@@ -4,7 +4,7 @@
   "provider_family_id": null,
   "offer_label": null,
   "offer_scope": "specialized",
-  "description": null,
+  "description": "GitHub Models is a catalogue/gateway service from GitHub, whose headquarters are in San Francisco, California.",
   "link": "https://docs.github.com/en/github-models",
   "residency_mode": null,
   "default_execution_regions": null,
@@ -22,7 +22,7 @@
   "regional_pricing_uplift_percent": null,
   "pricing_source_url": null,
   "regional_pricing_notes": null,
-  "country_code": null,
+  "country_code": "US",
   "status": "Active",
   "colour": null,
   "gateway_kind": "gateway",
@@ -42,11 +42,17 @@
       "url": "https://models.dev/api.json",
       "accessed_at": "2026-07-22T11:23:04.646Z",
       "notes": "Gateway metadata seed; verify provider policy and regional semantics before enabling routing."
+    },
+    {
+      "kind": "official_company_page",
+      "url": "https://github.com/about/press",
+      "accessed_at": "2026-08-09T00:00:00Z",
+      "notes": "GitHub's official press page identifies its headquarters as San Francisco."
     }
   ],
   "verification": {
     "status": "partial",
-    "checked_at": "2026-07-22T11:23:04.646Z",
-    "notes": "Imported from the public models.dev provider registry; not a Phaseo-routable offer."
+    "checked_at": "2026-08-09T00:00:00Z",
+    "notes": "Location metadata verified; other provider policy and catalogue fields were not re-audited. Existing provider verification note: Gateway metadata seed; verify provider policy and regional semantics before enabling routing."
   }
 }

--- a/packages/data/catalog/src/data/api_providers/mistral/api_provider.json
+++ b/packages/data/catalog/src/data/api_providers/mistral/api_provider.json
@@ -3,7 +3,7 @@
   "api_provider_name": "Mistral",
   "provider_family_id": "mistral",
   "offer_scope": "global",
-  "description": null,
+  "description": "Mistral AI's API is provided by Mistral AI SAS, whose registered offices are in Paris, France.",
   "link": "https://docs.mistral.ai/",
   "zero_data_retention": "optional",
   "residency_source_url": "https://help.mistral.ai/en/articles/347612-can-i-activate-zero-data-retention-zdr",
@@ -25,10 +25,17 @@
   "auth_env": null,
   "api_formats": [],
   "service_tiers": [],
-  "sources": [],
+  "sources": [
+    {
+      "kind": "official_legal_notice",
+      "url": "https://legal.mistral.ai/legal-notice",
+      "accessed_at": "2026-08-09T00:00:00Z",
+      "notes": "Mistral AI SAS's official legal notice lists its registered offices at 15 Rue des Halles, 75001 Paris, France."
+    }
+  ],
   "verification": {
-    "status": "unverified",
-    "checked_at": null,
-    "notes": null
+    "status": "partial",
+    "checked_at": "2026-08-09T00:00:00Z",
+    "notes": "Location metadata verified; other provider policy and catalogue fields were not re-audited."
   }
 }

--- a/packages/data/catalog/src/data/api_providers/openai/api_provider.json
+++ b/packages/data/catalog/src/data/api_providers/openai/api_provider.json
@@ -3,7 +3,7 @@
   "api_provider_name": "OpenAI",
   "provider_family_id": "openai",
   "offer_scope": "global",
-  "description": null,
+  "description": "OpenAI's API is provided by an AI research and deployment company based in San Francisco, California.",
   "link": "https://platform.openai.com/docs/overview",
   "residency_mode": "provider_managed",
   "default_execution_regions": [
@@ -37,10 +37,17 @@
   "auth_env": null,
   "api_formats": [],
   "service_tiers": [],
-  "sources": [],
+  "sources": [
+    {
+      "kind": "official_terms_pdf",
+      "url": "https://cdn.openai.com/pdf/d5caec5a-ee81-419d-b0d7-39f1424d819c/OpenAI%20Model%20Craft_%20Parameter%20Golf%20Challenge%20Terms%20and%20Conditions.pdf",
+      "accessed_at": "2026-08-09T00:00:00Z",
+      "notes": "OpenAI OpCo, LLC's official terms list 1455 Third Street, San Francisco, CA 94158."
+    }
+  ],
   "verification": {
-    "status": "unverified",
-    "checked_at": null,
-    "notes": null
+    "status": "partial",
+    "checked_at": "2026-08-09T00:00:00Z",
+    "notes": "Location metadata verified; other provider policy and catalogue fields were not re-audited."
   }
 }

--- a/packages/data/catalog/src/data/api_providers/perplexity-agent/api_provider.json
+++ b/packages/data/catalog/src/data/api_providers/perplexity-agent/api_provider.json
@@ -4,7 +4,7 @@
   "provider_family_id": null,
   "offer_label": null,
   "offer_scope": "specialized",
-  "description": null,
+  "description": "Perplexity Agent is a Perplexity AI service; Perplexity AI, Inc. has its corporate address in San Francisco, California.",
   "link": "https://docs.perplexity.ai/docs/agent-api/models",
   "residency_mode": null,
   "default_execution_regions": null,
@@ -22,7 +22,7 @@
   "regional_pricing_uplift_percent": null,
   "pricing_source_url": null,
   "regional_pricing_notes": null,
-  "country_code": null,
+  "country_code": "US",
   "status": "Active",
   "colour": null,
   "gateway_kind": "catalogue",
@@ -42,11 +42,17 @@
       "url": "https://models.dev/api.json",
       "accessed_at": "2026-07-23T09:08:52.190Z",
       "notes": "Provider metadata and model support enrichment; not a Phaseo-routable offer."
+    },
+    {
+      "kind": "official_terms",
+      "url": "https://www.perplexity.ai/es/hub/legal/terms-of-service",
+      "accessed_at": "2026-08-09T00:00:00Z",
+      "notes": "Perplexity AI, Inc.'s official terms list 115 Sansome St., Suite 900, San Francisco, CA 94104."
     }
   ],
   "verification": {
     "status": "partial",
-    "checked_at": "2026-07-23T09:08:52.190Z",
-    "notes": "Imported from the public models.dev provider registry."
+    "checked_at": "2026-08-09T00:00:00Z",
+    "notes": "Location metadata verified; other provider policy and catalogue fields were not re-audited. Existing provider verification note: Provider metadata and model support enrichment; not a Phaseo-routable offer."
   }
 }

--- a/packages/data/catalog/src/data/api_providers/stackit/api_provider.json
+++ b/packages/data/catalog/src/data/api_providers/stackit/api_provider.json
@@ -4,7 +4,7 @@
   "provider_family_id": null,
   "offer_label": null,
   "offer_scope": "specialized",
-  "description": null,
+  "description": "STACKIT is a cloud/AI provider with its registered seat in Neckarsulm, Germany.",
   "link": "https://docs.stackit.cloud/products/data-and-ai/ai-model-serving/basics/available-shared-models",
   "residency_mode": null,
   "default_execution_regions": null,
@@ -22,7 +22,7 @@
   "regional_pricing_uplift_percent": null,
   "pricing_source_url": null,
   "regional_pricing_notes": null,
-  "country_code": null,
+  "country_code": "DE",
   "status": "Active",
   "colour": null,
   "gateway_kind": "catalogue",
@@ -42,11 +42,17 @@
       "url": "https://models.dev/api.json",
       "accessed_at": "2026-07-23T09:08:52.190Z",
       "notes": "Provider metadata and model support enrichment; not a Phaseo-routable offer."
+    },
+    {
+      "kind": "official_terms",
+      "url": "https://www.stackit.de/en/general-terms-and-conditions/terms-of-use/",
+      "accessed_at": "2026-08-09T00:00:00Z",
+      "notes": "STACKIT's official terms of use identify STACKIT GmbH & Co. KG at Stiftsbergstraße 1, 74172 Neckarsulm, Germany."
     }
   ],
   "verification": {
     "status": "partial",
-    "checked_at": "2026-07-23T09:08:52.190Z",
-    "notes": "Imported from the public models.dev provider registry."
+    "checked_at": "2026-08-09T00:00:00Z",
+    "notes": "Location metadata verified; other provider policy and catalogue fields were not re-audited. Existing provider verification note: Provider metadata and model support enrichment; not a Phaseo-routable offer."
   }
 }

--- a/packages/data/catalog/src/data/api_providers/togetherai/api_provider.json
+++ b/packages/data/catalog/src/data/api_providers/togetherai/api_provider.json
@@ -4,7 +4,7 @@
   "provider_family_id": null,
   "offer_label": null,
   "offer_scope": "specialized",
-  "description": null,
+  "description": "Together AI's hosted models API is operated by Together Computer, Inc., whose official terms list a San Francisco, California address.",
   "link": "https://docs.together.ai/docs/serverless-models",
   "residency_mode": null,
   "default_execution_regions": null,
@@ -22,7 +22,7 @@
   "regional_pricing_uplift_percent": null,
   "pricing_source_url": null,
   "regional_pricing_notes": null,
-  "country_code": null,
+  "country_code": "US",
   "status": "Active",
   "colour": null,
   "gateway_kind": "catalogue",
@@ -42,11 +42,17 @@
       "url": "https://models.dev/api.json",
       "accessed_at": "2026-07-23T09:08:52.190Z",
       "notes": "Provider metadata and model support enrichment; not a Phaseo-routable offer."
+    },
+    {
+      "kind": "official_terms",
+      "url": "https://www.together.ai/terms-of-service",
+      "accessed_at": "2026-08-09T00:00:00Z",
+      "notes": "Together AI's official terms identify Together Computer, Inc. at 251 Rhode Island Street, Suite 200, San Francisco, CA 94103."
     }
   ],
   "verification": {
     "status": "partial",
-    "checked_at": "2026-07-23T09:08:52.190Z",
-    "notes": "Imported from the public models.dev provider registry."
+    "checked_at": "2026-08-09T00:00:00Z",
+    "notes": "Location metadata verified; other provider policy and catalogue fields were not re-audited. Existing provider verification note: Provider metadata and model support enrichment; not a Phaseo-routable offer."
   }
 }

--- a/packages/data/catalog/src/data/api_providers/vercel/api_provider.json
+++ b/packages/data/catalog/src/data/api_providers/vercel/api_provider.json
@@ -4,7 +4,7 @@
   "provider_family_id": null,
   "offer_label": null,
   "offer_scope": "specialized",
-  "description": null,
+  "description": "Vercel AI Gateway is Vercel's gateway service; Vercel's San Francisco headquarters are listed at 201 Mission Street.",
   "link": "https://github.com/vercel/ai/tree/5eb85cc45a259553501f535b8ac79a77d0e79223/packages/gateway",
   "residency_mode": null,
   "default_execution_regions": null,
@@ -22,7 +22,7 @@
   "regional_pricing_uplift_percent": null,
   "pricing_source_url": null,
   "regional_pricing_notes": null,
-  "country_code": null,
+  "country_code": "US",
   "status": "Active",
   "colour": null,
   "gateway_kind": "gateway",
@@ -42,11 +42,17 @@
       "url": "https://models.dev/api.json",
       "accessed_at": "2026-07-22T11:23:04.646Z",
       "notes": "Gateway metadata seed; verify provider policy and regional semantics before enabling routing."
+    },
+    {
+      "kind": "official_company_event_page",
+      "url": "https://vercel.com/go/builder-day",
+      "accessed_at": "2026-08-09T00:00:00Z",
+      "notes": "Vercel's official Builder Day page identifies its San Francisco headquarters at 201 Mission Street."
     }
   ],
   "verification": {
     "status": "partial",
-    "checked_at": "2026-07-22T11:23:04.646Z",
-    "notes": "Imported from the public models.dev provider registry; not a Phaseo-routable offer."
+    "checked_at": "2026-08-09T00:00:00Z",
+    "notes": "Location metadata verified; other provider policy and catalogue fields were not re-audited. Existing provider verification note: Gateway metadata seed; verify provider policy and regional semantics before enabling routing."
   }
 }

--- a/packages/data/catalog/src/data/api_providers/wandb/api_provider.json
+++ b/packages/data/catalog/src/data/api_providers/wandb/api_provider.json
@@ -4,7 +4,7 @@
   "provider_family_id": null,
   "offer_label": null,
   "offer_scope": "specialized",
-  "description": null,
+  "description": "Weights & Biases is an ML tooling provider with US headquarters in San Francisco, California.",
   "link": "https://docs.wandb.ai/guides/integrations/inference/",
   "residency_mode": null,
   "default_execution_regions": null,
@@ -22,7 +22,7 @@
   "regional_pricing_uplift_percent": null,
   "pricing_source_url": null,
   "regional_pricing_notes": null,
-  "country_code": null,
+  "country_code": "US",
   "status": "Active",
   "colour": null,
   "gateway_kind": "catalogue",
@@ -42,11 +42,17 @@
       "url": "https://models.dev/api.json",
       "accessed_at": "2026-07-23T09:08:52.190Z",
       "notes": "Provider metadata and model support enrichment; not a Phaseo-routable offer."
+    },
+    {
+      "kind": "official_office_page",
+      "url": "https://wandb.ai/site/blocks/",
+      "accessed_at": "2026-08-09T00:00:00Z",
+      "notes": "Weights & Biases' official office page lists its U.S. headquarters at 1479 Folsom Street, San Francisco, CA 94103."
     }
   ],
   "verification": {
     "status": "partial",
-    "checked_at": "2026-07-23T09:08:52.190Z",
-    "notes": "Imported from the public models.dev provider registry."
+    "checked_at": "2026-08-09T00:00:00Z",
+    "notes": "Location metadata verified; other provider policy and catalogue fields were not re-audited. Existing provider verification note: Provider metadata and model support enrichment; not a Phaseo-routable offer."
   }
 }

--- a/packages/data/catalog/src/data/organisations/amazon/organisation.json
+++ b/packages/data/catalog/src/data/organisations/amazon/organisation.json
@@ -2,7 +2,7 @@
   "organisation_id": "amazon",
   "name": "Amazon",
   "country_code": "US",
-  "description": "Amazon is a technology and infrastructure company. Their mission is to make generative AI and foundation models accessible and scalable across businesses and services, helping users solve problems, boost productivity and innovate.",
+  "description": "Amazon is a Seattle-headquartered technology and infrastructure company. Their mission is to make generative AI and foundation models accessible and scalable across businesses and services, helping users solve problems, boost productivity and innovate.",
   "colour": "#FF9900",
   "organisation_links": [
     {
@@ -48,10 +48,17 @@
   ],
   "status": "active",
   "routable": null,
-  "sources": [],
+  "sources": [
+    {
+      "kind": "official_investor_faq",
+      "url": "https://ir.aboutamazon.com/faqs/default.aspx/1000/",
+      "accessed_at": "2026-08-09T00:00:00Z",
+      "notes": "Amazon's investor FAQ says its principal corporate offices are located in Seattle, Washington."
+    }
+  ],
   "verification": {
-    "status": "unverified",
-    "checked_at": null,
-    "notes": null
+    "status": "partial",
+    "checked_at": "2026-08-09T00:00:00Z",
+    "notes": "Location metadata verified; the broader catalogue record was not re-audited."
   }
 }

--- a/packages/data/catalog/src/data/organisations/anthropic/organisation.json
+++ b/packages/data/catalog/src/data/organisations/anthropic/organisation.json
@@ -2,7 +2,7 @@
   "organisation_id": "anthropic",
   "name": "Anthropic",
   "country_code": "US",
-  "description": "Anthropic is an AI research and deployment company. Their mission is to build reliable, interpretable and steerable AI systems so that increasingly capable technologies remain beneficial to humanity.",
+  "description": "Anthropic is an AI research and deployment company with its corporate address in San Francisco, California. Their mission is to build reliable, interpretable and steerable AI systems so that increasingly capable technologies remain beneficial to humanity.",
   "colour": "#cc785c",
   "organisation_links": [
     {
@@ -44,10 +44,17 @@
   ],
   "status": "active",
   "routable": null,
-  "sources": [],
+  "sources": [
+    {
+      "kind": "official_privacy_notice",
+      "url": "https://www-cdn.anthropic.com/8fd65f023a39d74220c5ebff85c788875c05533f.pdf",
+      "accessed_at": "2026-08-09T00:00:00Z",
+      "notes": "Anthropic's official employee/candidate privacy notice lists Anthropic, PBC at 548 Market Street, PMB 90375, San Francisco, CA 94104."
+    }
+  ],
   "verification": {
-    "status": "unverified",
-    "checked_at": null,
-    "notes": null
+    "status": "partial",
+    "checked_at": "2026-08-09T00:00:00Z",
+    "notes": "Location metadata verified; the broader catalogue record was not re-audited."
   }
 }

--- a/packages/data/catalog/src/data/organisations/cohere/organisation.json
+++ b/packages/data/catalog/src/data/organisations/cohere/organisation.json
@@ -2,7 +2,7 @@
   "organisation_id": "cohere",
   "name": "Cohere",
   "country_code": "CA",
-  "description": "Cohere is an enterprise-AI company. Their mission is to scale intelligence for organisations by delivering powerful foundation models and secure AI solutions tailored for real-world business needs.",
+  "description": "Cohere is an enterprise-AI company with its principal place of business in Toronto, Ontario, Canada. Their mission is to scale intelligence for organisations by delivering powerful foundation models and secure AI solutions tailored for real-world business needs.",
   "colour": "#41584f",
   "organisation_links": [
     {
@@ -32,10 +32,17 @@
   ],
   "status": "active",
   "routable": null,
-  "sources": [],
+  "sources": [
+    {
+      "kind": "official_saas_agreement",
+      "url": "https://cohere.com/saas-agreement",
+      "accessed_at": "2026-08-09T00:00:00Z",
+      "notes": "Cohere's SaaS Agreement identifies Cohere Inc.'s principal place of business as 171 John Street, Suite 200, Toronto, Ontario M5T 1X3."
+    }
+  ],
   "verification": {
-    "status": "unverified",
-    "checked_at": null,
-    "notes": null
+    "status": "partial",
+    "checked_at": "2026-08-09T00:00:00Z",
+    "notes": "Location metadata verified; the broader catalogue record was not re-audited."
   }
 }

--- a/packages/data/catalog/src/data/organisations/eleven-labs/organisation.json
+++ b/packages/data/catalog/src/data/organisations/eleven-labs/organisation.json
@@ -2,7 +2,7 @@
   "organisation_id": "eleven-labs",
   "name": "ElevenLabs",
   "country_code": "GB",
-  "description": "Eleven Labs is an AI audio-model company. Their mission is to enable expressive and high-quality voice and audio generation—bringing natural, human-level text-to-speech and voice-cloning to creators and applications.",
+  "description": "Eleven Labs is an AI audio-model company with its European headquarters in London, United Kingdom. Their mission is to enable expressive and high-quality voice and audio generation, bringing natural, human-level text-to-speech and voice-cloning to creators and applications.",
   "colour": "#6E6E6E",
   "organisation_links": [
     {
@@ -52,10 +52,17 @@
   ],
   "status": "active",
   "routable": null,
-  "sources": [],
+  "sources": [
+    {
+      "kind": "official_company_blog",
+      "url": "https://elevenlabs.io/blog/london-office-opening",
+      "accessed_at": "2026-08-09T00:00:00Z",
+      "notes": "ElevenLabs describes its London office as its European headquarters and the centre for worldwide operations; this record therefore uses the scoped wording European headquarters."
+    }
+  ],
   "verification": {
-    "status": "unverified",
-    "checked_at": null,
-    "notes": null
+    "status": "partial",
+    "checked_at": "2026-08-09T00:00:00Z",
+    "notes": "Location metadata verified as a regional headquarters; no unsupported claim is made about a sole global headquarters."
   }
 }

--- a/packages/data/catalog/src/data/organisations/github/organisation.json
+++ b/packages/data/catalog/src/data/organisations/github/organisation.json
@@ -2,7 +2,7 @@
   "organisation_id": "github",
   "name": "GitHub",
   "country_code": "US",
-  "description": "GitHub is a developer platform and Microsoft subsidiary. GitHub Copilot provides AI coding assistance, chat, agent workflows, code review, and access to models from OpenAI, Anthropic, Google, and other providers.",
+  "description": "GitHub is a developer platform and Microsoft subsidiary headquartered in San Francisco, California. GitHub Copilot provides AI coding assistance, chat, agent workflows, code review, and access to models from OpenAI, Anthropic, Google, and other providers.",
   "colour": "#24292f",
   "organisation_links": [
     {
@@ -20,10 +20,17 @@
   ],
   "status": "active",
   "routable": null,
-  "sources": [],
+  "sources": [
+    {
+      "kind": "official_company_page",
+      "url": "https://github.com/about/press",
+      "accessed_at": "2026-08-09T00:00:00Z",
+      "notes": "GitHub's official press page identifies its headquarters as San Francisco."
+    }
+  ],
   "verification": {
-    "status": "unverified",
-    "checked_at": null,
-    "notes": null
+    "status": "partial",
+    "checked_at": "2026-08-09T00:00:00Z",
+    "notes": "Location metadata verified; the broader catalogue record was not re-audited."
   }
 }

--- a/packages/data/catalog/src/data/organisations/google/organisation.json
+++ b/packages/data/catalog/src/data/organisations/google/organisation.json
@@ -2,7 +2,7 @@
   "organisation_id": "google",
   "name": "Google",
   "country_code": "US",
-  "description": "Google is a technology and AI company. Their mission is to advance multimodal, generative and agentic AI across vision, language and platforms to support users and creators around the world.",
+  "description": "Google is a technology and AI company within Alphabet, whose headquarters are in Mountain View, California. Their mission is to advance multimodal, generative and agentic AI across vision, language and platforms to support users and creators around the world.",
   "colour": "#4285F4",
   "organisation_links": [
     {
@@ -52,10 +52,17 @@
   ],
   "status": "active",
   "routable": null,
-  "sources": [],
+  "sources": [
+    {
+      "kind": "official_annual_report",
+      "url": "https://abc.xyz/assets/b0/4e/cfdb7b7e34a432489ad8e0d4ddcc/029c678cedfc6224410b83f263da7eb1.pdf",
+      "accessed_at": "2026-08-09T00:00:00Z",
+      "notes": "Alphabet's official annual report states that its headquarters are located in Mountain View, California; the description scopes this legal-company fact to Google as an Alphabet company."
+    }
+  ],
   "verification": {
-    "status": "unverified",
-    "checked_at": null,
-    "notes": null
+    "status": "partial",
+    "checked_at": "2026-08-09T00:00:00Z",
+    "notes": "Location metadata verified for Google's parent company; the broader catalogue record was not re-audited."
   }
 }

--- a/packages/data/catalog/src/data/organisations/ibm/organisation.json
+++ b/packages/data/catalog/src/data/organisations/ibm/organisation.json
@@ -2,7 +2,7 @@
   "organisation_id": "ibm",
   "name": "IBM",
   "country_code": "US",
-  "description": "IBM is an enterprise-technology and AI company. Their mission is to deliver AI solutions, large-model capabilities and industrial-scale platforms for organisations to apply intelligence across operations.",
+  "description": "IBM is an enterprise-technology and AI company headquartered in Armonk, New York. Their mission is to deliver AI solutions, large-model capabilities and industrial-scale platforms for organisations to apply intelligence across operations.",
   "colour": "#415eb4",
   "organisation_links": [
     {
@@ -44,10 +44,17 @@
   ],
   "status": "active",
   "routable": null,
-  "sources": [],
+  "sources": [
+    {
+      "kind": "official_company_history",
+      "url": "https://www.ibm.com/history/architecture",
+      "accessed_at": "2026-08-09T00:00:00Z",
+      "notes": "IBM's official history page identifies its central headquarters as being in Armonk, New York."
+    }
+  ],
   "verification": {
-    "status": "unverified",
-    "checked_at": null,
-    "notes": null
+    "status": "partial",
+    "checked_at": "2026-08-09T00:00:00Z",
+    "notes": "Location metadata verified; the broader catalogue record was not re-audited."
   }
 }

--- a/packages/data/catalog/src/data/organisations/inception/organisation.json
+++ b/packages/data/catalog/src/data/organisations/inception/organisation.json
@@ -2,15 +2,22 @@
   "organisation_id": "inception",
   "name": "Inception",
   "country_code": "US",
-  "description": "Inception Labs is an AI research + product company building diffusion-based language models (the Mercury family) aimed at very low latency, high throughput, and production deployment (API + on-prem).",
+  "description": "Inception Labs is an AI research + product company with its corporate address in Palo Alto, California, building diffusion-based language models (the Mercury family) aimed at very low latency, high throughput, and production deployment (API + on-prem).",
   "colour": "#2563EB",
   "organisation_links": [],
   "status": "active",
   "routable": null,
-  "sources": [],
+  "sources": [
+    {
+      "kind": "official_terms",
+      "url": "https://www.inceptionlabs.ai/docs/terms-of-use",
+      "accessed_at": "2026-08-09T00:00:00Z",
+      "notes": "Inception AI, Inc.'s official Terms of Use list 117 University Ave., Palo Alto, CA 94301."
+    }
+  ],
   "verification": {
-    "status": "unverified",
-    "checked_at": null,
-    "notes": null
+    "status": "partial",
+    "checked_at": "2026-08-09T00:00:00Z",
+    "notes": "Location metadata verified; the broader catalogue record was not re-audited."
   }
 }

--- a/packages/data/catalog/src/data/organisations/liquid-ai/organisation.json
+++ b/packages/data/catalog/src/data/organisations/liquid-ai/organisation.json
@@ -2,7 +2,7 @@
   "organisation_id": "liquid-ai",
   "name": "Liquid AI",
   "country_code": "US",
-  "description": "Liquid AI builds efficient, general-purpose foundation models for organisations, publishing models and related resources publicly (e.g., on Hugging Face) alongside their main site.",
+  "description": "Liquid AI is a US AI company headquartered in Cambridge, Massachusetts. It builds efficient, general-purpose foundation models for organisations, publishing models and related resources publicly (e.g., on Hugging Face) alongside its main site.",
   "colour": "#000000",
   "organisation_links": [
     {
@@ -32,10 +32,17 @@
   ],
   "status": "active",
   "routable": null,
-  "sources": [],
+  "sources": [
+    {
+      "kind": "official_press_release",
+      "url": "https://www.liquid.ai/press/g42-and-liquid-ai-partner-to-deliver-private-local-and-efficient-ai-solutions-to-enterprises-at-scale",
+      "accessed_at": "2026-08-09T00:00:00Z",
+      "notes": "Liquid AI's official press release describes Liquid AI as headquartered in Cambridge, Massachusetts."
+    }
+  ],
   "verification": {
-    "status": "unverified",
-    "checked_at": null,
-    "notes": null
+    "status": "partial",
+    "checked_at": "2026-08-09T00:00:00Z",
+    "notes": "Location metadata verified; the broader catalogue record was not re-audited."
   }
 }

--- a/packages/data/catalog/src/data/organisations/meta/organisation.json
+++ b/packages/data/catalog/src/data/organisations/meta/organisation.json
@@ -2,7 +2,7 @@
   "organisation_id": "meta",
   "name": "Meta",
   "country_code": "US",
-  "description": "Meta is an AI and social-technology company. Their mission is to develop large-model systems, open-weight research and generative-AI platforms in vision, language and agents to advance how people create and interact.",
+  "description": "Meta is an AI and social-technology company headquartered in Menlo Park, California. Their mission is to develop large-model systems, open-weight research and generative-AI platforms in vision, language and agents to advance how people create and interact.",
   "colour": "#1980e1",
   "organisation_links": [
     {
@@ -40,10 +40,17 @@
   ],
   "status": "active",
   "routable": null,
-  "sources": [],
+  "sources": [
+    {
+      "kind": "official_company_news",
+      "url": "https://about.fb.com/news/2018/09/expanding-our-home-in-menlo-park/",
+      "accessed_at": "2026-08-09T00:00:00Z",
+      "notes": "Meta's official company news page identifies Menlo Park as the headquarters of Facebook, now Meta."
+    }
+  ],
   "verification": {
-    "status": "unverified",
-    "checked_at": null,
-    "notes": null
+    "status": "partial",
+    "checked_at": "2026-08-09T00:00:00Z",
+    "notes": "Location metadata verified; the broader catalogue record was not re-audited."
   }
 }

--- a/packages/data/catalog/src/data/organisations/mistral/organisation.json
+++ b/packages/data/catalog/src/data/organisations/mistral/organisation.json
@@ -2,7 +2,7 @@
   "organisation_id": "mistral",
   "name": "Mistral",
   "country_code": "FR",
-  "description": "Mistral is an AI model company. Their mission is to democratise artificial intelligence by building efficient, open-source and high-performance models which organisations can deploy and own.",
+  "description": "Mistral is an AI model company with registered offices in Paris, France. Their mission is to democratise artificial intelligence by building efficient, open-source and high-performance models which organisations can deploy and own.",
   "colour": "#e97a35",
   "organisation_links": [
     {
@@ -28,10 +28,17 @@
   ],
   "status": "active",
   "routable": null,
-  "sources": [],
+  "sources": [
+    {
+      "kind": "official_legal_notice",
+      "url": "https://legal.mistral.ai/legal-notice",
+      "accessed_at": "2026-08-09T00:00:00Z",
+      "notes": "Mistral AI SAS's official legal notice lists its registered offices at 15 Rue des Halles, 75001 Paris, France."
+    }
+  ],
   "verification": {
-    "status": "unverified",
-    "checked_at": null,
-    "notes": null
+    "status": "partial",
+    "checked_at": "2026-08-09T00:00:00Z",
+    "notes": "Registered-location metadata verified; the broader catalogue record was not re-audited."
   }
 }

--- a/packages/data/catalog/src/data/organisations/nvidia/organisation.json
+++ b/packages/data/catalog/src/data/organisations/nvidia/organisation.json
@@ -2,7 +2,7 @@
   "organisation_id": "nvidia",
   "name": "Nvidia",
   "country_code": "US",
-  "description": "NVIDIA is a hardware- and software-AI company. Their mission is to enable the training and deployment of large-scale models through specialised architecture, infrastructure and model frameworks.",
+  "description": "NVIDIA is a hardware- and software-AI company headquartered in Santa Clara, California. Their mission is to enable the training and deployment of large-scale models through specialised architecture, infrastructure and model frameworks.",
   "colour": "#76B900",
   "organisation_links": [
     {
@@ -36,10 +36,17 @@
   ],
   "status": "active",
   "routable": null,
-  "sources": [],
+  "sources": [
+    {
+      "kind": "official_company_page",
+      "url": "https://www.nvidia.com/en-us/about-nvidia/governance/management-team/debora-shoquist/",
+      "accessed_at": "2026-08-09T00:00:00Z",
+      "notes": "NVIDIA's official company page refers to its Santa Clara headquarters."
+    }
+  ],
   "verification": {
-    "status": "unverified",
-    "checked_at": null,
-    "notes": null
+    "status": "partial",
+    "checked_at": "2026-08-09T00:00:00Z",
+    "notes": "Location metadata verified; the broader catalogue record was not re-audited."
   }
 }

--- a/packages/data/catalog/src/data/organisations/openai/organisation.json
+++ b/packages/data/catalog/src/data/organisations/openai/organisation.json
@@ -2,7 +2,7 @@
   "organisation_id": "openai",
   "name": "OpenAI",
   "country_code": "US",
-  "description": "OpenAI is an AI research and deployment company. Their mission is to ensure that artificial general intelligence (AGI) benefits all of humanity.",
+  "description": "OpenAI is an AI research and deployment company based in San Francisco, California. Their mission is to ensure that artificial general intelligence (AGI) benefits all of humanity.",
   "colour": "#333333",
   "organisation_links": [
     {
@@ -52,10 +52,17 @@
   ],
   "status": "active",
   "routable": null,
-  "sources": [],
+  "sources": [
+    {
+      "kind": "official_terms_pdf",
+      "url": "https://cdn.openai.com/pdf/d5caec5a-ee81-419d-b0d7-39f1424d819c/OpenAI%20Model%20Craft_%20Parameter%20Golf%20Challenge%20Terms%20and%20Conditions.pdf",
+      "accessed_at": "2026-08-09T00:00:00Z",
+      "notes": "OpenAI OpCo, LLC's official terms list 1455 Third Street, San Francisco, CA 94158."
+    }
+  ],
   "verification": {
-    "status": "unverified",
-    "checked_at": null,
-    "notes": null
+    "status": "partial",
+    "checked_at": "2026-08-09T00:00:00Z",
+    "notes": "Location metadata verified; the broader catalogue record was not re-audited."
   }
 }

--- a/packages/data/catalog/src/data/organisations/perplexity/organisation.json
+++ b/packages/data/catalog/src/data/organisations/perplexity/organisation.json
@@ -2,7 +2,7 @@
   "organisation_id": "perplexity",
   "name": "Perplexity",
   "country_code": "US",
-  "description": "Perplexity AI is an AI application company. Their mission is to combine generative models, retrieval-augmented search and agentic interfaces so that people can access accurate information and intelligence in new ways.",
+  "description": "Perplexity AI is an AI application company with its corporate address in San Francisco, California. Their mission is to combine generative models, retrieval-augmented search and agentic interfaces so that people can access accurate information and intelligence in new ways.",
   "colour": "#20b8cd",
   "organisation_links": [
     {
@@ -28,10 +28,17 @@
   ],
   "status": "active",
   "routable": null,
-  "sources": [],
+  "sources": [
+    {
+      "kind": "official_terms",
+      "url": "https://www.perplexity.ai/es/hub/legal/terms-of-service",
+      "accessed_at": "2026-08-09T00:00:00Z",
+      "notes": "Perplexity AI, Inc.'s official terms list 115 Sansome St., Suite 900, San Francisco, CA 94104."
+    }
+  ],
   "verification": {
-    "status": "unverified",
-    "checked_at": null,
-    "notes": null
+    "status": "partial",
+    "checked_at": "2026-08-09T00:00:00Z",
+    "notes": "Location metadata verified; the broader catalogue record was not re-audited."
   }
 }

--- a/packages/data/catalog/src/data/organisations/sourceful/organisation.json
+++ b/packages/data/catalog/src/data/organisations/sourceful/organisation.json
@@ -2,7 +2,7 @@
   "organisation_id": "sourceful",
   "name": "Sourceful",
   "country_code": "GB",
-  "description": "Sourceful is an AI-powered packaging design platform that helps teams create and iterate packaging designs through conversational workflows.",
+  "description": "Sourceful is an AI-powered packaging design platform headquartered in Manchester, United Kingdom, that helps teams create and iterate packaging designs through conversational workflows.",
   "colour": "#654CFF",
   "organisation_links": [
     {
@@ -24,10 +24,17 @@
   ],
   "status": "active",
   "routable": null,
-  "sources": [],
+  "sources": [
+    {
+      "kind": "official_company_blog",
+      "url": "https://www.sourceful.com/blog/betting-big-on-manchester-why-we-are-building-sourceful-in-the-worlds-original-industrialised-city",
+      "accessed_at": "2026-08-09T00:00:00Z",
+      "notes": "Sourceful's official company blog describes Manchester as its main headquarters."
+    }
+  ],
   "verification": {
-    "status": "unverified",
-    "checked_at": null,
-    "notes": null
+    "status": "partial",
+    "checked_at": "2026-08-09T00:00:00Z",
+    "notes": "Location metadata verified; the broader catalogue record was not re-audited."
   }
 }

--- a/packages/data/catalog/src/data/organisations/upstage/organisation.json
+++ b/packages/data/catalog/src/data/organisations/upstage/organisation.json
@@ -2,7 +2,7 @@
   "organisation_id": "upstage",
   "name": "Upstage",
   "country_code": "KR",
-  "description": "Upstage is a South Korean AI company. Its mission is to improve work productivity by building cost-effective enterprise AI, including large language models (e.g., Solar) and document AI/OCR systems that automate and scale knowledge work.",
+  "description": "Upstage is a South Korean AI company with its registered/business address in Seoul. Its mission is to improve work productivity by building cost-effective enterprise AI, including large language models (e.g., Solar) and document AI/OCR systems that automate and scale knowledge work.",
   "colour": "#5b52ff",
   "organisation_links": [
     {
@@ -28,10 +28,17 @@
   ],
   "status": "active",
   "routable": null,
-  "sources": [],
+  "sources": [
+    {
+      "kind": "official_company_page",
+      "url": "https://www.upstage.ai/about",
+      "accessed_at": "2026-08-09T00:00:00Z",
+      "notes": "Upstage's official About page lists Upstage Co., Ltd.'s business address in Gangnam-gu, Seoul, South Korea."
+    }
+  ],
   "verification": {
-    "status": "unverified",
-    "checked_at": null,
-    "notes": null
+    "status": "partial",
+    "checked_at": "2026-08-09T00:00:00Z",
+    "notes": "Registered/business location metadata verified; the broader catalogue record was not re-audited."
   }
 }

--- a/packages/data/catalog/src/data/organisations/vercel/organisation.json
+++ b/packages/data/catalog/src/data/organisations/vercel/organisation.json
@@ -2,7 +2,7 @@
   "organisation_id": "vercel",
   "name": "Vercel",
   "country_code": "US",
-  "description": "Vercel is a developer cloud platform for building and deploying web experiences (including AI apps), providing tooling and infrastructure for shipping and scaling modern frontends.",
+  "description": "Vercel is a developer cloud platform headquartered in San Francisco, California, for building and deploying web experiences (including AI apps), providing tooling and infrastructure for shipping and scaling modern frontends.",
   "colour": "#000000",
   "organisation_links": [
     {
@@ -28,10 +28,17 @@
   ],
   "status": "active",
   "routable": null,
-  "sources": [],
+  "sources": [
+    {
+      "kind": "official_company_event_page",
+      "url": "https://vercel.com/go/builder-day",
+      "accessed_at": "2026-08-09T00:00:00Z",
+      "notes": "Vercel's official Builder Day page identifies its San Francisco headquarters at 201 Mission Street."
+    }
+  ],
   "verification": {
-    "status": "unverified",
-    "checked_at": null,
-    "notes": null
+    "status": "partial",
+    "checked_at": "2026-08-09T00:00:00Z",
+    "notes": "Location metadata verified; the broader catalogue record was not re-audited."
   }
 }


### PR DESCRIPTION
## Summary

Adds evidence-backed headquarters, principal-place-of-business, and registered-location metadata to 28 catalog records:

- 17 organisation records
- 11 API-provider records

Each update records an authoritative public source and uses repository-appropriate wording. Where the source supported only a corporate address, principal place of business, registered seat, or regional headquarters, the description preserves that narrower claim.

Ambiguous cases were deliberately left untouched: no location was inferred from a country code, office listing without headquarters context, or non-authoritative third-party directory. Existing provider provenance notes were preserved.

## Validation

- `pnpm validate:data` — passed all 9 enforced checks
- Catalog manifest — in sync
- 175 non-blocking existing validation warnings remain

Created with Codex